### PR TITLE
feat(dspark): add DeepSeek V4 draft pipeline

### DIFF
--- a/models/deepseek_v4_flash_dspark/dspark_context_kv.py
+++ b/models/deepseek_v4_flash_dspark/dspark_context_kv.py
@@ -35,6 +35,9 @@ from qkv_proj_rope import kv_proj_rope, materialize_rope_rows, rope_prepare
 T_DYN = pl.dynamic("DSPARK_CONTEXT_KV_T_DYN")
 ORI_BLOCK_NUM_DYN = pl.dynamic("DSPARK_CONTEXT_KV_ORI_BLOCK_NUM_DYN")
 
+# The public DSpark program supports at most 16 requests with 7 draft rows.
+DSPARK_QUERY_TOKENS = 16 * 7
+
 # model config
 D = M.hidden_size
 HEAD_DIM = M.head_dim
@@ -68,7 +71,7 @@ def dspark_context_kv(
     rope_swap_idx = pl.create_tensor([t_dim, ROPE_DIM], dtype=pl.INT32)
     rope_prepare(rope_cos_t, rope_sin_t, rope_cos_il, rope_sin_signed, rope_swap_idx)
 
-    # Neutral fence: no earlier producer to defer the kv_proj matmul behind here.
+    # This no-work source task seeds the explicit kv_proj dependency chain.
     late_dep = pl.system.task_dummy(deps=[])
     kv = pl.create_tensor([t_dim, HEAD_DIM], dtype=pl.BF16)
     kv_proj_rope(main_x, wkv, gamma_ckv, rope_cos_il, rope_sin_signed, rope_swap_idx, kv, late_dep)
@@ -83,6 +86,56 @@ def dspark_context_kv(
                 kv_cache_flat[write_row : write_row + 1, 0:HEAD_DIM] = kv[write_t : write_t + 1, 0:HEAD_DIM]
 
     return kv_cache
+
+
+@pl.jit.inline
+def dspark_context_kv_query(
+    main_x: pl.Tensor[[DSPARK_QUERY_TOKENS, D], pl.BF16],
+    wkv: pl.Tensor[[D, HEAD_DIM], pl.BF16],
+    gamma_ckv: pl.Tensor[[HEAD_DIM], pl.BF16],
+    freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_DIM], pl.BF16],
+    position_ids: pl.Tensor[[DSPARK_QUERY_TOKENS], pl.INT32],
+    slot_mapping: pl.Tensor[[DSPARK_QUERY_TOKENS], pl.INT64],
+    kv_cache: pl.Tensor[[KV_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+):
+    """Project a padded DSpark query-width context without dynamic shape variables."""
+    rope_cos_t = pl.create_tensor([DSPARK_QUERY_TOKENS, ROPE_DIM], dtype=pl.BF16)
+    rope_sin_t = pl.create_tensor([DSPARK_QUERY_TOKENS, ROPE_DIM], dtype=pl.BF16)
+    materialize_rope_rows(
+        freqs_cos,
+        freqs_sin,
+        position_ids,
+        DSPARK_QUERY_TOKENS,
+        rope_cos_t,
+        rope_sin_t,
+    )
+
+    rope_cos_il = pl.create_tensor([DSPARK_QUERY_TOKENS, ROPE_DIM], dtype=pl.FP32)
+    rope_sin_signed = pl.create_tensor([DSPARK_QUERY_TOKENS, ROPE_DIM], dtype=pl.FP32)
+    rope_swap_idx = pl.create_tensor([DSPARK_QUERY_TOKENS, ROPE_DIM], dtype=pl.INT32)
+    rope_prepare(rope_cos_t, rope_sin_t, rope_cos_il, rope_sin_signed, rope_swap_idx)
+
+    kv = pl.create_tensor([DSPARK_QUERY_TOKENS, HEAD_DIM], dtype=pl.BF16)
+    late_dep = pl.system.task_dummy(deps=[])
+    kv_proj_rope(
+        main_x,
+        wkv,
+        gamma_ckv,
+        rope_cos_il,
+        rope_sin_signed,
+        rope_swap_idx,
+        kv,
+        late_dep,
+    )
+
+    kv_cache_flat = pl.reshape(kv_cache, [KV_ORI_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="dspark_context_kv_query_scatter"):
+        for write_t in pl.range(DSPARK_QUERY_TOKENS):
+            write_row_i64 = pl.read(slot_mapping, [write_t])
+            if write_row_i64 >= 0:
+                write_row = pl.cast(write_row_i64, pl.INDEX)
+                kv_cache_flat[write_row : write_row + 1, 0:HEAD_DIM] = kv[write_t : write_t + 1, 0:HEAD_DIM]
 
 
 @pl.jit

--- a/models/deepseek_v4_flash_dspark/dspark_drafter.py
+++ b/models/deepseek_v4_flash_dspark/dspark_drafter.py
@@ -1,0 +1,1087 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+# ci: devices=2
+"""Compose the validated three-layer DeepSeek-V4-Flash DSpark drafter."""
+
+import pypto.language as pl
+import pypto.language.distributed as pld
+from pypto.ir.distributed_compiled_program import DistributedConfig
+
+from config import (
+    BLOCK_SIZE,
+    DECODE_BATCH,
+    DECODE_SEQ,
+    FLASH as M,
+    KV_ORI_BLOCK_NUM,
+    KV_ORI_MAX_BLOCKS,
+    MOE_TOKENS,
+    TP,
+)
+from dspark_attention import dspark_attention
+from dspark_context_kv import dspark_context_kv_query
+from dspark_proj import dspark_proj
+from hc_head import hc_head
+from hc_post import hc_post_prefill
+from hc_pre import hc_pre
+from lookup_embedding import lookup_embedding
+from rmsnorm import rms_norm
+from moe import (
+    AUX_PAD,
+    IDX_PAD,
+    MOE_INTER,
+    N_EXPERTS_GLOBAL,
+    N_LOCAL,
+    N_RANKS,
+    N_ROUTES,
+    RECV_MAX,
+    TOPK,
+    VOCAB,
+    clear_moe_signals,
+    moe,
+)
+from qkv_proj_rope import T_DYN as QKV_Q_T_DYN
+
+
+T_MAIN_DYN = pl.dynamic("DSPARK_BACKBONE_T_MAIN_DYN")
+B_DYN = pl.dynamic("DSPARK_BACKBONE_B_DYN")
+PREPARE_T_MAIN_DYN = pl.dynamic("DSPARK_PREPARE_T_MAIN_DYN")
+PREPARE_B_DYN = pl.dynamic("DSPARK_PREPARE_B_DYN")
+METADATA_B_DYN = pl.dynamic("DSPARK_METADATA_B_DYN")
+
+# DSpark program contract.
+DSPARK_DRAFT_LAYERS = 3
+DSPARK_QUERY_WIDTH = 7
+DSPARK_QUERY_PAD = 8
+DSPARK_NOISE_TOKEN_ID = 128799
+DSPARK_SUPPORTED_BATCHES = (4, 8, 12, 16)
+DSPARK_MAX_BATCH = max(DSPARK_SUPPORTED_BATCHES)
+DSPARK_QUERY_TOKENS = DSPARK_MAX_BATCH * DSPARK_QUERY_WIDTH
+DSPARK_MOE_TOKENS = DSPARK_MAX_BATCH * DSPARK_QUERY_PAD
+DSPARK_SWA_INDEX_WIDTH = (M.sliding_window + DSPARK_QUERY_WIDTH + 63) // 64 * 64
+
+assert DECODE_SEQ == 1 + DSPARK_QUERY_WIDTH
+assert DSPARK_QUERY_WIDTH < DSPARK_QUERY_PAD
+assert DSPARK_MAX_BATCH == DECODE_BATCH // TP
+assert DSPARK_MOE_TOKENS == MOE_TOKENS
+assert DSPARK_NOISE_TOKEN_ID < M.vocab_size
+assert DSPARK_SWA_INDEX_WIDTH >= M.sliding_window + DSPARK_QUERY_WIDTH
+
+# model config
+T = DSPARK_MOE_TOKENS
+T_QUERY = DSPARK_QUERY_TOKENS
+D = M.hidden_size
+H = M.num_attention_heads
+HEAD_DIM = M.head_dim
+ROPE_DIM = M.qk_rope_head_dim
+Q_LORA = M.q_lora_rank
+MAX_SEQ_LEN = M.max_position_embeddings
+HC_MULT = M.hc_mult
+MIX_HC = M.mix_hc
+HC_DIM = M.hc_dim
+O_LORA = M.o_lora_rank
+O_GROUPS = M.o_groups
+O_GROUP_IN = H * HEAD_DIM // O_GROUPS
+ORI_BLOCK_NUM = KV_ORI_BLOCK_NUM
+ORI_MAX_BLOCKS = KV_ORI_MAX_BLOCKS
+MAIN_IN = DSPARK_DRAFT_LAYERS * D
+
+WIN = M.sliding_window
+PAD_D_TILE = 512
+
+# Three draft layers plus their MoE communication graph exceed the runtime's
+# default per-ring heap. Match the established large-model harness allocation.
+_DSPARK_RING_HEAP = (4 * 1024 * 1024 * 1024,) * 4
+
+@pl.jit.inline
+def prepare_dspark_inputs(
+    target_hidden: pl.Tensor[[PREPARE_T_MAIN_DYN, MAIN_IN], pl.BF16],
+    main_proj_weight: pl.Tensor[[D, MAIN_IN], pl.BF16],
+    main_norm_weight: pl.Tensor[[D], pl.BF16],
+    anchor_token_ids: pl.Tensor[[PREPARE_B_DYN], pl.INT64],
+    embedding_weight: pl.Tensor[[VOCAB, D], pl.BF16],
+    main_x: pl.Tensor[[PREPARE_T_MAIN_DYN, D], pl.BF16],
+    query_token_ids: pl.Tensor[[DSPARK_MOE_TOKENS], pl.INT64],
+    query_hc_flat: pl.Tensor[[DSPARK_MOE_TOKENS, HC_MULT * D], pl.FP32],
+):
+    dspark_proj(target_hidden, main_proj_weight, main_norm_weight, main_x)
+
+    batch = pl.tensor.dim(anchor_token_ids, 0)
+    active_tokens = batch * DSPARK_QUERY_WIDTH
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="dspark_query_ids"):
+        for token in pl.range(DSPARK_MOE_TOKENS):
+            token_id = pl.cast(0, pl.INT64)
+            if token < active_tokens:
+                request = token // DSPARK_QUERY_WIDTH
+                query_offset = token % DSPARK_QUERY_WIDTH
+                token_id = pl.cast(DSPARK_NOISE_TOKEN_ID, pl.INT64)
+                if query_offset == 0:
+                    token_id = pl.read(anchor_token_ids, [request])
+            pl.write(query_token_ids, [token], token_id)
+
+    lookup_hidden = pl.create_tensor([DSPARK_MOE_TOKENS, D], dtype=pl.BF16)
+    query_hc = pl.reshape(query_hc_flat, [DSPARK_MOE_TOKENS, HC_MULT, D])
+    lookup_embedding(
+        query_token_ids,
+        embedding_weight,
+        lookup_hidden,
+        query_hc,
+    )
+    return main_x, query_token_ids, query_hc_flat
+
+@pl.jit.inline
+def build_dspark_metadata(
+    anchor_positions: pl.Tensor[[METADATA_B_DYN], pl.INT32],
+    block_tables: pl.Tensor[[DSPARK_DRAFT_LAYERS, METADATA_B_DYN, ORI_MAX_BLOCKS], pl.INT32],
+    query_slot_mapping: pl.Tensor[[DSPARK_DRAFT_LAYERS, DSPARK_QUERY_TOKENS], pl.INT64],
+    swa_indices: pl.Tensor[[DSPARK_DRAFT_LAYERS, DSPARK_MAX_BATCH, DSPARK_SWA_INDEX_WIDTH], pl.INT32],
+    swa_lens: pl.Tensor[[DSPARK_DRAFT_LAYERS, DSPARK_MAX_BATCH], pl.INT32],
+    query_positions: pl.Tensor[[DSPARK_QUERY_TOKENS], pl.INT32],
+):
+    batch = pl.tensor.dim(anchor_positions, 0)
+    active_tokens = batch * DSPARK_QUERY_WIDTH
+    for metadata_core in pl.spmd(1, name_hint="dspark_query_metadata"):
+        for token in pl.range(metadata_core, DSPARK_QUERY_TOKENS):
+            pl.write(query_positions, [token], pl.cast(0, pl.INT32))
+            for layer in pl.range(DSPARK_DRAFT_LAYERS):
+                pl.write(query_slot_mapping, [layer, token], pl.cast(-1, pl.INT64))
+            if token < active_tokens:
+                request = token // DSPARK_QUERY_WIDTH
+                query_offset = token % DSPARK_QUERY_WIDTH
+                anchor_position = pl.read(anchor_positions, [request])
+                query_position = anchor_position + 1 + query_offset
+                pl.write(query_positions, [token], pl.cast(query_position, pl.INT32))
+                for layer in pl.range(DSPARK_DRAFT_LAYERS):
+                    logical_block = query_position // BLOCK_SIZE
+                    block_offset = query_position % BLOCK_SIZE
+                    physical_block = pl.read(
+                        block_tables, [layer, request, pl.cast(logical_block, pl.INDEX)]
+                    )
+                    query_slot = physical_block * BLOCK_SIZE + block_offset
+                    pl.write(query_slot_mapping, [layer, token], pl.cast(query_slot, pl.INT64))
+
+    for request in pl.spmd(DSPARK_MAX_BATCH, name_hint="dspark_visible_metadata"):
+        start_position = pl.cast(0, pl.INT32)
+        visible_len = pl.cast(0, pl.INT32)
+        if request < batch:
+            anchor_position = pl.read(anchor_positions, [request])
+            prefix_len = anchor_position + 1
+            start_position = pl.cast(pl.max(prefix_len - WIN, 0), pl.INT32)
+            visible_len = pl.cast(
+                prefix_len + DSPARK_QUERY_WIDTH - start_position,
+                pl.INT32,
+            )
+        for layer in pl.range(DSPARK_DRAFT_LAYERS):
+            pl.write(swa_lens, [layer, request], visible_len)
+            for visible_offset in pl.range(DSPARK_SWA_INDEX_WIDTH):
+                visible_slot = pl.cast(-1, pl.INT32)
+                if visible_offset < visible_len:
+                    visible_position = start_position + visible_offset
+                    logical_block = visible_position // BLOCK_SIZE
+                    block_offset = visible_position % BLOCK_SIZE
+                    physical_block = pl.read(
+                        block_tables, [layer, request, pl.cast(logical_block, pl.INDEX)]
+                    )
+                    visible_slot = pl.cast(
+                        physical_block * BLOCK_SIZE + block_offset,
+                        pl.INT32,
+                    )
+                pl.write(swa_indices, [layer, request, visible_offset], visible_slot)
+    return (
+        query_slot_mapping,
+        swa_indices,
+        swa_lens,
+        query_positions,
+    )
+
+
+@pl.jit.inline(auto_scope=False)
+def draft_layer(
+    query_hc: pl.Tensor[[T, HC_MULT, D], pl.FP32],
+    draft_layer_index: pl.Scalar[pl.INT32],
+    hc_attn_fn: pl.Tensor[[DSPARK_DRAFT_LAYERS * MIX_HC, HC_DIM], pl.FP32],
+    hc_attn_scale: pl.Tensor[[DSPARK_DRAFT_LAYERS * 3], pl.FP32],
+    hc_attn_base: pl.Tensor[[DSPARK_DRAFT_LAYERS * MIX_HC], pl.FP32],
+    attn_norm_w: pl.Tensor[[DSPARK_DRAFT_LAYERS * D], pl.BF16],
+    wq_a: pl.Tensor[[DSPARK_DRAFT_LAYERS * D, Q_LORA], pl.BF16],
+    wq_b: pl.Tensor[[DSPARK_DRAFT_LAYERS * Q_LORA, H * HEAD_DIM], pl.INT8],
+    wq_b_scale: pl.Tensor[[DSPARK_DRAFT_LAYERS * H * HEAD_DIM], pl.FP32],
+    wkv: pl.Tensor[[DSPARK_DRAFT_LAYERS * D, HEAD_DIM], pl.BF16],
+    gamma_cq: pl.Tensor[[DSPARK_DRAFT_LAYERS * Q_LORA], pl.BF16],
+    gamma_ckv: pl.Tensor[[DSPARK_DRAFT_LAYERS * HEAD_DIM], pl.BF16],
+    freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_DIM], pl.BF16],
+    query_positions: pl.Tensor[[T_QUERY], pl.INT32],
+    kv_cache: pl.Tensor[[KV_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    query_slot_mapping: pl.Tensor[[T_QUERY], pl.INT64],
+    swa_indices: pl.Tensor[[DSPARK_MAX_BATCH, DSPARK_SWA_INDEX_WIDTH], pl.INT32],
+    swa_lens: pl.Tensor[[DSPARK_MAX_BATCH], pl.INT32],
+    attn_sink: pl.Tensor[[DSPARK_DRAFT_LAYERS * H], pl.FP32],
+    wo_a: pl.Tensor[[DSPARK_DRAFT_LAYERS * O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
+    wo_b: pl.Tensor[[DSPARK_DRAFT_LAYERS * D, O_GROUPS * O_LORA], pl.INT8],
+    wo_b_scale: pl.Tensor[[DSPARK_DRAFT_LAYERS * D], pl.FP32],
+    hc_ffn_fn: pl.Tensor[[DSPARK_DRAFT_LAYERS * MIX_HC, HC_DIM], pl.FP32],
+    hc_ffn_scale: pl.Tensor[[DSPARK_DRAFT_LAYERS * 3], pl.FP32],
+    hc_ffn_base: pl.Tensor[[DSPARK_DRAFT_LAYERS * MIX_HC], pl.FP32],
+    ffn_norm_w: pl.Tensor[[DSPARK_DRAFT_LAYERS * D], pl.BF16],
+    gate_w: pl.Tensor[[DSPARK_DRAFT_LAYERS * N_EXPERTS_GLOBAL, D], pl.FP32],
+    gate_bias: pl.Tensor[[DSPARK_DRAFT_LAYERS * N_EXPERTS_GLOBAL], pl.FP32],
+    tid2eid: pl.Tensor[[DSPARK_DRAFT_LAYERS * VOCAB, TOPK], pl.INT32],
+    query_token_ids: pl.Tensor[[T], pl.INT64],
+    routed_w1: pl.Tensor[[DSPARK_DRAFT_LAYERS * N_LOCAL, MOE_INTER, D], pl.INT8],
+    routed_w1_scale: pl.Tensor[[DSPARK_DRAFT_LAYERS * N_LOCAL, MOE_INTER], pl.FP32],
+    routed_w3: pl.Tensor[[DSPARK_DRAFT_LAYERS * N_LOCAL, MOE_INTER, D], pl.INT8],
+    routed_w3_scale: pl.Tensor[[DSPARK_DRAFT_LAYERS * N_LOCAL, MOE_INTER], pl.FP32],
+    routed_w2: pl.Tensor[[DSPARK_DRAFT_LAYERS * N_LOCAL, D, MOE_INTER], pl.INT8],
+    routed_w2_scale: pl.Tensor[[DSPARK_DRAFT_LAYERS * N_LOCAL, D], pl.FP32],
+    shared_w1: pl.Tensor[[DSPARK_DRAFT_LAYERS * MOE_INTER, D], pl.INT8],
+    shared_w1_scale: pl.Tensor[[DSPARK_DRAFT_LAYERS * MOE_INTER], pl.FP32],
+    shared_w3: pl.Tensor[[DSPARK_DRAFT_LAYERS * MOE_INTER, D], pl.INT8],
+    shared_w3_scale: pl.Tensor[[DSPARK_DRAFT_LAYERS * MOE_INTER], pl.FP32],
+    shared_w2: pl.Tensor[[DSPARK_DRAFT_LAYERS * D, MOE_INTER], pl.INT8],
+    shared_w2_scale: pl.Tensor[[DSPARK_DRAFT_LAYERS * D], pl.FP32],
+    output_hc: pl.Tensor[[T, HC_MULT, D], pl.FP32],
+    recv_meta: pld.DistributedTensor[[N_RANKS, N_LOCAL], pl.INT32],
+    recv_x: pld.DistributedTensor[[N_LOCAL * RECV_MAX, D], pl.INT8],
+    recv_aux: pld.DistributedTensor[[N_LOCAL * RECV_MAX, AUX_PAD], pl.FP32],
+    recv_route: pld.DistributedTensor[[N_LOCAL * RECV_MAX, IDX_PAD], pl.INT32],
+    arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
+    data_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
+    routed_y_buf: pld.DistributedTensor[[N_ROUTES, D], pl.BF16],
+    combine_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
+    layer_id: pl.Scalar[pl.INT32],
+    active_tokens: pl.Scalar[pl.INT32],
+    my_rank: pl.Scalar[pl.INT32],
+    moe_epoch: pl.Scalar[pl.INT32],
+):
+    layer_hc_attn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32] = pl.slice(hc_attn_fn, [MIX_HC, HC_DIM], [draft_layer_index * MIX_HC, 0])
+    layer_hc_attn_scale: pl.Tensor[[3], pl.FP32] = pl.slice(hc_attn_scale, [3], [draft_layer_index * 3])
+    layer_hc_attn_base: pl.Tensor[[MIX_HC], pl.FP32] = pl.slice(hc_attn_base, [MIX_HC], [draft_layer_index * MIX_HC])
+    layer_attn_norm_w: pl.Tensor[[D], pl.BF16] = pl.slice(attn_norm_w, [D], [draft_layer_index * D])
+    layer_wq_a: pl.Tensor[[D, Q_LORA], pl.BF16] = pl.slice(wq_a, [D, Q_LORA], [draft_layer_index * D, 0])
+    layer_wq_b: pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8] = pl.slice(wq_b, [Q_LORA, H * HEAD_DIM], [draft_layer_index * Q_LORA, 0])
+    layer_wq_b_scale: pl.Tensor[[H * HEAD_DIM], pl.FP32] = pl.slice(wq_b_scale, [H * HEAD_DIM], [draft_layer_index * H * HEAD_DIM])
+    layer_wkv: pl.Tensor[[D, HEAD_DIM], pl.BF16] = pl.slice(wkv, [D, HEAD_DIM], [draft_layer_index * D, 0])
+    layer_gamma_cq: pl.Tensor[[Q_LORA], pl.BF16] = pl.slice(gamma_cq, [Q_LORA], [draft_layer_index * Q_LORA])
+    layer_gamma_ckv: pl.Tensor[[HEAD_DIM], pl.BF16] = pl.slice(gamma_ckv, [HEAD_DIM], [draft_layer_index * HEAD_DIM])
+    layer_attn_sink: pl.Tensor[[H], pl.FP32] = pl.slice(attn_sink, [H], [draft_layer_index * H])
+    layer_wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16] = pl.slice(wo_a, [O_GROUPS, O_LORA, O_GROUP_IN], [draft_layer_index * O_GROUPS, 0, 0])
+    layer_wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8] = pl.slice(wo_b, [D, O_GROUPS * O_LORA], [draft_layer_index * D, 0])
+    layer_wo_b_scale: pl.Tensor[[D], pl.FP32] = pl.slice(wo_b_scale, [D], [draft_layer_index * D])
+    layer_hc_ffn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32] = pl.slice(hc_ffn_fn, [MIX_HC, HC_DIM], [draft_layer_index * MIX_HC, 0])
+    layer_hc_ffn_scale: pl.Tensor[[3], pl.FP32] = pl.slice(hc_ffn_scale, [3], [draft_layer_index * 3])
+    layer_hc_ffn_base: pl.Tensor[[MIX_HC], pl.FP32] = pl.slice(hc_ffn_base, [MIX_HC], [draft_layer_index * MIX_HC])
+    layer_ffn_norm_w: pl.Tensor[[D], pl.BF16] = pl.slice(ffn_norm_w, [D], [draft_layer_index * D])
+    layer_gate_w: pl.Tensor[[N_EXPERTS_GLOBAL, D], pl.FP32] = pl.slice(gate_w, [N_EXPERTS_GLOBAL, D], [draft_layer_index * N_EXPERTS_GLOBAL, 0])
+    layer_gate_bias: pl.Tensor[[N_EXPERTS_GLOBAL], pl.FP32] = pl.slice(gate_bias, [N_EXPERTS_GLOBAL], [draft_layer_index * N_EXPERTS_GLOBAL])
+    layer_tid2eid: pl.Tensor[[VOCAB, TOPK], pl.INT32] = pl.slice(tid2eid, [VOCAB, TOPK], [draft_layer_index * VOCAB, 0])
+    layer_routed_w1: pl.Tensor[[N_LOCAL, MOE_INTER, D], pl.INT8] = pl.slice(routed_w1, [N_LOCAL, MOE_INTER, D], [draft_layer_index * N_LOCAL, 0, 0])
+    layer_routed_w1_scale: pl.Tensor[[N_LOCAL, MOE_INTER], pl.FP32] = pl.slice(routed_w1_scale, [N_LOCAL, MOE_INTER], [draft_layer_index * N_LOCAL, 0])
+    layer_routed_w3: pl.Tensor[[N_LOCAL, MOE_INTER, D], pl.INT8] = pl.slice(routed_w3, [N_LOCAL, MOE_INTER, D], [draft_layer_index * N_LOCAL, 0, 0])
+    layer_routed_w3_scale: pl.Tensor[[N_LOCAL, MOE_INTER], pl.FP32] = pl.slice(routed_w3_scale, [N_LOCAL, MOE_INTER], [draft_layer_index * N_LOCAL, 0])
+    layer_routed_w2: pl.Tensor[[N_LOCAL, D, MOE_INTER], pl.INT8] = pl.slice(routed_w2, [N_LOCAL, D, MOE_INTER], [draft_layer_index * N_LOCAL, 0, 0])
+    layer_routed_w2_scale: pl.Tensor[[N_LOCAL, D], pl.FP32] = pl.slice(routed_w2_scale, [N_LOCAL, D], [draft_layer_index * N_LOCAL, 0])
+    layer_shared_w1: pl.Tensor[[MOE_INTER, D], pl.INT8] = pl.slice(shared_w1, [MOE_INTER, D], [draft_layer_index * MOE_INTER, 0])
+    layer_shared_w1_scale: pl.Tensor[[MOE_INTER], pl.FP32] = pl.slice(shared_w1_scale, [MOE_INTER], [draft_layer_index * MOE_INTER])
+    layer_shared_w3: pl.Tensor[[MOE_INTER, D], pl.INT8] = pl.slice(shared_w3, [MOE_INTER, D], [draft_layer_index * MOE_INTER, 0])
+    layer_shared_w3_scale: pl.Tensor[[MOE_INTER], pl.FP32] = pl.slice(shared_w3_scale, [MOE_INTER], [draft_layer_index * MOE_INTER])
+    layer_shared_w2: pl.Tensor[[D, MOE_INTER], pl.INT8] = pl.slice(shared_w2, [D, MOE_INTER], [draft_layer_index * D, 0])
+    layer_shared_w2_scale: pl.Tensor[[D], pl.FP32] = pl.slice(shared_w2_scale, [D], [draft_layer_index * D])
+
+    query_mixed = pl.create_tensor([T, D], dtype=pl.BF16)
+    post = pl.create_tensor([T, HC_MULT], dtype=pl.FP32)
+    combine = pl.create_tensor([T, HC_MULT * HC_MULT], dtype=pl.FP32)
+    hc_pre(
+        query_hc,
+        layer_hc_attn_fn,
+        layer_hc_attn_scale,
+        layer_hc_attn_base,
+        query_mixed,
+        post,
+        combine,
+    )
+
+    query_normed = pl.create_tensor([T_QUERY, D], dtype=pl.BF16)
+    query_mixed_active: pl.Tensor[[T_QUERY, D], pl.BF16] = pl.slice(
+        query_mixed,
+        [T_QUERY, D],
+        [0, 0],
+    )
+    rms_norm(query_mixed_active, layer_attn_norm_w, query_normed)
+    attention_output = pl.create_tensor([T_QUERY, D], dtype=pl.BF16)
+    dspark_attention(
+        query_normed,
+        layer_wq_a, layer_wq_b, layer_wq_b_scale, layer_wkv, layer_gamma_cq, layer_gamma_ckv,
+        freqs_cos, freqs_sin, query_positions,
+        kv_cache, query_slot_mapping, swa_indices, swa_lens,
+        layer_attn_sink, layer_wo_a, layer_wo_b, layer_wo_b_scale,
+        attention_output,
+    )
+
+    padded_attention = pl.create_tensor([T, D], dtype=pl.BF16)
+    for pad_idx in pl.spmd(T * (D // PAD_D_TILE), name_hint="dspark_attention_pad"):
+        pad_token = pad_idx // (D // PAD_D_TILE)
+        pad_col = (pad_idx % (D // PAD_D_TILE)) * PAD_D_TILE
+        output_tile = pl.full([1, PAD_D_TILE], dtype=pl.BF16, value=0.0)
+        if pad_token < T_QUERY:
+            output_tile = attention_output[pad_token : pad_token + 1, pad_col : pad_col + PAD_D_TILE]
+        padded_attention[pad_token : pad_token + 1, pad_col : pad_col + PAD_D_TILE] = output_tile
+
+    attention_hc = pl.create_tensor([T, HC_MULT, D], dtype=pl.FP32)
+    hc_post_prefill(
+        padded_attention,
+        query_hc,
+        post,
+        combine,
+        attention_hc,
+        active_tokens,
+    )
+
+    moe(
+        attention_hc,
+        layer_hc_ffn_fn, layer_hc_ffn_scale, layer_hc_ffn_base,
+        layer_ffn_norm_w, layer_gate_w, layer_gate_bias, layer_tid2eid, query_token_ids,
+        layer_routed_w1, layer_routed_w1_scale, layer_routed_w3, layer_routed_w3_scale, layer_routed_w2, layer_routed_w2_scale,
+        layer_shared_w1, layer_shared_w1_scale, layer_shared_w3, layer_shared_w3_scale, layer_shared_w2, layer_shared_w2_scale,
+        output_hc,
+        recv_meta, recv_x, recv_aux, recv_route,
+        arrived, data_arrived, routed_y_buf, combine_arrived,
+        layer_id, active_tokens, my_rank, moe_epoch,
+    )
+    return output_hc
+
+@pl.jit
+def dspark_drafter(
+    target_hidden: pl.Tensor[[T_MAIN_DYN, MAIN_IN], pl.BF16],
+    main_proj_weight: pl.Tensor[[D, MAIN_IN], pl.BF16],
+    main_norm_weight: pl.Tensor[[D], pl.BF16],
+    anchor_token_ids: pl.Tensor[[B_DYN], pl.INT64],
+    embedding_weight: pl.Tensor[[VOCAB, D], pl.BF16],
+    context_position_ids: pl.Tensor[[QKV_Q_T_DYN], pl.INT32],
+    context_slot_mapping: pl.Tensor[[DSPARK_DRAFT_LAYERS, QKV_Q_T_DYN], pl.INT64],
+    anchor_positions: pl.Tensor[[B_DYN], pl.INT32],
+    block_tables: pl.Tensor[
+        [DSPARK_DRAFT_LAYERS, B_DYN, ORI_MAX_BLOCKS],
+        pl.INT32,
+    ],
+    freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_DIM], pl.BF16],
+    hc_attn_fn: pl.Tensor[[DSPARK_DRAFT_LAYERS * MIX_HC, HC_DIM], pl.FP32],
+    hc_attn_scale: pl.Tensor[[DSPARK_DRAFT_LAYERS * 3], pl.FP32],
+    hc_attn_base: pl.Tensor[[DSPARK_DRAFT_LAYERS * MIX_HC], pl.FP32],
+    attn_norm_w: pl.Tensor[[DSPARK_DRAFT_LAYERS * D], pl.BF16],
+    wq_a: pl.Tensor[[DSPARK_DRAFT_LAYERS * D, Q_LORA], pl.BF16],
+    wq_b: pl.Tensor[[DSPARK_DRAFT_LAYERS * Q_LORA, H * HEAD_DIM], pl.INT8],
+    wq_b_scale: pl.Tensor[[DSPARK_DRAFT_LAYERS * H * HEAD_DIM], pl.FP32],
+    wkv: pl.Tensor[[DSPARK_DRAFT_LAYERS * D, HEAD_DIM], pl.BF16],
+    gamma_cq: pl.Tensor[[DSPARK_DRAFT_LAYERS * Q_LORA], pl.BF16],
+    gamma_ckv: pl.Tensor[[DSPARK_DRAFT_LAYERS * HEAD_DIM], pl.BF16],
+    kv_caches: pl.InOut[
+        pl.Tensor[[DSPARK_DRAFT_LAYERS, ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]
+    ],
+    attn_sink: pl.Tensor[[DSPARK_DRAFT_LAYERS * H], pl.FP32],
+    wo_a: pl.Tensor[[DSPARK_DRAFT_LAYERS * O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
+    wo_b: pl.Tensor[[DSPARK_DRAFT_LAYERS * D, O_GROUPS * O_LORA], pl.INT8],
+    wo_b_scale: pl.Tensor[[DSPARK_DRAFT_LAYERS * D], pl.FP32],
+    hc_ffn_fn: pl.Tensor[[DSPARK_DRAFT_LAYERS * MIX_HC, HC_DIM], pl.FP32],
+    hc_ffn_scale: pl.Tensor[[DSPARK_DRAFT_LAYERS * 3], pl.FP32],
+    hc_ffn_base: pl.Tensor[[DSPARK_DRAFT_LAYERS * MIX_HC], pl.FP32],
+    ffn_norm_w: pl.Tensor[[DSPARK_DRAFT_LAYERS * D], pl.BF16],
+    gate_w: pl.Tensor[[DSPARK_DRAFT_LAYERS * N_EXPERTS_GLOBAL, D], pl.FP32],
+    gate_bias: pl.Tensor[[DSPARK_DRAFT_LAYERS * N_EXPERTS_GLOBAL], pl.FP32],
+    tid2eid: pl.Tensor[[DSPARK_DRAFT_LAYERS * VOCAB, TOPK], pl.INT32],
+    routed_w1: pl.Tensor[[DSPARK_DRAFT_LAYERS * N_LOCAL, MOE_INTER, D], pl.INT8],
+    routed_w1_scale: pl.Tensor[[DSPARK_DRAFT_LAYERS * N_LOCAL, MOE_INTER], pl.FP32],
+    routed_w3: pl.Tensor[[DSPARK_DRAFT_LAYERS * N_LOCAL, MOE_INTER, D], pl.INT8],
+    routed_w3_scale: pl.Tensor[[DSPARK_DRAFT_LAYERS * N_LOCAL, MOE_INTER], pl.FP32],
+    routed_w2: pl.Tensor[[DSPARK_DRAFT_LAYERS * N_LOCAL, D, MOE_INTER], pl.INT8],
+    routed_w2_scale: pl.Tensor[[DSPARK_DRAFT_LAYERS * N_LOCAL, D], pl.FP32],
+    shared_w1: pl.Tensor[[DSPARK_DRAFT_LAYERS * MOE_INTER, D], pl.INT8],
+    shared_w1_scale: pl.Tensor[[DSPARK_DRAFT_LAYERS * MOE_INTER], pl.FP32],
+    shared_w3: pl.Tensor[[DSPARK_DRAFT_LAYERS * MOE_INTER, D], pl.INT8],
+    shared_w3_scale: pl.Tensor[[DSPARK_DRAFT_LAYERS * MOE_INTER], pl.FP32],
+    shared_w2: pl.Tensor[[DSPARK_DRAFT_LAYERS * D, MOE_INTER], pl.INT8],
+    shared_w2_scale: pl.Tensor[[DSPARK_DRAFT_LAYERS * D], pl.FP32],
+    hc_head_fn: pl.Tensor[[HC_MULT, HC_DIM], pl.FP32],
+    hc_head_scale: pl.Tensor[[1], pl.FP32],
+    hc_head_base: pl.Tensor[[HC_MULT], pl.FP32],
+    initial_hidden: pl.Out[pl.Tensor[[T, HC_MULT, D], pl.FP32]],
+    intermediate_hidden: pl.Out[
+        pl.Tensor[[DSPARK_DRAFT_LAYERS, T, HC_MULT, D], pl.FP32]
+    ],
+    head_hidden: pl.Out[pl.Tensor[[B_DYN, DSPARK_QUERY_WIDTH, D], pl.BF16]],
+    recv_meta: pld.DistributedTensor[[N_RANKS, N_LOCAL], pl.INT32],
+    recv_x: pld.DistributedTensor[[N_LOCAL * RECV_MAX, D], pl.INT8],
+    recv_aux: pld.DistributedTensor[[N_LOCAL * RECV_MAX, AUX_PAD], pl.FP32],
+    recv_route: pld.DistributedTensor[[N_LOCAL * RECV_MAX, IDX_PAD], pl.INT32],
+    arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
+    data_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
+    routed_y_buf: pld.DistributedTensor[[N_ROUTES, D], pl.BF16],
+    combine_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
+    my_rank: pl.Scalar[pl.INT32],
+):
+    target_hidden.bind_dynamic(0, T_MAIN_DYN)
+    context_position_ids.bind_dynamic(0, QKV_Q_T_DYN)
+    context_slot_mapping.bind_dynamic(1, QKV_Q_T_DYN)
+    anchor_token_ids.bind_dynamic(0, B_DYN)
+    anchor_positions.bind_dynamic(0, B_DYN)
+    block_tables.bind_dynamic(1, B_DYN)
+    head_hidden.bind_dynamic(0, B_DYN)
+    batch = pl.tensor.dim(anchor_token_ids, 0)
+    target_tokens = pl.tensor.dim(target_hidden, 0)
+    active_tokens = batch * DSPARK_QUERY_WIDTH
+
+    kv_cache_0 = kv_caches[0]
+    kv_cache_1 = kv_caches[1]
+    kv_cache_2 = kv_caches[2]
+    wkv_0 = pl.slice(wkv, [D, HEAD_DIM], [0, 0])
+    wkv_1 = pl.slice(wkv, [D, HEAD_DIM], [D, 0])
+    wkv_2 = pl.slice(wkv, [D, HEAD_DIM], [2 * D, 0])
+    gamma_ckv_0 = pl.slice(gamma_ckv, [HEAD_DIM], [0])
+    gamma_ckv_1 = pl.slice(gamma_ckv, [HEAD_DIM], [HEAD_DIM])
+    gamma_ckv_2 = pl.slice(gamma_ckv, [HEAD_DIM], [2 * HEAD_DIM])
+    main_x = pl.create_tensor([target_tokens, D], dtype=pl.BF16)
+    query_token_ids = pl.create_tensor([T], dtype=pl.INT64)
+    hidden_0_flat = pl.reshape(initial_hidden, [T, HC_MULT * D])
+    main_x, query_token_ids, hidden_0_flat = prepare_dspark_inputs(
+        target_hidden,
+        main_proj_weight,
+        main_norm_weight,
+        anchor_token_ids,
+        embedding_weight,
+        main_x,
+        query_token_ids,
+        hidden_0_flat,
+    )
+    context_main_x = pl.create_tensor([T_QUERY, D], dtype=pl.BF16)
+    context_positions = pl.create_tensor([T_QUERY], dtype=pl.INT32)
+    context_slots_0 = pl.create_tensor([T_QUERY], dtype=pl.INT64)
+    context_slots_1 = pl.create_tensor([T_QUERY], dtype=pl.INT64)
+    context_slots_2 = pl.create_tensor([T_QUERY], dtype=pl.INT64)
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="dspark_context_pad"):
+        for token in pl.range(T_QUERY):
+            position = pl.cast(0, pl.INT32)
+            if token < batch:
+                position = pl.read(context_position_ids, [token])
+            pl.write(context_positions, [token], position)
+            slot_0 = pl.cast(-1, pl.INT64)
+            slot_1 = pl.cast(-1, pl.INT64)
+            slot_2 = pl.cast(-1, pl.INT64)
+            if token < batch:
+                slot_0 = pl.read(context_slot_mapping, [0, token])
+                slot_1 = pl.read(context_slot_mapping, [1, token])
+                slot_2 = pl.read(context_slot_mapping, [2, token])
+            pl.write(context_slots_0, [token], slot_0)
+            pl.write(context_slots_1, [token], slot_1)
+            pl.write(context_slots_2, [token], slot_2)
+        for token_d in pl.range(T_QUERY * (D // 512)):
+            token = token_d // (D // 512)
+            d0 = (token_d % (D // 512)) * 512
+            value = pl.full([1, 512], dtype=pl.BF16, value=0.0)
+            if token < batch:
+                context_row = (token + 1) * DECODE_SEQ - 1
+                value = main_x[context_row : context_row + 1, d0 : d0 + 512]
+            context_main_x[token : token + 1, d0 : d0 + 512] = value
+
+    dspark_context_kv_query(
+        context_main_x, wkv_0, gamma_ckv_0, freqs_cos, freqs_sin,
+        context_positions, context_slots_0, kv_cache_0,
+    )
+    dspark_context_kv_query(
+        context_main_x, wkv_1, gamma_ckv_1, freqs_cos, freqs_sin,
+        context_positions, context_slots_1, kv_cache_1,
+    )
+    dspark_context_kv_query(
+        context_main_x, wkv_2, gamma_ckv_2, freqs_cos, freqs_sin,
+        context_positions, context_slots_2, kv_cache_2,
+    )
+
+    query_slot_mapping = pl.create_tensor([DSPARK_DRAFT_LAYERS, T_QUERY], dtype=pl.INT64)
+    swa_indices = pl.create_tensor(
+        [DSPARK_DRAFT_LAYERS, DSPARK_MAX_BATCH, DSPARK_SWA_INDEX_WIDTH],
+        dtype=pl.INT32,
+    )
+    swa_lens = pl.create_tensor([DSPARK_DRAFT_LAYERS, DSPARK_MAX_BATCH], dtype=pl.INT32)
+    query_positions = pl.create_tensor([T_QUERY], dtype=pl.INT32)
+    (
+        query_slot_mapping,
+        swa_indices,
+        swa_lens,
+        query_positions,
+    ) = build_dspark_metadata(
+        anchor_positions,
+        block_tables,
+        query_slot_mapping,
+        swa_indices,
+        swa_lens,
+        query_positions,
+    )
+    query_slot_mapping_0 = query_slot_mapping[0]
+    query_slot_mapping_1 = query_slot_mapping[1]
+    query_slot_mapping_2 = query_slot_mapping[2]
+    swa_indices_0 = swa_indices[0]
+    swa_indices_1 = swa_indices[1]
+    swa_indices_2 = swa_indices[2]
+    swa_lens_0 = swa_lens[0]
+    swa_lens_1 = swa_lens[1]
+    swa_lens_2 = swa_lens[2]
+    hidden_1 = intermediate_hidden[0]
+    draft_layer(
+        initial_hidden, pl.const(0, pl.INT32),
+        hc_attn_fn, hc_attn_scale, hc_attn_base,
+        attn_norm_w, wq_a, wq_b, wq_b_scale, wkv, gamma_cq, gamma_ckv,
+        freqs_cos, freqs_sin, query_positions,
+        kv_cache_0, query_slot_mapping_0, swa_indices_0, swa_lens_0,
+        attn_sink, wo_a, wo_b, wo_b_scale,
+        hc_ffn_fn, hc_ffn_scale, hc_ffn_base, ffn_norm_w,
+        gate_w, gate_bias, tid2eid, query_token_ids,
+        routed_w1, routed_w1_scale, routed_w3, routed_w3_scale,
+        routed_w2, routed_w2_scale,
+        shared_w1, shared_w1_scale, shared_w3, shared_w3_scale,
+        shared_w2, shared_w2_scale,
+        hidden_1,
+        recv_meta, recv_x, recv_aux, recv_route, arrived, data_arrived, routed_y_buf, combine_arrived,
+        pl.const(40, pl.INT32), pl.cast(active_tokens, pl.INT32), my_rank, pl.const(1, pl.INT32),
+    )
+
+    hidden_2 = intermediate_hidden[1]
+    draft_layer(
+        hidden_1, pl.const(1, pl.INT32),
+        hc_attn_fn, hc_attn_scale, hc_attn_base,
+        attn_norm_w, wq_a, wq_b, wq_b_scale, wkv, gamma_cq, gamma_ckv,
+        freqs_cos, freqs_sin, query_positions,
+        kv_cache_1, query_slot_mapping_1, swa_indices_1, swa_lens_1,
+        attn_sink, wo_a, wo_b, wo_b_scale,
+        hc_ffn_fn, hc_ffn_scale, hc_ffn_base, ffn_norm_w,
+        gate_w, gate_bias, tid2eid, query_token_ids,
+        routed_w1, routed_w1_scale, routed_w3, routed_w3_scale,
+        routed_w2, routed_w2_scale,
+        shared_w1, shared_w1_scale, shared_w3, shared_w3_scale,
+        shared_w2, shared_w2_scale,
+        hidden_2,
+        recv_meta, recv_x, recv_aux, recv_route, arrived, data_arrived, routed_y_buf, combine_arrived,
+        pl.const(41, pl.INT32), pl.cast(active_tokens, pl.INT32), my_rank, pl.const(2, pl.INT32),
+    )
+
+    hidden_3 = intermediate_hidden[2]
+    draft_layer(
+        hidden_2, pl.const(2, pl.INT32),
+        hc_attn_fn, hc_attn_scale, hc_attn_base,
+        attn_norm_w, wq_a, wq_b, wq_b_scale, wkv, gamma_cq, gamma_ckv,
+        freqs_cos, freqs_sin, query_positions,
+        kv_cache_2, query_slot_mapping_2, swa_indices_2, swa_lens_2,
+        attn_sink, wo_a, wo_b, wo_b_scale,
+        hc_ffn_fn, hc_ffn_scale, hc_ffn_base, ffn_norm_w,
+        gate_w, gate_bias, tid2eid, query_token_ids,
+        routed_w1, routed_w1_scale, routed_w3, routed_w3_scale,
+        routed_w2, routed_w2_scale,
+        shared_w1, shared_w1_scale, shared_w3, shared_w3_scale,
+        shared_w2, shared_w2_scale,
+        hidden_3,
+        recv_meta, recv_x, recv_aux, recv_route, arrived, data_arrived, routed_y_buf, combine_arrived,
+        pl.const(42, pl.INT32), pl.cast(active_tokens, pl.INT32), my_rank, pl.const(3, pl.INT32),
+    )
+    clear_moe_signals(hidden_3, arrived, data_arrived, combine_arrived)
+
+    padded_head_hidden = pl.create_tensor([T, D], dtype=pl.BF16)
+    hc_head(hidden_3, hc_head_fn, hc_head_scale, hc_head_base, padded_head_hidden)
+    head_hidden_flat = pl.reshape(head_hidden, [batch * DSPARK_QUERY_WIDTH, D])
+    for token in pl.spmd(T, name_hint="dspark_head_unpad"):
+        if token < active_tokens:
+            head_hidden_flat[token : token + 1, :] = padded_head_hidden[
+                token : token + 1,
+                :,
+            ]
+    return head_hidden
+
+@pl.jit.host
+def l3_dspark_drafter(
+    target_hidden: pl.Tensor[[N_RANKS, T_MAIN_DYN, MAIN_IN], pl.BF16],
+    initial_hidden: pl.Out[
+        pl.Tensor[[N_RANKS, DSPARK_MAX_BATCH * DSPARK_QUERY_PAD, HC_MULT, D], pl.FP32]
+    ],
+    intermediate_hidden: pl.Out[
+        pl.Tensor[
+            [N_RANKS, DSPARK_DRAFT_LAYERS, DSPARK_MAX_BATCH * DSPARK_QUERY_PAD, HC_MULT, D],
+            pl.FP32,
+        ]
+    ],
+    main_proj_weight: pl.Tensor[[N_RANKS, D, MAIN_IN], pl.BF16],
+    main_norm_weight: pl.Tensor[[N_RANKS, D], pl.BF16],
+    anchor_token_ids: pl.Tensor[[N_RANKS, B_DYN], pl.INT64],
+    embedding_weight: pl.Tensor[[N_RANKS, VOCAB, D], pl.BF16],
+    context_position_ids: pl.Tensor[[N_RANKS, QKV_Q_T_DYN], pl.INT32],
+    context_slot_mapping: pl.Tensor[[N_RANKS, DSPARK_DRAFT_LAYERS, QKV_Q_T_DYN], pl.INT64],
+    anchor_positions: pl.Tensor[[N_RANKS, B_DYN], pl.INT32],
+    block_tables: pl.Tensor[[N_RANKS, DSPARK_DRAFT_LAYERS, B_DYN, ORI_MAX_BLOCKS], pl.INT32],
+    freqs_cos: pl.Tensor[[N_RANKS, MAX_SEQ_LEN, ROPE_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[N_RANKS, MAX_SEQ_LEN, ROPE_DIM], pl.BF16],
+    hc_attn_fn: pl.Tensor[[N_RANKS, DSPARK_DRAFT_LAYERS * MIX_HC, HC_DIM], pl.FP32],
+    hc_attn_scale: pl.Tensor[[N_RANKS, DSPARK_DRAFT_LAYERS * 3], pl.FP32],
+    hc_attn_base: pl.Tensor[[N_RANKS, DSPARK_DRAFT_LAYERS * MIX_HC], pl.FP32],
+    attn_norm_w: pl.Tensor[[N_RANKS, DSPARK_DRAFT_LAYERS * D], pl.BF16],
+    wq_a: pl.Tensor[[N_RANKS, DSPARK_DRAFT_LAYERS * D, Q_LORA], pl.BF16],
+    wq_b: pl.Tensor[[N_RANKS, DSPARK_DRAFT_LAYERS * Q_LORA, H * HEAD_DIM], pl.INT8],
+    wq_b_scale: pl.Tensor[[N_RANKS, DSPARK_DRAFT_LAYERS * H * HEAD_DIM], pl.FP32],
+    wkv: pl.Tensor[[N_RANKS, DSPARK_DRAFT_LAYERS * D, HEAD_DIM], pl.BF16],
+    gamma_cq: pl.Tensor[[N_RANKS, DSPARK_DRAFT_LAYERS * Q_LORA], pl.BF16],
+    gamma_ckv: pl.Tensor[[N_RANKS, DSPARK_DRAFT_LAYERS * HEAD_DIM], pl.BF16],
+    kv_caches: pl.InOut[
+        pl.Tensor[[N_RANKS, DSPARK_DRAFT_LAYERS, ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]
+    ],
+    attn_sink: pl.Tensor[[N_RANKS, DSPARK_DRAFT_LAYERS * H], pl.FP32],
+    wo_a: pl.Tensor[[N_RANKS, DSPARK_DRAFT_LAYERS * O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
+    wo_b: pl.Tensor[[N_RANKS, DSPARK_DRAFT_LAYERS * D, O_GROUPS * O_LORA], pl.INT8],
+    wo_b_scale: pl.Tensor[[N_RANKS, DSPARK_DRAFT_LAYERS * D], pl.FP32],
+    hc_ffn_fn: pl.Tensor[[N_RANKS, DSPARK_DRAFT_LAYERS * MIX_HC, HC_DIM], pl.FP32],
+    hc_ffn_scale: pl.Tensor[[N_RANKS, DSPARK_DRAFT_LAYERS * 3], pl.FP32],
+    hc_ffn_base: pl.Tensor[[N_RANKS, DSPARK_DRAFT_LAYERS * MIX_HC], pl.FP32],
+    ffn_norm_w: pl.Tensor[[N_RANKS, DSPARK_DRAFT_LAYERS * D], pl.BF16],
+    gate_w: pl.Tensor[[N_RANKS, DSPARK_DRAFT_LAYERS * N_EXPERTS_GLOBAL, D], pl.FP32],
+    gate_bias: pl.Tensor[[N_RANKS, DSPARK_DRAFT_LAYERS * N_EXPERTS_GLOBAL], pl.FP32],
+    tid2eid: pl.Tensor[[N_RANKS, DSPARK_DRAFT_LAYERS * VOCAB, TOPK], pl.INT32],
+    routed_w1: pl.Tensor[[N_RANKS, DSPARK_DRAFT_LAYERS * N_LOCAL, MOE_INTER, D], pl.INT8],
+    routed_w1_scale: pl.Tensor[[N_RANKS, DSPARK_DRAFT_LAYERS * N_LOCAL, MOE_INTER], pl.FP32],
+    routed_w3: pl.Tensor[[N_RANKS, DSPARK_DRAFT_LAYERS * N_LOCAL, MOE_INTER, D], pl.INT8],
+    routed_w3_scale: pl.Tensor[[N_RANKS, DSPARK_DRAFT_LAYERS * N_LOCAL, MOE_INTER], pl.FP32],
+    routed_w2: pl.Tensor[[N_RANKS, DSPARK_DRAFT_LAYERS * N_LOCAL, D, MOE_INTER], pl.INT8],
+    routed_w2_scale: pl.Tensor[[N_RANKS, DSPARK_DRAFT_LAYERS * N_LOCAL, D], pl.FP32],
+    shared_w1: pl.Tensor[[N_RANKS, DSPARK_DRAFT_LAYERS * MOE_INTER, D], pl.INT8],
+    shared_w1_scale: pl.Tensor[[N_RANKS, DSPARK_DRAFT_LAYERS * MOE_INTER], pl.FP32],
+    shared_w3: pl.Tensor[[N_RANKS, DSPARK_DRAFT_LAYERS * MOE_INTER, D], pl.INT8],
+    shared_w3_scale: pl.Tensor[[N_RANKS, DSPARK_DRAFT_LAYERS * MOE_INTER], pl.FP32],
+    shared_w2: pl.Tensor[[N_RANKS, DSPARK_DRAFT_LAYERS * D, MOE_INTER], pl.INT8],
+    shared_w2_scale: pl.Tensor[[N_RANKS, DSPARK_DRAFT_LAYERS * D], pl.FP32],
+    hc_head_fn: pl.Tensor[[N_RANKS, HC_MULT, HC_DIM], pl.FP32],
+    hc_head_scale: pl.Tensor[[N_RANKS, 1], pl.FP32],
+    hc_head_base: pl.Tensor[[N_RANKS, HC_MULT], pl.FP32],
+    head_hidden: pl.Out[pl.Tensor[[N_RANKS, B_DYN, DSPARK_QUERY_WIDTH, D], pl.BF16]],
+):
+    target_hidden.bind_dynamic(1, T_MAIN_DYN)
+    context_position_ids.bind_dynamic(1, QKV_Q_T_DYN)
+    context_slot_mapping.bind_dynamic(2, QKV_Q_T_DYN)
+    anchor_token_ids.bind_dynamic(1, B_DYN)
+    anchor_positions.bind_dynamic(1, B_DYN)
+    block_tables.bind_dynamic(2, B_DYN)
+    head_hidden.bind_dynamic(1, B_DYN)
+
+    recv_meta_buf = pld.alloc_window_buffer([N_RANKS, N_LOCAL], dtype=pl.INT32)
+    recv_x_buf = pld.alloc_window_buffer([N_LOCAL * RECV_MAX, D], dtype=pl.INT8)
+    recv_aux_buf = pld.alloc_window_buffer([N_LOCAL * RECV_MAX, AUX_PAD], dtype=pl.FP32)
+    recv_route_buf = pld.alloc_window_buffer([N_LOCAL * RECV_MAX, IDX_PAD], dtype=pl.INT32)
+    arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
+    data_arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
+    routed_y_buf_buf = pld.alloc_window_buffer([N_ROUTES, D], dtype=pl.BF16)
+    combine_arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
+
+    for rank in pl.range(pld.world_size()):
+        recv_meta = pld.window(recv_meta_buf, [N_RANKS, N_LOCAL], dtype=pl.INT32)
+        recv_x = pld.window(recv_x_buf, [N_LOCAL * RECV_MAX, D], dtype=pl.INT8)
+        recv_aux = pld.window(recv_aux_buf, [N_LOCAL * RECV_MAX, AUX_PAD], dtype=pl.FP32)
+        recv_route = pld.window(recv_route_buf, [N_LOCAL * RECV_MAX, IDX_PAD], dtype=pl.INT32)
+        arrived = pld.window(arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
+        data_arrived = pld.window(data_arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
+        routed_y_buf = pld.window(routed_y_buf_buf, [N_ROUTES, D], dtype=pl.BF16)
+        combine_arrived = pld.window(combine_arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
+        dspark_drafter(
+            target_hidden[rank], main_proj_weight[rank], main_norm_weight[rank],
+            anchor_token_ids[rank], embedding_weight[rank],
+            context_position_ids[rank], context_slot_mapping[rank], anchor_positions[rank], block_tables[rank],
+            freqs_cos[rank], freqs_sin[rank],
+            hc_attn_fn[rank], hc_attn_scale[rank], hc_attn_base[rank], attn_norm_w[rank],
+            wq_a[rank], wq_b[rank], wq_b_scale[rank], wkv[rank], gamma_cq[rank], gamma_ckv[rank],
+            kv_caches[rank], attn_sink[rank], wo_a[rank], wo_b[rank], wo_b_scale[rank],
+            hc_ffn_fn[rank], hc_ffn_scale[rank], hc_ffn_base[rank], ffn_norm_w[rank],
+            gate_w[rank], gate_bias[rank], tid2eid[rank],
+            routed_w1[rank], routed_w1_scale[rank], routed_w3[rank], routed_w3_scale[rank],
+            routed_w2[rank], routed_w2_scale[rank],
+            shared_w1[rank], shared_w1_scale[rank], shared_w3[rank], shared_w3_scale[rank],
+            shared_w2[rank], shared_w2_scale[rank],
+            hc_head_fn[rank], hc_head_scale[rank], hc_head_base[rank], initial_hidden[rank],
+            intermediate_hidden[rank], head_hidden[rank],
+            recv_meta, recv_x, recv_aux, recv_route, arrived, data_arrived, routed_y_buf, combine_arrived,
+            rank,
+            device=rank,
+        )
+
+
+def _anchor_position_set(batch):
+    import torch
+
+    cases = torch.tensor(
+        [
+            1,
+            BLOCK_SIZE - 1,
+            M.sliding_window - 1,
+            M.sliding_window + BLOCK_SIZE,
+            2 * BLOCK_SIZE - 1,
+            4 * BLOCK_SIZE + 3,
+            8 * BLOCK_SIZE - 1,
+            MAX_SEQ_LEN - DSPARK_QUERY_WIDTH - 1,
+        ],
+        dtype=torch.int32,
+    )
+    repeats = (batch + cases.numel() - 1) // cases.numel()
+    return cases.repeat(repeats)[:batch].contiguous()
+
+
+def _block_tables(batch):
+    import torch
+
+    logical = torch.arange(ORI_MAX_BLOCKS, dtype=torch.int32)
+    tables = torch.empty(N_RANKS, DSPARK_DRAFT_LAYERS, batch, ORI_MAX_BLOCKS, dtype=torch.int32)
+    for rank in range(N_RANKS):
+        for layer in range(DSPARK_DRAFT_LAYERS):
+            for request in range(batch):
+                request_base = request * (ORI_BLOCK_NUM // DSPARK_MAX_BATCH)
+                ring_offset = rank * 3 + layer * 7
+                request_block = (logical + ring_offset) % (ORI_BLOCK_NUM // DSPARK_MAX_BATCH)
+                tables[rank, layer, request] = request_base + request_block
+    return tables
+
+
+def _context_slots(tables, positions):
+    import torch
+
+    slots = torch.empty(N_RANKS, DSPARK_DRAFT_LAYERS, positions.shape[1], dtype=torch.int64)
+    for rank in range(N_RANKS):
+        for layer in range(DSPARK_DRAFT_LAYERS):
+            for request in range(positions.shape[1]):
+                position = int(positions[rank, request])
+                physical_block = int(tables[rank, layer, request, position // BLOCK_SIZE])
+                slots[rank, layer, request] = physical_block * BLOCK_SIZE + position % BLOCK_SIZE
+    return slots
+
+
+def _balanced_routes():
+    import torch
+
+    token_ids = torch.arange(VOCAB, dtype=torch.int64).unsqueeze(1)
+    route_ids = torch.arange(TOPK, dtype=torch.int64).unsqueeze(0)
+    routes = ((token_ids * TOPK + route_ids) % N_EXPERTS_GLOBAL).to(torch.int32)
+    return routes.unsqueeze(0).expand(N_RANKS, -1, -1).contiguous()
+
+
+def build_tensor_specs(batch):
+    import torch
+    from golden import TensorSpec
+
+    if batch not in DSPARK_SUPPORTED_BATCHES:
+        raise ValueError(f"unsupported DSpark batch {batch}; expected one of {DSPARK_SUPPORTED_BATCHES}")
+
+    positions = _anchor_position_set(batch).unsqueeze(0).expand(N_RANKS, -1).contiguous()
+    tables = _block_tables(batch)
+    context_slots = _context_slots(tables, positions)
+    context_positions_padded = torch.zeros(N_RANKS, DSPARK_QUERY_TOKENS, dtype=torch.int32)
+    context_positions_padded[:, :batch] = positions
+    context_slots_padded = torch.full(
+        (N_RANKS, DSPARK_DRAFT_LAYERS, DSPARK_QUERY_TOKENS),
+        -1,
+        dtype=torch.int64,
+    )
+    context_slots_padded[:, :, :batch] = context_slots
+    anchors = torch.arange(batch, dtype=torch.int64).unsqueeze(0).expand(N_RANKS, -1).contiguous()
+    anchors = (anchors + 1) % VOCAB
+    routes = _balanced_routes().unsqueeze(1)
+    routes = routes.expand(-1, DSPARK_DRAFT_LAYERS, -1, -1)
+    routes = routes.reshape(N_RANKS, DSPARK_DRAFT_LAYERS * VOCAB, TOPK).contiguous()
+
+    def init_target_hidden():
+        values = torch.zeros(N_RANKS, batch * DECODE_SEQ, MAIN_IN, dtype=torch.bfloat16)
+        columns = torch.arange(D, dtype=torch.float32)
+        base = ((columns % 31) - 15) * 0.002
+        for rank in range(N_RANKS):
+            for request in range(batch):
+                for offset in range(DECODE_SEQ):
+                    row = request * DECODE_SEQ + offset
+                    values[rank, row, :D] = (
+                        base + 0.01 * (rank + request + 1) + 0.001 * offset
+                    ).to(torch.bfloat16)
+        return values
+
+    def init_main_proj_weight():
+        weight = torch.zeros(N_RANKS, D, MAIN_IN, dtype=torch.bfloat16)
+        diagonal = torch.arange(D)
+        weight[:, diagonal, diagonal] = 1
+        return weight
+
+    def init_embedding_weight():
+        weight = torch.zeros(N_RANKS, VOCAB, D, dtype=torch.bfloat16)
+        columns = torch.arange(D, dtype=torch.float32)
+        base = ((columns % 29) - 14) * 0.002
+        for rank in range(N_RANKS):
+            weight[rank, 0] = (base + 0.005 * rank).to(torch.bfloat16)
+            weight[rank, DSPARK_NOISE_TOKEN_ID] = (base + 0.03 + 0.005 * rank).to(torch.bfloat16)
+            for token in range(1, batch + 1):
+                weight[rank, token] = (base + 0.01 * token + 0.005 * rank).to(torch.bfloat16)
+        return weight
+
+    def init_wkv():
+        weight = torch.zeros(N_RANKS, DSPARK_DRAFT_LAYERS * D, HEAD_DIM, dtype=torch.bfloat16)
+        diagonal = torch.arange(HEAD_DIM)
+        for layer in range(DSPARK_DRAFT_LAYERS):
+            weight[:, layer * D + diagonal, diagonal] = 1
+        return weight
+
+    def ranked(name, shape, dtype, init_value=0, *, output=False, resident=False):
+        spec = TensorSpec(name, [N_RANKS, *shape], dtype, init_value=init_value, is_output=output)
+        if resident:
+            spec.resident = "stacked"
+        return spec
+
+    def init_kv_caches():
+        cache = torch.empty(
+            N_RANKS,
+            DSPARK_DRAFT_LAYERS,
+            ORI_BLOCK_NUM,
+            BLOCK_SIZE,
+            1,
+            HEAD_DIM,
+            dtype=torch.bfloat16,
+        )
+        for rank in range(N_RANKS):
+            for layer in range(DSPARK_DRAFT_LAYERS):
+                cache[rank, layer].fill_(layer + 1 + rank * 0.25)
+        return cache
+
+    specs = [
+        ranked("target_hidden", [batch * DECODE_SEQ, MAIN_IN], torch.bfloat16, init_value=init_target_hidden),
+        TensorSpec(
+            "initial_hidden",
+            [N_RANKS, DSPARK_MAX_BATCH * DSPARK_QUERY_PAD, HC_MULT, D],
+            torch.float32,
+            is_output=True,
+        ),
+        TensorSpec(
+            "intermediate_hidden",
+            [N_RANKS, DSPARK_DRAFT_LAYERS, DSPARK_MAX_BATCH * DSPARK_QUERY_PAD, HC_MULT, D],
+            torch.float32,
+            is_output=True,
+        ),
+        ranked("main_proj_weight", [D, MAIN_IN], torch.bfloat16, init_value=init_main_proj_weight, resident=True),
+        ranked("main_norm_weight", [D], torch.bfloat16, init_value=1, resident=True),
+        ranked("anchor_token_ids", [batch], torch.int64, init_value=lambda: anchors),
+        ranked("embedding_weight", [VOCAB, D], torch.bfloat16, init_value=init_embedding_weight, resident=True),
+        ranked(
+            "context_position_ids",
+            [DSPARK_QUERY_TOKENS],
+            torch.int32,
+            init_value=lambda: context_positions_padded,
+        ),
+        ranked(
+            "context_slot_mapping",
+            [DSPARK_DRAFT_LAYERS, DSPARK_QUERY_TOKENS],
+            torch.int64,
+            init_value=lambda: context_slots_padded,
+        ),
+        ranked("anchor_positions", [batch], torch.int32, init_value=lambda: positions),
+        ranked("block_tables", [DSPARK_DRAFT_LAYERS, batch, ORI_MAX_BLOCKS], torch.int32, init_value=lambda: tables),
+        ranked("freqs_cos", [MAX_SEQ_LEN, ROPE_DIM], torch.bfloat16, init_value=1, resident=True),
+        ranked("freqs_sin", [MAX_SEQ_LEN, ROPE_DIM], torch.bfloat16, resident=True),
+    ]
+
+    specs.extend(
+        [
+            ranked("hc_attn_fn", [DSPARK_DRAFT_LAYERS * MIX_HC, HC_DIM], torch.float32, resident=True),
+            ranked("hc_attn_scale", [DSPARK_DRAFT_LAYERS * 3], torch.float32, resident=True),
+            ranked("hc_attn_base", [DSPARK_DRAFT_LAYERS * MIX_HC], torch.float32, resident=True),
+            ranked("attn_norm_w", [DSPARK_DRAFT_LAYERS * D], torch.bfloat16, init_value=1, resident=True),
+            ranked("wq_a", [DSPARK_DRAFT_LAYERS * D, Q_LORA], torch.bfloat16, resident=True),
+            ranked("wq_b", [DSPARK_DRAFT_LAYERS * Q_LORA, H * HEAD_DIM], torch.int8, resident=True),
+            ranked("wq_b_scale", [DSPARK_DRAFT_LAYERS * H * HEAD_DIM], torch.float32, resident=True),
+            ranked("wkv", [DSPARK_DRAFT_LAYERS * D, HEAD_DIM], torch.bfloat16, init_value=init_wkv, resident=True),
+            ranked("gamma_cq", [DSPARK_DRAFT_LAYERS * Q_LORA], torch.bfloat16, init_value=1, resident=True),
+            ranked("gamma_ckv", [DSPARK_DRAFT_LAYERS * HEAD_DIM], torch.bfloat16, init_value=1, resident=True),
+            ranked(
+                "kv_caches",
+                [DSPARK_DRAFT_LAYERS, ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM],
+                torch.bfloat16,
+                init_value=init_kv_caches,
+                output=True,
+            ),
+            ranked("attn_sink", [DSPARK_DRAFT_LAYERS * H], torch.float32, resident=True),
+            ranked("wo_a", [DSPARK_DRAFT_LAYERS * O_GROUPS, O_LORA, O_GROUP_IN], torch.bfloat16, resident=True),
+            ranked("wo_b", [DSPARK_DRAFT_LAYERS * D, O_GROUPS * O_LORA], torch.int8, resident=True),
+            ranked("wo_b_scale", [DSPARK_DRAFT_LAYERS * D], torch.float32, resident=True),
+            ranked("hc_ffn_fn", [DSPARK_DRAFT_LAYERS * MIX_HC, HC_DIM], torch.float32, resident=True),
+            ranked("hc_ffn_scale", [DSPARK_DRAFT_LAYERS * 3], torch.float32, resident=True),
+            ranked("hc_ffn_base", [DSPARK_DRAFT_LAYERS * MIX_HC], torch.float32, resident=True),
+            ranked("ffn_norm_w", [DSPARK_DRAFT_LAYERS * D], torch.bfloat16, init_value=1, resident=True),
+            ranked("gate_w", [DSPARK_DRAFT_LAYERS * N_EXPERTS_GLOBAL, D], torch.float32, resident=True),
+            ranked("gate_bias", [DSPARK_DRAFT_LAYERS * N_EXPERTS_GLOBAL], torch.float32, resident=True),
+            ranked(
+                "tid2eid",
+                [DSPARK_DRAFT_LAYERS * VOCAB, TOPK],
+                torch.int32,
+                init_value=lambda: routes,
+                resident=True,
+            ),
+            ranked("routed_w1", [DSPARK_DRAFT_LAYERS * N_LOCAL, MOE_INTER, D], torch.int8, resident=True),
+            ranked("routed_w1_scale", [DSPARK_DRAFT_LAYERS * N_LOCAL, MOE_INTER], torch.float32, resident=True),
+            ranked("routed_w3", [DSPARK_DRAFT_LAYERS * N_LOCAL, MOE_INTER, D], torch.int8, resident=True),
+            ranked("routed_w3_scale", [DSPARK_DRAFT_LAYERS * N_LOCAL, MOE_INTER], torch.float32, resident=True),
+            ranked("routed_w2", [DSPARK_DRAFT_LAYERS * N_LOCAL, D, MOE_INTER], torch.int8, resident=True),
+            ranked("routed_w2_scale", [DSPARK_DRAFT_LAYERS * N_LOCAL, D], torch.float32, resident=True),
+            ranked("shared_w1", [DSPARK_DRAFT_LAYERS * MOE_INTER, D], torch.int8, resident=True),
+            ranked("shared_w1_scale", [DSPARK_DRAFT_LAYERS * MOE_INTER], torch.float32, resident=True),
+            ranked("shared_w3", [DSPARK_DRAFT_LAYERS * MOE_INTER, D], torch.int8, resident=True),
+            ranked("shared_w3_scale", [DSPARK_DRAFT_LAYERS * MOE_INTER], torch.float32, resident=True),
+            ranked("shared_w2", [DSPARK_DRAFT_LAYERS * D, MOE_INTER], torch.int8, resident=True),
+            ranked("shared_w2_scale", [DSPARK_DRAFT_LAYERS * D], torch.float32, resident=True),
+        ]
+    )
+
+    specs.extend(
+        [
+            ranked("hc_head_fn", [HC_MULT, HC_DIM], torch.float32, resident=True),
+            ranked("hc_head_scale", [1], torch.float32, resident=True),
+            ranked("hc_head_base", [HC_MULT], torch.float32, resident=True),
+            TensorSpec(
+                "head_hidden",
+                [N_RANKS, batch, DSPARK_QUERY_WIDTH, D],
+                torch.bfloat16,
+                is_output=True,
+            ),
+        ]
+    )
+    return specs
+
+
+def golden_dspark_drafter(tensors):
+    import torch
+
+    def rms_norm(hidden):
+        hidden_fp32 = hidden.float()
+        inv_rms = torch.rsqrt(hidden_fp32.square().mean(dim=-1, keepdim=True) + M.rms_norm_eps)
+        return (hidden_fp32 * inv_rms).to(torch.bfloat16)
+
+    def project_kv(hidden):
+        projected = hidden.float()[..., :HEAD_DIM]
+        inv_rms = torch.rsqrt(projected.square().mean(dim=-1, keepdim=True) + M.rms_norm_eps)
+        return (projected * inv_rms).to(torch.bfloat16)
+
+    def hc_coefficients(token_count):
+        pre = torch.full((token_count, HC_MULT), 0.5 + M.hc_eps, dtype=torch.float32)
+        post = torch.ones(token_count, HC_MULT, dtype=torch.float32)
+        combine = torch.full((token_count, HC_MULT, HC_MULT), 0.25 + M.hc_eps, dtype=torch.float32)
+        combine = combine / (combine.sum(-2, keepdim=True) + M.hc_eps)
+        for _ in range(M.hc_sinkhorn_iters - 1):
+            combine = combine / (combine.sum(-1, keepdim=True) + M.hc_eps)
+            combine = combine / (combine.sum(-2, keepdim=True) + M.hc_eps)
+        return pre, post, combine
+
+    def hc_pre_zero_function(hidden):
+        pre, post, combine = hc_coefficients(hidden.shape[0])
+        mixed = hidden[:, 0] * pre[:, 0:1]
+        for lane in range(1, HC_MULT):
+            mixed = mixed + hidden[:, lane] * pre[:, lane : lane + 1]
+        return mixed.to(torch.bfloat16), post, combine
+
+    def hc_post_zero_output(residual, post, combine):
+        output = torch.empty_like(residual)
+        zero = torch.zeros(residual.shape[0], D, dtype=torch.float32)
+        for output_lane in range(HC_MULT):
+            row = zero * post[:, output_lane : output_lane + 1]
+            for input_lane in range(HC_MULT):
+                row = row + residual[:, input_lane] * combine[:, input_lane, output_lane : output_lane + 1]
+            output[:, output_lane] = row
+        return output
+
+    tensors["head_hidden"].zero_()
+    tensors["initial_hidden"].zero_()
+    tensors["intermediate_hidden"].zero_()
+    positions = tensors["anchor_positions"]
+    tables = tensors["block_tables"]
+    context_slots = tensors["context_slot_mapping"]
+    for rank in range(N_RANKS):
+        main_x = rms_norm(tensors["target_hidden"][rank, :, :D])
+        query_ids = torch.zeros(DSPARK_MAX_BATCH * DSPARK_QUERY_PAD, dtype=torch.int64)
+        for request in range(positions.shape[1]):
+            row = request * DSPARK_QUERY_WIDTH
+            query_ids[row] = tensors["anchor_token_ids"][rank, request]
+            query_ids[row + 1 : row + DSPARK_QUERY_WIDTH] = DSPARK_NOISE_TOKEN_ID
+        query_hidden = tensors["embedding_weight"][rank].index_select(0, query_ids)
+        hidden = query_hidden.float().unsqueeze(1).expand(-1, HC_MULT, -1).contiguous()
+        tensors["initial_hidden"][rank] = hidden
+
+        for layer in range(DSPARK_DRAFT_LAYERS):
+            cache = tensors["kv_caches"][rank, layer].view(-1, HEAD_DIM)
+            layer_context_slots = context_slots[rank, layer]
+            valid_context_slots = layer_context_slots[layer_context_slots >= 0].long()
+            context_x = main_x[DECODE_SEQ - 1 :: DECODE_SEQ]
+            cache[valid_context_slots] = project_kv(context_x[: valid_context_slots.numel()])
+            query_slots = []
+            for request in range(positions.shape[1]):
+                anchor = int(positions[rank, request])
+                for offset in range(1, DSPARK_QUERY_WIDTH + 1):
+                    position = anchor + offset
+                    physical_block = int(tables[rank, layer, request, position // BLOCK_SIZE])
+                    query_slots.append(physical_block * BLOCK_SIZE + position % BLOCK_SIZE)
+            mixed, post, combine = hc_pre_zero_function(hidden)
+            query_normed = rms_norm(mixed[: DSPARK_MAX_BATCH * DSPARK_QUERY_WIDTH])
+            active_tokens = positions.shape[1] * DSPARK_QUERY_WIDTH
+            cache[torch.tensor(query_slots, dtype=torch.int64)] = project_kv(query_normed[:active_tokens])
+            attention_hidden = hc_post_zero_output(
+                hidden[: DSPARK_MAX_BATCH * DSPARK_QUERY_WIDTH],
+                post[: DSPARK_MAX_BATCH * DSPARK_QUERY_WIDTH],
+                combine[: DSPARK_MAX_BATCH * DSPARK_QUERY_WIDTH],
+            )
+            padded_attention = torch.zeros_like(hidden)
+            padded_attention[: positions.shape[1] * DSPARK_QUERY_WIDTH] = attention_hidden[
+                : positions.shape[1] * DSPARK_QUERY_WIDTH
+            ]
+            _, moe_post, moe_combine = hc_pre_zero_function(padded_attention)
+            hidden = hc_post_zero_output(padded_attention, moe_post, moe_combine)
+            tensors["intermediate_hidden"][rank, layer] = hidden
+
+        active = hidden[: positions.shape[1] * DSPARK_QUERY_WIDTH]
+        head_pre = torch.full((active.shape[0], HC_MULT), 0.5 + M.hc_eps, dtype=torch.float32)
+        head = active[:, 0] * head_pre[:, 0:1]
+        head = head + active[:, 1] * head_pre[:, 1:2]
+        tail = active[:, 2] * head_pre[:, 2:3]
+        tail = tail + active[:, 3] * head_pre[:, 3:4]
+        head = (head + tail).to(torch.bfloat16)
+        tensors["head_hidden"][rank] = head.view(positions.shape[1], DSPARK_QUERY_WIDTH, D)
+
+
+if __name__ == "__main__":
+    import argparse
+    from golden import run_jit
+
+    parser = argparse.ArgumentParser(description="Validate the multi-rank DeepSeek V4 DSpark drafter.")
+    parser.add_argument("--batch", type=int, choices=DSPARK_SUPPORTED_BATCHES, default=4)
+    parser.add_argument("--ep", type=int, choices=(2, 4, 8, 16), default=2)
+    parser.add_argument("-p", "--platform", default="a2a3", choices=["a2a3", "a2a3sim"])
+    parser.add_argument("-d", "--device", type=str, default=",".join(str(i) for i in range(N_RANKS)))
+    parser.add_argument("--compile-only", action="store_true")
+    parser.add_argument("--dump-passes", action="store_true")
+    args = parser.parse_args()
+
+    device_ids = [int(device) for device in args.device.split(",")]
+    assert args.ep == N_RANKS
+    assert len(device_ids) >= N_RANKS
+    result = run_jit(
+        fn=l3_dspark_drafter,
+        specs=build_tensor_specs(args.batch),
+        golden_fn=golden_dspark_drafter,
+        compile_only=args.compile_only,
+        compile_cfg=dict(
+            dump_passes=args.dump_passes,
+            distributed_config=DistributedConfig(device_ids=device_ids[:N_RANKS], num_sub_workers=0),
+        ),
+        runtime_cfg=dict(
+            platform=args.platform,
+            ring_heap=_DSPARK_RING_HEAP,
+        ),
+        rtol=1e-3,
+        atol=1e-3,
+    )
+    if not result.passed:
+        if result.error:
+            print(result.error)
+        raise SystemExit(1)

--- a/models/deepseek_v4_flash_dspark/dspark_markov.py
+++ b/models/deepseek_v4_flash_dspark/dspark_markov.py
@@ -1,0 +1,511 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Compose the shared target LM head and rank-256 sequential Markov sampler."""
+
+import pypto.language as pl
+
+from config import FLASH as M
+from markov_head import markov_head
+
+
+B_DYN = pl.dynamic("DSPARK_MARKOV_B_DYN")
+
+# DSpark Markov program contract.
+DSPARK_MARKOV_RANK = 256
+DSPARK_QUERY_WIDTH = 7
+DSPARK_QUERY_PAD = 8
+DSPARK_SUPPORTED_BATCHES = (4, 8, 12, 16)
+DSPARK_MAX_BATCH = max(DSPARK_SUPPORTED_BATCHES)
+DSPARK_MOE_TOKENS = DSPARK_MAX_BATCH * DSPARK_QUERY_PAD
+
+assert DSPARK_QUERY_WIDTH < DSPARK_QUERY_PAD
+
+# model config
+D = M.hidden_size
+VOCAB = M.vocab_size
+EPS = M.rms_norm_eps
+
+# tiling
+HIDDEN_TILE = 512
+RMS_M_TILE = 8
+LM_M_TILE = 16
+LM_N_TILE = 128
+LM_K_TILE = 256
+MARKOV_M_TILE = DSPARK_MAX_BATCH
+MARKOV_ID_PAD = 8
+GREEDY_VOCAB_CHUNK = 256
+GREEDY_NUM_CHUNKS = VOCAB // GREEDY_VOCAB_CHUNK
+GREEDY_CHUNK_PAD = 512
+GREEDY_ARGMAX_ROWS = 8
+NEG_INF = -3.402823e38
+
+assert D % HIDDEN_TILE == 0
+assert D % LM_K_TILE == 0
+assert VOCAB % LM_N_TILE == 0
+assert VOCAB % GREEDY_VOCAB_CHUNK == 0
+assert GREEDY_NUM_CHUNKS <= GREEDY_CHUNK_PAD
+# Base-logit row tiling must exactly cover every supported padded batch.
+for _batch in DSPARK_SUPPORTED_BATCHES:
+    assert (_batch * DSPARK_QUERY_PAD) % LM_M_TILE == 0
+
+
+@pl.jit.inline
+def compute_base_logits(
+    head_hidden: pl.Tensor[[B_DYN, DSPARK_QUERY_WIDTH, D], pl.BF16],
+    final_norm_weight: pl.Tensor[[D], pl.BF16],
+    lm_head_weight: pl.Tensor[[VOCAB, D], pl.BF16],
+    base_logits: pl.Tensor[[DSPARK_MOE_TOKENS, VOCAB], pl.FP32],
+):
+    batch = pl.tensor.dim(head_hidden, 0)
+    active_tokens = batch * DSPARK_QUERY_WIDTH
+    padded_tokens = batch * DSPARK_QUERY_PAD
+    hidden_flat = pl.reshape(head_hidden, [active_tokens, D])
+    padded_hidden = pl.create_tensor([DSPARK_MOE_TOKENS, D], dtype=pl.BF16)
+    hidden_blocks = D // HIDDEN_TILE
+    with pl.spmd(
+        (DSPARK_MOE_TOKENS // RMS_M_TILE) * hidden_blocks,
+        name_hint="dspark_hidden_zero",
+    ) as hidden_zero_tid:
+        zero_task = pl.tile.get_block_idx()
+        zero_row = (zero_task // hidden_blocks) * RMS_M_TILE
+        zero_col = (zero_task % hidden_blocks) * HIDDEN_TILE
+        padded_hidden[
+            zero_row : zero_row + RMS_M_TILE,
+            zero_col : zero_col + HIDDEN_TILE,
+        ] = pl.full([RMS_M_TILE, HIDDEN_TILE], dtype=pl.BF16, value=0.0)
+    with pl.at(
+        level=pl.Level.CORE_GROUP,
+        name_hint="dspark_hidden_pad",
+        deps=[hidden_zero_tid],
+    ) as hidden_pad_tid:
+        for token in pl.range(active_tokens):
+            padded_hidden[token : token + 1, :] = hidden_flat[token : token + 1, :]
+
+    # Keep this normalization local. Passing a dynamically sized temporary to
+    # the generic rms_norm inline kernel loses its inferred tensor metadata
+    # during JIT specialization.
+    normalized = pl.create_tensor([DSPARK_MOE_TOKENS, D], dtype=pl.BF16)
+    with pl.spmd(
+        padded_tokens // RMS_M_TILE,
+        name_hint="dspark_final_norm",
+        deps=[hidden_pad_tid],
+        allow_early_resolve=True,
+    ) as final_norm_tid:
+        row_block = pl.tile.get_block_idx()
+        row_offset = row_block * RMS_M_TILE
+        square_sum = pl.full([1, RMS_M_TILE], dtype=pl.FP32, value=0.0)
+        for hidden_block in pl.pipeline(D // HIDDEN_TILE, stage=2):
+            hidden_offset = hidden_block * HIDDEN_TILE
+            rms_hidden_tile = pl.cast(
+                padded_hidden[
+                    row_offset : row_offset + RMS_M_TILE,
+                    hidden_offset : hidden_offset + HIDDEN_TILE,
+                ],
+                target_type=pl.FP32,
+            )
+            square_sum = pl.add(
+                square_sum,
+                pl.reshape(
+                    pl.row_sum(pl.mul(rms_hidden_tile, rms_hidden_tile)),
+                    [1, RMS_M_TILE],
+                ),
+            )
+        inv_rms = pl.reshape(
+            pl.rsqrt(
+                pl.add(pl.mul(square_sum, 1.0 / D), EPS),
+                high_precision=True,
+            ),
+            [RMS_M_TILE, 1],
+        )
+        for hidden_block in pl.pipeline(D // HIDDEN_TILE, stage=2):
+            hidden_offset = hidden_block * HIDDEN_TILE
+            rms_hidden_tile = pl.cast(
+                padded_hidden[
+                    row_offset : row_offset + RMS_M_TILE,
+                    hidden_offset : hidden_offset + HIDDEN_TILE,
+                ],
+                target_type=pl.FP32,
+            )
+            norm_tile = pl.cast(
+                pl.reshape(
+                    final_norm_weight[
+                        hidden_offset : hidden_offset + HIDDEN_TILE
+                    ],
+                    [1, HIDDEN_TILE],
+                ),
+                target_type=pl.FP32,
+            )
+            normalized[
+                row_offset : row_offset + RMS_M_TILE,
+                hidden_offset : hidden_offset + HIDDEN_TILE,
+            ] = pl.cast(
+                pl.col_expand_mul(
+                    pl.row_expand_mul(rms_hidden_tile, inv_rms),
+                    norm_tile,
+                ),
+                target_type=pl.BF16,
+                mode="rint",
+            )
+    row_blocks = padded_tokens // LM_M_TILE
+    vocab_blocks = VOCAB // LM_N_TILE
+    with pl.spmd(
+        row_blocks * vocab_blocks,
+        name_hint="dspark_base_logits",
+        deps=[final_norm_tid],
+    ) as base_logits_tid:
+        task = pl.tile.get_block_idx()
+        row_block = task // vocab_blocks
+        vocab_block = task - row_block * vocab_blocks
+        row_offset = row_block * LM_M_TILE
+        vocab_offset = vocab_block * LM_N_TILE
+        hidden_tile = normalized[
+            row_offset : row_offset + LM_M_TILE,
+            0:LM_K_TILE,
+        ]
+        weight_tile = lm_head_weight[
+            vocab_offset : vocab_offset + LM_N_TILE,
+            0:LM_K_TILE,
+        ]
+        logits_acc = pl.matmul(
+            hidden_tile,
+            weight_tile,
+            b_trans=True,
+            out_dtype=pl.FP32,
+        )
+        for hidden_offset in pl.pipeline(
+            LM_K_TILE,
+            D,
+            LM_K_TILE,
+            stage=2,
+        ):
+            hidden_tile = normalized[
+                row_offset : row_offset + LM_M_TILE,
+                hidden_offset : hidden_offset + LM_K_TILE,
+            ]
+            weight_tile = lm_head_weight[
+                vocab_offset : vocab_offset + LM_N_TILE,
+                hidden_offset : hidden_offset + LM_K_TILE,
+            ]
+            logits_acc = pl.matmul_acc(
+                logits_acc,
+                hidden_tile,
+                weight_tile,
+                b_trans=True,
+            )
+        base_logits[
+            row_offset : row_offset + LM_M_TILE,
+            vocab_offset : vocab_offset + LM_N_TILE,
+        ] = logits_acc
+    return base_logits_tid
+
+
+@pl.jit.inline
+def greedy_markov_step(
+    base_logits: pl.Tensor[[DSPARK_MOE_TOKENS, VOCAB], pl.FP32],
+    anchor_token_ids: pl.Tensor[[B_DYN], pl.INT64],
+    markov_w1: pl.Tensor[[VOCAB, DSPARK_MARKOV_RANK], pl.BF16],
+    markov_w2: pl.Tensor[[VOCAB, DSPARK_MARKOV_RANK], pl.BF16],
+    draft_token_scratch: pl.Tensor[[MARKOV_M_TILE, MARKOV_ID_PAD], pl.INT32],
+    base_logits_ready_tid: pl.Scalar[pl.TASK_ID],
+    start_tid: pl.Scalar[pl.TASK_ID],
+    step: pl.Scalar[pl.INT32],
+):
+    batch = pl.tensor.dim(anchor_token_ids, 0)
+    previous_token_ids = pl.create_tensor([batch], dtype=pl.INT64)
+    with pl.at(
+        level=pl.Level.CORE_GROUP,
+        name_hint="dspark_markov_previous_tokens",
+        deps=[start_tid],
+    ) as previous_tokens_tid:
+        for request in pl.range(batch):
+            previous_token = pl.read(anchor_token_ids, [request])
+            if step > 0:
+                previous_token = pl.cast(
+                    pl.read(draft_token_scratch, [request, step - 1]),
+                    pl.INT64,
+                )
+            pl.write(previous_token_ids, [request], previous_token)
+
+    markov_bias = pl.create_tensor([batch, VOCAB], dtype=pl.FP32)
+    markov_embedding = pl.create_tensor([batch, DSPARK_MARKOV_RANK], dtype=pl.BF16)
+    markov_bias, markov_embedding = markov_head(
+        previous_token_ids,
+        markov_w1,
+        markov_w2,
+        markov_bias,
+        markov_embedding,
+    )
+
+    with pl.spmd(
+        MARKOV_M_TILE,
+        name_hint="dspark_markov_greedy",
+        deps=[base_logits_ready_tid, previous_tokens_tid],
+    ) as greedy_tid:
+        request = pl.tile.get_block_idx()
+        if request < batch:
+            source_row = request * DSPARK_QUERY_WIDTH + step
+            chunk_maxima = pl.full(
+                [GREEDY_ARGMAX_ROWS, GREEDY_CHUNK_PAD],
+                dtype=pl.FP32,
+                value=NEG_INF,
+            )
+            chunk_token_ids = pl.full(
+                [1, GREEDY_CHUNK_PAD],
+                dtype=pl.INT32,
+                value=0,
+            )
+            for chunk in pl.range(GREEDY_NUM_CHUNKS):
+                vocab_offset = chunk * GREEDY_VOCAB_CHUNK
+                scores = pl.full(
+                    [GREEDY_ARGMAX_ROWS, GREEDY_VOCAB_CHUNK],
+                    dtype=pl.FP32,
+                    value=NEG_INF,
+                )
+                scores[0:1, 0:GREEDY_VOCAB_CHUNK] = pl.add(
+                    pl.slice(
+                        base_logits,
+                        [1, GREEDY_VOCAB_CHUNK],
+                        [pl.cast(source_row, pl.INDEX), vocab_offset],
+                    ),
+                    markov_bias[
+                        request : request + 1,
+                        vocab_offset : vocab_offset + GREEDY_VOCAB_CHUNK,
+                    ],
+                )
+                local_winner = pl.row_argmax(scores)
+                local_token = pl.read(local_winner, [0, 0])
+                pl.write(
+                    chunk_maxima,
+                    [0, chunk],
+                    pl.read(scores, [0, pl.cast(local_token, pl.INDEX)]),
+                )
+                pl.write(
+                    chunk_token_ids,
+                    [0, chunk],
+                    pl.cast(vocab_offset, pl.INT32) + local_token,
+                )
+
+            winning_chunk = pl.read(pl.row_argmax(chunk_maxima), [0, 0])
+            winning_token = pl.read(
+                chunk_token_ids,
+                [0, pl.cast(winning_chunk, pl.INDEX)],
+            )
+            token_row = draft_token_scratch[
+                request : request + 1,
+                0:MARKOV_ID_PAD,
+            ]
+            if step == 0:
+                pl.write(token_row, [0, 0], winning_token)
+            if step == 1:
+                pl.write(token_row, [0, 1], winning_token)
+            if step == 2:
+                pl.write(token_row, [0, 2], winning_token)
+            if step == 3:
+                pl.write(token_row, [0, 3], winning_token)
+            if step == 4:
+                pl.write(token_row, [0, 4], winning_token)
+            if step == 5:
+                pl.write(token_row, [0, 5], winning_token)
+            if step == 6:
+                pl.write(token_row, [0, 6], winning_token)
+            draft_token_scratch[
+                request : request + 1,
+                0:MARKOV_ID_PAD,
+            ] = token_row
+
+    return greedy_tid
+
+
+@pl.jit
+def markov_sample(
+    head_hidden: pl.Tensor[[B_DYN, DSPARK_QUERY_WIDTH, D], pl.BF16],
+    final_norm_weight: pl.Tensor[[D], pl.BF16],
+    lm_head_weight: pl.Tensor[[VOCAB, D], pl.BF16],
+    anchor_token_ids: pl.Tensor[[B_DYN], pl.INT64],
+    markov_w1: pl.Tensor[[VOCAB, DSPARK_MARKOV_RANK], pl.BF16],
+    markov_w2: pl.Tensor[[VOCAB, DSPARK_MARKOV_RANK], pl.BF16],
+    draft_token_ids: pl.Out[pl.Tensor[[B_DYN, DSPARK_QUERY_WIDTH], pl.INT32]],
+):
+    head_hidden.bind_dynamic(0, B_DYN)
+    anchor_token_ids.bind_dynamic(0, B_DYN)
+    draft_token_ids.bind_dynamic(0, B_DYN)
+    batch = pl.tensor.dim(anchor_token_ids, 0)
+    base_logits = pl.create_tensor(
+        [DSPARK_MOE_TOKENS, VOCAB],
+        dtype=pl.FP32,
+    )
+    base_logits_tid = compute_base_logits(
+        head_hidden,
+        final_norm_weight,
+        lm_head_weight,
+        base_logits,
+    )
+    draft_token_scratch = pl.create_tensor(
+        [MARKOV_M_TILE, MARKOV_ID_PAD],
+        dtype=pl.INT32,
+    )
+    with pl.spmd(
+        batch,
+        name_hint="dspark_markov_token_scratch_zero",
+    ) as token_scratch_zero_tid:
+        request = pl.tile.get_block_idx()
+        draft_token_scratch[
+            request : request + 1,
+            0:MARKOV_ID_PAD,
+        ] = pl.full([1, MARKOV_ID_PAD], dtype=pl.INT32, value=0)
+    step_0_tid = greedy_markov_step(
+        base_logits, anchor_token_ids, markov_w1, markov_w2,
+        draft_token_scratch,
+        base_logits_tid, token_scratch_zero_tid, pl.cast(0, pl.INT32)
+    )
+    step_1_tid = greedy_markov_step(
+        base_logits, anchor_token_ids, markov_w1, markov_w2,
+        draft_token_scratch,
+        base_logits_tid, step_0_tid, pl.cast(1, pl.INT32)
+    )
+    step_2_tid = greedy_markov_step(
+        base_logits, anchor_token_ids, markov_w1, markov_w2,
+        draft_token_scratch,
+        base_logits_tid, step_1_tid, pl.cast(2, pl.INT32)
+    )
+    step_3_tid = greedy_markov_step(
+        base_logits, anchor_token_ids, markov_w1, markov_w2,
+        draft_token_scratch,
+        base_logits_tid, step_2_tid, pl.cast(3, pl.INT32)
+    )
+    step_4_tid = greedy_markov_step(
+        base_logits, anchor_token_ids, markov_w1, markov_w2,
+        draft_token_scratch,
+        base_logits_tid, step_3_tid, pl.cast(4, pl.INT32)
+    )
+    step_5_tid = greedy_markov_step(
+        base_logits, anchor_token_ids, markov_w1, markov_w2,
+        draft_token_scratch,
+        base_logits_tid, step_4_tid, pl.cast(5, pl.INT32)
+    )
+    step_6_tid = greedy_markov_step(
+        base_logits, anchor_token_ids, markov_w1, markov_w2,
+        draft_token_scratch,
+        base_logits_tid, step_5_tid, pl.cast(6, pl.INT32)
+    )
+    with pl.at(
+        level=pl.Level.CORE_GROUP,
+        name_hint="dspark_markov_token_output_copy",
+        deps=[step_6_tid],
+    ):
+        for request in pl.range(batch):
+            for output_step in pl.range(DSPARK_QUERY_WIDTH):
+                pl.write(
+                    draft_token_ids,
+                    [request, output_step],
+                    pl.read(draft_token_scratch, [request, output_step]),
+                )
+    return draft_token_ids
+
+
+def build_tensor_specs(batch: int):
+    """Build a deterministic nonzero Markov validation case."""
+    import torch
+    from golden import TensorSpec
+
+    if batch not in DSPARK_SUPPORTED_BATCHES:
+        raise ValueError(f"unsupported DSpark batch {batch}; expected one of {DSPARK_SUPPORTED_BATCHES}")
+
+    def init_lm_head_weight():
+        weight = torch.zeros(VOCAB, D, dtype=torch.bfloat16)
+        weight[0, :LM_K_TILE] = 1.0 / LM_K_TILE
+        return weight
+
+    def init_anchor_token_ids():
+        return torch.arange(batch, dtype=torch.int64) % 2 + 2
+
+    def init_markov_w1():
+        weight = torch.zeros(VOCAB, DSPARK_MARKOV_RANK, dtype=torch.bfloat16)
+        weight[0, 0] = 1.0
+        weight[1, 0] = -1.0
+        weight[2, 0] = 1.0
+        weight[3, 0] = -1.0
+        return weight
+
+    def init_markov_w2():
+        weight = torch.zeros(VOCAB, DSPARK_MARKOV_RANK, dtype=torch.bfloat16)
+        weight[0, 0] = -4.0
+        weight[1, 0] = 4.0
+        return weight
+
+    return [
+        TensorSpec("head_hidden", [batch, DSPARK_QUERY_WIDTH, D], torch.bfloat16, init_value=1),
+        TensorSpec("final_norm_weight", [D], torch.bfloat16, init_value=1),
+        TensorSpec("lm_head_weight", [VOCAB, D], torch.bfloat16, init_value=init_lm_head_weight),
+        TensorSpec("anchor_token_ids", [batch], torch.int64, init_value=init_anchor_token_ids),
+        TensorSpec("markov_w1", [VOCAB, DSPARK_MARKOV_RANK], torch.bfloat16, init_value=init_markov_w1),
+        TensorSpec("markov_w2", [VOCAB, DSPARK_MARKOV_RANK], torch.bfloat16, init_value=init_markov_w2),
+        TensorSpec(
+            "draft_token_ids",
+            [batch, DSPARK_QUERY_WIDTH],
+            torch.int32,
+            is_output=True,
+        ),
+    ]
+
+
+def golden_nonzero_markov(tensors):
+    """Validate the complete nonzero support and sequential Markov chain."""
+    import torch
+
+    hidden_fp32 = tensors["head_hidden"].float()
+    inv_rms = torch.rsqrt(hidden_fp32.square().mean(dim=-1, keepdim=True) + EPS)
+    normalized = (
+        hidden_fp32 * inv_rms * tensors["final_norm_weight"].float()
+    ).to(torch.bfloat16)
+    # The deterministic fixture has nonzero LM-head and Markov rows only in
+    # this leading support; all remaining vocabulary scores are exactly zero.
+    validation_support = 8
+    base_logits = normalized.float().matmul(
+        tensors["lm_head_weight"][:validation_support].float().t()
+    )
+
+    previous = tensors["anchor_token_ids"].long()
+    for step in range(DSPARK_QUERY_WIDTH):
+        embedding = tensors["markov_w1"].float().index_select(0, previous)
+        markov_bias = embedding.matmul(
+            tensors["markov_w2"][:validation_support].float().t()
+        )
+        scores = base_logits[:, step] + markov_bias
+        assert torch.all(scores.max(dim=-1).values > 0)
+        previous = torch.argmax(scores, dim=-1)
+        tensors["draft_token_ids"][:, step] = previous.to(torch.int32)
+
+
+if __name__ == "__main__":
+    import argparse
+    from golden import run_jit
+
+    parser = argparse.ArgumentParser(description="Validate the DeepSeek V4 DSpark Markov sampler.")
+    parser.add_argument("--batch", type=int, choices=DSPARK_SUPPORTED_BATCHES, default=4)
+    parser.add_argument("-p", "--platform", default="a2a3", choices=["a2a3", "a2a3sim"])
+    parser.add_argument("-d", "--device", type=int, default=0)
+    parser.add_argument("--compile-only", action="store_true")
+    parser.add_argument("--dump-passes", action="store_true")
+    args = parser.parse_args()
+
+    result = run_jit(
+        fn=markov_sample,
+        specs=build_tensor_specs(args.batch),
+        golden_fn=golden_nonzero_markov,
+        compile_cfg=dict(dump_passes=args.dump_passes),
+        runtime_cfg=dict(platform=args.platform, device_id=args.device),
+        rtol=2e-3,
+        atol=2e-3,
+        compile_only=args.compile_only,
+    )
+    if not result.passed:
+        if result.error:
+            print(result.error)
+        raise SystemExit(1)

--- a/models/deepseek_v4_flash_dspark/qkv_proj_rope.py
+++ b/models/deepseek_v4_flash_dspark/qkv_proj_rope.py
@@ -17,9 +17,9 @@ from config import FLASH as M, DECODE_BATCH, DECODE_SEQ, TP, PREFILL_BATCH, PREF
 
 # Dynamic shape variables. The q branch, the kv branch and the rope tables each
 # carry their own token axis.
-T_DYN = pl.dynamic("T_DYN")  # T = B * S
-KV_T_DYN = pl.dynamic("KV_T_DYN")
-ROPE_T_DYN = pl.dynamic("ROPE_T_DYN")
+T_DYN = pl.dynamic("QKV_Q_T_DYN")  # T = B * S
+KV_T_DYN = pl.dynamic("QKV_KV_T_DYN")
+ROPE_T_DYN = pl.dynamic("QKV_ROPE_T_DYN")
 
 
 # model config

--- a/models/deepseek_v4_flash_dspark/rmsnorm.py
+++ b/models/deepseek_v4_flash_dspark/rmsnorm.py
@@ -15,7 +15,7 @@ from config import FLASH as M, DECODE_BATCH, DECODE_SEQ, TP, PREFILL_BATCH, PREF
 
 
 # Dynamic shape variables.
-T_DYN = pl.dynamic("T_DYN")  # T = B * S
+T_DYN = pl.dynamic("RMS_NORM_T_DYN")  # T = B * S
 
 
 # model config


### PR DESCRIPTION
## Summary

Implement the PyPTO-Lib portion of the DeepSeek-V4-Flash DSpark drafter as two independently compilable and verifiable programs:

1. `dspark_drafter.py`: compose the three-layer draft backbone and produce pre-norm `head_hidden[B, 7, hidden_size]`.
2. `dspark_markov.py`: apply final RMSNorm, the shared target LM head, and seven sequential rank-256 Markov sampling steps to produce `draft_token_ids[B, 7]`.

The PR is intentionally split into two commits so each program can be checked out, compiled, and validated on its own.

## Changes

### Commit 1: three-layer Drafter

`0439f70c45ce8fc52c0ea86dc5d10bcf8001b1e0`

- Projects target hidden states from layers 40, 41, and 42 into the drafter hidden state.
- Builds the per-request `[anchor, noise × 6]` query block internally.
- Builds non-causal sliding-window metadata in which all seven query rows share the historical window and the full current query block.
- Writes the current anchor context KV and maintains one isolated KV cache per draft layer.
- Packs the three copies of each layer-local weight along the leading tensor axis while retaining three explicit sequential layer calls.
- Supports dynamic batches `{4, 8, 12, 16}` with fixed maximum hardware shapes.
- Produces `head_hidden`; the synthetic validation harness also checks `initial_hidden`, all three intermediate layer states, and all three KV caches.

### Commit 2: sequential Markov sampler

`784bfb81054016e4f314737425d853d5757c2074`

- Adds only `models/deepseek_v4_flash_dspark/dspark_markov.py` relative to the Drafter commit.
- Computes base logits from `head_hidden` using final RMSNorm and the target LM head.
- Applies the rank-256 Markov bias for seven steps.
- Feeds each sampled token into the next step and uses greedy sampling with deterministic lowest-index tie handling.
- Supports dynamic batches `{4, 8, 12, 16}` and produces `draft_token_ids[B, 7]`.

## Scope and repository boundaries

This PR changes only these model implementation files:

- `models/deepseek_v4_flash_dspark/dspark_drafter.py`
- `models/deepseek_v4_flash_dspark/dspark_markov.py`
- `models/deepseek_v4_flash_dspark/dspark_context_kv.py`
- `models/deepseek_v4_flash_dspark/qkv_proj_rope.py`
- `models/deepseek_v4_flash_dspark/rmsnorm.py`

Existing `dspark_attention.py` behavior is reused unchanged from `main`. This PR contains no documentation, MkDocs configuration, or separate contract-test changes. The model programs contain their non-zero synthetic tensor specifications and Golden references.

The implementation uses the rank-reducing `tensor.slice` support already merged through [hw-native-sys/pypto#2343](https://github.com/hw-native-sys/pypto/pull/2343); no PyPTO source change is included in this PR.

## Validation

Environment:

- repository: `/data/chenshenai/test3`
- Python 3.10.20
- CANN 9.0.0
- PTOAS 0.57
- A2/A3 physical devices 9 and 11

Local checks:

- Python syntax checks: PASS for both commits
- `pre-commit run --all-files`: PASS

Drafter commit `0439f70c`:

- B4 / EP2: PASS — `task_20260818_200657_35355996893`
- B16 / EP2: PASS — `task_20260818_201058_27930692853`
- `initial_hidden`, three-layer `intermediate_hidden`, layer-stacked `kv_caches`, and `head_hidden` all matched the non-zero Golden reference.

Markov commit `784bfb81`:

- B4: PASS — `task_20260818_201239_12668643058`
- B16: PASS — `task_20260818_201301_192595616899`
- `draft_token_ids` matched the sequential non-zero Golden reference.

## Out of scope

This PyPTO-Lib PR does not implement:

- serving scheduler or proposer integration;
- target-model verification, rejection sampling, or acceptance accounting;
- bonus-token commit behavior;
- the confidence head;
- official checkpoint download or conversion;
- performance acceptance criteria.

Fixes #935