### PR TITLE
Add: compose DeepSeek V4 SWA decode TP output

### DIFF
--- a/models/deepseek_v4_flash_dspark/decode_o_proj.py
+++ b/models/deepseek_v4_flash_dspark/decode_o_proj.py
@@ -92,6 +92,8 @@ if D % O_B_D_TILE != 0 or O_B_D_TILE % O_B_N_TILE != 0:
     raise ValueError("O-B output tiles must divide the hidden dimension")
 if D % ACT_N_TILE != 0:
     raise ValueError(f"O-B activation tile {ACT_N_TILE} must divide hidden size {D}")
+if GROUP_T_PAD % O_B_T_TILE != 0:
+    raise ValueError(f"O-B token tile {O_B_T_TILE} must divide token capacity {GROUP_T_PAD}")
 
 
 @pl.jit.inline
@@ -158,7 +160,8 @@ def decode_o_proj_tp1(
                     g_amax = pl.maximum(g_amax_floor, g_row_max)
                     g_scale_num = pl.full([1, QUANT_TOKEN_TILE], dtype=pl.FP32, value=INT8_SCALE_MAX)
                     g_sq_row = pl.div(g_scale_num, g_amax)
-                    act_scale_dq[g : g + 1, qt : qt + QUANT_TOKEN_TILE] = pl.recip(g_sq_row)
+                    g_scale_dq = pl.mul(g_amax, 1.0 / INT8_SCALE_MAX)
+                    act_scale_dq[g : g + 1, qt : qt + QUANT_TOKEN_TILE] = g_scale_dq
                     g_sq_col = pl.reshape(g_sq_row, [QUANT_TOKEN_TILE, 1])
                     oc_q = o_r_pad[qt : qt + QUANT_TOKEN_TILE, col_g : col_g + O_LORA]
                     oq_scaled = pl.row_expand_mul(oc_q, g_sq_col)
@@ -519,6 +522,7 @@ def decode_sharded_o_projection(
     group_t = TP_SIZE * local_t
     o_a_rows = (group_t + O_A_T_TILE - 1) // O_A_T_TILE
     o_b_rows = (group_t + O_B_T_TILE - 1) // O_B_T_TILE
+    o_b_group_t = o_b_rows * O_B_T_TILE
     act_rows = (group_t + ACT_T_TILE - 1) // ACT_T_TILE
 
     attn_2d = pl.reshape(attention_local_groups, [LOCAL_O_GROUPS * GROUP_T_PAD, O_GROUP_IN])
@@ -571,6 +575,13 @@ def decode_sharded_o_projection(
                 o_a_quant = pl.cast(o_a_fp16, target_type=pl.INT8, mode="trunc")
                 o_a_quant_valid = pl.set_validshape(o_a_quant, quant_rows, O_LORA)
                 o_a_i8[qt : qt + QUANT_T_TILE, o_a_col : o_a_col + O_LORA] = o_a_quant_valid
+            # Pad the compact O-A prefix to complete 128-row O-B slabs.
+            for qt in pl.range(group_t, o_b_group_t, QUANT_T_TILE):
+                pad_rows = pl.min(QUANT_T_TILE, o_b_group_t - qt)
+                o_a_padding_fp16 = pl.full([QUANT_T_TILE, O_LORA], dtype=pl.FP16, value=0.0)
+                o_a_padding = pl.cast(o_a_padding_fp16, target_type=pl.INT8, mode="trunc")
+                o_a_padding_valid = pl.set_validshape(o_a_padding, pad_rows, O_LORA)
+                o_a_i8[qt : qt + QUANT_T_TILE, o_a_col : o_a_col + O_LORA] = o_a_padding_valid
 
         with pl.spmd(o_b_rows * (D // O_B_D_TILE), name_hint="tp_o_b", deps=[quant_tid]) as proj_b_tid:
             proj_b_unit = pl.tile.get_block_idx()
@@ -578,19 +589,17 @@ def decode_sharded_o_projection(
             d_block = proj_b_unit - row_block * (D // O_B_D_TILE)
             t0 = row_block * O_B_T_TILE
             d0 = d_block * O_B_D_TILE
-            b_rows = pl.min(O_B_T_TILE, group_t - t0)
             for n0 in pl.range(d0, d0 + O_B_D_TILE, O_B_N_TILE):
-                o_b_x0 = pl.slice(o_a_i8, [O_B_T_TILE, O_B_K_TILE], [t0, o_a_col], valid_shape=[b_rows, O_B_K_TILE])
+                o_b_x0 = o_a_i8[t0 : t0 + O_B_T_TILE, o_a_col : o_a_col + O_B_K_TILE]
                 o_b_w0 = wo_b[n0 : n0 + O_B_N_TILE, o_a_col : o_a_col + O_B_K_TILE]
                 o_b_acc = pl.matmul(o_b_x0, o_b_w0, b_trans=True, out_dtype=pl.INT32)
                 for k0 in pl.pipeline(O_B_K_TILE, O_LORA, O_B_K_TILE, stage=2):
                     b_k0 = o_a_col + k0
-                    o_b_xk = pl.slice(o_a_i8, [O_B_T_TILE, O_B_K_TILE], [t0, b_k0], valid_shape=[b_rows, O_B_K_TILE])
+                    o_b_xk = o_a_i8[t0 : t0 + O_B_T_TILE, b_k0 : b_k0 + O_B_K_TILE]
                     o_b_wk = wo_b[n0 : n0 + O_B_N_TILE, b_k0 : b_k0 + O_B_K_TILE]
                     o_b_acc = pl.matmul_acc(o_b_acc, o_b_xk, o_b_wk, b_trans=True)
-                o_b_i32_valid = pl.set_validshape(o_b_acc, b_rows, O_B_N_TILE)
                 partial_col = local_group * D + n0
-                o_b_i32[t0 : t0 + O_B_T_TILE, partial_col : partial_col + O_B_N_TILE] = o_b_i32_valid
+                o_b_i32[t0 : t0 + O_B_T_TILE, partial_col : partial_col + O_B_N_TILE] = o_b_acc
         proj_b_tids[local_group] = proj_b_tid
 
     with pl.spmd(

--- a/models/deepseek_v4_flash_dspark/decode_sparse_attn_swa.py
+++ b/models/deepseek_v4_flash_dspark/decode_sparse_attn_swa.py
@@ -26,6 +26,7 @@ from config import (
     INT8_SCALE_MAX,
     INT8_AMAX_EPS,
 )
+from decode_o_proj import decode_o_proj_tp1
 
 
 # Dynamic shape variables.
@@ -64,25 +65,9 @@ QK_M_TILE = 32           # qk_pv M rows per QK/PV matmul; QK_M_TILE/H_TILE-way K
 ATTN_K_TILE = 128
 ROPE_TILE = 16
 ROPE_INTERLEAVE_TILE = 2 * ROPE_TILE
-A_K_TILE = 256           # proj_a cube K frag
-PROJ_A_MM_N_TILE = 128   # proj_a cube N frag
 T_PAD = ((T + 16 - 1) // 16) * 16  # T padded up to the 16-row cube M floor
-MM_T_TILE = T_PAD  # one cube M tile spans every token row of the T_PAD-strided scratch
 ROPE_CS_T_TILE = 8  # rope cos/sin row block; T is a multiple of 8 by the batch contract
 BIAS_T_TILE = 8     # swa_valid_bias row block, same contract
-PROJ_A_ROW_TILE = 16  # proj_a cube M; row-blocked so uninitialized pad rows never enter the matmul
-PA_N_FRAGS = O_LORA // PROJ_A_MM_N_TILE
-B_K_TILE = 256           # proj_b_mm cube K frag
-# proj_b_mm cube N frag; Acc = MM_T_TILE*N*4 = 128KB sits exactly on the a2a3 L0C wall.
-PROJ_B_MM_N_TILE = 256
-PROJ_B_ACT_N_TILE = 512  # proj_b_act vector N frag; keeps the O_GROUPS-way accumulate inside UB
-# Fused amax+quant token tile. 8 keeps the [1, QUANT_TOKEN_TILE] fp32 amax tile
-# 32-byte aligned (8*4=32B, the alloc-tile row floor).
-QUANT_TOKEN_TILE = 8
-PROJ_B_D_TILE = 512      # proj_b_mm D chunk per task; its N frags loop inside the task
-PROJ_B_ACT_T_TILE = 8    # proj_b_act inner token tile for the O_GROUPS-way INT32->FP32 accumulate
-PROJ_B_ACT_TASK_T_TILE = 8   # proj_b_act token block per task
-PROJ_B_ACT_N_REGS = D // PROJ_B_ACT_N_TILE
 TOPK = WIN               # SWA sparse-K width: sliding window only
 SPARSE_BLOCKS = 1        # the SWA window fits one attention K tile
 PADDED_TOPK = SPARSE_BLOCKS * ATTN_K_TILE
@@ -290,148 +275,6 @@ def sparse_attn_swa_heads(
 
 
 @pl.jit.inline
-def sparse_attn_swa_local_o_proj(
-    o_packed_heads: pl.Tensor[[O_GROUPS * T_PAD * HEADS_PER_GROUP, HEAD_DIM], pl.BF16],
-    wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
-    wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
-    wo_b_scale: pl.Tensor[[D], pl.FP32],
-    attn_out: pl.Tensor[[T_DYN, D], pl.BF16],
-    heads_dep: pl.Scalar[pl.TASK_ID],
-):
-    """Project local-token, full-group SWA heads into BF16 hidden rows."""
-    # ========================================================================
-    # Back-to-back grouped output projection (manual scope, PER-GROUP INT8 quant).
-    #
-    # Per-GROUP amax localizes the quant reduction to each O_LORA group (vs the
-    # per-ROW-amax form, where a full-8192-row reduction is a hard barrier between
-    # proj_a and proj_b), so the three stages PIPELINE per group with qwen3-style
-    # fine-grained deps: proj_b[*, g] waits only on quant[g], which waits only on
-    # proj_a[g, *] -- so proj_b's cube for group g runs while proj_a/quant of later
-    # groups are still in flight (a genuine proj_a<->proj_b back-to-back GEMM).
-    #
-    # manual_scope SUPPRESSES auto-dep, so every edge is explicit: proj_a[g]
-    # reads only its o_packed slab -> deps=[heads_dep]; quant[g] deps on group
-    # g's proj_a task; proj_b depends directly on quant[g] and writes a disjoint
-    # group partial. proj_b_act combines those partials with their group row scales,
-    # applies the per-channel weight scale, and is the consolidated attn_out writer.
-    # ========================================================================
-    t_dim = pl.tensor.dim(attn_out, 0)
-    proj_a_rows = (t_dim + PROJ_A_ROW_TILE - 1) // PROJ_A_ROW_TILE
-    act_t_blks = t_dim // PROJ_B_ACT_TASK_T_TILE
-
-    o_packed = pl.reshape(o_packed_heads, [O_GROUPS * T_PAD, O_GROUP_IN])
-    o_r_pad = pl.create_tensor([T_PAD, O_GROUPS * O_LORA], dtype=pl.FP32)
-    o_r_i8_pad = pl.create_tensor([T_PAD, O_GROUPS * O_LORA], dtype=pl.INT8)
-    # [G, T] keeps each group's per-row scale as one contiguous row;
-    # column reads would become unsupported strided GM->VecTile loads.
-    # Per-group INT32 partials: proj_b_mm (pure cube) writes group g's contribution to
-    # output channel n at partials[:, g*D + n]; proj_b_act (pure vector) sums the
-    # O_GROUPS partials with their per-group act scales. No atomic-add -> no zero-seed.
-    # Package each group's fragments into one grid. The group TaskId is the
-    # exact dependency granularity needed by quant/proj_b, while 80 individual
-    # orchestration submissions disappear from the critical projection tail.
-    partials = pl.create_tensor([T_PAD, O_GROUPS * D], dtype=pl.INT32)
-    act_scale_dq = pl.create_tensor([O_GROUPS, T_PAD], dtype=pl.FP32)
-    proj_b_tids = pl.array.create(O_GROUPS, pl.TASK_ID)
-    with pl.manual_scope():
-        for g in pl.parallel(O_GROUPS):
-            row_base_o = g * T_PAD
-            out_col_g = g * O_LORA
-
-            with pl.spmd(proj_a_rows * PA_N_FRAGS, name_hint="proj_a_mm", deps=[heads_dep],
-                         allow_early_resolve=True) as pa_tid:
-                pa_unit = pl.tile.get_block_idx()
-                pa_rb = pa_unit // PA_N_FRAGS  # row block outermost
-                nf = pa_unit - pa_rb * PA_N_FRAGS
-                pa_r0 = pa_rb * PROJ_A_ROW_TILE
-                pa_rows = pl.min(PROJ_A_ROW_TILE, t_dim - pa_r0)
-                pa_src0 = row_base_o + pa_r0
-                n0 = nf * PROJ_A_MM_N_TILE
-                xa0_chunk = pl.slice(o_packed, [PROJ_A_ROW_TILE, A_K_TILE], [pa_src0, 0], valid_shape=[pa_rows, A_K_TILE])
-                wa0_chunk = wo_a[g : g + 1, n0 : n0 + PROJ_A_MM_N_TILE, 0:A_K_TILE]
-                acc_a = pl.matmul(xa0_chunk, wa0_chunk, b_trans=True, out_dtype=pl.FP32)
-                for kb in pl.pipeline(1, O_GROUP_IN // A_K_TILE, stage=2):
-                    k0 = kb * A_K_TILE
-                    xa_k_chunk = pl.slice(o_packed, [PROJ_A_ROW_TILE, A_K_TILE], [pa_src0, k0], valid_shape=[pa_rows, A_K_TILE])
-                    wa_k_chunk = wo_a[g : g + 1, n0 : n0 + PROJ_A_MM_N_TILE, k0 : k0 + A_K_TILE]
-                    acc_a = pl.matmul_acc(acc_a, xa_k_chunk, wa_k_chunk, b_trans=True)
-                # acc_a is 3D (wo_a keeps its group axis), which subscript-write cannot express.
-                o_r_pad = pl.assemble(o_r_pad, acc_a, [pa_r0, out_col_g + n0])
-
-            col_g = g * O_LORA
-            with pl.at(level=pl.Level.CORE_GROUP, name_hint="quant", deps=[pa_tid], allow_early_resolve=True) as q_tid:
-                for qt in pl.pipeline(0, t_dim, QUANT_TOKEN_TILE, stage=2):
-                    oc_amax = o_r_pad[qt : qt + QUANT_TOKEN_TILE, col_g : col_g + O_LORA]
-                    g_abs = pl.abs(oc_amax)
-                    g_row_max = pl.row_max(g_abs)
-                    g_row_max = pl.reshape(g_row_max, [1, QUANT_TOKEN_TILE])
-                    g_amax_floor = pl.full([1, QUANT_TOKEN_TILE], dtype=pl.FP32, value=INT8_AMAX_EPS)
-                    g_amax = pl.maximum(g_amax_floor, g_row_max)
-                    g_scale_num = pl.full([1, QUANT_TOKEN_TILE], dtype=pl.FP32, value=INT8_SCALE_MAX)
-                    g_sq_row = pl.div(g_scale_num, g_amax)
-                    g_scale_dq = pl.mul(g_amax, 1.0 / INT8_SCALE_MAX)
-                    act_scale_dq[g : g + 1, qt : qt + QUANT_TOKEN_TILE] = g_scale_dq
-                    g_sq_col = pl.reshape(g_sq_row, [QUANT_TOKEN_TILE, 1])
-                    oc_q = o_r_pad[qt : qt + QUANT_TOKEN_TILE, col_g : col_g + O_LORA]
-                    oq_scaled = pl.row_expand_mul(oc_q, g_sq_col)
-                    oq_i32 = pl.cast(oq_scaled, target_type=pl.INT32, mode="rint")
-                    oq_half = pl.cast(oq_i32, target_type=pl.FP16, mode="round")
-                    oq_i8 = pl.cast(oq_half, target_type=pl.INT8, mode="trunc")
-                    o_r_i8_pad[qt : qt + QUANT_TOKEN_TILE, col_g : col_g + O_LORA] = oq_i8
-                # Zero the rows past the runtime token count; proj_b_mm reads the full T_PAD extent.
-                for zt in pl.range(t_dim, T_PAD, QUANT_TOKEN_TILE):
-                    zero_half = pl.full([QUANT_TOKEN_TILE, O_LORA], dtype=pl.FP16, value=0.0)
-                    o_r_i8_pad[zt : zt + QUANT_TOKEN_TILE, col_g : col_g + O_LORA] = pl.cast(
-                        zero_half, target_type=pl.INT8, mode="trunc")
-
-            with pl.spmd(D // PROJ_B_D_TILE, name_hint="proj_b_mm", deps=[q_tid], allow_early_resolve=True) as pb_tid:
-                dc = pl.tile.get_block_idx()
-                d0 = dc * PROJ_B_D_TILE
-                for nf in pl.range(PROJ_B_D_TILE // PROJ_B_MM_N_TILE):
-                    n0 = d0 + nf * PROJ_B_MM_N_TILE
-                    acc_b = pl.create_tensor([MM_T_TILE, PROJ_B_MM_N_TILE], dtype=pl.INT32)
-                    for kb in pl.pipeline(0, O_LORA // B_K_TILE, stage=2):
-                        k0 = col_g + kb * B_K_TILE
-                        if kb == 0:
-                            b_act = o_r_i8_pad[:, col_g : col_g + B_K_TILE]
-                            b_weight = wo_b[n0 : n0 + PROJ_B_MM_N_TILE, col_g : col_g + B_K_TILE]
-                            acc_b = pl.matmul(b_act, b_weight, b_trans=True, out_dtype=pl.INT32)
-                        else:
-                            b_act = o_r_i8_pad[:, k0 : k0 + B_K_TILE]
-                            b_weight = wo_b[n0 : n0 + PROJ_B_MM_N_TILE, k0 : k0 + B_K_TILE]
-                            acc_b = pl.matmul_acc(acc_b, b_act, b_weight, b_trans=True)
-                    partials[0:MM_T_TILE, g * D + n0 : g * D + n0 + PROJ_B_MM_N_TILE] = acc_b
-            proj_b_tids[g] = pb_tid
-
-    # Consolidate the eight grouped INT32 partials in one vector epilogue. Keep
-    # the direct per-group task dependencies so there is no synthetic join task
-    # between the output-projection cubes and dequantization.
-    with pl.spmd(act_t_blks * PROJ_B_ACT_N_REGS, name_hint="proj_b_act",
-                 deps=[proj_b_tids[i] for i in range(O_GROUPS)], allow_early_resolve=True) as _act_tid:
-        act_idx = pl.tile.get_block_idx()
-        tblk = act_idx // PROJ_B_ACT_N_REGS  # token block outermost
-        nreg = act_idx - tblk * PROJ_B_ACT_N_REGS
-        ob_n0 = nreg * PROJ_B_ACT_N_TILE
-        t0 = tblk * PROJ_B_ACT_TASK_T_TILE
-        wb_scale = wo_b_scale[ob_n0 : ob_n0 + PROJ_B_ACT_N_TILE]
-        wb_scale_chunk = pl.reshape(wb_scale, [1, PROJ_B_ACT_N_TILE])
-        for b_tb in pl.range(t0, t0 + PROJ_B_ACT_TASK_T_TILE, PROJ_B_ACT_T_TILE):
-            acc = pl.full([PROJ_B_ACT_T_TILE, PROJ_B_ACT_N_TILE], dtype=pl.FP32, value=0.0)
-            for act_g in pl.pipeline(O_GROUPS, stage=2):
-                p_col0 = act_g * D + ob_n0
-                p_g = partials[b_tb : b_tb + PROJ_B_ACT_T_TILE, p_col0 : p_col0 + PROJ_B_ACT_N_TILE]
-                g_scale_row = act_scale_dq[act_g : act_g + 1, b_tb : b_tb + PROJ_B_ACT_T_TILE]
-                g_scale = pl.reshape(g_scale_row, [PROJ_B_ACT_T_TILE, 1])
-                p_g_f32 = pl.cast(p_g, target_type=pl.FP32, mode="none")
-                p_g_scaled = pl.row_expand_mul(p_g_f32, g_scale)
-                acc = pl.add(acc, p_g_scaled)
-            out_t = pl.col_expand_mul(acc, wb_scale_chunk)
-            out_bf16 = pl.cast(out_t, target_type=pl.BF16, mode="rint")
-            attn_out[b_tb : b_tb + PROJ_B_ACT_T_TILE, ob_n0 : ob_n0 + PROJ_B_ACT_N_TILE] = out_bf16
-    return attn_out
-
-
-@pl.jit.inline
 def sparse_attn_swa(
     q: pl.Tensor[[T_DYN, H, HEAD_DIM], pl.BF16],
     ori_kv: pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
@@ -452,8 +295,9 @@ def sparse_attn_swa(
         attn_sink, freqs_cos, freqs_sin,
         o_packed_heads,
     )
-    attn_out = sparse_attn_swa_local_o_proj(
-        o_packed_heads,
+    o_packed = pl.reshape(o_packed_heads, [O_GROUPS * T_PAD, O_GROUP_IN])
+    attn_out = decode_o_proj_tp1(
+        o_packed,
         wo_a, wo_b, wo_b_scale,
         attn_out, heads_dep,
     )

--- a/models/deepseek_v4_flash_dspark/decode_swa.py
+++ b/models/deepseek_v4_flash_dspark/decode_swa.py
@@ -6,9 +6,34 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-# ci: devices=4
-"""DeepSeek-V4 SWA decode orchestration for rank-local and TP4 output paths."""
+# ci: devices=2  # CI: 2-card run; borrows 2 cards via task-submit --device-num
+"""DeepSeek-V4 SWA decode orchestration with configurable TP output."""
 
+
+import sys
+
+import config
+
+
+# Sub-kernels freeze TP-derived shapes at import time, so select the standalone
+# program's TP world before importing them below.
+_TP_CHOICES = (1, 2, 4)
+_TP_DEFAULT = 2
+
+
+def _parse_tp_argv():
+    for index, arg in enumerate(sys.argv):
+        if arg == "--tp" and index + 1 < len(sys.argv):
+            return int(sys.argv[index + 1])
+        if arg.startswith("--tp="):
+            return int(arg.split("=", 1)[1])
+    return _TP_DEFAULT
+
+
+TP_SIZE = _parse_tp_argv()
+if TP_SIZE not in _TP_CHOICES:
+    raise ValueError(f"--tp must be one of {_TP_CHOICES} (got {TP_SIZE})")
+config.TP = TP_SIZE
 
 import pypto.language as pl
 import pypto.language.distributed as pld
@@ -16,7 +41,6 @@ import pypto.language.distributed as pld
 from config import (
     FLASH as M,
     DECODE_BATCH,
-    TP,
     KV_ORI_BLOCK_NUM,
     DECODE_SEQ,
     BLOCK_SIZE,
@@ -37,7 +61,6 @@ from decode_o_proj import (
     LOCAL_T,
     LOCAL_T_PAD,
     O_WINDOW_ROWS,
-    TP_SIZE,
     attention_token_head_all_to_all_step,
     decode_sharded_o_projection,
     o_projection_reduce_scatter_step,
@@ -49,7 +72,7 @@ T_DYN = pl.dynamic("T_DYN")  # T = B * S
 
 
 # model config
-B = DECODE_BATCH // TP
+B = DECODE_BATCH // TP_SIZE
 S = DECODE_SEQ
 T = B * S
 BIAS_T_TILE = 8  # sparse_bias row block; T is a multiple of 8 by the batch contract
@@ -88,14 +111,14 @@ SPARSE_ROPE_INTERLEAVE_TILE = 2 * SPARSE_ROPE_TILE
 NEG_INF = -1.0e20
 
 # fixture
-TP4_FIXTURE_WINDOW_BLOCKS = (WIN + BLOCK_SIZE - 1) // BLOCK_SIZE
-TP4_FIXTURE_OUTPUT_SENTINEL = -7.0
+TP_FIXTURE_WINDOW_BLOCKS = (WIN + BLOCK_SIZE - 1) // BLOCK_SIZE
+TP_FIXTURE_OUTPUT_SENTINEL = -7.0
 
 if T != LOCAL_T:
     raise ValueError(f"SWA token capacity {T} must equal TP-local token capacity {LOCAL_T}")
 if T_PAD != LOCAL_T_PAD:
     raise ValueError(f"SWA padded token capacity {T_PAD} must equal TP capacity {LOCAL_T_PAD}")
-if TP4_FIXTURE_WINDOW_BLOCKS > ORI_BLOCK_NUM:
+if TP_FIXTURE_WINDOW_BLOCKS > ORI_BLOCK_NUM:
     raise ValueError("SWA fixture window exceeds the original KV cache capacity")
 
 @pl.jit.inline
@@ -617,8 +640,8 @@ def build_tensor_specs(start_pos=None, batch=B):
     ]
 
 
-def build_tp4_tensor_specs(local_t):
-    """Build deterministic four-rank SWA output-half inputs."""
+def build_tp_tensor_specs(local_t):
+    """Build deterministic tensor-parallel SWA output-half inputs."""
     import torch
 
     from golden import ScalarSpec, TensorSpec
@@ -637,8 +660,8 @@ def build_tp4_tensor_specs(local_t):
     def init_ori_kv():
         shape = (ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM)
         cache = torch.full(shape, float("nan"), dtype=torch.bfloat16)
-        cache[:TP4_FIXTURE_WINDOW_BLOCKS, :, 0, :] = 0.0
-        cache[:TP4_FIXTURE_WINDOW_BLOCKS, :, 0, 0] = 0.25
+        cache[:TP_FIXTURE_WINDOW_BLOCKS, :, 0, :] = 0.0
+        cache[:TP_FIXTURE_WINDOW_BLOCKS, :, 0, 0] = 0.25
         return cache.unsqueeze(0).expand(TP_SIZE, *shape).clone()
 
     def init_swa_indices():
@@ -692,7 +715,7 @@ def build_tp4_tensor_specs(local_t):
         TensorSpec("wo_b_scale", [TP_SIZE, D], torch.float32, init_value=init_wo_b_scale),
         TensorSpec(
             "o_local", [TP_SIZE, LOCAL_T_PAD, D], torch.bfloat16,
-            init_value=TP4_FIXTURE_OUTPUT_SENTINEL, is_output=True,
+            init_value=TP_FIXTURE_OUTPUT_SENTINEL, is_output=True,
         ),
         ScalarSpec("local_t", torch.int32, local_t),
     ]
@@ -743,7 +766,7 @@ def golden_decode_swa_output(tensors):
         partials[rank] *= tensors["wo_b_scale"][rank].float().reshape(1, D)
 
     reduced = partials.sum(dim=0)
-    tensors["o_local"].fill_(TP4_FIXTURE_OUTPUT_SENTINEL)
+    tensors["o_local"].fill_(TP_FIXTURE_OUTPUT_SENTINEL)
     for rank in range(TP_SIZE):
         row_start = rank * local_t
         tensors["o_local"][rank, :local_t] = reduced[row_start : row_start + local_t].to(torch.bfloat16)
@@ -775,163 +798,51 @@ def build_o_local_compare(local_t):
 if __name__ == "__main__":
     import argparse
 
+    from golden import run_jit
+    from pypto.ir.distributed_compiled_program import DistributedConfig
+
     parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "--mode",
-        choices=("all", "tp1", "tp4"),
-        default=None,
-        help="execution mode; defaults to TP1 for an explicit single device and all paths otherwise",
-    )
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
-    parser.add_argument("-d", "--device", type=str, default=None)
-    parser.add_argument("-b", "--batch", type=int, default=B,
-                        help=f"runtime request count; a multiple of 4 up to {B} (the compile-time "
-                             "upper bound). The token axis is pl.dynamic, so one compiled program "
-                             "serves every value.")
-    parser.add_argument("--start-pos", type=int, default=None,
-                        help="Uniform fixture-only start_pos override for all batches; "
-                             "default (unset) uses the canonical per-batch SWA set that includes the 8k point.")
-    parser.add_argument("--enable-l2-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2, 4))
-    parser.add_argument("--runtime-dir", type=str, default=None)
-    parser.add_argument("--golden-data", type=str, default=None)
-    parser.add_argument("--case", choices=("all", "max", "subcapacity"), default=None)
+    parser.add_argument("--tp", type=int, default=TP_SIZE, choices=list(_TP_CHOICES),
+                        help="tensor-parallel world size")
+    parser.add_argument("-d", "--device", type=str, default=",".join(str(rank) for rank in range(TP_SIZE)),
+                        help=f"comma-separated device ids; need exactly {TP_SIZE}")
+    parser.add_argument("--case", choices=("all", "max", "subcapacity"), default="all")
     parser.add_argument("--compile-only", action="store_true", default=False)
     parser.add_argument("--dump-passes", action="store_true", default=False)
     args = parser.parse_args()
 
-    mode = args.mode
-    if mode is None:
-        mode = "tp1" if args.device is not None and "," not in args.device else "all"
+    if args.tp != TP_SIZE:
+        parser.error(f"--tp must remain {TP_SIZE} after import-time specialization")
+    try:
+        device_ids = [int(device) for device in args.device.split(",")]
+    except ValueError:
+        parser.error(f"--device must be a comma-separated integer list, got {args.device!r}")
+    if len(device_ids) != TP_SIZE:
+        parser.error(f"need exactly {TP_SIZE} devices, got {device_ids}")
+    if any(device < 0 for device in device_ids):
+        parser.error(f"--device IDs must be non-negative, got {device_ids}")
+    if len(set(device_ids)) != TP_SIZE:
+        parser.error(f"need {TP_SIZE} distinct devices, got {device_ids}")
 
-    if mode in ("all", "tp4"):
-        tp4_device = ",".join(str(rank) for rank in range(TP_SIZE)) if args.device is None else args.device
-        try:
-            device_ids = [int(device) for device in tp4_device.split(",")]
-        except ValueError:
-            parser.error(f"--device must be a comma-separated integer list, got {tp4_device!r}")
-        if len(device_ids) != TP_SIZE:
-            parser.error(f"--mode {mode} needs exactly {TP_SIZE} devices, got {device_ids}")
-        if any(device < 0 for device in device_ids):
-            parser.error(f"--device IDs must be non-negative, got {device_ids}")
-        if len(set(device_ids)) != TP_SIZE:
-            parser.error(f"--mode {mode} needs {TP_SIZE} distinct devices, got {device_ids}")
-    else:
-        tp1_device = "0" if args.device is None else args.device
-        if "," in tp1_device:
-            parser.error("--mode tp1 accepts exactly one device")
-        try:
-            device_ids = [int(tp1_device)]
-        except ValueError:
-            parser.error(f"--device must be an integer, got {tp1_device!r}")
-        if device_ids[0] < 0:
-            parser.error(f"--device ID must be non-negative, got {device_ids[0]}")
-
-    if mode in ("all", "tp1") and (args.batch < 4 or args.batch > B or args.batch % 4 != 0):
-        parser.error(f"--batch must be a multiple of 4 in [4, {B}], got {args.batch}")
-    if mode == "tp1" and args.case is not None:
-        parser.error("--case is only valid with --mode tp4")
-
-    if mode == "all":
-        import subprocess
-        import sys
-        from pathlib import Path
-
-        common_command = [sys.executable, str(Path(__file__).resolve()), "-p", args.platform]
-        tp1_command = [
-            *common_command,
-            "--mode", "tp1",
-            "-d", str(device_ids[0]),
-            "-b", str(args.batch),
-        ]
-        tp4_command = [
-            *common_command,
-            "--mode", "tp4",
-            "-d", ",".join(str(device) for device in device_ids),
-        ]
-        if args.start_pos is not None:
-            tp1_command.extend(("--start-pos", str(args.start_pos)))
-        if args.enable_l2_swimlane:
-            tp1_command.extend(("--enable-l2-swimlane", str(args.enable_l2_swimlane)))
-        if args.runtime_dir is not None:
-            tp1_command.extend(("--runtime-dir", args.runtime_dir))
-        if args.golden_data is not None:
-            tp1_command.extend(("--golden-data", args.golden_data))
-        if args.case is not None:
-            tp4_command.extend(("--case", args.case))
-        if args.compile_only:
-            tp1_command.append("--compile-only")
-            tp4_command.append("--compile-only")
-        if args.dump_passes:
-            tp1_command.append("--dump-passes")
-            tp4_command.append("--dump-passes")
-
-        for command in (tp1_command, tp4_command):
-            completed = subprocess.run(command, check=False)
-            if completed.returncode:
-                exit_code = completed.returncode if completed.returncode > 0 else 128 - completed.returncode
-                raise SystemExit(exit_code)
-        raise SystemExit(0)
-
-    from golden import ratio_allclose, ratio_reldiff, run_jit
-    from pypto.ir.distributed_compiled_program import DistributedConfig
-
-    if mode == "tp1":
+    case_local_t = {"max": LOCAL_T, "subcapacity": LOCAL_T - BIAS_T_TILE}
+    selected_cases = tuple(case_local_t) if args.case == "all" else (args.case,)
+    for case in selected_cases:
+        local_t = case_local_t[case]
         result = run_jit(
-            fn=attention_swa_test,
-            specs=build_tensor_specs(args.start_pos, batch=args.batch),
-            golden_fn=golden_attention_swa,
-            runtime_dir=args.runtime_dir,
-            golden_data=args.golden_data,
+            fn=l3_decode_swa_output,
+            specs=build_tp_tensor_specs(local_t),
+            golden_fn=golden_decode_swa_output,
             compile_only=args.compile_only,
-            compile_cfg=dict(dump_passes=args.dump_passes),
-            runtime_cfg=dict(
-                platform=args.platform,
-                device_id=device_ids[0],
-                enable_l2_swimlane=args.enable_l2_swimlane,
+            compile_cfg=dict(
+                dump_passes=args.dump_passes,
+                distributed_config=DistributedConfig(device_ids=device_ids, num_sub_workers=0),
             ),
-            rtol=1e-2,
-            atol=1e-2,
-            compare_fn={
-                # Tightened from CANN's 1e-2 bar: realistic hc_attn gates keep x_out
-                # well-conditioned (0% over 3e-3 across seeds; worst rdiff ~0.16).
-                "x_out": ratio_reldiff(diff_thd=3e-3, pct_thd=0.008, max_diff_hd=1),
-                "kv_cache": ratio_allclose(atol=1e-4, rtol=1.0 / 128),
-            },
+            runtime_cfg=dict(platform=args.platform),
+            compare_fn={"o_local": build_o_local_compare(local_t)},
         )
         if not result.passed:
             if result.error:
                 print(result.error)
             raise SystemExit(1)
-    if mode == "tp4":
-        if args.start_pos is not None:
-            parser.error("--start-pos is not supported by the TP4 fixture")
-        if args.batch != B:
-            parser.error("--batch is not supported by the TP4 fixture")
-        if args.runtime_dir is not None:
-            parser.error("--runtime-dir is not supported by the TP4 fixture")
-        if args.golden_data is not None:
-            parser.error("--golden-data is not supported by the TP4 fixture")
-        if args.enable_l2_swimlane != 0:
-            parser.error("--enable-l2-swimlane is not supported by the TP4 fixture")
-        case_local_t = {"max": LOCAL_T, "subcapacity": LOCAL_T - BIAS_T_TILE}
-        selected_case = "all" if args.case is None else args.case
-        selected_cases = tuple(case_local_t) if selected_case == "all" else (selected_case,)
-        for case in selected_cases:
-            local_t = case_local_t[case]
-            result = run_jit(
-                fn=l3_decode_swa_output,
-                specs=build_tp4_tensor_specs(local_t),
-                golden_fn=golden_decode_swa_output,
-                compile_only=args.compile_only,
-                compile_cfg=dict(
-                    dump_passes=args.dump_passes,
-                    distributed_config=DistributedConfig(device_ids=device_ids, num_sub_workers=0),
-                ),
-                runtime_cfg=dict(platform=args.platform),
-                compare_fn={"o_local": build_o_local_compare(local_t)},
-            )
-            if not result.passed:
-                if result.error:
-                    print(result.error)
-                raise SystemExit(1)

--- a/models/deepseek_v4_flash_dspark/decode_swa.py
+++ b/models/deepseek_v4_flash_dspark/decode_swa.py
@@ -6,16 +6,12 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-"""DeepSeek-V4 SWA (Sliding Window Attention) decode orchestration — `compress_ratio == 0` path.
-Active in layers 0/1/7 of the model (3 of the 8 layers in demo). No KV compression, so neither
-compressor nor indexer is invoked; topk for sparse_attn is window_topk_idxs only and the KV cache
-holds only the sliding window (no compressed portion). YaRN frequency scaling is also disabled
-in this path (model.py:478-479 selects base rope_theta when compress_ratio==0).
-Companion files: attention_csa_draft.py (ratio=4)
-                 attention_hca_draft.py (ratio=128)."""
+# ci: devices=4
+"""DeepSeek-V4 SWA decode orchestration for rank-local and TP4 output paths."""
 
 
 import pypto.language as pl
+import pypto.language.distributed as pld
 
 from config import (
     FLASH as M,
@@ -33,7 +29,20 @@ from hc_pre import hc_pre
 from hc_post import hc_post
 from qkv_proj_rope import qkv_proj_rope
 from rmsnorm import rms_norm
-from decode_sparse_attn_swa import sparse_attn_swa
+from decode_o_proj import (
+    ATTENTION_WINDOW_ROWS,
+    GROUP_T_PAD,
+    LOCAL_O_GROUPS,
+    LOCAL_O_WIDTH,
+    LOCAL_T,
+    LOCAL_T_PAD,
+    O_WINDOW_ROWS,
+    TP_SIZE,
+    attention_token_head_all_to_all_step,
+    decode_sharded_o_projection,
+    o_projection_reduce_scatter_step,
+)
+from decode_sparse_attn_swa import ATTN_K_TILE, PADDED_TOPK, T_PAD, sparse_attn_swa, sparse_attn_swa_heads
 
 # Dynamic shape variables.
 T_DYN = pl.dynamic("T_DYN")  # T = B * S
@@ -61,6 +70,7 @@ HC_EPS = M.hc_eps
 MAX_SEQ_LEN = M.max_position_embeddings
 O_LORA = M.o_lora_rank
 O_GROUPS = M.o_groups
+HEADS_PER_GROUP = H // O_GROUPS
 O_GROUP_IN = H * HEAD_DIM // O_GROUPS
 
 # kernel-local (SWA: ratio-0, no compressor/indexer)
@@ -76,6 +86,17 @@ SPARSE_CMP_MAX_BLOCKS = KV_CMP_MAX_BLOCKS
 SPARSE_ROPE_TILE = 16
 SPARSE_ROPE_INTERLEAVE_TILE = 2 * SPARSE_ROPE_TILE
 NEG_INF = -1.0e20
+
+# fixture
+TP4_FIXTURE_WINDOW_BLOCKS = (WIN + BLOCK_SIZE - 1) // BLOCK_SIZE
+TP4_FIXTURE_OUTPUT_SENTINEL = -7.0
+
+if T != LOCAL_T:
+    raise ValueError(f"SWA token capacity {T} must equal TP-local token capacity {LOCAL_T}")
+if T_PAD != LOCAL_T_PAD:
+    raise ValueError(f"SWA padded token capacity {T_PAD} must equal TP capacity {LOCAL_T_PAD}")
+if TP4_FIXTURE_WINDOW_BLOCKS > ORI_BLOCK_NUM:
+    raise ValueError("SWA fixture window exceeds the original KV cache capacity")
 
 @pl.jit.inline
 def attention_swa(
@@ -225,6 +246,124 @@ def attention_swa_test(
         x_out,
     )
     return x_out
+
+
+@pl.jit
+def decode_swa_output(
+    q: pl.Tensor[[T_DYN, H, HEAD_DIM], pl.BF16],
+    ori_kv: pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
+    swa_lens: pl.Tensor[[T_DYN], pl.INT32],
+    attn_sink: pl.Tensor[[H], pl.FP32],
+    freqs_cos: pl.Tensor[[T_DYN, ROPE_HEAD_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[T_DYN, ROPE_HEAD_DIM], pl.BF16],
+    wo_a: pl.Tensor[[LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
+    wo_b: pl.Tensor[[D, LOCAL_O_WIDTH], pl.INT8],
+    wo_b_scale: pl.Tensor[[D], pl.FP32],
+    o_local: pl.InOut[pl.Tensor[[LOCAL_T_PAD, D], pl.BF16]],
+    attention_window: pld.DistributedTensor[[ATTENTION_WINDOW_ROWS, O_GROUP_IN], pl.BF16],
+    attention_signal: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
+    o_window: pld.DistributedTensor[[O_WINDOW_ROWS, D], pl.FP32],
+    o_signal: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
+    group_base: pl.Scalar[pl.INT32],
+    tp_rank: pl.Scalar[pl.INT32],
+    local_t: pl.Scalar[pl.INT32],
+):
+    """Run rank-local SWA heads, output A2A, sharded O projection, and RS."""
+    q.bind_dynamic(0, T_DYN)
+    swa_indices.bind_dynamic(0, T_DYN)
+    swa_lens.bind_dynamic(0, T_DYN)
+    freqs_cos.bind_dynamic(0, T_DYN)
+    freqs_sin.bind_dynamic(0, T_DYN)
+
+    t_dim = pl.tensor.dim(q, 0)
+    sparse_bias = pl.create_tensor([t_dim, PADDED_TOPK], dtype=pl.FP32)
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="swa_valid_bias"):
+        valid_col = pl.cast(pl.arange(0, [1, ATTN_K_TILE], dtype=pl.INT32), target_type=pl.FP32)
+        for bias_block in pl.range(t_dim // BIAS_T_TILE):
+            token_start = bias_block * BIAS_T_TILE
+            zero_rows = pl.full([BIAS_T_TILE, ATTN_K_TILE], dtype=pl.FP32, value=0.0)
+            valid_cols = pl.col_expand(zero_rows, valid_col)
+            lens_slice = swa_lens[token_start : token_start + BIAS_T_TILE]
+            lens_col = pl.reshape(lens_slice, [BIAS_T_TILE, 1])
+            lens_fp32 = pl.cast(lens_col, target_type=pl.FP32)
+            valid = pl.neg(pl.row_expand_sub(valid_cols, lens_fp32))
+            valid = pl.maximum(valid, 0.0)
+            valid = pl.minimum(valid, 1.0)
+            invalid = pl.sub(valid, 1.0)
+            sparse_bias[token_start : token_start + BIAS_T_TILE, 0:ATTN_K_TILE] = pl.mul(invalid, -NEG_INF)
+
+    o_packed_heads = pl.create_tensor([O_GROUPS * T_PAD * HEADS_PER_GROUP, HEAD_DIM], dtype=pl.BF16)
+    o_packed_heads, _ = sparse_attn_swa_heads(
+        q, ori_kv, swa_indices, sparse_bias,
+        attn_sink, freqs_cos, freqs_sin,
+        o_packed_heads,
+    )
+
+    attention_grouped = pl.reshape(o_packed_heads, [O_GROUPS * LOCAL_T_PAD, O_GROUP_IN])
+    attention_local_flat = pl.create_tensor([ATTENTION_WINDOW_ROWS, O_GROUP_IN], dtype=pl.BF16)
+    attention_local_flat, attention_signal = attention_token_head_all_to_all_step(
+        attention_grouped, attention_local_flat,
+        attention_window, attention_signal,
+        group_base, tp_rank, local_t,
+    )
+
+    attention_local_groups = pl.reshape(attention_local_flat, [LOCAL_O_GROUPS, GROUP_T_PAD, O_GROUP_IN])
+    o_partial = pl.create_tensor([GROUP_T_PAD, D], dtype=pl.FP32)
+    o_partial, projection_tid = decode_sharded_o_projection(
+        attention_local_groups,
+        wo_a, wo_b, wo_b_scale,
+        local_t, o_partial,
+    )
+
+    with pl.spmd(1, name_hint="tp_o_reduce_scatter", deps=[projection_tid]) as _reduce_scatter_tid:
+        o_local, o_signal = o_projection_reduce_scatter_step(
+            o_partial, o_local,
+            o_window, o_signal,
+            group_base, tp_rank, local_t,
+        )
+    return o_local, attention_signal, o_signal
+
+
+@pl.jit.host
+def l3_decode_swa_output(
+    q: pl.Tensor[[TP_SIZE, T_DYN, H, HEAD_DIM], pl.BF16],
+    ori_kv: pl.Tensor[[TP_SIZE, ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    swa_indices: pl.Tensor[[TP_SIZE, T_DYN, WIN], pl.INT32],
+    swa_lens: pl.Tensor[[TP_SIZE, T_DYN], pl.INT32],
+    attn_sink: pl.Tensor[[TP_SIZE, H], pl.FP32],
+    freqs_cos: pl.Tensor[[TP_SIZE, T_DYN, ROPE_HEAD_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[TP_SIZE, T_DYN, ROPE_HEAD_DIM], pl.BF16],
+    wo_a: pl.Tensor[[TP_SIZE, LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
+    wo_b: pl.Tensor[[TP_SIZE, D, LOCAL_O_WIDTH], pl.INT8],
+    wo_b_scale: pl.Tensor[[TP_SIZE, D], pl.FP32],
+    o_local: pl.InOut[pl.Tensor[[TP_SIZE, LOCAL_T_PAD, D], pl.BF16]],
+    local_t: pl.Scalar[pl.INT32],
+):
+    """Launch the SWA output half on one physical TP group."""
+    q.bind_dynamic(1, T_DYN)
+    swa_indices.bind_dynamic(1, T_DYN)
+    swa_lens.bind_dynamic(1, T_DYN)
+    freqs_cos.bind_dynamic(1, T_DYN)
+    freqs_sin.bind_dynamic(1, T_DYN)
+
+    attention_window_buf = pld.alloc_window_buffer([ATTENTION_WINDOW_ROWS, O_GROUP_IN], dtype=pl.BF16)
+    attention_signal_buf = pld.alloc_window_buffer([TP_SIZE, 1], dtype=pl.INT32)
+    o_window_buf = pld.alloc_window_buffer([O_WINDOW_ROWS, D], dtype=pl.FP32)
+    o_signal_buf = pld.alloc_window_buffer([TP_SIZE, 1], dtype=pl.INT32)
+
+    for rank in pl.range(pld.world_size()):
+        attention_window = pld.window(attention_window_buf, [ATTENTION_WINDOW_ROWS, O_GROUP_IN], dtype=pl.BF16)
+        attention_signal = pld.window(attention_signal_buf, [TP_SIZE, 1], dtype=pl.INT32)
+        o_window = pld.window(o_window_buf, [O_WINDOW_ROWS, D], dtype=pl.FP32)
+        o_signal = pld.window(o_signal_buf, [TP_SIZE, 1], dtype=pl.INT32)
+        decode_swa_output(
+            q[rank], ori_kv[rank], swa_indices[rank], swa_lens[rank],
+            attn_sink[rank], freqs_cos[rank], freqs_sin[rank],
+            wo_a[rank], wo_b[rank], wo_b_scale[rank], o_local[rank],
+            attention_window, attention_signal, o_window, o_signal,
+            0, rank, local_t, device=rank,
+        )
 
 
 def golden_attention_swa(tensors):
@@ -478,14 +617,174 @@ def build_tensor_specs(start_pos=None, batch=B):
     ]
 
 
+def build_tp4_tensor_specs(local_t):
+    """Build deterministic four-rank SWA output-half inputs."""
+    import torch
+
+    from golden import ScalarSpec, TensorSpec
+
+    if local_t < BIAS_T_TILE or local_t > LOCAL_T or local_t % BIAS_T_TILE != 0 or local_t % S != 0:
+        raise ValueError(f"local_t must be a multiple of {BIAS_T_TILE} in [{BIAS_T_TILE}, {LOCAL_T}], got {local_t}")
+
+    def init_q():
+        q = torch.zeros(TP_SIZE, local_t, H, HEAD_DIM, dtype=torch.bfloat16)
+        rank = torch.arange(TP_SIZE, dtype=torch.float32).reshape(TP_SIZE, 1, 1)
+        token = torch.arange(local_t, dtype=torch.float32).reshape(1, local_t, 1)
+        head = torch.arange(H, dtype=torch.float32).reshape(1, 1, H)
+        q[..., 0] = (rank + token * 0.25 + head * 0.0625).to(torch.bfloat16)
+        return q
+
+    def init_ori_kv():
+        shape = (ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM)
+        cache = torch.full(shape, float("nan"), dtype=torch.bfloat16)
+        cache[:TP4_FIXTURE_WINDOW_BLOCKS, :, 0, :] = 0.0
+        cache[:TP4_FIXTURE_WINDOW_BLOCKS, :, 0, 0] = 0.25
+        return cache.unsqueeze(0).expand(TP_SIZE, *shape).clone()
+
+    def init_swa_indices():
+        window_row = torch.arange(WIN, dtype=torch.int32)
+        return window_row.reshape(1, 1, WIN).expand(TP_SIZE, local_t, WIN).clone()
+
+    def init_swa_lens():
+        return torch.full((TP_SIZE, local_t), WIN, dtype=torch.int32)
+
+    def init_attn_sink():
+        head = torch.arange(H, dtype=torch.int32).remainder(HEADS_PER_GROUP).to(torch.float32)
+        sink = 4.0 + head * 0.125
+        return sink.reshape(1, H).expand(TP_SIZE, H).clone()
+
+    def init_freqs_cos():
+        cos = torch.ones(local_t, ROPE_HEAD_DIM, dtype=torch.bfloat16)
+        return cos.unsqueeze(0).expand(TP_SIZE, local_t, ROPE_HEAD_DIM).clone()
+
+    def init_freqs_sin():
+        sin = torch.zeros(local_t, ROPE_HEAD_DIM, dtype=torch.bfloat16)
+        return sin.unsqueeze(0).expand(TP_SIZE, local_t, ROPE_HEAD_DIM).clone()
+
+    def init_wo_a():
+        wo_a = torch.zeros(TP_SIZE, LOCAL_O_GROUPS, O_LORA, O_GROUP_IN, dtype=torch.bfloat16)
+        for rank in range(TP_SIZE):
+            for local_group in range(LOCAL_O_GROUPS):
+                shard_scale = (rank + 1) * (local_group + 1) * 0.125
+                for head in range(HEADS_PER_GROUP):
+                    wo_a[rank, local_group, head, head * HEAD_DIM] = shard_scale * (head + 1)
+        return wo_a
+
+    def init_wo_b():
+        base = torch.arange(D * LOCAL_O_WIDTH, dtype=torch.int32).reshape(D, LOCAL_O_WIDTH)
+        rank = torch.arange(TP_SIZE, dtype=torch.int32).reshape(TP_SIZE, 1, 1)
+        return (base.unsqueeze(0) + rank).remainder(7).sub(3).to(torch.int8)
+
+    def init_wo_b_scale():
+        channel_scale = torch.arange(D, dtype=torch.int32).remainder(4).to(torch.float32) * 0.25 + 0.5
+        return channel_scale.reshape(1, D).expand(TP_SIZE, D).clone()
+
+    return [
+        TensorSpec("q", [TP_SIZE, local_t, H, HEAD_DIM], torch.bfloat16, init_value=init_q),
+        TensorSpec("ori_kv", [TP_SIZE, ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_ori_kv),
+        TensorSpec("swa_indices", [TP_SIZE, local_t, WIN], torch.int32, init_value=init_swa_indices),
+        TensorSpec("swa_lens", [TP_SIZE, local_t], torch.int32, init_value=init_swa_lens),
+        TensorSpec("attn_sink", [TP_SIZE, H], torch.float32, init_value=init_attn_sink),
+        TensorSpec("freqs_cos", [TP_SIZE, local_t, ROPE_HEAD_DIM], torch.bfloat16, init_value=init_freqs_cos),
+        TensorSpec("freqs_sin", [TP_SIZE, local_t, ROPE_HEAD_DIM], torch.bfloat16, init_value=init_freqs_sin),
+        TensorSpec("wo_a", [TP_SIZE, LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], torch.bfloat16, init_value=init_wo_a),
+        TensorSpec("wo_b", [TP_SIZE, D, LOCAL_O_WIDTH], torch.int8, init_value=init_wo_b),
+        TensorSpec("wo_b_scale", [TP_SIZE, D], torch.float32, init_value=init_wo_b_scale),
+        TensorSpec(
+            "o_local", [TP_SIZE, LOCAL_T_PAD, D], torch.bfloat16,
+            init_value=TP4_FIXTURE_OUTPUT_SENTINEL, is_output=True,
+        ),
+        ScalarSpec("local_t", torch.int32, local_t),
+    ]
+
+
+def golden_decode_swa_output(tensors):
+    """Compute the controlled SWA heads, sharded O projection, and reduced rows."""
+    import torch
+
+    local_t = tensors["q"].shape[1]
+    group_t = TP_SIZE * local_t
+    q0 = tensors["q"][..., 0].float()
+    kv0 = tensors["ori_kv"][:, 0, 0, 0, 0].float()
+    sink = tensors["attn_sink"].float()
+    score = q0 * kv0.reshape(TP_SIZE, 1, 1) * M.softmax_scale
+    numerator = WIN * kv0.reshape(TP_SIZE, 1, 1)
+    head_value = numerator / (WIN + torch.exp(sink.reshape(TP_SIZE, 1, H) - score))
+    head_value = head_value.to(torch.bfloat16)
+
+    attention_grouped = torch.zeros(TP_SIZE, O_GROUPS, local_t, O_GROUP_IN, dtype=torch.bfloat16)
+    for group in range(O_GROUPS):
+        for head in range(HEADS_PER_GROUP):
+            global_head = group * HEADS_PER_GROUP + head
+            group_col = head * HEAD_DIM
+            attention_grouped[:, group, :, group_col] = head_value[:, :, global_head]
+
+    attention_local = torch.zeros(TP_SIZE, LOCAL_O_GROUPS, group_t, O_GROUP_IN, dtype=torch.bfloat16)
+    for destination_rank in range(TP_SIZE):
+        for local_group in range(LOCAL_O_GROUPS):
+            global_group = destination_rank * LOCAL_O_GROUPS + local_group
+            group_rows = attention_grouped[:, global_group].reshape(group_t, O_GROUP_IN)
+            attention_local[destination_rank, local_group] = group_rows
+
+    partials = torch.zeros(TP_SIZE, group_t, D, dtype=torch.float32)
+    for rank in range(TP_SIZE):
+        attention = attention_local[rank].float()
+        o_a = torch.einsum("gti,gri->gtr", attention, tensors["wo_a"][rank].float())
+        row_amax = o_a.abs().amax(dim=-1, keepdim=True).clamp_min(INT8_AMAX_EPS)
+        scale_q = INT8_SCALE_MAX / row_amax
+        o_a_i8 = torch.round(o_a * scale_q).to(torch.int32).to(torch.float16).to(torch.int8)
+        scale_dq = 1.0 / scale_q
+        wo_b = tensors["wo_b"][rank].reshape(D, LOCAL_O_GROUPS, O_LORA)
+        for local_group in range(LOCAL_O_GROUPS):
+            group_i32 = o_a_i8[local_group].to(torch.int32)
+            weight_i32 = wo_b[:, local_group].to(torch.int32)
+            group_partial = group_i32 @ weight_i32.T
+            partials[rank] += group_partial.float() * scale_dq[local_group]
+        partials[rank] *= tensors["wo_b_scale"][rank].float().reshape(1, D)
+
+    reduced = partials.sum(dim=0)
+    tensors["o_local"].fill_(TP4_FIXTURE_OUTPUT_SENTINEL)
+    for rank in range(TP_SIZE):
+        row_start = rank * local_t
+        tensors["o_local"][rank, :local_t] = reduced[row_start : row_start + local_t].to(torch.bfloat16)
+
+
+def build_o_local_compare(local_t):
+    """Compare valid token rows and require the poisoned capacity tail to survive."""
+    import torch
+
+    from golden import ratio_allclose
+
+    prefix_compare = ratio_allclose(
+        atol=1e-4, rtol=1.0 / 128, max_error_ratio=0.0,
+        valid_rows=local_t, valid_axis=1,
+    )
+
+    def compare(actual, expected, **kwargs):
+        actual_tail = actual[:, local_t:]
+        expected_tail = expected[:, local_t:]
+        if not torch.equal(actual_tail, expected_tail):
+            mismatch_count = int((actual_tail != expected_tail).sum().item())
+            return False, f"    inactive token tail mismatch count={mismatch_count}"
+        return prefix_compare(actual, expected, **kwargs)
+
+    compare.__name__ = f"swa_output_prefix_and_tail(local_t={local_t})"
+    return compare
+
+
 if __name__ == "__main__":
     import argparse
-    from golden import ratio_allclose, ratio_reldiff, run_jit
 
     parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--mode",
+        choices=("all", "tp1", "tp4"),
+        default=None,
+        help="execution mode; defaults to TP1 for an explicit single device and all paths otherwise",
+    )
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
-    parser.add_argument("-d", "--device", type=int, default=0)
+    parser.add_argument("-d", "--device", type=str, default=None)
     parser.add_argument("-b", "--batch", type=int, default=B,
                         help=f"runtime request count; a multiple of 4 up to {B} (the compile-time "
                              "upper bound). The token axis is pl.dynamic, so one compiled program "
@@ -496,33 +795,143 @@ if __name__ == "__main__":
     parser.add_argument("--enable-l2-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2, 4))
     parser.add_argument("--runtime-dir", type=str, default=None)
     parser.add_argument("--golden-data", type=str, default=None)
+    parser.add_argument("--case", choices=("all", "max", "subcapacity"), default=None)
+    parser.add_argument("--compile-only", action="store_true", default=False)
     parser.add_argument("--dump-passes", action="store_true", default=False)
     args = parser.parse_args()
-    if args.batch < 4 or args.batch > B or args.batch % 4 != 0:
-        parser.error(f"--batch must be a multiple of 4 in [4, {B}], got {args.batch}")
 
-    result = run_jit(
-        fn=attention_swa_test,
-        specs=build_tensor_specs(args.start_pos, batch=args.batch),
-        golden_fn=golden_attention_swa,
-        runtime_dir=args.runtime_dir,
-        golden_data=args.golden_data,
-        compile_cfg=dict(dump_passes=args.dump_passes),
-        runtime_cfg=dict(
-            platform=args.platform,
-            device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
-        ),
-        rtol=1e-2,
-        atol=1e-2,
-        compare_fn={
-            # Tightened from CANN's 1e-2 bar: realistic hc_attn gates keep x_out
-            # well-conditioned (0% over 3e-3 across seeds; worst rdiff ~0.16).
-            "x_out": ratio_reldiff(diff_thd=3e-3, pct_thd=0.008, max_diff_hd=1),
-            "kv_cache": ratio_allclose(atol=1e-4, rtol=1.0 / 128),
-        },
-    )
-    if not result.passed:
-        if result.error:
-            print(result.error)
-        raise SystemExit(1)
+    mode = args.mode
+    if mode is None:
+        mode = "tp1" if args.device is not None and "," not in args.device else "all"
+
+    if mode in ("all", "tp4"):
+        tp4_device = ",".join(str(rank) for rank in range(TP_SIZE)) if args.device is None else args.device
+        try:
+            device_ids = [int(device) for device in tp4_device.split(",")]
+        except ValueError:
+            parser.error(f"--device must be a comma-separated integer list, got {tp4_device!r}")
+        if len(device_ids) != TP_SIZE:
+            parser.error(f"--mode {mode} needs exactly {TP_SIZE} devices, got {device_ids}")
+        if any(device < 0 for device in device_ids):
+            parser.error(f"--device IDs must be non-negative, got {device_ids}")
+        if len(set(device_ids)) != TP_SIZE:
+            parser.error(f"--mode {mode} needs {TP_SIZE} distinct devices, got {device_ids}")
+    else:
+        tp1_device = "0" if args.device is None else args.device
+        if "," in tp1_device:
+            parser.error("--mode tp1 accepts exactly one device")
+        try:
+            device_ids = [int(tp1_device)]
+        except ValueError:
+            parser.error(f"--device must be an integer, got {tp1_device!r}")
+        if device_ids[0] < 0:
+            parser.error(f"--device ID must be non-negative, got {device_ids[0]}")
+
+    if mode in ("all", "tp1") and (args.batch < 4 or args.batch > B or args.batch % 4 != 0):
+        parser.error(f"--batch must be a multiple of 4 in [4, {B}], got {args.batch}")
+    if mode == "tp1" and args.case is not None:
+        parser.error("--case is only valid with --mode tp4")
+
+    if mode == "all":
+        import subprocess
+        import sys
+        from pathlib import Path
+
+        common_command = [sys.executable, str(Path(__file__).resolve()), "-p", args.platform]
+        tp1_command = [
+            *common_command,
+            "--mode", "tp1",
+            "-d", str(device_ids[0]),
+            "-b", str(args.batch),
+        ]
+        tp4_command = [
+            *common_command,
+            "--mode", "tp4",
+            "-d", ",".join(str(device) for device in device_ids),
+        ]
+        if args.start_pos is not None:
+            tp1_command.extend(("--start-pos", str(args.start_pos)))
+        if args.enable_l2_swimlane:
+            tp1_command.extend(("--enable-l2-swimlane", str(args.enable_l2_swimlane)))
+        if args.runtime_dir is not None:
+            tp1_command.extend(("--runtime-dir", args.runtime_dir))
+        if args.golden_data is not None:
+            tp1_command.extend(("--golden-data", args.golden_data))
+        if args.case is not None:
+            tp4_command.extend(("--case", args.case))
+        if args.compile_only:
+            tp1_command.append("--compile-only")
+            tp4_command.append("--compile-only")
+        if args.dump_passes:
+            tp1_command.append("--dump-passes")
+            tp4_command.append("--dump-passes")
+
+        for command in (tp1_command, tp4_command):
+            completed = subprocess.run(command, check=False)
+            if completed.returncode:
+                exit_code = completed.returncode if completed.returncode > 0 else 128 - completed.returncode
+                raise SystemExit(exit_code)
+        raise SystemExit(0)
+
+    from golden import ratio_allclose, ratio_reldiff, run_jit
+    from pypto.ir.distributed_compiled_program import DistributedConfig
+
+    if mode == "tp1":
+        result = run_jit(
+            fn=attention_swa_test,
+            specs=build_tensor_specs(args.start_pos, batch=args.batch),
+            golden_fn=golden_attention_swa,
+            runtime_dir=args.runtime_dir,
+            golden_data=args.golden_data,
+            compile_only=args.compile_only,
+            compile_cfg=dict(dump_passes=args.dump_passes),
+            runtime_cfg=dict(
+                platform=args.platform,
+                device_id=device_ids[0],
+                enable_l2_swimlane=args.enable_l2_swimlane,
+            ),
+            rtol=1e-2,
+            atol=1e-2,
+            compare_fn={
+                # Tightened from CANN's 1e-2 bar: realistic hc_attn gates keep x_out
+                # well-conditioned (0% over 3e-3 across seeds; worst rdiff ~0.16).
+                "x_out": ratio_reldiff(diff_thd=3e-3, pct_thd=0.008, max_diff_hd=1),
+                "kv_cache": ratio_allclose(atol=1e-4, rtol=1.0 / 128),
+            },
+        )
+        if not result.passed:
+            if result.error:
+                print(result.error)
+            raise SystemExit(1)
+    if mode == "tp4":
+        if args.start_pos is not None:
+            parser.error("--start-pos is not supported by the TP4 fixture")
+        if args.batch != B:
+            parser.error("--batch is not supported by the TP4 fixture")
+        if args.runtime_dir is not None:
+            parser.error("--runtime-dir is not supported by the TP4 fixture")
+        if args.golden_data is not None:
+            parser.error("--golden-data is not supported by the TP4 fixture")
+        if args.enable_l2_swimlane != 0:
+            parser.error("--enable-l2-swimlane is not supported by the TP4 fixture")
+        case_local_t = {"max": LOCAL_T, "subcapacity": LOCAL_T - BIAS_T_TILE}
+        selected_case = "all" if args.case is None else args.case
+        selected_cases = tuple(case_local_t) if selected_case == "all" else (selected_case,)
+        for case in selected_cases:
+            local_t = case_local_t[case]
+            result = run_jit(
+                fn=l3_decode_swa_output,
+                specs=build_tp4_tensor_specs(local_t),
+                golden_fn=golden_decode_swa_output,
+                compile_only=args.compile_only,
+                compile_cfg=dict(
+                    dump_passes=args.dump_passes,
+                    distributed_config=DistributedConfig(device_ids=device_ids, num_sub_workers=0),
+                ),
+                runtime_cfg=dict(platform=args.platform),
+                compare_fn={"o_local": build_o_local_compare(local_t)},
+            )
+            if not result.passed:
+                if result.error:
+                    print(result.error)
+                raise SystemExit(1)


### PR DESCRIPTION
- Chain rank-local SWA heads through TP token/head exchange, sharded
  output projection, and dependency-ordered FP32 reduce-scatter.
- Select TP-derived shapes from `--tp 1/2/4` at import time and default
  standalone and CI execution to TP2.
- Consolidate the TP output path and fixtures into `decode_swa.py`, reuse
  the shared output projection, and validate max and subcapacity layouts
  with exact inactive-tail checks.