### PR TITLE
Add: compose DeepSeek V4 CSA decode TP output

### DIFF
--- a/models/deepseek_v4_flash_dspark/decode_csa.py
+++ b/models/deepseek_v4_flash_dspark/decode_csa.py
@@ -6,33 +6,41 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-"""DeepSeek-V4 CSA (Compressed Sparse Attention) decode orchestration.
+# ci: devices=2  # CI: 2-card run; borrows 2 cards via task-submit --device-num
+"""DeepSeek-V4 CSA decode orchestration with configurable TP output."""
 
-This standalone harness targets the ratio-4 compression step used by the current
-workflow checkpoint. It composes:
 
-- hc_pre
-- qkv_proj_rope
-- main compressor (ratio=4, rotate=False)
-- inner compressor (ratio=4, rotate=True)
-- indexer
-- sparse_attn_csa (with fused grouped o_proj)
-- hc_post
+import sys
 
-The helper stack in this repo has already moved to the refreshed v4 contracts:
-q_proj runs through the W8A8 path, sparse_attn_csa owns grouped o_proj, and the
-indexer consumes a prepared `idx_kv_cache` instead of owning the inner
-compressor itself. This file aligns to that stack instead of the older draft
-surface.
-"""
+import config
 
+
+# Sub-kernels freeze TP-derived shapes at import time, so select the standalone
+# program's TP world before importing them below.
+_TP_CHOICES = (1, 2, 4)
+_TP_DEFAULT = 2
+
+
+def _parse_tp_argv():
+    for index, arg in enumerate(sys.argv):
+        if arg == "--tp" and index + 1 < len(sys.argv):
+            return int(sys.argv[index + 1])
+        if arg.startswith("--tp="):
+            return int(arg.split("=", 1)[1])
+    return _TP_DEFAULT
+
+
+TP_SIZE = _parse_tp_argv()
+if TP_SIZE not in _TP_CHOICES:
+    raise ValueError(f"--tp must be one of {_TP_CHOICES} (got {TP_SIZE})")
+config.TP = TP_SIZE
 
 import pypto.language as pl
+import pypto.language.distributed as pld
 
 from config import (
     FLASH as M,
     DECODE_BATCH,
-    TP,
     DECODE_SEQ,
     BLOCK_SIZE,
     C4A_COMPRESSOR_BLOCK_SIZE,
@@ -54,14 +62,36 @@ from decode_indexer import indexer
 from qkv_proj_rope import qkv_proj_rope
 from rmsnorm import rms_norm
 from rope_interleave import rope_interleave
-from decode_sparse_attn_csa import sparse_attn_csa
+from decode_o_proj import (
+    ATTENTION_WINDOW_ROWS,
+    GROUP_T_PAD,
+    LOCAL_O_GROUPS,
+    LOCAL_O_WIDTH,
+    LOCAL_T,
+    LOCAL_T_PAD,
+    O_WINDOW_ROWS,
+    attention_token_head_all_to_all_step,
+    decode_sharded_o_projection,
+    o_projection_reduce_scatter_step,
+)
+from decode_sparse_attn_csa import (
+    ATTN_K_TILE,
+    CMP_TOPK,
+    NOPE_DIM,
+    ROPE_DIM,
+    ROPE_CS_T_TILE,
+    SOFTMAX_SCALE,
+    T_PAD,
+    sparse_attn_csa,
+    sparse_attn_csa_heads,
+)
 
 # Dynamic shape variables.
 B_DYN = pl.dynamic("B_DYN")  # per-request axis
 T_DYN = pl.dynamic("T_DYN")  # T = B * S
 
 # model config
-B = DECODE_BATCH // TP
+B = DECODE_BATCH // TP_SIZE
 S = DECODE_SEQ
 T = B * S
 EPS = M.rms_norm_eps
@@ -82,6 +112,7 @@ IDX_TOPK = M.index_topk
 INDEXER_SCORE_LEN = MAX_SEQ_LEN // 4
 O_LORA = M.o_lora_rank
 O_GROUPS = M.o_groups
+HEADS_PER_GROUP = H // O_GROUPS
 O_GROUP_IN = H * HEAD_DIM // O_GROUPS
 
 # kernel-local
@@ -112,6 +143,52 @@ CMP_BLOCK_NUM_DYN = pl.dynamic("CMP_BLOCK_NUM_DYN")
 
 # tiling
 CSA_WB_TOKEN_TILE = 8
+
+# fixture
+FIXTURE_CMP_ENTRIES = (
+    (ATTN_K_TILE - 1, BLOCK_SIZE // 4 - 1),
+    (2 * ATTN_K_TILE - 1, BLOCK_SIZE),
+    (3 * ATTN_K_TILE - 1, 2 * BLOCK_SIZE),
+    (4 * ATTN_K_TILE - 1, 4 * BLOCK_SIZE - 3),
+)
+FIXTURE_FILTERED_POSITIONS = (1, ATTN_K_TILE + 1, 2 * ATTN_K_TILE + 1, 3 * ATTN_K_TILE + 1)
+FIXTURE_CMP_SLOTS = tuple(slot for _, slot in FIXTURE_CMP_ENTRIES)
+FIXTURE_CMP_LOGICAL_BLOCKS = (max(FIXTURE_CMP_SLOTS) + 1 + BLOCK_SIZE - 1) // BLOCK_SIZE
+FIXTURE_CMP_BOUND = 4 * BLOCK_SIZE - 2
+FIXTURE_FILTERED_SLOT = FIXTURE_CMP_BOUND
+FIXTURE_POSITION_ID = COMPRESS_RATIO * FIXTURE_CMP_BOUND - 1
+FIXTURE_WINDOW_HEAD = (FIXTURE_POSITION_ID - WIN + 1) % BLOCK_SIZE
+FIXTURE_WINDOW_BLOCKS = (FIXTURE_WINDOW_HEAD + WIN + BLOCK_SIZE - 1) // BLOCK_SIZE
+FIXTURE_CMP_BLOCKS = (LOCAL_T // S) * FIXTURE_CMP_LOGICAL_BLOCKS
+FIXTURE_OUTPUT_SENTINEL = -7.0
+
+if T != LOCAL_T:
+    raise ValueError(f"CSA token capacity {T} must equal TP local token capacity {LOCAL_T}")
+if T_PAD != LOCAL_T_PAD:
+    raise ValueError(f"CSA token capacity {T_PAD} must equal TP local token capacity {LOCAL_T_PAD}")
+if LOCAL_T < 2 * ROPE_CS_T_TILE:
+    raise ValueError("CSA fixture token capacity must leave one RoPE row tile for subcapacity")
+if LOCAL_T % ROPE_CS_T_TILE != 0:
+    raise ValueError("CSA fixture token capacity must align to the RoPE row tile")
+if (LOCAL_T - ROPE_CS_T_TILE) % S != 0:
+    raise ValueError("CSA fixture subcapacity must preserve whole decode requests")
+if max(position for position, _ in FIXTURE_CMP_ENTRIES) >= INDEXER_SCORE_LEN:
+    raise ValueError("CSA fixture compressed positions exceed the indexer score row")
+if max(position for position, _ in FIXTURE_CMP_ENTRIES) >= 4 * ATTN_K_TILE:
+    raise ValueError("CSA fixture compressed positions exceed the four sparse tiles")
+if max(FIXTURE_FILTERED_POSITIONS) >= CMP_TOPK:
+    raise ValueError("CSA fixture filtered positions exceed the compressed top-k row")
+if FIXTURE_FILTERED_SLOT >= FIXTURE_CMP_LOGICAL_BLOCKS * BLOCK_SIZE:
+    raise ValueError("CSA filtered slot must remain inside the fixture block table")
+if FIXTURE_WINDOW_BLOCKS > ORI_BLOCK_NUM:
+    raise ValueError("CSA fixture window exceeds the original KV cache capacity")
+if FIXTURE_CMP_LOGICAL_BLOCKS > CMP_MAX_BLOCKS:
+    raise ValueError("CSA fixture compressed slots exceed the compressed block table")
+if FIXTURE_CMP_BLOCKS > CMP_BLOCK_NUM:
+    raise ValueError("CSA fixture compressed-cache pool exceeds its physical capacity")
+if O_LORA < 4 * HEADS_PER_GROUP:
+    raise ValueError("CSA fixture output projection needs four observable rows per local head")
+
 
 @pl.jit.inline
 def attention_csa(
@@ -373,6 +450,128 @@ def attention_csa_test(
         x_out,
     )
     return x_out
+
+
+@pl.jit
+def decode_csa_output(
+    q: pl.Tensor[[T_DYN, H, HEAD_DIM], pl.BF16],
+    ori_kv: pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    window_swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
+    cmp_kv: pl.Tensor[[CMP_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    cmp_block_table: pl.Tensor[[B_DYN, CMP_MAX_BLOCKS], pl.INT32],
+    idx_topk: pl.Tensor[[T_DYN, INDEXER_SCORE_LEN], pl.INT32],
+    position_ids: pl.Tensor[[T_DYN, 1], pl.INT32],
+    attn_sink: pl.Tensor[[H], pl.FP32],
+    freqs_cos: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
+    wo_a: pl.Tensor[[LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
+    wo_b: pl.Tensor[[D, LOCAL_O_WIDTH], pl.INT8],
+    wo_b_scale: pl.Tensor[[D], pl.FP32],
+    o_local: pl.InOut[pl.Tensor[[LOCAL_T_PAD, D], pl.BF16]],
+    attention_window: pld.DistributedTensor[[ATTENTION_WINDOW_ROWS, O_GROUP_IN], pl.BF16],
+    attention_signal: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
+    o_window: pld.DistributedTensor[[O_WINDOW_ROWS, D], pl.FP32],
+    o_signal: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
+    group_base: pl.Scalar[pl.INT32],
+    tp_rank: pl.Scalar[pl.INT32],
+    local_t: pl.Scalar[pl.INT32],
+):
+    """Run rank-local CSA heads, output A2A, sharded O projection, and RS."""
+    q.bind_dynamic(0, T_DYN)
+    ori_kv.bind_dynamic(0, ORI_BLOCK_NUM_DYN)
+    window_swa_indices.bind_dynamic(0, T_DYN)
+    cmp_kv.bind_dynamic(0, CMP_BLOCK_NUM_DYN)
+    cmp_block_table.bind_dynamic(0, B_DYN)
+    idx_topk.bind_dynamic(0, T_DYN)
+    position_ids.bind_dynamic(0, T_DYN)
+    freqs_cos.bind_dynamic(0, T_DYN)
+    freqs_sin.bind_dynamic(0, T_DYN)
+
+    attention_grouped = pl.create_tensor([O_GROUPS * LOCAL_T_PAD, O_GROUP_IN], dtype=pl.BF16)
+    attention_grouped, _ = sparse_attn_csa_heads(
+        q, ori_kv, window_swa_indices,
+        cmp_kv, cmp_block_table, idx_topk,
+        position_ids, attn_sink, freqs_cos, freqs_sin,
+        attention_grouped,
+    )
+
+    attention_local_flat = pl.create_tensor([ATTENTION_WINDOW_ROWS, O_GROUP_IN], dtype=pl.BF16)
+    attention_local_flat, attention_signal = attention_token_head_all_to_all_step(
+        attention_grouped, attention_local_flat,
+        attention_window, attention_signal,
+        group_base, tp_rank, local_t,
+    )
+
+    attention_local_groups = pl.reshape(attention_local_flat, [LOCAL_O_GROUPS, GROUP_T_PAD, O_GROUP_IN])
+    o_partial = pl.create_tensor([GROUP_T_PAD, D], dtype=pl.FP32)
+    o_partial, projection_tid = decode_sharded_o_projection(
+        attention_local_groups,
+        wo_a, wo_b, wo_b_scale,
+        local_t, o_partial,
+    )
+
+    with pl.spmd(1, name_hint="tp_o_reduce_scatter", deps=[projection_tid]) as _reduce_scatter_tid:
+        o_local, o_signal = o_projection_reduce_scatter_step(
+            o_partial, o_local,
+            o_window, o_signal,
+            group_base, tp_rank, local_t,
+        )
+    return o_local, attention_signal, o_signal
+
+
+@pl.jit.host
+def l3_decode_csa_output(
+    q: pl.Tensor[[TP_SIZE, T_DYN, H, HEAD_DIM], pl.BF16],
+    ori_kv: pl.Tensor[[TP_SIZE, ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    window_swa_indices: pl.Tensor[[TP_SIZE, T_DYN, WIN], pl.INT32],
+    cmp_kv: pl.Tensor[[TP_SIZE, CMP_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    cmp_block_table: pl.Tensor[[TP_SIZE, B_DYN, CMP_MAX_BLOCKS], pl.INT32],
+    idx_topk: pl.Tensor[[TP_SIZE, T_DYN, INDEXER_SCORE_LEN], pl.INT32],
+    position_ids: pl.Tensor[[TP_SIZE, T_DYN, 1], pl.INT32],
+    attn_sink: pl.Tensor[[TP_SIZE, H], pl.FP32],
+    freqs_cos: pl.Tensor[[TP_SIZE, T_DYN, ROPE_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[TP_SIZE, T_DYN, ROPE_DIM], pl.BF16],
+    wo_a: pl.Tensor[[TP_SIZE, LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
+    wo_b: pl.Tensor[[TP_SIZE, D, LOCAL_O_WIDTH], pl.INT8],
+    wo_b_scale: pl.Tensor[[TP_SIZE, D], pl.FP32],
+    o_local: pl.InOut[pl.Tensor[[TP_SIZE, LOCAL_T_PAD, D], pl.BF16]],
+    local_t: pl.Scalar[pl.INT32],
+):
+    """Launch the CSA output path on one TP group."""
+    q.bind_dynamic(1, T_DYN)
+    ori_kv.bind_dynamic(1, ORI_BLOCK_NUM_DYN)
+    window_swa_indices.bind_dynamic(1, T_DYN)
+    cmp_kv.bind_dynamic(1, CMP_BLOCK_NUM_DYN)
+    cmp_block_table.bind_dynamic(1, B_DYN)
+    idx_topk.bind_dynamic(1, T_DYN)
+    position_ids.bind_dynamic(1, T_DYN)
+    freqs_cos.bind_dynamic(1, T_DYN)
+    freqs_sin.bind_dynamic(1, T_DYN)
+
+    attention_window_buf = pld.alloc_window_buffer([ATTENTION_WINDOW_ROWS, O_GROUP_IN], dtype=pl.BF16)
+    attention_signal_buf = pld.alloc_window_buffer([TP_SIZE, 1], dtype=pl.INT32)
+    o_window_buf = pld.alloc_window_buffer([O_WINDOW_ROWS, D], dtype=pl.FP32)
+    o_signal_buf = pld.alloc_window_buffer([TP_SIZE, 1], dtype=pl.INT32)
+
+    for rank in pl.range(pld.world_size()):
+        attention_window = pld.window(attention_window_buf, [ATTENTION_WINDOW_ROWS, O_GROUP_IN], dtype=pl.BF16)
+        attention_signal = pld.window(attention_signal_buf, [TP_SIZE, 1], dtype=pl.INT32)
+        o_window = pld.window(o_window_buf, [O_WINDOW_ROWS, D], dtype=pl.FP32)
+        o_signal = pld.window(o_signal_buf, [TP_SIZE, 1], dtype=pl.INT32)
+        decode_csa_output(
+            q[rank],
+            ori_kv[rank], window_swa_indices[rank],
+            cmp_kv[rank], cmp_block_table[rank], idx_topk[rank],
+            position_ids[rank], attn_sink[rank],
+            freqs_cos[rank], freqs_sin[rank],
+            wo_a[rank], wo_b[rank], wo_b_scale[rank],
+            o_local[rank],
+            attention_window, attention_signal,
+            o_window, o_signal,
+            0, rank, local_t,
+            device=rank,
+        )
+
 
 
 def golden_attention_csa(tensors):
@@ -908,51 +1107,352 @@ def build_tensor_specs(start_pos=None, batch=B):
     ]
 
 
+def build_tp_tensor_specs(local_t):
+    """Build deterministic tensor-parallel CSA output inputs."""
+    import torch
+
+    from golden import ScalarSpec, TensorSpec
+
+    if (local_t < ROPE_CS_T_TILE or local_t > LOCAL_T
+            or local_t % ROPE_CS_T_TILE != 0 or local_t % S != 0):
+        raise ValueError(
+            f"local_t must be a multiple of {ROPE_CS_T_TILE} "
+            f"in [{ROPE_CS_T_TILE}, {LOCAL_T}], got {local_t}"
+        )
+    local_batch = local_t // S
+    cmp_block_table_shape = [TP_SIZE, local_batch, CMP_MAX_BLOCKS]
+
+    def init_q():
+        q = torch.zeros(TP_SIZE, local_t, H, HEAD_DIM, dtype=torch.bfloat16)
+        rank = torch.arange(TP_SIZE, dtype=torch.float32).reshape(TP_SIZE, 1, 1)
+        token = torch.arange(local_t, dtype=torch.float32).reshape(1, local_t, 1)
+        head = torch.arange(H, dtype=torch.float32).reshape(1, 1, H)
+        q[..., 0] = (rank + token * 0.25 + head * 0.0625).to(torch.bfloat16)
+        return q
+
+    def init_ori_kv():
+        shape = (TP_SIZE, FIXTURE_WINDOW_BLOCKS, BLOCK_SIZE, 1, HEAD_DIM)
+        ori_kv = torch.zeros(shape, dtype=torch.bfloat16)
+        rank = torch.arange(TP_SIZE, dtype=torch.float32).reshape(TP_SIZE, 1, 1)
+        block = torch.arange(FIXTURE_WINDOW_BLOCKS, dtype=torch.float32).reshape(1, FIXTURE_WINDOW_BLOCKS, 1)
+        row = torch.arange(BLOCK_SIZE, dtype=torch.float32).reshape(1, 1, BLOCK_SIZE)
+        ori_kv[:, :, :, 0, 0] = 0.25
+        ori_kv[:, :, :, 0, 1] = (
+            (rank + 1.0) * 0.0625
+            + (block + 1.0) * 0.015625
+            + (row + 1.0) * 0.0001220703125
+        ).to(torch.bfloat16)
+        return ori_kv
+
+    def init_window_swa_indices():
+        logical_row = FIXTURE_WINDOW_HEAD + torch.arange(WIN, dtype=torch.int32)
+        logical_block = logical_row // BLOCK_SIZE
+        physical_block = FIXTURE_WINDOW_BLOCKS - 1 - logical_block
+        physical_row = logical_row % BLOCK_SIZE
+        window_row = physical_block * BLOCK_SIZE + physical_row
+        return window_row.reshape(1, 1, WIN).expand(TP_SIZE, local_t, WIN).clone()
+
+    def init_cmp_kv():
+        shape = (TP_SIZE, FIXTURE_CMP_BLOCKS, BLOCK_SIZE, 1, HEAD_DIM)
+        cmp_kv = torch.full(shape, float("nan"), dtype=torch.bfloat16)
+        for rank in range(TP_SIZE):
+            for request in range(local_batch):
+                request_block_base = request * FIXTURE_CMP_LOGICAL_BLOCKS
+                for entry_index, cmp_slot in enumerate(FIXTURE_CMP_SLOTS):
+                    logical_block = cmp_slot // BLOCK_SIZE
+                    physical_block = request_block_base + FIXTURE_CMP_LOGICAL_BLOCKS - 1 - logical_block
+                    row = cmp_slot % BLOCK_SIZE
+                    cmp_kv[rank, physical_block, row, 0, :] = 0.0
+                    cmp_kv[rank, physical_block, row, 0, 0] = 0.25
+                    cmp_kv[rank, physical_block, row, 0, 1] = (
+                        (rank + 1) * 0.03125
+                        + (request + 1) * 0.0078125
+                        + (entry_index + 1) * 0.001953125
+                    )
+                    cmp_kv[rank, physical_block, row, 0, NOPE_DIM] = (
+                        (rank + 1) * 0.0625
+                        + (request + 1) * 0.015625
+                        + (entry_index + 1) * 0.00390625
+                    )
+                    cmp_kv[rank, physical_block, row, 0, NOPE_DIM + 1] = (
+                        -(logical_block + 1) * 0.0625
+                        + (rank + 1) * 0.0078125
+                        + (request + 1) * 0.001953125
+                    )
+        return cmp_kv
+
+    def init_cmp_block_table():
+        table = torch.full(cmp_block_table_shape, -1, dtype=torch.int32)
+        for rank in range(TP_SIZE):
+            for request in range(local_batch):
+                request_block_base = request * FIXTURE_CMP_LOGICAL_BLOCKS
+                for logical_block in range(FIXTURE_CMP_LOGICAL_BLOCKS):
+                    table[rank, request, logical_block] = (
+                        request_block_base + FIXTURE_CMP_LOGICAL_BLOCKS - 1 - logical_block
+                    )
+        return table
+
+    def init_idx_topk():
+        topk = torch.full((TP_SIZE, local_t, INDEXER_SCORE_LEN), -1, dtype=torch.int32)
+        for position, cmp_slot in FIXTURE_CMP_ENTRIES:
+            topk[:, :, position] = cmp_slot
+        for position in FIXTURE_FILTERED_POSITIONS:
+            topk[:, :, position] = FIXTURE_FILTERED_SLOT
+        return topk
+
+    def init_position_ids():
+        return torch.full((TP_SIZE, local_t, 1), FIXTURE_POSITION_ID, dtype=torch.int32)
+
+    def init_attn_sink():
+        head = torch.arange(H, dtype=torch.int32).remainder(HEADS_PER_GROUP).to(torch.float32)
+        sink = 4.0 + head * 0.125
+        return sink.reshape(1, H).expand(TP_SIZE, H).clone()
+
+    def init_freqs_cos():
+        rank = torch.arange(TP_SIZE, dtype=torch.int32).reshape(TP_SIZE, 1, 1)
+        token = torch.arange(local_t, dtype=torch.int32).reshape(1, local_t, 1)
+        column = torch.arange(ROPE_DIM, dtype=torch.int32).reshape(1, 1, ROPE_DIM)
+        phase = (rank + token + column).remainder(4)
+        phase[:, :, HALF_ROPE:] = (phase[:, :, HALF_ROPE:] + 1).remainder(4)
+        values = torch.tensor((1.0, 0.0, -1.0, 0.0), dtype=torch.bfloat16)
+        return values[phase]
+
+    def init_freqs_sin():
+        rank = torch.arange(TP_SIZE, dtype=torch.int32).reshape(TP_SIZE, 1, 1)
+        token = torch.arange(local_t, dtype=torch.int32).reshape(1, local_t, 1)
+        column = torch.arange(ROPE_DIM, dtype=torch.int32).reshape(1, 1, ROPE_DIM)
+        phase = (rank + token + column).remainder(4)
+        phase[:, :, HALF_ROPE:] = (phase[:, :, HALF_ROPE:] + 1).remainder(4)
+        values = torch.tensor((0.0, 1.0, 0.0, -1.0), dtype=torch.bfloat16)
+        return values[phase]
+
+    def init_wo_a():
+        wo_a = torch.zeros(TP_SIZE, LOCAL_O_GROUPS, O_LORA, O_GROUP_IN, dtype=torch.bfloat16)
+        for rank in range(TP_SIZE):
+            for local_group in range(LOCAL_O_GROUPS):
+                shard_scale = (rank + 1) * (local_group + 1) * 0.125
+                for head in range(HEADS_PER_GROUP):
+                    wo_a[rank, local_group, head, head * HEAD_DIM] = shard_scale * (head + 1)
+                    wo_a[
+                        rank, local_group, HEADS_PER_GROUP + head,
+                        head * HEAD_DIM + 1,
+                    ] = shard_scale * (head + 1) * 0.75
+                    wo_a[
+                        rank, local_group, 2 * HEADS_PER_GROUP + head,
+                        head * HEAD_DIM + NOPE_DIM,
+                    ] = -shard_scale * (head + 1) * 0.5
+                    wo_a[
+                        rank, local_group, 3 * HEADS_PER_GROUP + head,
+                        head * HEAD_DIM + NOPE_DIM + 1,
+                    ] = shard_scale * (head + 1) * 0.25
+        return wo_a
+
+    def init_wo_b():
+        base = torch.arange(D * LOCAL_O_WIDTH, dtype=torch.int32).reshape(D, LOCAL_O_WIDTH)
+        rank = torch.arange(TP_SIZE, dtype=torch.int32).reshape(TP_SIZE, 1, 1)
+        return (base.unsqueeze(0) + rank).remainder(7).sub(3).to(torch.int8)
+
+    def init_wo_b_scale():
+        channel_scale = torch.arange(D, dtype=torch.int32).remainder(4).to(torch.float32) * 0.25 + 0.5
+        return channel_scale.reshape(1, D).expand(TP_SIZE, D).clone()
+
+    return [
+        TensorSpec("q", [TP_SIZE, local_t, H, HEAD_DIM], torch.bfloat16, init_value=init_q),
+        TensorSpec(
+            "ori_kv", [TP_SIZE, FIXTURE_WINDOW_BLOCKS, BLOCK_SIZE, 1, HEAD_DIM],
+            torch.bfloat16, init_value=init_ori_kv,
+        ),
+        TensorSpec("window_swa_indices", [TP_SIZE, local_t, WIN], torch.int32, init_value=init_window_swa_indices),
+        TensorSpec(
+            "cmp_kv", [TP_SIZE, FIXTURE_CMP_BLOCKS, BLOCK_SIZE, 1, HEAD_DIM],
+            torch.bfloat16, init_value=init_cmp_kv,
+        ),
+        TensorSpec("cmp_block_table", cmp_block_table_shape, torch.int32, init_value=init_cmp_block_table),
+        TensorSpec("idx_topk", [TP_SIZE, local_t, INDEXER_SCORE_LEN], torch.int32, init_value=init_idx_topk),
+        TensorSpec("position_ids", [TP_SIZE, local_t, 1], torch.int32, init_value=init_position_ids),
+        TensorSpec("attn_sink", [TP_SIZE, H], torch.float32, init_value=init_attn_sink),
+        TensorSpec("freqs_cos", [TP_SIZE, local_t, ROPE_DIM], torch.bfloat16, init_value=init_freqs_cos),
+        TensorSpec("freqs_sin", [TP_SIZE, local_t, ROPE_DIM], torch.bfloat16, init_value=init_freqs_sin),
+        TensorSpec("wo_a", [TP_SIZE, LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], torch.bfloat16, init_value=init_wo_a),
+        TensorSpec("wo_b", [TP_SIZE, D, LOCAL_O_WIDTH], torch.int8, init_value=init_wo_b),
+        TensorSpec("wo_b_scale", [TP_SIZE, D], torch.float32, init_value=init_wo_b_scale),
+        TensorSpec(
+            "o_local", [TP_SIZE, LOCAL_T_PAD, D], torch.bfloat16,
+            init_value=FIXTURE_OUTPUT_SENTINEL, is_output=True,
+        ),
+        ScalarSpec("local_t", torch.int32, local_t),
+    ]
+
+
+def golden_decode_csa_output(tensors):
+    """Compute the controlled CSA heads, sharded O projection, and reduced rows."""
+    import torch
+
+    local_t = int(tensors["local_t"])
+    group_t = TP_SIZE * local_t
+    observed_dims = torch.tensor((0, 1, NOPE_DIM, NOPE_DIM + 1), dtype=torch.int64)
+    q = tensors["q"].float()
+
+    window_indices = tensors["window_swa_indices"].long()
+    window_valid = window_indices >= 0
+    safe_window_indices = window_indices.clamp_min(0)
+    ori_rows = tensors["ori_kv"][:, :, :, 0].reshape(TP_SIZE, -1, HEAD_DIM)
+    ori_values = ori_rows[..., observed_dims].float()
+    window_sum = torch.zeros(TP_SIZE, local_t, len(observed_dims), dtype=torch.float32)
+    for rank in range(TP_SIZE):
+        gathered = ori_values[rank][safe_window_indices[rank]]
+        window_sum[rank] = (
+            gathered * window_valid[rank].unsqueeze(-1)
+        ).sum(dim=1)
+    window_count = window_valid.sum(dim=-1).to(torch.float32)
+
+    raw = tensors["idx_topk"][:, :, :CMP_TOPK].to(torch.int64)
+    bound = ((tensors["position_ids"][:, :, 0].to(torch.int64) + 1) // COMPRESS_RATIO).unsqueeze(-1)
+    keep = (raw >= 0) & (raw < bound)
+    cmp_rows = tensors["cmp_kv"][:, :, :, 0]
+    cmp_sum = torch.zeros_like(window_sum)
+    cmp_count = torch.zeros(TP_SIZE, local_t, dtype=torch.float32)
+    for rank in range(TP_SIZE):
+        for token in range(local_t):
+            request = token // S
+            valid_slots = raw[rank, token][keep[rank, token]]
+            cmp_count[rank, token] = valid_slots.numel()
+            for cmp_slot_tensor in valid_slots:
+                cmp_slot = int(cmp_slot_tensor.item())
+                logical_block = cmp_slot // BLOCK_SIZE
+                physical_block = int(tensors["cmp_block_table"][rank, request, logical_block].item())
+                cmp_sum[rank, token] += cmp_rows[
+                    rank, physical_block, cmp_slot % BLOCK_SIZE, observed_dims
+                ].float()
+
+    kv_sum = window_sum + cmp_sum
+    valid_count = window_count + cmp_count
+    scores = q[..., 0] * 0.25 * SOFTMAX_SCALE
+    sink = tensors["attn_sink"].float().reshape(TP_SIZE, 1, H)
+    denominator = valid_count.unsqueeze(-1) + torch.exp(sink - scores)
+    head_observed = kv_sum.unsqueeze(2) / denominator.unsqueeze(-1)
+    head_value = torch.zeros(TP_SIZE, local_t, H, HEAD_DIM, dtype=torch.float32)
+    head_value[..., observed_dims] = head_observed
+
+    rope_pair = head_value[..., NOPE_DIM:].unflatten(-1, (-1, 2))
+    rope_even = rope_pair[..., 0]
+    rope_odd = rope_pair[..., 1]
+    cos_half = tensors["freqs_cos"][..., :HALF_ROPE].float().unsqueeze(2)
+    sin_half = tensors["freqs_sin"][..., :HALF_ROPE].float().unsqueeze(2)
+    inverse_even = (rope_even * cos_half + rope_odd * sin_half).to(torch.bfloat16).float()
+    inverse_odd = (rope_odd * cos_half - rope_even * sin_half).to(torch.bfloat16).float()
+    inverse_rope = torch.stack((inverse_even, inverse_odd), dim=-1).flatten(-2)
+    head_value = torch.cat((head_value[..., :NOPE_DIM], inverse_rope), dim=-1).to(torch.bfloat16)
+
+    attention_grouped = head_value.reshape(
+        TP_SIZE, local_t, O_GROUPS, HEADS_PER_GROUP, HEAD_DIM,
+    )
+    attention_grouped = attention_grouped.permute(0, 2, 1, 3, 4)
+    attention_grouped = attention_grouped.reshape(
+        TP_SIZE, O_GROUPS, local_t, O_GROUP_IN,
+    )
+
+    attention_local = torch.zeros(TP_SIZE, LOCAL_O_GROUPS, group_t, O_GROUP_IN, dtype=torch.bfloat16)
+    for destination_rank in range(TP_SIZE):
+        for local_group in range(LOCAL_O_GROUPS):
+            global_group = destination_rank * LOCAL_O_GROUPS + local_group
+            group_rows = attention_grouped[:, global_group].reshape(group_t, O_GROUP_IN)
+            attention_local[destination_rank, local_group] = group_rows
+
+    partials = torch.zeros(TP_SIZE, group_t, D, dtype=torch.float32)
+    for rank in range(TP_SIZE):
+        attention = attention_local[rank].float()
+        o_a = torch.einsum("gti,gri->gtr", attention, tensors["wo_a"][rank].float())
+        row_amax = o_a.abs().amax(dim=-1, keepdim=True).clamp_min(INT8_AMAX_EPS)
+        scale_q = INT8_SCALE_MAX / row_amax
+        o_a_i8 = torch.round(o_a * scale_q).to(torch.int32).to(torch.float16).to(torch.int8)
+        scale_dq = 1.0 / scale_q
+        wo_b = tensors["wo_b"][rank].reshape(D, LOCAL_O_GROUPS, O_LORA)
+        for local_group in range(LOCAL_O_GROUPS):
+            group_i32 = o_a_i8[local_group].to(torch.int32)
+            weight_i32 = wo_b[:, local_group].to(torch.int32)
+            group_partial = group_i32 @ weight_i32.T
+            partials[rank] += group_partial.float() * scale_dq[local_group]
+        partials[rank] *= tensors["wo_b_scale"][rank].float().reshape(1, D)
+
+    reduced = partials.sum(dim=0)
+    tensors["o_local"].fill_(FIXTURE_OUTPUT_SENTINEL)
+    for rank in range(TP_SIZE):
+        row_start = rank * local_t
+        tensors["o_local"][rank, :local_t] = reduced[row_start : row_start + local_t].to(torch.bfloat16)
+
+
+def build_o_local_compare(local_t):
+    """Compare valid token rows and require the poisoned capacity tail to survive."""
+    import torch
+
+    from golden import ratio_allclose
+
+    prefix_compare = ratio_allclose(
+        atol=1e-4, rtol=1.0 / 128, max_error_ratio=0.005,
+        valid_rows=local_t, valid_axis=1,
+    )
+
+    def compare(actual, expected, **kwargs):
+        actual_tail = actual[:, local_t:]
+        expected_tail = expected[:, local_t:]
+        if not torch.equal(actual_tail, expected_tail):
+            mismatch_count = int((actual_tail != expected_tail).sum().item())
+            return False, f"    inactive token tail mismatch count={mismatch_count}"
+        return prefix_compare(actual, expected, **kwargs)
+
+    compare.__name__ = f"csa_output_prefix_and_tail(local_t={local_t})"
+    return compare
+
+
 if __name__ == "__main__":
     import argparse
-    from golden import ratio_allclose, ratio_reldiff, run_jit
+
+    from golden import run_jit
+    from pypto.ir.distributed_compiled_program import DistributedConfig
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("-p", "--platform", type=str, default="a2a3", choices=["a2a3", "a2a3sim", "a5", "a5sim"])
-    parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("-b", "--batch", type=int, default=B,
-                        help=f"runtime request count; a multiple of 4 up to {B} (the compile-time "
-                             "upper bound). The token axis is pl.dynamic, so one compiled program "
-                             "serves every value.")
-    parser.add_argument("--start-pos", type=int, default=None,
-                        help="Uniform fixture-only start_pos override for all batches; "
-                             "default (unset) uses the canonical per-batch CSA set that includes the 8k point.")
-    parser.add_argument("--enable-l2-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2, 4))
-    parser.add_argument("--runtime-dir", type=str, default=None)
-    parser.add_argument("--golden-data", type=str, default=None,
-                        help="Reuse a prior run's data/{in,out} (skips golden recompute); "
-                             "requires an unchanged spec set.")
+    parser.add_argument("-p", "--platform", type=str, default="a2a3",
+                        choices=["a2a3", "a2a3sim", "a5", "a5sim"])
+    parser.add_argument("--tp", type=int, default=TP_SIZE, choices=list(_TP_CHOICES),
+                        help="tensor-parallel world size")
+    parser.add_argument("-d", "--device", type=str, default=",".join(str(rank) for rank in range(TP_SIZE)),
+                        help=f"comma-separated device ids; need exactly {TP_SIZE}")
+    parser.add_argument("--case", choices=("all", "max", "subcapacity"), default="all")
+    parser.add_argument("--compile-only", action="store_true", default=False)
     parser.add_argument("--dump-passes", action="store_true", default=False)
     args = parser.parse_args()
-    if args.batch < 4 or args.batch > B or args.batch % 4 != 0:
-        parser.error(f"--batch must be a multiple of 4 in [4, {B}], got {args.batch}")
 
-    result = run_jit(
-        fn=attention_csa_test,
-        specs=build_tensor_specs(args.start_pos, batch=args.batch),
-        golden_fn=golden_attention_csa,
-        runtime_dir=args.runtime_dir,
-        golden_data=args.golden_data,
-        compile_cfg=dict(dump_passes=args.dump_passes),
-        runtime_cfg=dict(
-            platform=args.platform,
-            device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
-        ),
-        rtol=1e-2,
-        atol=1e-2,
-        compare_fn={
-            # Tightened from CANN's 1e-2 bar while allowing one BF16 step around unit-scale values.
-            "x_out": ratio_reldiff(diff_thd=4e-3, pct_thd=0.008, max_diff_hd=1),
-            "kv_cache": ratio_allclose(atol=1e-4, rtol=1.0 / 128),
-        },
-    )
-    if not result.passed:
-        if result.error:
-            print(result.error)
-        raise SystemExit(1)
+    if args.tp != TP_SIZE:
+        parser.error(f"--tp must remain {TP_SIZE} after import-time specialization")
+    try:
+        device_ids = [int(device) for device in args.device.split(",")]
+    except ValueError:
+        parser.error(f"--device must be a comma-separated integer list, got {args.device!r}")
+    if len(device_ids) != TP_SIZE:
+        parser.error(f"need exactly {TP_SIZE} devices, got {device_ids}")
+    if any(device < 0 for device in device_ids):
+        parser.error(f"--device IDs must be non-negative, got {device_ids}")
+    if len(set(device_ids)) != TP_SIZE:
+        parser.error(f"need {TP_SIZE} distinct devices, got {device_ids}")
+
+    case_local_t = {"max": LOCAL_T, "subcapacity": LOCAL_T - ROPE_CS_T_TILE}
+    selected_cases = tuple(case_local_t) if args.case == "all" else (args.case,)
+    for case in selected_cases:
+        local_t = case_local_t[case]
+        result = run_jit(
+            fn=l3_decode_csa_output,
+            specs=build_tp_tensor_specs(local_t),
+            golden_fn=golden_decode_csa_output,
+            compile_only=args.compile_only,
+            compile_cfg=dict(
+                dump_passes=args.dump_passes,
+                distributed_config=DistributedConfig(device_ids=device_ids, num_sub_workers=0),
+            ),
+            runtime_cfg=dict(platform=args.platform),
+            compare_fn={"o_local": build_o_local_compare(local_t)},
+        )
+        if not result.passed:
+            if result.error:
+                print(result.error)
+            raise SystemExit(1)

--- a/models/deepseek_v4_flash_dspark/decode_sparse_attn_csa.py
+++ b/models/deepseek_v4_flash_dspark/decode_sparse_attn_csa.py
@@ -28,6 +28,7 @@ from config import (
     INT8_SCALE_MAX,
     INT8_AMAX_EPS,
 )
+from decode_o_proj import decode_o_proj_tp1
 
 
 # Dynamic shape variables.
@@ -72,24 +73,8 @@ H_TILE = 16
 QK_M_TILE = 32           # qk_pv M rows per QK/PV matmul; QK_M_TILE/H_TILE-way KV L1->L0 reuse
 ATTN_K_TILE = 128
 NUM_QK_CORES = 24        # qk_pv dispatch lanes = a2a3 AIC count; re-sweep for other AIC counts
-A_K_TILE = 256           # proj_a cube K frag
-PROJ_A_MM_N_TILE = 128   # proj_a cube N frag
 T_PAD = ((T + 16 - 1) // 16) * 16  # T padded up to the 16-row cube M floor
-MM_T_TILE = T_PAD  # one cube M tile spans every token row of the T_PAD-strided scratch
 ROPE_CS_T_TILE = 8    # rope cos/sin row block; T is a multiple of 8 by the batch contract
-PROJ_A_ROW_TILE = 16  # proj_a cube M; row-blocked so unwritten pad rows never enter the matmul
-PA_N_FRAGS = O_LORA // PROJ_A_MM_N_TILE
-B_K_TILE = 256           # proj_b_mm cube K frag
-# proj_b_mm cube N frag; Acc = MM_T_TILE*N*4 = 128KB sits exactly on the a2a3 L0C wall.
-PROJ_B_MM_N_TILE = 256
-PROJ_B_ACT_N_TILE = 512  # proj_b_act vector N frag
-PROJ_B_ACT_N_REGS = D // PROJ_B_ACT_N_TILE
-# Fused amax+quant token tile. 8 keeps the [1, QUANT_TOKEN_TILE] fp32 amax tile
-# 32-byte aligned (8*4=32B, the alloc-tile row floor).
-QUANT_TOKEN_TILE = 8
-PROJ_B_D_TILE = 512      # proj_b_mm D chunk per task; its N frags loop inside the task
-PROJ_B_ACT_T_TILE = 8    # proj_b_act inner token tile for the O_GROUPS-way INT32->FP32 accumulate
-PROJ_B_ACT_TASK_T_TILE = 8   # proj_b_act token block per task
 TOPK = WIN + CMP_TOPK
 # Floor to 2: a single sparse-K block miscompiles in pypto (S-stride cross-token
 # output mixup); a 2-block build with an all-invalid 2nd block is bit-exact.
@@ -143,14 +128,12 @@ def sparse_attn_csa_heads(
     # lose its WAR edge against the qk_pv gather read. add_inout is a param-level
     # property, so this one no-op tile self-copy suffices.
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="kv_touch", allow_early_resolve=True):
-        ori_kv_flat[0:T, 0:HEAD_DIM] = ori_kv_flat[0:T, 0:HEAD_DIM]
+        ori_kv_flat[0:1, 0:HEAD_DIM] = ori_kv_flat[0:1, 0:HEAD_DIM]
 
-    # qk_plan compacts the T*SPARSE_BLOCKS (token, sparse-block) work items into
+    # qk_plan compacts the t_dim * SPARSE_BLOCKS (token, sparse-block) work items into
     # qk_order[] -- non-empty tiles (valid_block_mask > 0) first, empty tiles
     # appended -- through one running write cursor, so qk_pv's NUM_QK_CORES lanes
-    # take the heavy tiles one-per-lane before any lane takes a second. The
-    # T/SPARSE_BLOCKS scan loops are trace-time unrolled so the cursor
-    # read-modify-write is an explicit sequential chain.
+    # take the heavy tiles one-per-lane before any lane takes a second.
     sparse_bias = pl.create_tensor([t_dim, PADDED_TOPK], dtype=pl.FP32)
     cmp_sparse_indices = pl.create_tensor([t_dim, CMP_TOPK], dtype=pl.INT32)
     valid_block_mask = pl.create_tensor([t_dim, SPARSE_BLOCKS], dtype=pl.INT32)
@@ -198,17 +181,15 @@ def sparse_attn_csa_heads(
 
         pl.write(qk_wcur, [0], pl.cast(0, pl.INT32))
         # Pass 1: non-empty tiles to the front of qk_order.
-        for plan_t in pl.unroll(T):  # static upper bound; the guard below drops absent tokens
-            for plan_sb in pl.unroll(SPARSE_BLOCKS):
-              if plan_t < t_dim:
+        for plan_t in pl.range(t_dim):
+            for plan_sb in pl.range(SPARSE_BLOCKS):
                 if pl.read(valid_block_mask, [plan_t, plan_sb]) > 0:
                     plan_w = pl.read(qk_wcur, [0])
                     pl.write(qk_order, [plan_w], pl.cast(plan_t * SPARSE_BLOCKS + plan_sb, pl.INT32))
                     pl.write(qk_wcur, [0], pl.cast(plan_w + 1, pl.INT32))
         # Pass 2: empty tiles appended to the tail.
-        for plan_t in pl.unroll(T):  # static upper bound; the guard below drops absent tokens
-            for plan_sb in pl.unroll(SPARSE_BLOCKS):
-              if plan_t < t_dim:
+        for plan_t in pl.range(t_dim):
+            for plan_sb in pl.range(SPARSE_BLOCKS):
                 if pl.read(valid_block_mask, [plan_t, plan_sb]) <= 0:
                     plan_w = pl.read(qk_wcur, [0])
                     pl.write(qk_order, [plan_w], pl.cast(plan_t * SPARSE_BLOCKS + plan_sb, pl.INT32))
@@ -228,7 +209,7 @@ def sparse_attn_csa_heads(
         qk_core = pl.tile.get_block_idx()
         # Items for this lane: qk_core, qk_core + NUM_QK_CORES, ...  The per-lane
         # count is derived from the lane index (no stored per-core count); a lane
-        # with index >= QK_ITEMS runs zero iterations.
+        # with index >= qk_items runs zero iterations.
         qk_lane_iters = (qk_items - qk_core + NUM_QK_CORES - 1) // NUM_QK_CORES
         for qk_it in pl.range(qk_lane_iters):
             qk_flat = qk_core + qk_it * NUM_QK_CORES
@@ -423,132 +404,6 @@ def sparse_attn_csa_heads(
 
 
 @pl.jit.inline
-def sparse_attn_csa_local_o_proj(
-    o_packed: pl.Tensor[[O_GROUPS * T_PAD, O_GROUP_IN], pl.BF16],
-    wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
-    wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
-    wo_b_scale: pl.Tensor[[D], pl.FP32],
-    attn_out: pl.Tensor[[T_DYN, D], pl.BF16],
-    heads_dep: pl.Scalar[pl.TASK_ID],
-):
-    """Project local-token, full-group CSA heads into BF16 hidden rows."""
-    t_dim = pl.tensor.dim(attn_out, 0)
-    act_t_blks = t_dim // PROJ_B_ACT_TASK_T_TILE
-    proj_a_rows = (t_dim + PROJ_A_ROW_TILE - 1) // PROJ_A_ROW_TILE
-
-    # Back-to-back grouped output projection: proj_a[g] -> quant[g] -> proj_b[g]
-    # pipelines per group, because the PER-GROUP amax keeps the quant reduction
-    # inside one O_LORA group instead of barriering the whole row. manual_scope
-    # suppresses auto-dep, so every edge is explicit: proj_a waits on merge_norm,
-    # quant[g] on proj_a[g], proj_b[g] on quant[g]. proj_b_act combines the group
-    # partials with their row scales and is the consolidated attn_out writer.
-    o_r_pad = pl.create_tensor([T_PAD, O_GROUPS * O_LORA], dtype=pl.FP32)
-    o_r_i8_pad = pl.create_tensor([T_PAD, O_GROUPS * O_LORA], dtype=pl.INT8)
-    act_scale_dq = pl.create_tensor([O_GROUPS, T_PAD], dtype=pl.FP32)
-    # Per-group INT32 partials: proj_b_mm writes group g's contribution to output
-    # channel n at partials[:, g*D + n]. No atomic-add -> no zero-seed.
-    partials = pl.create_tensor([T_PAD, O_GROUPS * D], dtype=pl.INT32)
-    proj_b_tids = pl.array.create(O_GROUPS, pl.TASK_ID)
-
-    with pl.manual_scope():
-        for g in pl.parallel(O_GROUPS):
-            row_base_o = g * T_PAD
-            out_col_g = g * O_LORA
-
-            with pl.spmd(proj_a_rows * PA_N_FRAGS, name_hint="proj_a_mm", deps=[heads_dep],
-                         allow_early_resolve=True) as pa_tid:
-                pa_unit = pl.tile.get_block_idx()
-                pa_rb = pa_unit // PA_N_FRAGS  # row block outermost
-                nf = pa_unit - pa_rb * PA_N_FRAGS
-                pa_r0 = pa_rb * PROJ_A_ROW_TILE
-                pa_rows = pl.min(PROJ_A_ROW_TILE, t_dim - pa_r0)
-                pa_src0 = row_base_o + pa_r0
-                n0 = nf * PROJ_A_MM_N_TILE
-                xa0_chunk = pl.slice(o_packed, [PROJ_A_ROW_TILE, A_K_TILE], [pa_src0, 0], valid_shape=[pa_rows, A_K_TILE])
-                wa0_chunk = wo_a[g : g + 1, n0 : n0 + PROJ_A_MM_N_TILE, 0:A_K_TILE]
-                acc_a = pl.matmul(xa0_chunk, wa0_chunk, b_trans=True, out_dtype=pl.FP32)
-                for kb in pl.pipeline(1, O_GROUP_IN // A_K_TILE, stage=2):
-                    k0 = kb * A_K_TILE
-                    xa_k_chunk = pl.slice(o_packed, [PROJ_A_ROW_TILE, A_K_TILE], [pa_src0, k0], valid_shape=[pa_rows, A_K_TILE])
-                    wa_k_chunk = wo_a[g : g + 1, n0 : n0 + PROJ_A_MM_N_TILE, k0 : k0 + A_K_TILE]
-                    acc_a = pl.matmul_acc(acc_a, xa_k_chunk, wa_k_chunk, b_trans=True)
-                # acc_a is 3D (wo_a keeps its group axis), which subscript-write cannot express.
-                o_r_pad = pl.assemble(o_r_pad, acc_a, [pa_r0, out_col_g + n0])
-
-            col_g = g * O_LORA
-            with pl.at(level=pl.Level.CORE_GROUP, name_hint="quant", deps=[pa_tid], allow_early_resolve=True) as q_tid:
-                for qt in pl.pipeline(0, t_dim, QUANT_TOKEN_TILE, stage=2):
-                    oc_amax = o_r_pad[qt : qt + QUANT_TOKEN_TILE, col_g : col_g + O_LORA]
-                    g_abs = pl.abs(oc_amax)
-                    g_row_max = pl.row_max(g_abs)
-                    g_row_max = pl.reshape(g_row_max, [1, QUANT_TOKEN_TILE])
-                    g_amax_floor = pl.full([1, QUANT_TOKEN_TILE], dtype=pl.FP32, value=INT8_AMAX_EPS)
-                    g_amax = pl.maximum(g_amax_floor, g_row_max)
-                    g_scale_num = pl.full([1, QUANT_TOKEN_TILE], dtype=pl.FP32, value=INT8_SCALE_MAX)
-                    g_sq_row = pl.div(g_scale_num, g_amax)
-                    act_scale_dq[g : g + 1, qt : qt + QUANT_TOKEN_TILE] = pl.recip(g_sq_row)
-                    g_sq_col = pl.reshape(g_sq_row, [QUANT_TOKEN_TILE, 1])
-                    oc_q = o_r_pad[qt : qt + QUANT_TOKEN_TILE, col_g : col_g + O_LORA]
-                    oq_scaled = pl.row_expand_mul(oc_q, g_sq_col)
-                    oq_i32 = pl.cast(oq_scaled, target_type=pl.INT32, mode="rint")
-                    oq_half = pl.cast(oq_i32, target_type=pl.FP16, mode="round")
-                    oq_i8 = pl.cast(oq_half, target_type=pl.INT8, mode="trunc")
-                    o_r_i8_pad[qt : qt + QUANT_TOKEN_TILE, col_g : col_g + O_LORA] = oq_i8
-                # Zero the rows past the runtime token count; proj_b_mm reads the full T_PAD extent.
-                for zt in pl.range(t_dim, T_PAD, QUANT_TOKEN_TILE):
-                    zero_half = pl.full([QUANT_TOKEN_TILE, O_LORA], dtype=pl.FP16, value=0.0)
-                    o_r_i8_pad[zt : zt + QUANT_TOKEN_TILE, col_g : col_g + O_LORA] = pl.cast(
-                        zero_half, target_type=pl.INT8, mode="trunc")
-
-            with pl.spmd(D // PROJ_B_D_TILE, name_hint="proj_b_mm", deps=[q_tid], allow_early_resolve=True) as pb_tid:
-                dc = pl.tile.get_block_idx()
-                d0 = dc * PROJ_B_D_TILE
-                for nf in pl.range(PROJ_B_D_TILE // PROJ_B_MM_N_TILE):
-                    n0 = d0 + nf * PROJ_B_MM_N_TILE
-                    acc_b = pl.create_tensor([MM_T_TILE, PROJ_B_MM_N_TILE], dtype=pl.INT32)
-                    for kb in pl.pipeline(0, O_LORA // B_K_TILE, stage=2):
-                        k0 = col_g + kb * B_K_TILE
-                        if kb == 0:
-                            b_act = o_r_i8_pad[:, col_g : col_g + B_K_TILE]
-                            b_weight = wo_b[n0 : n0 + PROJ_B_MM_N_TILE, col_g : col_g + B_K_TILE]
-                            acc_b = pl.matmul(b_act, b_weight, b_trans=True, out_dtype=pl.INT32)
-                        else:
-                            b_act = o_r_i8_pad[:, k0 : k0 + B_K_TILE]
-                            b_weight = wo_b[n0 : n0 + PROJ_B_MM_N_TILE, k0 : k0 + B_K_TILE]
-                            acc_b = pl.matmul_acc(acc_b, b_act, b_weight, b_trans=True)
-                    partials[0:MM_T_TILE, g * D + n0 : g * D + n0 + PROJ_B_MM_N_TILE] = acc_b
-            proj_b_tids[g] = pb_tid
-
-    # proj_b_act sums the O_GROUPS INT32 partials -- each dequantized by its group's
-    # per-row act scale -- then applies the per-channel weight scale -> BF16. Explicit
-    # deps on all proj_b_mm tasks bridge manual_scope -> the return's auto-dep.
-    with pl.spmd(act_t_blks * PROJ_B_ACT_N_REGS, name_hint="proj_b_act",
-                 deps=[proj_b_tids[i] for i in range(O_GROUPS)], allow_early_resolve=True) as _act_tid:
-        act_idx = pl.tile.get_block_idx()
-        tblk = act_idx // PROJ_B_ACT_N_REGS  # token block outermost
-        nreg = act_idx - tblk * PROJ_B_ACT_N_REGS
-        ob_n0 = nreg * PROJ_B_ACT_N_TILE
-        t0 = tblk * PROJ_B_ACT_TASK_T_TILE
-        wb_scale = wo_b_scale[ob_n0 : ob_n0 + PROJ_B_ACT_N_TILE]
-        wb_scale_chunk = pl.reshape(wb_scale, [1, PROJ_B_ACT_N_TILE])
-        for b_tb in pl.range(t0, t0 + PROJ_B_ACT_TASK_T_TILE, PROJ_B_ACT_T_TILE):
-            acc = pl.full([PROJ_B_ACT_T_TILE, PROJ_B_ACT_N_TILE], dtype=pl.FP32, value=0.0)
-            for act_g in pl.pipeline(O_GROUPS, stage=2):
-                p_col0 = act_g * D + ob_n0
-                p_g = partials[b_tb : b_tb + PROJ_B_ACT_T_TILE, p_col0 : p_col0 + PROJ_B_ACT_N_TILE]
-                g_scale_row = act_scale_dq[act_g : act_g + 1, b_tb : b_tb + PROJ_B_ACT_T_TILE]
-                g_scale = pl.reshape(g_scale_row, [PROJ_B_ACT_T_TILE, 1])
-                p_g_f32 = pl.cast(p_g, target_type=pl.FP32, mode="none")
-                p_g_scaled = pl.row_expand_mul(p_g_f32, g_scale)
-                acc = pl.add(acc, p_g_scaled)
-            out_t = pl.col_expand_mul(acc, wb_scale_chunk)
-            out_bf16 = pl.cast(out_t, target_type=pl.BF16, mode="rint")
-            attn_out[b_tb : b_tb + PROJ_B_ACT_T_TILE, ob_n0 : ob_n0 + PROJ_B_ACT_N_TILE] = out_bf16
-
-    return attn_out
-
-
-@pl.jit.inline
 def sparse_attn_csa(
     q: pl.Tensor[[T_DYN, H, HEAD_DIM], pl.BF16],
     ori_kv: pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
@@ -575,7 +430,7 @@ def sparse_attn_csa(
         freqs_cos, freqs_sin,
         o_packed_heads,
     )
-    attn_out = sparse_attn_csa_local_o_proj(
+    attn_out = decode_o_proj_tp1(
         o_packed_heads,
         wo_a, wo_b, wo_b_scale,
         attn_out, heads_dep,


### PR DESCRIPTION
- Chain CSA heads through configurable TP token/head exchange, sharded
  output projection, and dependency-ordered FP32 reduce-scatter.
- Consolidate TP1/2/4 max and subcapacity fixtures into the CSA
  entrypoint.
- Reuse the shared TP1 output projection and bound sparse planning by the
  runtime token count.
