### PR TITLE
Fix: build qwen3 paged-attention CCE against both runtime ABIs

### DIFF
--- a/models/qwen3_14b/kernels/paged_attention_cce/kernel/fai_body.hpp
+++ b/models/qwen3_14b/kernels/paged_attention_cce/kernel/fai_body.hpp
@@ -28,7 +28,7 @@
 #endif
 
 #include "intrinsic.h"
-#include "tensor.h"
+#include "runtime_tensor_compat.hpp"
 
 #include "../generated/kernel_tiling/kernel_tiling.h"
 #include "metadata_layout.h"
@@ -68,7 +68,8 @@ acquire_qwen_fai_metadata(GM_ADDR metadata) {
 template <typename T>
 static __aicore__ __attribute__((always_inline)) GM_ADDR
 tensor_data(__gm__ int64_t *args, int32_t index) {
-  __gm__ Tensor *tensor = reinterpret_cast<__gm__ Tensor *>(args[index]);
+  __gm__ PyPTORuntimeTensor *tensor =
+      reinterpret_cast<__gm__ PyPTORuntimeTensor *>(args[index]);
   __gm__ T *data =
       reinterpret_cast<__gm__ T *>(tensor->buffer.addr) + tensor->start_offset;
   return reinterpret_cast<GM_ADDR>(data);

--- a/models/qwen3_14b/kernels/paged_attention_cce/kernel/runtime_tensor_compat.hpp
+++ b/models/qwen3_14b/kernels/paged_attention_cce/kernel/runtime_tensor_compat.hpp
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) PyPTO Contributors.
+ * This program is free software, you can redistribute it and/or modify it under
+ * the terms and conditions of CANN Open Software License Agreement Version 2.0.
+ * Please refer to the LICENSE file in the root of the software repository.
+ */
+
+#ifndef PYPTO_QWEN_RUNTIME_TENSOR_COMPAT_HPP
+#define PYPTO_QWEN_RUNTIME_TENSOR_COMPAT_HPP
+
+#include "tensor.h"
+
+// Simpler's address-free Buffer ABI added task_interface/buffer.h and renamed
+// the device-side Tensor descriptor to ChipTensor.  Keep this external kernel
+// source compilable with both the preceding PyPTO runtime and the new ABI so
+// the pypto-lib compatibility change can land before PyPTO updates its pin.
+#if __has_include("task_interface/buffer.h")
+using PyPTORuntimeTensor = ChipTensor;
+#else
+using PyPTORuntimeTensor = Tensor;
+#endif
+
+#endif  // PYPTO_QWEN_RUNTIME_TENSOR_COMPAT_HPP

--- a/models/qwen3_14b/kernels/paged_attention_cce/tiling/entry.cpp
+++ b/models/qwen3_14b/kernels/paged_attention_cce/tiling/entry.cpp
@@ -11,7 +11,7 @@
 
 #include <cstdint>
 
-#include "tensor.h"
+#include "../kernel/runtime_tensor_compat.hpp"
 
 #ifdef __CPU_SIM
 #ifndef __gm__
@@ -34,7 +34,7 @@ namespace {
 
 template <typename T>
 static __aicore__ __attribute__((always_inline)) __gm__ T *tensor_data(__gm__ int64_t *args, int32_t index) {
-    __gm__ Tensor *tensor = reinterpret_cast<__gm__ Tensor *>(args[index]);
+    __gm__ PyPTORuntimeTensor *tensor = reinterpret_cast<__gm__ PyPTORuntimeTensor *>(args[index]);
     return reinterpret_cast<__gm__ T *>(tensor->buffer.addr) + tensor->start_offset;
 }
 


### PR DESCRIPTION
- Add runtime_tensor_compat.hpp, which probes for the runtime-only
  task_interface/buffer.h header and aliases PyPTORuntimeTensor to
  ChipTensor when that header exists and to Tensor otherwise.
- Cast through PyPTORuntimeTensor at the two runtime-descriptor access
  points, in the FAI kernel body and in the paged-attention tiling
  entry, replacing their direct "tensor.h" includes.
- Keep reading tensor data as buffer.addr + start_offset, so argument
  layout, offsets, and device-address calculation are unchanged on the
  AIC, AIV, RoPE, and non-RoPE paths.

Simpler renamed the device-side Tensor descriptor to ChipTensor in its
address-free Buffer ABI. The alias lets pypto-lib compile against both
that runtime and the currently pinned one, so this change can land
before hw-native-sys/pypto#2273 moves the runtime pin; it can be
dropped once the legacy runtime is no longer supported.