### PR TITLE
Add: DeepSeek V4 Pro staged EP2 execution smoke

### DIFF
--- a/docs/models/deepseek_v4_pro.md
+++ b/docs/models/deepseek_v4_pro.md
@@ -17,7 +17,7 @@ is the same architecture at a shorter sequence budget.
 | Decode context length | up to 16,384 positions (`KERNEL_MAX_SEQ_LEN`), 128-token pages |
 | Prefill shape | one request of 128 tokens per program |
 | Platform | Ascend A5 (`-p a5`); the parsers also accept A2/A3 and both simulators |
-| Expert parallelism | `--ep 2/4/8`, `384 / ep` routed experts per rank |
+| Expert parallelism | EP8 deployment: 384 global / 48 per rank; reduced EP2/EP4 smoke fixtures keep 48 per rank |
 | LM-head parallelism | `--tp 2/4/8` vocab shards; `LM_HEAD_TP_SIZE = 8` is the deployment value |
 | Other components | no tensor parallelism — attention is data-parallel, MoE is expert-parallel |
 | Quantization | Hybrid MXFP8-MXFP4 — MXFP8 for the dense path, MXFP4 for the routed-expert weights |
@@ -35,6 +35,39 @@ stand-in with the same tensor split as
 [V4-Flash](deepseek_v4_flash_mtp.md#what-is-quantized): `gen_routed_weight` in
 [expert_routed.py](../../models/deepseek_v4_pro/expert_routed.py) re-quantizes
 off the MXFP4 grid into INT8 rather than feeding the cube MXFP4 weights.
+
+### Staged EP2 execution smoke
+
+The draft staged drivers execute all 61 main-model layers in order while
+keeping one layer's synthetic weights live at a time. They compile four
+attention/routing specializations, chain `x_next` and each layer's mutable
+attention state across rounds, then run `hc_head` and the final RMSNorm.
+
+This path is an execution smoke rather than a numerical validation:
+
+- `smoke_weights=True` uses zero INT8 routed/shared expert payloads and unit
+  FP32 scales; native MXFP8-MXFP4 is not exercised.
+- The EP2 fixture keeps 48 routed experts per rank, or 96 globally. The
+  deployment configuration remains 384 global experts at EP8.
+- The drivers pass no golden function or replay data. A successful run covers
+  compilation, runtime scheduling, EP dispatch/combine, cache/state chaining,
+  and output shapes, but not output values.
+- Embedding, MTP, the standalone LM head, and logits are omitted; execution
+  ends at the normalized hidden state.
+
+Select a PTOAS build with operation fusion disabled for bring-up runs:
+
+```bash
+export PTOAS_ROOT=/path/to/ptoas-nofuse
+
+task-submit --device auto --device-num 2 --env PTOAS_ROOT --max-time 0 --run \
+  "python models/deepseek_v4_pro/decode_fwd_staged_draft.py \
+  -p a5 --ep 2 -d \$TASK_DEVICE --rounds 2"
+
+task-submit --device auto --device-num 2 --env PTOAS_ROOT --max-time 0 --run \
+  "python models/deepseek_v4_pro/prefill_fwd_staged_draft.py \
+  -p a5 --ep 2 -d \$TASK_DEVICE --rounds 2"
+```
 
 ### Model shape and layer schedule
 
@@ -127,6 +160,7 @@ prefill_mtp     mtp_projection → prefill_attention_swa → moe → hc_head →
 | Group | Files |
 | --- | --- |
 | Full forward | [decode_fwd.py](../../models/deepseek_v4_pro/decode_fwd.py), [prefill_fwd.py](../../models/deepseek_v4_pro/prefill_fwd.py) |
+| Staged execution smoke | [decode_fwd_staged_draft.py](../../models/deepseek_v4_pro/decode_fwd_staged_draft.py), [prefill_fwd_staged_draft.py](../../models/deepseek_v4_pro/prefill_fwd_staged_draft.py), [staged_fwd_tail.py](../../models/deepseek_v4_pro/staged_fwd_tail.py), [staged_fwd_utils.py](../../models/deepseek_v4_pro/staged_fwd_utils.py) |
 | Layer composition | [decode_layer.py](../../models/deepseek_v4_pro/decode_layer.py), [prefill_layer.py](../../models/deepseek_v4_pro/prefill_layer.py) |
 | MTP | [decode_mtp.py](../../models/deepseek_v4_pro/decode_mtp.py), [prefill_mtp.py](../../models/deepseek_v4_pro/prefill_mtp.py), [mtp_projection.py](../../models/deepseek_v4_pro/mtp_projection.py) |
 | Decode attention orchestration | [decode_attention_swa.py](../../models/deepseek_v4_pro/decode_attention_swa.py), [decode_attention_csa.py](../../models/deepseek_v4_pro/decode_attention_csa.py), [decode_attention_hca.py](../../models/deepseek_v4_pro/decode_attention_hca.py) |

--- a/docs/run-and-validate/compile-runtime-workflow.md
+++ b/docs/run-and-validate/compile-runtime-workflow.md
@@ -253,6 +253,9 @@ after dispatch.
 `runtime_cfg` is therefore not forwarded verbatim in every case:
 
 - `log_level` is consumed by the harness to configure PyPTO's runtime logger;
+- `startup_timeout_s` optionally overrides the positive finite startup
+  readiness deadline for the prepared L3 resident-worker path and is not
+  forwarded to single-chip execution;
 - the five DFX fields below are bundled into the runtime's DFX options on the
   single-chip path;
 - remaining single-chip fields are passed to `execute_compiled`, which rejects

--- a/docs/run-and-validate/golden-harness.md
+++ b/docs/run-and-validate/golden-harness.md
@@ -132,6 +132,7 @@ RunResult(
     execution_time=...,
     work_dir=...,
     bench=...,
+    outputs=...,
 )
 ```
 
@@ -147,6 +148,14 @@ if not result.passed:
 
 `work_dir` identifies the generated build directory and is the reliable way
 to locate its reports and optional saved data.
+
+Set `return_outputs=True` on `run` or `run_jit` to expose the live tensors for
+every `TensorSpec(is_output=True)` through `result.outputs`. The default is
+`None`, avoiding unnecessary resident-output readback. With output capture
+enabled, resident state is copied back once before its worker is released,
+which lets execution-only staged drivers chain an activation or cache without
+enabling a golden comparison. This remains a launchability mechanism, not a
+correctness check.
 
 ## Golden CPU threads
 

--- a/golden/runner.py
+++ b/golden/runner.py
@@ -813,37 +813,51 @@ def _prepare_l3_worker(
     """
     import inspect
 
+    def accepts_keyword(parameters, name):
+        parameter = parameters.get(name)
+        accepts_named_keyword = parameter is not None and parameter.kind in (
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            inspect.Parameter.KEYWORD_ONLY,
+        )
+        return accepts_named_keyword or any(
+            parameter.kind is inspect.Parameter.VAR_KEYWORD
+            for parameter in parameters.values()
+        )
+
     args = (run_config,) if bench else ()
     kwargs = (
         {"persistent": True, "reset_persistent_windows": False}
         if bench
         else {}
     )
-    if startup_timeout_s is not None:
-        kwargs["startup_timeout_s"] = startup_timeout_s
-    if not inherited_host_tensors:
-        return compiled.prepare(*args, **kwargs)
-
-    parameters = inspect.signature(compiled.prepare).parameters.values()
-    accepts_inherited = any(
-        parameter.name == "inherited_host_tensors"
-        for parameter in parameters
+    prepare_parameters = inspect.signature(compiled.prepare).parameters
+    prepare_kwargs = dict(kwargs)
+    if startup_timeout_s is not None and accepts_keyword(
+        prepare_parameters, "startup_timeout_s"
+    ):
+        prepare_kwargs["startup_timeout_s"] = startup_timeout_s
+    accepts_inherited = accepts_keyword(
+        prepare_parameters, "inherited_host_tensors"
     )
-    if accepts_inherited:
-        return compiled.prepare(
-            *args,
-            inherited_host_tensors=inherited_host_tensors,
-            **kwargs,
-        )
+    if not inherited_host_tensors or accepts_inherited:
+        if inherited_host_tensors:
+            prepare_kwargs["inherited_host_tensors"] = inherited_host_tensors
+        return compiled.prepare(*args, **prepare_kwargs)
 
     from pypto.runtime import DistributedWorker
 
+    worker_kwargs = dict(kwargs)
+    worker_parameters = inspect.signature(DistributedWorker).parameters
+    if startup_timeout_s is not None and accepts_keyword(
+        worker_parameters, "startup_timeout_s"
+    ):
+        worker_kwargs["startup_timeout_s"] = startup_timeout_s
     config = run_config if bench else None
     return DistributedWorker(
         compiled,
         config,
         inherited_host_tensors=inherited_host_tensors,
-        **kwargs,
+        **worker_kwargs,
     )
 
 

--- a/golden/runner.py
+++ b/golden/runner.py
@@ -14,7 +14,7 @@ Public entry points: :func:`run` and :func:`run_jit`.
 
 import statistics
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -34,6 +34,7 @@ class RunResult:
     execution_time: float | None = None
     work_dir: Path | None = None
     bench: Any = None  # BenchmarkStats when benchmark=True; None otherwise
+    outputs: dict[str, torch.Tensor] | None = None
 
     def __str__(self) -> str:
         time_str = f" ({self.execution_time:.2f}s)" if self.execution_time is not None else ""
@@ -123,15 +124,22 @@ _DFX_FLAG_KEYS = (
     "enable_scope_stats",
 )
 
+_L3_ONLY_RUNTIME_KEYS = ("startup_timeout_s",)
+
 
 def _execute_compiled_kwargs(runtime: dict[str, Any]) -> dict[str, Any]:
     """Translate user-facing ``runtime_cfg`` into ``execute_compiled`` kwargs.
 
-    The five DFX flags get bundled into a single ``dfx: _DfxOpts``; all other
-    keys pass through unfiltered, so ``execute_compiled`` raises ``TypeError``
-    on unknown keys rather than us silently dropping them.
+    The five DFX flags get bundled into a single ``dfx: _DfxOpts``. L3-only
+    worker controls are retained for the distributed path but omitted here;
+    all remaining keys pass through unfiltered, so ``execute_compiled`` raises
+    ``TypeError`` on unknown keys rather than us silently dropping them.
     """
-    out: dict[str, Any] = {k: v for k, v in runtime.items() if k not in _DFX_FLAG_KEYS}
+    out: dict[str, Any] = {
+        k: v
+        for k, v in runtime.items()
+        if k not in _DFX_FLAG_KEYS and k not in _L3_ONLY_RUNTIME_KEYS
+    }
     dfx_flags = {k: runtime[k] for k in _DFX_FLAG_KEYS if runtime.get(k)}
     if dfx_flags:
         try:
@@ -249,6 +257,7 @@ def _prepare_inputs(
     data_dir: Path | None,
     work_dir: Path,
     save_data: bool = True,
+    snapshot_inputs: bool = True,
 ) -> tuple[dict[str, torch.Tensor], dict[str, ScalarSpec], dict[str, torch.Tensor]]:
     """Build inputs for the runtime stage.
 
@@ -256,20 +265,25 @@ def _prepare_inputs(
     leave ``input_snapshot`` empty (golden will be loaded from cache, no need
     to clone inputs for ``golden_fn``). Otherwise generate from *specs* and,
     when *save_data* is True, persist into ``{work_dir}/data/in/``. Set
+    *snapshot_inputs* False when neither a golden function nor persistence needs
+    an immutable copy; this avoids cloning large runtime-only inputs. Set
     *save_data* False to skip the on-disk ``.pt`` snapshot (validation still
-    works via the in-memory ``input_snapshot``); useful when inputs are large
-    (e.g. full-model weights) and golden replay is not needed.
+    works via ``input_snapshot`` when requested).
 
     Raises ``ValueError`` on missing files or scalar dtype mismatch.
     """
     if data_dir is None:
         tensors = {spec.name: spec.create_tensor() for spec in tensor_specs}
         scalar_specs_eff = {s.name: s for s in scalar_specs}
-        input_snapshot = {
-            spec.name: tensors[spec.name].clone()
-            for spec in tensor_specs
-            if not spec.is_output or spec.init_value is not None
-        }
+        input_snapshot = (
+            {
+                spec.name: tensors[spec.name].clone()
+                for spec in tensor_specs
+                if not spec.is_output or spec.init_value is not None
+            }
+            if snapshot_inputs or save_data
+            else {}
+        )
         if save_data:
             in_dir = work_dir / "data" / "in"
             _save_tensors(in_dir, input_snapshot)
@@ -746,21 +760,91 @@ def _try_l3_dispatch(
     return True
 
 
-def _share_in_place(tensors: dict[str, torch.Tensor]) -> None:
-    """Make every tensor shared-memory in place (required by the prepared L3 worker).
+def _share_in_place(
+    tensors: dict[str, torch.Tensor],
+    names: Iterable[str] | None = None,
+) -> None:
+    """Make selected tensors shared-memory in place for a prepared L3 worker.
 
     A prepared :class:`~pypto.runtime.distributed_runner.DistributedWorker` reads
-    per-call IO and resident-weight upload sources through the shared mapping the
-    forked chip worker inherits at ``prepare()``, so each buffer must be CPU,
-    contiguous and ``share_memory_()`` *before* the fork. Replaces any
-    non-contiguous / non-shared tensor with a contiguous shared copy in the same
-    dict, so the caller's later :func:`_validate` reads the device-written
-    outputs back from these same buffers.
+    per-call IO through the shared mapping the forked chip worker inherits at
+    ``prepare()``, so each such buffer must be CPU, contiguous and
+    ``share_memory_()`` *before* the fork. Replaces any non-contiguous /
+    non-shared selected tensor with a contiguous shared copy in the same dict,
+    so the caller's later :func:`_validate` reads device-written outputs from
+    these same buffers. With *names* omitted, preserves the historical behavior
+    of sharing every tensor.
     """
-    for name, t in list(tensors.items()):
+    selected = tensors.keys() if names is None else names
+    for name in selected:
+        t = tensors[name]
         if t.is_shared() and t.is_contiguous():
             continue
         tensors[name] = t.cpu().contiguous().share_memory_()
+
+
+def _make_cpu_contiguous_in_place(
+    tensors: dict[str, torch.Tensor],
+    names: Iterable[str],
+) -> None:
+    """Normalize selected tensors without moving their storage to shared memory."""
+    for name in names:
+        tensor = tensors[name]
+        if tensor.device.type == "cpu" and tensor.is_contiguous():
+            continue
+        tensors[name] = tensor.cpu().contiguous()
+
+
+def _prepare_l3_worker(
+    compiled: Any,
+    run_config: Any,
+    *,
+    bench: bool,
+    inherited_host_tensors: tuple[torch.Tensor, ...],
+    startup_timeout_s: float | None = None,
+) -> Any:
+    """Prepare an L3 worker while keeping read-only upload sources out of shm.
+
+    Newer ``DistributedCompiledProgram.prepare`` implementations may expose
+    ``inherited_host_tensors`` directly. The pinned runtime already supports the
+    contract on its public ``DistributedWorker`` constructor, so use that
+    constructor as a compatibility bridge when ``prepare`` has not yet plumbed
+    the keyword through.
+    """
+    import inspect
+
+    args = (run_config,) if bench else ()
+    kwargs = (
+        {"persistent": True, "reset_persistent_windows": False}
+        if bench
+        else {}
+    )
+    if startup_timeout_s is not None:
+        kwargs["startup_timeout_s"] = startup_timeout_s
+    if not inherited_host_tensors:
+        return compiled.prepare(*args, **kwargs)
+
+    parameters = inspect.signature(compiled.prepare).parameters.values()
+    accepts_inherited = any(
+        parameter.name == "inherited_host_tensors"
+        for parameter in parameters
+    )
+    if accepts_inherited:
+        return compiled.prepare(
+            *args,
+            inherited_host_tensors=inherited_host_tensors,
+            **kwargs,
+        )
+
+    from pypto.runtime import DistributedWorker
+
+    config = run_config if bench else None
+    return DistributedWorker(
+        compiled,
+        config,
+        inherited_host_tensors=inherited_host_tensors,
+        **kwargs,
+    )
 
 
 def _strip_ssa_suffix(name: str) -> str:
@@ -879,17 +963,19 @@ def _run_l3_resident(
     rtol: float,
     atol: float,
     compare_fn: dict[str, Callable],
+    return_outputs: bool = False,
 ) -> Any:
     """Dispatch an L3 program keeping resident weights device-resident.
 
-    Routes through :meth:`DistributedCompiledProgram.prepare` — the only path
-    that can build worker-resident :class:`~pypto.runtime.DeviceTensor` buffers.
+    Routes through a prepared ``DistributedWorker`` that can build
+    worker-resident :class:`~pypto.runtime.DeviceTensor` buffers.
     Each resident input / ``InOut`` spec is uploaded once via
     ``rt.alloc_tensor(init=...)`` and reused across the validation dispatch and
     every benchmark round. A pure ``Out`` resident is allocated uninitialized,
     because its host tensor is only an output destination and uploading its
     zero-filled placeholder would be wasted work. Resident outputs are read back
-    once before golden validation via :func:`_readback_resident_outputs`.
+    once for golden validation or requested output capture via
+    :func:`_readback_resident_outputs`.
 
     When :func:`_bench_enabled` (``PYPTO_BENCH``), the resident weights are reused
     for :func:`_bench_loop_sizes` timed rounds. This cannot go through
@@ -919,14 +1005,31 @@ def _run_l3_resident(
             "(a @pl.jit.host kernel compiled with distributed_config)."
         )
 
-    # Per-call IO + resident upload sources must be shared memory before prepare().
-    _share_in_place(tensors)
-
     ordered_names = _l3_ordered_names(compiled)
     pure_out_names = _l3_pure_out_names(compiled)
     run_config = _l3_run_config(runtime_cfg)
     resident_specs = [s for s in tensor_specs if s.is_resident]
     bench = _bench_enabled()
+
+    # Only direct per-call host IO must use shared memory. Read-only resident
+    # upload sources can stay in ordinary CPU memory: the worker registers their
+    # storage before fork and the children inherit it copy-on-write. A resident
+    # output needs shared storage only when it will actually be read back.
+    needs_resident_readback = golden_outputs is not None or return_outputs
+    shared_names = [
+        spec.name
+        for spec in tensor_specs
+        if not spec.is_resident or (needs_resident_readback and spec.is_output)
+    ]
+    _share_in_place(tensors, shared_names)
+    shared_name_set = set(shared_names)
+    inherited_names = [
+        spec.name
+        for spec in resident_specs
+        if spec.name not in pure_out_names and spec.name not in shared_name_set
+    ]
+    _make_cpu_contiguous_in_place(tensors, inherited_names)
+    inherited_host_tensors = tuple(tensors[name] for name in inherited_names)
 
     def _dispatch_resident(
         dispatch_fn: "Callable[[Any, list[Any], list], None]",
@@ -944,14 +1047,13 @@ def _run_l3_resident(
         # Benchmarks model serving's steady-state dispatch: retain CommDomains
         # across rounds and let kernels clear their own signal windows. Keep the
         # ordinary validation path one-shot.
-        if bench:
-            prepared = compiled.prepare(
-                run_config,
-                persistent=True,
-                reset_persistent_windows=False,
-            )
-        else:
-            prepared = compiled.prepare()
+        prepared = _prepare_l3_worker(
+            compiled,
+            run_config,
+            bench=bench,
+            inherited_host_tensors=inherited_host_tensors,
+            startup_timeout_s=runtime_cfg.get("startup_timeout_s"),
+        )
         with prepared as rt:
             # (name, handle, is_stacked, worker_id) — is_stacked picks the matching
             # free below; worker_id is the card a whole-tensor buffer was allocated on.
@@ -1002,23 +1104,28 @@ def _run_l3_resident(
                     except Exception as e:  # noqa: BLE001 — best-effort cleanup
                         print(f"[RUN] warning: failed to free resident tensor {name}: {e}", flush=True)
 
-    def _validate_once(rt: Any, resident_handles: list[tuple[str, Any, bool, int]]) -> None:
-        if golden_outputs is None:
-            return
+    def _readback_once(rt: Any, resident_handles: list[tuple[str, Any, bool, int]]) -> None:
         # A resident spec that is also an output is a read-write state buffer
         # (e.g. a KV cache): updated in place on-device and skipping the
         # per-dispatch D2H, so its host tensor is stale. Read the final device
-        # state back once into that host tensor — while the prepare() context and
-        # its handles are still live — so _validate compares what the kernel
-        # actually produced (one end-of-run D2H, not a per-dispatch one).
+        # state back once into that host tensor while the prepare() context and
+        # its handles are still live.
         _readback_resident_outputs(rt, resident_specs, resident_handles, tensors)
+
+    def _validate_once(rt: Any, resident_handles: list[tuple[str, Any, bool, int]]) -> None:
+        if golden_outputs is None:
+            return
+        _readback_once(rt, resident_handles)
         _validate(tensor_specs, tensors, golden_outputs, rtol, atol, compare_fn)
 
     # Non-benchmark: one validation dispatch, no capture.
     if not bench:
         def _plain_dispatch(rt: Any, ordered: list[Any], resident_handles: list) -> None:
             rt(*ordered, config=run_config)
-            _validate_once(rt, resident_handles)
+            if golden_outputs is not None:
+                _validate_once(rt, resident_handles)
+            elif return_outputs:
+                _readback_once(rt, resident_handles)
 
         _dispatch_resident(_plain_dispatch)
         return None
@@ -1054,6 +1161,11 @@ def _run_l3_resident(
                 rt(*ordered, config=run_config)
         except Exception as e:  # noqa: BLE001 — benchmark rounds are never a correctness gate
             print(f"[RUN] benchmark rounds interrupted: {type(e).__name__}: {e}", flush=True)
+        if return_outputs:
+            # Capture the final resident state after all timed dispatches. With
+            # golden validation this is intentionally a second readback: the
+            # first one validates the correctness-gate dispatch above.
+            _readback_once(rt, resident_handles)
 
     prior_level = current_level()
     configure_log(_STRACE_LOG_LEVEL)
@@ -1184,6 +1296,17 @@ def _validate(
         )
 
 
+def _collect_outputs(
+    tensor_specs: list[TensorSpec],
+    tensors: dict[str, torch.Tensor],
+    enabled: bool,
+) -> dict[str, torch.Tensor] | None:
+    """Return live output tensors when opt-in output capture is enabled."""
+    if not enabled:
+        return None
+    return {spec.name: tensors[spec.name] for spec in tensor_specs if spec.is_output}
+
+
 def run(
     program: Any,
     specs: list[TensorSpec | ScalarSpec],
@@ -1197,6 +1320,7 @@ def run(
     compile_only: bool = False,
     runtime_dir: str | None = None,
     save_data: bool = False,
+    return_outputs: bool = False,
 ) -> RunResult:
     """Compile *program*, run on device, and validate against golden.
 
@@ -1231,6 +1355,9 @@ def run(
             Defaults to False, skipping the on-disk ``.pt`` snapshot;
             validation still runs against the in-memory golden. Enable it
             when you need to replay the exact inputs/outputs later.
+        return_outputs: When True, expose every ``TensorSpec(is_output=True)``
+            tensor in :attr:`RunResult.outputs`. Resident outputs are read back
+            from device even when validation is disabled. Defaults to False.
 
     Returns:
         :class:`RunResult`.
@@ -1294,7 +1421,13 @@ def run(
     try:
         with _Stage("generate inputs"):
             tensors, scalar_specs_eff, input_snapshot = _prepare_inputs(
-                specs, tensor_specs, scalar_specs, data_dir, work_dir, save_data,
+                specs,
+                tensor_specs,
+                scalar_specs,
+                data_dir,
+                work_dir,
+                save_data,
+                snapshot_inputs=golden_fn is not None or save_data,
             )
     except ValueError as e:
         return _fail(str(e))
@@ -1316,6 +1449,7 @@ def run(
                 bench = _run_l3_resident(
                     compiled, tensor_specs, tensors, scalar_specs_eff,
                     runtime_cfg, golden_outputs, rtol, atol, compare_fn,
+                    return_outputs=return_outputs,
                 )
             except (AssertionError, ValueError) as e:
                 return _fail(str(e))
@@ -1323,7 +1457,13 @@ def run(
         total = time.time() - start
         skip_note = ", validation skipped: no golden_fn or golden_data" if validation_skipped else ""
         print(f"[RUN] PASS ({total:.2f}s{skip_note})", flush=True)
-        return RunResult(passed=True, execution_time=total, work_dir=work_dir, bench=bench)
+        return RunResult(
+            passed=True,
+            execution_time=total,
+            work_dir=work_dir,
+            bench=bench,
+            outputs=_collect_outputs(tensor_specs, tensors, return_outputs),
+        )
 
     # Runtime
     with _Stage("runtime"):
@@ -1356,7 +1496,13 @@ def run(
     if golden_outputs is None:
         total = time.time() - start
         print(f"[RUN] PASS ({total:.2f}s, validation skipped: no golden_fn or golden_data)", flush=True)
-        return RunResult(passed=True, execution_time=total, work_dir=work_dir, bench=bench)
+        return RunResult(
+            passed=True,
+            execution_time=total,
+            work_dir=work_dir,
+            bench=bench,
+            outputs=_collect_outputs(tensor_specs, tensors, return_outputs),
+        )
     try:
         _validate(tensor_specs, tensors, golden_outputs, rtol, atol, compare_fn)
     except AssertionError as e:
@@ -1364,7 +1510,13 @@ def run(
 
     total = time.time() - start
     print(f"[RUN] PASS ({total:.2f}s)", flush=True)
-    return RunResult(passed=True, execution_time=total, work_dir=work_dir, bench=bench)
+    return RunResult(
+        passed=True,
+        execution_time=total,
+        work_dir=work_dir,
+        bench=bench,
+        outputs=_collect_outputs(tensor_specs, tensors, return_outputs),
+    )
 
 
 def run_jit(
@@ -1380,6 +1532,7 @@ def run_jit(
     compile_only: bool = False,
     runtime_dir: str | None = None,
     save_data: bool = False,
+    return_outputs: bool = False,
 ) -> RunResult:
     """JIT-flavoured :func:`run`: compile via ``@pl.jit``, then same harness.
 
@@ -1417,6 +1570,9 @@ def run_jit(
             Defaults to False, skipping the on-disk ``.pt`` snapshot;
             validation still runs against the in-memory golden. Enable it
             when you need to replay the exact inputs/outputs later.
+        return_outputs: When True, expose every ``TensorSpec(is_output=True)``
+            tensor in :attr:`RunResult.outputs`. Resident outputs are read back
+            from device even when validation is disabled. Defaults to False.
 
     Returns:
         :class:`RunResult`.
@@ -1484,7 +1640,13 @@ def run_jit(
     try:
         with _Stage("generate inputs"):
             tensors, scalar_specs_eff, input_snapshot = _prepare_inputs(
-                specs, tensor_specs, scalar_specs, data_dir, work_dir, save_data,
+                specs,
+                tensor_specs,
+                scalar_specs,
+                data_dir,
+                work_dir,
+                save_data,
+                snapshot_inputs=golden_fn is not None or save_data,
             )
     except ValueError as e:
         return _fail(str(e))
@@ -1506,6 +1668,7 @@ def run_jit(
                 bench = _run_l3_resident(
                     compiled, tensor_specs, tensors, scalar_specs_eff,
                     runtime_cfg, golden_outputs, rtol, atol, compare_fn,
+                    return_outputs=return_outputs,
                 )
             except (AssertionError, ValueError) as e:
                 return _fail(str(e))
@@ -1513,7 +1676,13 @@ def run_jit(
         total = time.time() - start
         skip_note = ", validation skipped: no golden_fn or golden_data" if validation_skipped else ""
         print(f"[RUN] PASS ({total:.2f}s{skip_note})", flush=True)
-        return RunResult(passed=True, execution_time=total, work_dir=work_dir, bench=bench)
+        return RunResult(
+            passed=True,
+            execution_time=total,
+            work_dir=work_dir,
+            bench=bench,
+            outputs=_collect_outputs(tensor_specs, tensors, return_outputs),
+        )
 
     # Runtime
     with _Stage("runtime"):
@@ -1549,7 +1718,13 @@ def run_jit(
     if golden_outputs is None:
         total = time.time() - start
         print(f"[RUN] PASS ({total:.2f}s, validation skipped: no golden_fn or golden_data)", flush=True)
-        return RunResult(passed=True, execution_time=total, work_dir=work_dir, bench=bench)
+        return RunResult(
+            passed=True,
+            execution_time=total,
+            work_dir=work_dir,
+            bench=bench,
+            outputs=_collect_outputs(tensor_specs, tensors, return_outputs),
+        )
     try:
         _validate(tensor_specs, tensors, golden_outputs, rtol, atol, compare_fn)
     except AssertionError as e:
@@ -1557,4 +1732,10 @@ def run_jit(
 
     total = time.time() - start
     print(f"[RUN] PASS ({total:.2f}s)", flush=True)
-    return RunResult(passed=True, execution_time=total, work_dir=work_dir, bench=bench)
+    return RunResult(
+        passed=True,
+        execution_time=total,
+        work_dir=work_dir,
+        bench=bench,
+        outputs=_collect_outputs(tensor_specs, tensors, return_outputs),
+    )

--- a/golden/spec.py
+++ b/golden/spec.py
@@ -57,7 +57,7 @@ class TensorSpec:
             (e.g. a KV cache): an ``InOut`` state is uploaded once from
             ``init_value``, both kinds are updated on-device, and they are read
             back **once** at the end (via ``copy_stacked_from`` / ``copy_from``)
-            when golden validation is enabled.
+            when golden validation or ``return_outputs`` capture is enabled.
             Values:
 
             - ``None`` / ``False`` — not resident (default).

--- a/models/deepseek_v4_pro/decode_fwd_staged_draft.py
+++ b/models/deepseek_v4_pro/decode_fwd_staged_draft.py
@@ -1,0 +1,299 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+# ci: devices=2
+# ci: no-sim
+"""Memory-bounded DeepSeek-V4 Pro decode forward bring-up.
+
+The monolithic forward stacks all 61 layers' synthetic weights in one host
+fixture. This driver instead runs ``decode_layer`` once per layer, immediately
+releases that layer's weights, and chains ``x_next`` into the following layer.
+Mutable attention caches are retained per layer and restored in later rounds.
+
+After layer 60, the main-model Hyper-Connections head and final RMSNorm run as
+a separate staged program. There is intentionally no golden comparison,
+embedding, MTP, LM head, or logits stage. Expert payloads use the current
+shape-correct INT8 smoke stand-in.
+"""
+
+import argparse
+import gc
+import math
+
+import torch
+from config import DECODE_SEQ, DECODE_START_POS, DECODE_TOKENS, PRO_KERNEL as MODEL_CONFIG
+from decode_layer import N_RANKS, build_tensor_specs, l3_decode_layer
+from golden import run_jit
+from pypto.ir.distributed_compiled_program import DistributedConfig
+from staged_fwd_tail import (
+    build_tensor_specs as build_fwd_tail_tensor_specs,
+    l3_decode_fwd_tail,
+)
+from staged_fwd_utils import override_inputs
+
+
+def _specialization_key(layer_id):
+    """Return the attention/routing branch pair constant-folded by JIT."""
+    ratio = MODEL_CONFIG.compress_ratios[layer_id]
+    attention = {128: "hca", 4: "csa"}[ratio]
+    routing = "hash" if layer_id < MODEL_CONFIG.num_hash_layers else "score"
+    return attention, routing
+
+
+def _specialization_representatives():
+    representatives = {}
+    for layer_id in range(MODEL_CONFIG.num_hidden_layers):
+        representatives.setdefault(_specialization_key(layer_id), layer_id)
+    expected = {("hca", "hash"), ("csa", "hash"), ("hca", "score"), ("csa", "score")}
+    if set(representatives) != expected:
+        raise ValueError(f"unexpected decode specialization classes: {representatives}")
+    return representatives
+
+
+def _active_cache_names(layer_id):
+    if MODEL_CONFIG.compress_ratios[layer_id] == 128:
+        return frozenset({"kv_cache", "cmp_kv", "hca_compress_state"})
+    return frozenset({
+        "kv_cache",
+        "cmp_kv",
+        "idx_kv_cache",
+        "idx_kv_scale",
+        "csa_compress_state",
+        "csa_inner_compress_state",
+    })
+
+
+def _run_compile_only(args, device_ids, representatives):
+    runtime_cfg = {
+        "platform": args.platform,
+        "enable_l2_swimlane": args.enable_l2_swimlane,
+        "startup_timeout_s": args.startup_timeout_s,
+    }
+    compile_cfg = {
+        "dump_passes": args.dump_passes,
+        "distributed_config": DistributedConfig(
+            device_ids=device_ids[:N_RANKS],
+            num_sub_workers=0,
+        ),
+    }
+    for key, layer_id in representatives.items():
+        print(f"[STAGED] compiling {key[0]}+{key[1]} with representative layer {layer_id}", flush=True)
+        torch.manual_seed(args.seed + layer_id)
+        specs = build_tensor_specs(
+            start_pos=args.start_pos,
+            layer_id=layer_id,
+            smoke_weights=True,
+            cache_outputs=True,
+        )
+        result = run_jit(
+            fn=l3_decode_layer,
+            specs=specs,
+            golden_fn=None,
+            compile_only=True,
+            save_data=False,
+            compile_cfg=compile_cfg,
+            runtime_cfg=runtime_cfg,
+        )
+        if not result.passed:
+            if result.error:
+                print(result.error)
+            return False
+        del result, specs
+        gc.collect()
+
+    print("[STAGED] compiling hc_head+final_rmsnorm tail", flush=True)
+    torch.manual_seed(args.seed + MODEL_CONFIG.num_hidden_layers)
+    specs = build_fwd_tail_tensor_specs(DECODE_TOKENS)
+    result = run_jit(
+        fn=l3_decode_fwd_tail,
+        specs=specs,
+        golden_fn=None,
+        compile_only=True,
+        save_data=False,
+        compile_cfg=compile_cfg,
+        runtime_cfg=runtime_cfg,
+    )
+    if not result.passed:
+        if result.error:
+            print(result.error)
+        return False
+    del result, specs
+    gc.collect()
+    return True
+
+
+def _run_staged(args, device_ids, representatives):
+    runtime_dirs = {}
+    tail_runtime_dir = None
+    caches_by_layer = {}
+    cache_rng_states_by_layer = {}
+    compile_cfg = {
+        "dump_passes": args.dump_passes,
+        "distributed_config": DistributedConfig(
+            device_ids=device_ids[:N_RANKS],
+            num_sub_workers=0,
+        ),
+    }
+    runtime_cfg = {
+        "platform": args.platform,
+        "enable_l2_swimlane": args.enable_l2_swimlane,
+        "startup_timeout_s": args.startup_timeout_s,
+    }
+
+    for round_id in range(args.rounds):
+        hidden = None
+        start_pos = args.start_pos + round_id * DECODE_SEQ
+        print(
+            f"[STAGED] decode round {round_id + 1}/{args.rounds}, start_pos={start_pos}",
+            flush=True,
+        )
+        for layer_id in range(MODEL_CONFIG.num_hidden_layers):
+            key = _specialization_key(layer_id)
+            representative = representatives[key]
+            runtime_dir = runtime_dirs.get(key)
+            action = "compile" if runtime_dir is None else "reuse"
+            print(
+                f"[STAGED] layer {layer_id:02d}/{MODEL_CONFIG.num_hidden_layers - 1}: "
+                f"{key[0]}+{key[1]} ({action} L{representative})",
+                flush=True,
+            )
+
+            torch.manual_seed(args.seed + layer_id)
+            specs = build_tensor_specs(
+                start_pos=start_pos,
+                layer_id=layer_id,
+                smoke_weights=True,
+                cache_outputs=True,
+            )
+            overrides = dict(caches_by_layer.get(layer_id, {}))
+            if hidden is not None:
+                overrides["x_hc"] = hidden
+            cache_rng_states = cache_rng_states_by_layer.setdefault(layer_id, {})
+            override_inputs(
+                specs,
+                overrides,
+                tracked_names=_active_cache_names(layer_id),
+                rng_after_init=cache_rng_states,
+            )
+
+            result = run_jit(
+                fn=l3_decode_layer,
+                specs=specs,
+                golden_fn=None,
+                compile_only=False,
+                runtime_dir=None if runtime_dir is None else str(runtime_dir),
+                save_data=False,
+                return_outputs=True,
+                compile_cfg=compile_cfg,
+                runtime_cfg=runtime_cfg,
+            )
+            if not result.passed:
+                if result.error:
+                    print(result.error)
+                return False
+            if result.work_dir is None or result.outputs is None:
+                raise RuntimeError(f"layer {layer_id} completed without a runtime directory or outputs")
+            runtime_dirs.setdefault(key, result.work_dir)
+
+            outputs = result.outputs
+            required = {"x_next", *_active_cache_names(layer_id)}
+            missing = required.difference(outputs)
+            if missing:
+                raise RuntimeError(f"layer {layer_id} did not return required outputs: {sorted(missing)}")
+            hidden = outputs["x_next"]
+            caches_by_layer[layer_id] = {
+                name: outputs[name]
+                for name in _active_cache_names(layer_id)
+            }
+
+            # Keep only the chained hidden state and active caches. All synthetic
+            # layer weights become unreachable before the next layer is built.
+            del outputs, result, overrides, specs
+            gc.collect()
+
+        if hidden is None:
+            raise RuntimeError("decode staged layers completed without a hidden state")
+        action = "compile" if tail_runtime_dir is None else "reuse"
+        print(f"[STAGED] hc_head+final_rmsnorm tail ({action})", flush=True)
+        torch.manual_seed(args.seed + MODEL_CONFIG.num_hidden_layers)
+        specs = build_fwd_tail_tensor_specs(DECODE_TOKENS)
+        override_inputs(specs, {"x_hc": hidden})
+        result = run_jit(
+            fn=l3_decode_fwd_tail,
+            specs=specs,
+            golden_fn=None,
+            compile_only=False,
+            runtime_dir=None if tail_runtime_dir is None else str(tail_runtime_dir),
+            save_data=False,
+            return_outputs=True,
+            compile_cfg=compile_cfg,
+            runtime_cfg=runtime_cfg,
+        )
+        if not result.passed:
+            if result.error:
+                print(result.error)
+            return False
+        if result.work_dir is None or result.outputs is None:
+            raise RuntimeError("decode tail completed without a runtime directory or outputs")
+        tail_runtime_dir = result.work_dir
+        if "hidden_out" not in result.outputs:
+            raise RuntimeError("decode tail did not return hidden_out")
+        normalized_shape = tuple(result.outputs["hidden_out"].shape)
+        del result, specs, hidden
+        gc.collect()
+
+        print(
+            f"[STAGED] decode round {round_id + 1}/{args.rounds} complete, "
+            f"normalized_hidden_shape={normalized_shape}",
+            flush=True,
+        )
+    return True
+
+
+def main():
+    parser = argparse.ArgumentParser(description="DeepSeek-V4 Pro staged 61-layer decode driver.")
+    parser.add_argument("-p", "--platform", type=str, default="a2a3", choices=["a2a3", "a5"])
+    parser.add_argument("--ep", type=int, default=N_RANKS, choices=[2, 4, 8],
+                        help="EP world size / rank count (parsed at import by moe)")
+    parser.add_argument("-d", "--device", type=str,
+                        default=",".join(str(i) for i in range(N_RANKS)),
+                        help=f"comma-separated device ids; need at least {N_RANKS}")
+    parser.add_argument("--start-pos", type=int, default=DECODE_START_POS)
+    parser.add_argument("--rounds", type=int, default=2)
+    parser.add_argument("--seed", type=int, default=0,
+                        help="base seed used to regenerate stable per-layer smoke weights")
+    parser.add_argument("--enable-l2-swimlane", type=int, nargs="?", const=1,
+                        default=0, choices=(0, 1, 2))
+    parser.add_argument("--startup-timeout-s", type=float, default=900.0,
+                        help="forked EP worker startup deadline in seconds")
+    parser.add_argument("--compile-only", action="store_true", default=False)
+    parser.add_argument("--dump-passes", action="store_true", default=False)
+    args = parser.parse_args()
+
+    if args.rounds <= 0:
+        parser.error("--rounds must be positive")
+    if not math.isfinite(args.startup_timeout_s) or args.startup_timeout_s <= 0:
+        parser.error("--startup-timeout-s must be positive and finite")
+    if args.ep != N_RANKS:
+        parser.error(f"--ep was imported as {N_RANKS}, got parsed value {args.ep}")
+    device_ids = [int(device) for device in args.device.split(",")]
+    if len(device_ids) < N_RANKS:
+        parser.error(f"need at least {N_RANKS} devices, got {device_ids}")
+
+    representatives = _specialization_representatives()
+    passed = (
+        _run_compile_only(args, device_ids, representatives)
+        if args.compile_only
+        else _run_staged(args, device_ids, representatives)
+    )
+    if not passed:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/models/deepseek_v4_pro/decode_layer.py
+++ b/models/deepseek_v4_pro/decode_layer.py
@@ -827,7 +827,13 @@ if __name__ == "__main__":
     device_ids = [int(d) for d in args.device.split(",")]
     assert len(device_ids) >= N_RANKS, f"need at least {N_RANKS} devices, got {device_ids}"
     host_fn = l3_decode_layer
-    golden_fn = golden_decode_layer_auto
+    golden_fn = None if args.smoke_weights else golden_decode_layer_auto
+    compare_fn = None if args.smoke_weights else {
+        # Real-weight x_next over-thd fractions (frac>5e-3 / frac>1e-2),
+        # to be re-measured at Pro dims: hca(L0/L1 lead, L9 steady), csa(L8).
+        "x_next": ratio_reldiff(diff_thd=0.01, pct_thd=0.05),
+        "kv_cache": ratio_allclose(atol=1e-4, rtol=1.0 / 128),
+    }
 
     result = run_jit(
         fn=host_fn,
@@ -852,12 +858,7 @@ if __name__ == "__main__":
         ),
         rtol=1e-3,
         atol=1e-3,
-        compare_fn={
-            # Real-weight x_next over-thd fractions (frac>5e-3 / frac>1e-2),
-            # to be re-measured at Pro dims: hca(L0/L1 lead, L9 steady), csa(L8).
-            "x_next": ratio_reldiff(diff_thd=0.01, pct_thd=0.05),
-            "kv_cache": ratio_allclose(atol=1e-4, rtol=1.0 / 128),
-        },
+        compare_fn=compare_fn,
     )
     if not result.passed:
         if result.error:

--- a/models/deepseek_v4_pro/decode_layer.py
+++ b/models/deepseek_v4_pro/decode_layer.py
@@ -150,16 +150,18 @@ def decode_layer(
     hca_cmp_wgate: pl.Tensor[[HCA_MAIN_OUT_DIM, D], pl.BF16],
     hca_cmp_ape: pl.Tensor[[HCA_COMPRESS_RATIO, HCA_MAIN_OUT_DIM], pl.FP32],
     hca_cmp_norm_w: pl.Tensor[[HEAD_DIM], pl.BF16],
-    hca_compress_state: pl.Tensor[
+    hca_compress_state: pl.InOut[pl.Tensor[
         [HCA_COMPRESS_STATE_BLOCK_NUM, HCA_COMPRESS_STATE_BLOCK_SIZE, HCA_COMPRESS_STATE_DIM],
         pl.FP32,
-    ],
+    ]],
     hca_compress_state_block_table: pl.Tensor[[B, HCA_COMPRESS_STATE_MAX_BLOCKS], pl.INT32],
     csa_cmp_wkv: pl.Tensor[[CSA_MAIN_OUT_DIM, D], pl.BF16],
     csa_cmp_wgate: pl.Tensor[[CSA_MAIN_OUT_DIM, D], pl.BF16],
     csa_cmp_ape: pl.Tensor[[CSA_COMPRESS_RATIO, CSA_MAIN_OUT_DIM], pl.FP32],
     csa_cmp_norm_w: pl.Tensor[[HEAD_DIM], pl.BF16],
-    csa_compress_state: pl.Tensor[[CSA_MAIN_STATE_BLOCK_NUM, CSA_MAIN_STATE_BLOCK_SIZE, CSA_MAIN_STATE_DIM], pl.FP32],
+    csa_compress_state: pl.InOut[
+        pl.Tensor[[CSA_MAIN_STATE_BLOCK_NUM, CSA_MAIN_STATE_BLOCK_SIZE, CSA_MAIN_STATE_DIM], pl.FP32]
+    ],
     csa_compress_state_block_table: pl.Tensor[[B, CSA_MAIN_STATE_MAX_BLOCKS], pl.INT32],
     csa_idx_wq_b: pl.Tensor[[Q_LORA, CSA_IDX_N_HEADS * CSA_IDX_HEAD_DIM], pl.INT8],
     csa_idx_wq_b_scale: pl.Tensor[[CSA_IDX_N_HEADS * CSA_IDX_HEAD_DIM], pl.FP32],
@@ -169,15 +171,17 @@ def decode_layer(
     csa_inner_wgate: pl.Tensor[[CSA_INNER_OUT_DIM, D], pl.BF16],
     csa_inner_ape: pl.Tensor[[CSA_COMPRESS_RATIO, CSA_INNER_OUT_DIM], pl.FP32],
     csa_inner_norm_w: pl.Tensor[[CSA_IDX_HEAD_DIM], pl.BF16],
-    csa_inner_compress_state: pl.Tensor[
+    csa_inner_compress_state: pl.InOut[pl.Tensor[
         [CSA_INNER_STATE_BLOCK_NUM, CSA_INNER_STATE_BLOCK_SIZE, CSA_INNER_STATE_DIM],
         pl.FP32,
-    ],
+    ]],
     csa_inner_compress_state_block_table: pl.Tensor[[B, CSA_INNER_STATE_MAX_BLOCKS], pl.INT32],
-    cmp_kv: pl.Tensor[[CSA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    cmp_kv: pl.InOut[pl.Tensor[[CSA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
     cmp_block_table: pl.Tensor[[B, CSA_CMP_MAX_BLOCKS], pl.INT32],
-    idx_kv_cache: pl.Tensor[[CSA_IDX_CACHE_BLOCK_NUM, BLOCK_SIZE, 1, CSA_IDX_HEAD_DIM], pl.INT8],
-    idx_kv_scale: pl.Tensor[[CSA_IDX_CACHE_BLOCK_NUM, BLOCK_SIZE, 1, 1], pl.FP32],
+    idx_kv_cache: pl.InOut[
+        pl.Tensor[[CSA_IDX_CACHE_BLOCK_NUM, BLOCK_SIZE, 1, CSA_IDX_HEAD_DIM], pl.INT8]
+    ],
+    idx_kv_scale: pl.InOut[pl.Tensor[[CSA_IDX_CACHE_BLOCK_NUM, BLOCK_SIZE, 1, 1], pl.FP32]],
     idx_block_table: pl.Tensor[[B, CSA_IDX_CACHE_MAX_BLOCKS], pl.INT32],
     hc_ffn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
     hc_ffn_scale: pl.Tensor[[3], pl.FP32],
@@ -301,19 +305,19 @@ def l3_decode_layer(
     hca_cmp_wgate: pl.Tensor[[N_RANKS, HCA_MAIN_OUT_DIM, D], pl.BF16],
     hca_cmp_ape: pl.Tensor[[N_RANKS, HCA_COMPRESS_RATIO, HCA_MAIN_OUT_DIM], pl.FP32],
     hca_cmp_norm_w: pl.Tensor[[N_RANKS, HEAD_DIM], pl.BF16],
-    hca_compress_state: pl.Tensor[
+    hca_compress_state: pl.InOut[pl.Tensor[
         [N_RANKS, HCA_COMPRESS_STATE_BLOCK_NUM, HCA_COMPRESS_STATE_BLOCK_SIZE, HCA_COMPRESS_STATE_DIM],
         pl.FP32,
-    ],
+    ]],
     hca_compress_state_block_table: pl.Tensor[[N_RANKS, B, HCA_COMPRESS_STATE_MAX_BLOCKS], pl.INT32],
     csa_cmp_wkv: pl.Tensor[[N_RANKS, CSA_MAIN_OUT_DIM, D], pl.BF16],
     csa_cmp_wgate: pl.Tensor[[N_RANKS, CSA_MAIN_OUT_DIM, D], pl.BF16],
     csa_cmp_ape: pl.Tensor[[N_RANKS, CSA_COMPRESS_RATIO, CSA_MAIN_OUT_DIM], pl.FP32],
     csa_cmp_norm_w: pl.Tensor[[N_RANKS, HEAD_DIM], pl.BF16],
-    csa_compress_state: pl.Tensor[
+    csa_compress_state: pl.InOut[pl.Tensor[
         [N_RANKS, CSA_MAIN_STATE_BLOCK_NUM, CSA_MAIN_STATE_BLOCK_SIZE, CSA_MAIN_STATE_DIM],
         pl.FP32,
-    ],
+    ]],
     csa_compress_state_block_table: pl.Tensor[[N_RANKS, B, CSA_MAIN_STATE_MAX_BLOCKS], pl.INT32],
     csa_idx_wq_b: pl.Tensor[[N_RANKS, Q_LORA, CSA_IDX_N_HEADS * CSA_IDX_HEAD_DIM], pl.INT8],
     csa_idx_wq_b_scale: pl.Tensor[[N_RANKS, CSA_IDX_N_HEADS * CSA_IDX_HEAD_DIM], pl.FP32],
@@ -323,15 +327,19 @@ def l3_decode_layer(
     csa_inner_wgate: pl.Tensor[[N_RANKS, CSA_INNER_OUT_DIM, D], pl.BF16],
     csa_inner_ape: pl.Tensor[[N_RANKS, CSA_COMPRESS_RATIO, CSA_INNER_OUT_DIM], pl.FP32],
     csa_inner_norm_w: pl.Tensor[[N_RANKS, CSA_IDX_HEAD_DIM], pl.BF16],
-    csa_inner_compress_state: pl.Tensor[
+    csa_inner_compress_state: pl.InOut[pl.Tensor[
         [N_RANKS, CSA_INNER_STATE_BLOCK_NUM, CSA_INNER_STATE_BLOCK_SIZE, CSA_INNER_STATE_DIM],
         pl.FP32,
-    ],
+    ]],
     csa_inner_compress_state_block_table: pl.Tensor[[N_RANKS, B, CSA_INNER_STATE_MAX_BLOCKS], pl.INT32],
-    cmp_kv: pl.Tensor[[N_RANKS, CSA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    cmp_kv: pl.InOut[pl.Tensor[[N_RANKS, CSA_CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
     cmp_block_table: pl.Tensor[[N_RANKS, B, CSA_CMP_MAX_BLOCKS], pl.INT32],
-    idx_kv_cache: pl.Tensor[[N_RANKS, CSA_IDX_CACHE_BLOCK_NUM, BLOCK_SIZE, 1, CSA_IDX_HEAD_DIM], pl.INT8],
-    idx_kv_scale: pl.Tensor[[N_RANKS, CSA_IDX_CACHE_BLOCK_NUM, BLOCK_SIZE, 1, 1], pl.FP32],
+    idx_kv_cache: pl.InOut[
+        pl.Tensor[[N_RANKS, CSA_IDX_CACHE_BLOCK_NUM, BLOCK_SIZE, 1, CSA_IDX_HEAD_DIM], pl.INT8]
+    ],
+    idx_kv_scale: pl.InOut[
+        pl.Tensor[[N_RANKS, CSA_IDX_CACHE_BLOCK_NUM, BLOCK_SIZE, 1, 1], pl.FP32]
+    ],
     idx_block_table: pl.Tensor[[N_RANKS, B, CSA_IDX_CACHE_MAX_BLOCKS], pl.INT32],
     hc_ffn_fn: pl.Tensor[[N_RANKS, MIX_HC, HC_DIM], pl.FP32],
     hc_ffn_scale: pl.Tensor[[N_RANKS, 3], pl.FP32],
@@ -595,7 +603,7 @@ def _attention_kind_for_layer(layer_id):
     )
 
 
-def build_tensor_specs(start_pos=DECODE_START_POS, layer_id=10):
+def build_tensor_specs(start_pos=DECODE_START_POS, layer_id=10, smoke_weights=False, cache_outputs=False):
     import torch
     from decode_metadata import block_table
     from golden import ScalarSpec, TensorSpec
@@ -612,7 +620,7 @@ def build_tensor_specs(start_pos=DECODE_START_POS, layer_id=10):
         for spec in build_csa_tensor_specs(start_pos)
         if isinstance(spec, TensorSpec)
     }
-    moe_specs = build_moe_tensor_specs(layer_id)
+    moe_specs = build_moe_tensor_specs(layer_id, smoke_weights=smoke_weights)
     moe_tensor_specs = {spec.name: spec for spec in moe_specs if isinstance(spec, TensorSpec)}
     attention_kind = _attention_kind_for_layer(layer_id)
     active_specs = {
@@ -717,13 +725,21 @@ def build_tensor_specs(start_pos=DECODE_START_POS, layer_id=10):
         ("idx_block_table", csa_specs["idx_block_table"]),
     ]
 
+    active_mutable_cache_names = {"kv_cache", "cmp_kv"}
+    if attention_kind == "hca":
+        active_mutable_cache_names.add("hca_compress_state")
+    else:
+        active_mutable_cache_names.update({
+            "idx_kv_cache", "idx_kv_scale",
+            "csa_compress_state", "csa_inner_compress_state",
+        })
     specs = [
         TensorSpec(
             name,
             [N_RANKS, *spec.shape],
             spec.dtype,
             init_value=_ranked_init(spec, replicated=name in replicated_attention),
-            is_output=name == "kv_cache",
+            is_output=name == "kv_cache" or (cache_outputs and name in active_mutable_cache_names),
         )
         for name, spec in attention_specs
     ]
@@ -756,9 +772,9 @@ def build_tensor_specs(start_pos=DECODE_START_POS, layer_id=10):
     # exactly ``replicated_attention`` (every attention param that is not a
     # KV/state cache or per-step metadata); the MoE set adds the FFN/gate/expert
     # weights and the static tid2eid route table. The KV/state caches
-    # (RESIDENT_CACHE_NAMES) are kept resident too — the written kv_cache is also
-    # is_output=True (line above) and read back once at the end for validation;
-    # the others are read-only inputs. NOT resident: the per-step slot mappings /
+    # (RESIDENT_CACHE_NAMES) are kept resident too. kv_cache is always read back;
+    # the staged driver opts the other mutable caches into readback as well.
+    # NOT resident: the per-step slot mappings /
     # block tables / ids / position_ids / kv_seq_lens, the input activation
     # (x_hc), and the output (x_next), which change per token.
     RESIDENT_WEIGHT_NAMES = replicated_attention | {
@@ -773,8 +789,9 @@ def build_tensor_specs(start_pos=DECODE_START_POS, layer_id=10):
         "kv_cache", "cmp_kv", "idx_kv_cache", "idx_kv_scale",
         "csa_compress_state", "csa_inner_compress_state", "hca_compress_state",
     }
+    resident_cache_names = active_mutable_cache_names if cache_outputs else RESIDENT_CACHE_NAMES
     for spec in specs:
-        if spec.name in RESIDENT_WEIGHT_NAMES or spec.name in RESIDENT_CACHE_NAMES:
+        if spec.name in RESIDENT_WEIGHT_NAMES or spec.name in resident_cache_names:
             spec.resident = "stacked"
 
     specs.extend([
@@ -799,6 +816,8 @@ if __name__ == "__main__":
     parser.add_argument("--start-pos", type=int, default=DECODE_START_POS,
                         help="Fixture-only start_pos for all batches; default is the 8k target position.")
     parser.add_argument("--layer-id", type=int, default=10)
+    parser.add_argument("--smoke-weights", action="store_true", default=False,
+                        help="use lazy constant expert weights for execution-only smoke runs")
     parser.add_argument("--enable-l2-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2))
     parser.add_argument("--compile-only", action="store_true", default=False)
     parser.add_argument("--runtime-dir", type=str, default=None)
@@ -815,6 +834,7 @@ if __name__ == "__main__":
         specs=build_tensor_specs(
             start_pos=args.start_pos,
             layer_id=args.layer_id,
+            smoke_weights=args.smoke_weights,
         ),
         golden_fn=golden_fn,
         compile_only=args.compile_only,

--- a/models/deepseek_v4_pro/moe.py
+++ b/models/deepseek_v4_pro/moe.py
@@ -1016,7 +1016,14 @@ if __name__ == "__main__":
     device_ids = [int(d) for d in args.device.split(",")]
     assert len(device_ids) == N_RANKS, f"need exactly {N_RANKS} devices, got {device_ids}"
 
-    golden_data = args.golden_data
+    golden_fn = None if args.smoke_weights else golden_moe
+    golden_data = None if args.smoke_weights else args.golden_data
+    compare_fn = None if args.smoke_weights else {
+        # BF16 x_next. Tightened 5e-3 -> 3e-3 with the real layer-0 hc_ffn
+        # gate (~2.1% of points > 3e-3). No max_diff_hd (near-zero
+        # residual/FFN cancellations blow up relatively).
+        "x_next": ratio_reldiff(diff_thd=3e-3, pct_thd=0.05),
+    }
 
     result = run_jit(
         fn=l3_moe,
@@ -1026,7 +1033,7 @@ if __name__ == "__main__":
             balanced_routing=args.balanced_routing,
             smoke_weights=args.smoke_weights,
         ),
-        golden_fn=golden_moe,
+        golden_fn=golden_fn,
         golden_data=golden_data,
         save_data=args.save_data,
         compile_only=args.compile_only,
@@ -1045,12 +1052,7 @@ if __name__ == "__main__":
         ),
         rtol=1e-3,
         atol=1e-3,
-        compare_fn={
-            # BF16 x_next. Tightened 5e-3 -> 3e-3 with the real layer-0 hc_ffn
-            # gate (~2.1% of points > 3e-3). No max_diff_hd (near-zero
-            # residual/FFN cancellations blow up relatively).
-            "x_next": ratio_reldiff(diff_thd=3e-3, pct_thd=0.05),
-        },
+        compare_fn=compare_fn,
     )
     if not result.passed:
         if result.error:

--- a/models/deepseek_v4_pro/moe.py
+++ b/models/deepseek_v4_pro/moe.py
@@ -797,7 +797,7 @@ def golden_moe(tensors):
     tensors["x_next"][:] = x_next_out
 
 
-def build_tensor_specs(layer_id=0, num_tokens=T, balanced_routing=False):
+def build_tensor_specs(layer_id=0, num_tokens=T, balanced_routing=False, smoke_weights=False):
     import torch
     from golden import ScalarSpec, TensorSpec
     from expert_routed import gen_routed_weight
@@ -877,41 +877,60 @@ def build_tensor_specs(layer_id=0, num_tokens=T, balanced_routing=False):
         assert active_routes % N_EXPERTS_GLOBAL == 0, \
             "balanced routing requires the active route count to divide evenly across experts"
 
-    # Per-rank routed expert weights (different shards).
-    routed_w1_i8_list = []
-    routed_w1_s_list = []
-    routed_w3_i8_list = []
-    routed_w3_s_list = []
-    routed_w2_i8_list = []
-    routed_w2_s_list = []
-    for _ in range(N_RANKS):
-        w1_i8, w1_s = gen_routed_weight((N_LOCAL, MOE_INTER, D), ROUTED_DEQUANT_STD["w1"])
-        w3_i8, w3_s = gen_routed_weight((N_LOCAL, MOE_INTER, D), ROUTED_DEQUANT_STD["w3"])
-        w2_i8, w2_s = gen_routed_weight((N_LOCAL, D, MOE_INTER), ROUTED_DEQUANT_STD["w2"])
-        routed_w1_i8_list.append(w1_i8)
-        routed_w1_s_list.append(w1_s)
-        routed_w3_i8_list.append(w3_i8)
-        routed_w3_s_list.append(w3_s)
-        routed_w2_i8_list.append(w2_i8)
-        routed_w2_s_list.append(w2_s)
+    if smoke_weights:
+        # Lazy shape-correct expert payloads for low-memory execution smoke runs.
+        routed_w1_init = routed_w3_init = routed_w2_init = torch.zeros
+        routed_w1_scale_init = routed_w3_scale_init = routed_w2_scale_init = torch.ones
+        shared_w1_init = shared_w3_init = shared_w2_init = torch.zeros
+        shared_w1_scale_init = shared_w3_scale_init = shared_w2_scale_init = torch.ones
+    else:
+        # Per-rank routed expert weights (different shards).
+        routed_w1_i8_list = []
+        routed_w1_s_list = []
+        routed_w3_i8_list = []
+        routed_w3_s_list = []
+        routed_w2_i8_list = []
+        routed_w2_s_list = []
+        for _ in range(N_RANKS):
+            w1_i8, w1_s = gen_routed_weight((N_LOCAL, MOE_INTER, D), ROUTED_DEQUANT_STD["w1"])
+            w3_i8, w3_s = gen_routed_weight((N_LOCAL, MOE_INTER, D), ROUTED_DEQUANT_STD["w3"])
+            w2_i8, w2_s = gen_routed_weight((N_LOCAL, D, MOE_INTER), ROUTED_DEQUANT_STD["w2"])
+            routed_w1_i8_list.append(w1_i8)
+            routed_w1_s_list.append(w1_s)
+            routed_w3_i8_list.append(w3_i8)
+            routed_w3_s_list.append(w3_s)
+            routed_w2_i8_list.append(w2_i8)
+            routed_w2_s_list.append(w2_s)
 
-    rw1_i8 = torch.stack(routed_w1_i8_list)
-    rw1_s = torch.stack(routed_w1_s_list)
-    rw3_i8 = torch.stack(routed_w3_i8_list)
-    rw3_s = torch.stack(routed_w3_s_list)
-    rw2_i8 = torch.stack(routed_w2_i8_list)
-    rw2_s = torch.stack(routed_w2_s_list)
+        rw1_i8 = torch.stack(routed_w1_i8_list)
+        rw1_s = torch.stack(routed_w1_s_list)
+        rw3_i8 = torch.stack(routed_w3_i8_list)
+        rw3_s = torch.stack(routed_w3_s_list)
+        rw2_i8 = torch.stack(routed_w2_i8_list)
+        rw2_s = torch.stack(routed_w2_s_list)
+        routed_w1_init = rw1_i8
+        routed_w1_scale_init = rw1_s
+        routed_w3_init = rw3_i8
+        routed_w3_scale_init = rw3_s
+        routed_w2_init = rw2_i8
+        routed_w2_scale_init = rw2_s
 
-    # Shared expert weights — replicated across ranks.
-    sw1_i8, sw1_s = gen_shared_weight((MOE_INTER, D), SHARED_DEQUANT_STD["w1"], chan_cv=0.50)
-    sw3_i8, sw3_s = gen_shared_weight((MOE_INTER, D), SHARED_DEQUANT_STD["w3"], chan_cv=0.50)
-    sw2_i8, sw2_s = gen_shared_weight((D, MOE_INTER), SHARED_DEQUANT_STD["w2"], chan_cv=0.33)
-    sw1_i8 = sw1_i8.unsqueeze(0).expand(N_RANKS, -1, -1).contiguous()
-    sw1_s = sw1_s.unsqueeze(0).expand(N_RANKS, -1).contiguous()
-    sw3_i8 = sw3_i8.unsqueeze(0).expand(N_RANKS, -1, -1).contiguous()
-    sw3_s = sw3_s.unsqueeze(0).expand(N_RANKS, -1).contiguous()
-    sw2_i8 = sw2_i8.unsqueeze(0).expand(N_RANKS, -1, -1).contiguous()
-    sw2_s = sw2_s.unsqueeze(0).expand(N_RANKS, -1).contiguous()
+        # Shared expert weights — replicated across ranks.
+        sw1_i8, sw1_s = gen_shared_weight((MOE_INTER, D), SHARED_DEQUANT_STD["w1"], chan_cv=0.50)
+        sw3_i8, sw3_s = gen_shared_weight((MOE_INTER, D), SHARED_DEQUANT_STD["w3"], chan_cv=0.50)
+        sw2_i8, sw2_s = gen_shared_weight((D, MOE_INTER), SHARED_DEQUANT_STD["w2"], chan_cv=0.33)
+        sw1_i8 = sw1_i8.unsqueeze(0).expand(N_RANKS, -1, -1).contiguous()
+        sw1_s = sw1_s.unsqueeze(0).expand(N_RANKS, -1).contiguous()
+        sw3_i8 = sw3_i8.unsqueeze(0).expand(N_RANKS, -1, -1).contiguous()
+        sw3_s = sw3_s.unsqueeze(0).expand(N_RANKS, -1).contiguous()
+        sw2_i8 = sw2_i8.unsqueeze(0).expand(N_RANKS, -1, -1).contiguous()
+        sw2_s = sw2_s.unsqueeze(0).expand(N_RANKS, -1).contiguous()
+        shared_w1_init = sw1_i8
+        shared_w1_scale_init = sw1_s
+        shared_w3_init = sw3_i8
+        shared_w3_scale_init = sw3_s
+        shared_w2_init = sw2_i8
+        shared_w2_scale_init = sw2_s
 
     specs = [
         TensorSpec("x_hc",          [N_RANKS, T, HC_MULT, D],     torch.float32, init_value=init_x_hc),
@@ -923,18 +942,18 @@ def build_tensor_specs(layer_id=0, num_tokens=T, balanced_routing=False):
         TensorSpec("gate_bias",     [N_RANKS, N_EXPERTS_GLOBAL],     torch.float32,  init_value=init_gate_bias),
         TensorSpec("tid2eid",       [N_RANKS, VOCAB, TOPK],          torch.int32,    init_value=init_tid2eid),
         TensorSpec("input_ids",     [N_RANKS, T],                 torch.int64,    init_value=init_input_ids),
-        TensorSpec("routed_w1",        [N_RANKS, N_LOCAL, MOE_INTER, D], torch.int8,    init_value=lambda: rw1_i8),
-        TensorSpec("routed_w1_scale",  [N_RANKS, N_LOCAL, MOE_INTER],    torch.float32, init_value=lambda: rw1_s),
-        TensorSpec("routed_w3",        [N_RANKS, N_LOCAL, MOE_INTER, D], torch.int8,    init_value=lambda: rw3_i8),
-        TensorSpec("routed_w3_scale",  [N_RANKS, N_LOCAL, MOE_INTER],    torch.float32, init_value=lambda: rw3_s),
-        TensorSpec("routed_w2",        [N_RANKS, N_LOCAL, D, MOE_INTER], torch.int8,    init_value=lambda: rw2_i8),
-        TensorSpec("routed_w2_scale",  [N_RANKS, N_LOCAL, D],            torch.float32, init_value=lambda: rw2_s),
-        TensorSpec("shared_w1",        [N_RANKS, MOE_INTER, D],          torch.int8,    init_value=lambda: sw1_i8),
-        TensorSpec("shared_w1_scale",  [N_RANKS, MOE_INTER],             torch.float32, init_value=lambda: sw1_s),
-        TensorSpec("shared_w3",        [N_RANKS, MOE_INTER, D],          torch.int8,    init_value=lambda: sw3_i8),
-        TensorSpec("shared_w3_scale",  [N_RANKS, MOE_INTER],             torch.float32, init_value=lambda: sw3_s),
-        TensorSpec("shared_w2",        [N_RANKS, D, MOE_INTER],          torch.int8,    init_value=lambda: sw2_i8),
-        TensorSpec("shared_w2_scale",  [N_RANKS, D],                     torch.float32, init_value=lambda: sw2_s),
+        TensorSpec("routed_w1", [N_RANKS, N_LOCAL, MOE_INTER, D], torch.int8, init_value=routed_w1_init),
+        TensorSpec("routed_w1_scale", [N_RANKS, N_LOCAL, MOE_INTER], torch.float32, init_value=routed_w1_scale_init),
+        TensorSpec("routed_w3", [N_RANKS, N_LOCAL, MOE_INTER, D], torch.int8, init_value=routed_w3_init),
+        TensorSpec("routed_w3_scale", [N_RANKS, N_LOCAL, MOE_INTER], torch.float32, init_value=routed_w3_scale_init),
+        TensorSpec("routed_w2", [N_RANKS, N_LOCAL, D, MOE_INTER], torch.int8, init_value=routed_w2_init),
+        TensorSpec("routed_w2_scale", [N_RANKS, N_LOCAL, D], torch.float32, init_value=routed_w2_scale_init),
+        TensorSpec("shared_w1", [N_RANKS, MOE_INTER, D], torch.int8, init_value=shared_w1_init),
+        TensorSpec("shared_w1_scale", [N_RANKS, MOE_INTER], torch.float32, init_value=shared_w1_scale_init),
+        TensorSpec("shared_w3", [N_RANKS, MOE_INTER, D], torch.int8, init_value=shared_w3_init),
+        TensorSpec("shared_w3_scale", [N_RANKS, MOE_INTER], torch.float32, init_value=shared_w3_scale_init),
+        TensorSpec("shared_w2", [N_RANKS, D, MOE_INTER], torch.int8, init_value=shared_w2_init),
+        TensorSpec("shared_w2_scale", [N_RANKS, D], torch.float32, init_value=shared_w2_scale_init),
         TensorSpec("x_next",           [N_RANKS, T, HC_MULT, D],      torch.float32, is_output=True),
         ScalarSpec("layer_id",         torch.int32,                      layer_id),
         ScalarSpec("num_tokens",       torch.int32,                      num_tokens),
@@ -980,6 +999,8 @@ if __name__ == "__main__":
                         help=f"active token count for MoE dispatch/combine (0..{T})")
     parser.add_argument("--balanced-routing", action="store_true", default=False,
                         help="use deterministic hash routes balanced evenly across all experts")
+    parser.add_argument("--smoke-weights", action="store_true", default=False,
+                        help="use lazy constant expert weights for execution-only smoke runs")
     parser.add_argument("--enable-l2-swimlane", type=int, nargs="?", const=1, default=0, choices=range(5))
     parser.add_argument("--compile-only", action="store_true", default=False)
     parser.add_argument("--runtime-dir", type=str, default=None)
@@ -1003,6 +1024,7 @@ if __name__ == "__main__":
             layer_id=args.layer_id,
             num_tokens=args.num_tokens,
             balanced_routing=args.balanced_routing,
+            smoke_weights=args.smoke_weights,
         ),
         golden_fn=golden_moe,
         golden_data=golden_data,

--- a/models/deepseek_v4_pro/prefill_fwd_staged_draft.py
+++ b/models/deepseek_v4_pro/prefill_fwd_staged_draft.py
@@ -1,0 +1,357 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+# ci: devices=2
+# ci: no-sim
+"""Memory-bounded DeepSeek-V4 Pro packed-prefill forward bring-up.
+
+This driver executes all 61 ``prefill_layer`` stages in model order while only
+one layer's synthetic weights are live. It chains ``x_next`` between layers and
+keeps each layer's mutable attention state for subsequent rounds. The default
+fixture is one 128-token request, which is the smallest first-bring-up case.
+
+After layer 60, the main-model Hyper-Connections head and final RMSNorm run in
+fixed-size packed-token tiles. There is intentionally no golden comparison,
+embedding, MTP, LM head, or logits stage. Expert payloads use the current
+shape-correct INT8 smoke stand-in.
+"""
+
+import argparse
+import gc
+import math
+
+import torch
+from config import PRO_KERNEL as MODEL_CONFIG
+from golden import run_jit
+from prefill_layer import N_RANKS, T, build_tensor_specs, l3_prefill_layer
+from pypto.ir.distributed_compiled_program import DistributedConfig
+from staged_fwd_tail import (
+    build_tensor_specs as build_fwd_tail_tensor_specs,
+    l3_prefill_fwd_tail,
+)
+from staged_fwd_utils import override_inputs
+
+
+RNG_CHECKPOINT_NAMES = frozenset({
+    "kv_cache",
+    "cmp_kv",
+    "idx_kv_cache",
+    "idx_kv_scale",
+    "hca_compress_state",
+    "csa_compress_state",
+    "csa_inner_compress_state",
+})
+
+
+def _specialization_key(layer_id):
+    """Return the attention/routing branch pair constant-folded by JIT."""
+    ratio = MODEL_CONFIG.compress_ratios[layer_id]
+    attention = {128: "hca", 4: "csa"}[ratio]
+    routing = "hash" if layer_id < MODEL_CONFIG.num_hash_layers else "score"
+    return attention, routing
+
+
+def _specialization_representatives():
+    representatives = {}
+    for layer_id in range(MODEL_CONFIG.num_hidden_layers):
+        representatives.setdefault(_specialization_key(layer_id), layer_id)
+    expected = {("hca", "hash"), ("csa", "hash"), ("hca", "score"), ("csa", "score")}
+    if set(representatives) != expected:
+        raise ValueError(f"unexpected prefill specialization classes: {representatives}")
+    return representatives
+
+
+def _active_cache_names(layer_id):
+    if MODEL_CONFIG.compress_ratios[layer_id] == 128:
+        return frozenset({"kv_cache", "cmp_kv", "hca_compress_state"})
+    return frozenset({
+        "kv_cache",
+        "cmp_kv",
+        "idx_kv_cache",
+        "idx_kv_scale",
+        "csa_compress_state",
+        "csa_inner_compress_state",
+    })
+
+
+def _round_start_positions(base_positions, chunk_lens, round_id):
+    return tuple(
+        start_pos + round_id * chunk_len
+        for start_pos, chunk_len in zip(base_positions, chunk_lens)
+    )
+
+
+def _run_compile_only(args, device_ids, representatives, chunk_lens, start_positions):
+    runtime_cfg = {
+        "platform": args.platform,
+        "enable_l2_swimlane": args.enable_l2_swimlane,
+        "startup_timeout_s": args.startup_timeout_s,
+    }
+    compile_cfg = {
+        "dump_passes": args.dump_passes,
+        "distributed_config": DistributedConfig(
+            device_ids=device_ids[:N_RANKS],
+            num_sub_workers=0,
+        ),
+    }
+    for key, layer_id in representatives.items():
+        print(f"[STAGED] compiling {key[0]}+{key[1]} with representative layer {layer_id}", flush=True)
+        torch.manual_seed(args.seed + layer_id)
+        specs = build_tensor_specs(
+            layer_id=layer_id,
+            chunk_lens=chunk_lens,
+            start_positions=start_positions,
+            smoke_weights=True,
+        )
+        result = run_jit(
+            fn=l3_prefill_layer,
+            specs=specs,
+            golden_fn=None,
+            compile_only=True,
+            save_data=False,
+            compile_cfg=compile_cfg,
+            runtime_cfg=runtime_cfg,
+        )
+        if not result.passed:
+            if result.error:
+                print(result.error)
+            return False
+        del result, specs
+        gc.collect()
+
+    print("[STAGED] compiling hc_head+final_rmsnorm tail", flush=True)
+    torch.manual_seed(args.seed + MODEL_CONFIG.num_hidden_layers)
+    specs = build_fwd_tail_tensor_specs(T)
+    result = run_jit(
+        fn=l3_prefill_fwd_tail,
+        specs=specs,
+        golden_fn=None,
+        compile_only=True,
+        save_data=False,
+        compile_cfg=compile_cfg,
+        runtime_cfg=runtime_cfg,
+    )
+    if not result.passed:
+        if result.error:
+            print(result.error)
+        return False
+    del result, specs
+    gc.collect()
+    return True
+
+
+def _run_staged(args, device_ids, representatives, chunk_lens, base_positions):
+    runtime_dirs = {}
+    tail_runtime_dir = None
+    caches_by_layer = {}
+    cache_rng_states_by_layer = {}
+    compile_cfg = {
+        "dump_passes": args.dump_passes,
+        "distributed_config": DistributedConfig(
+            device_ids=device_ids[:N_RANKS],
+            num_sub_workers=0,
+        ),
+    }
+    runtime_cfg = {
+        "platform": args.platform,
+        "enable_l2_swimlane": args.enable_l2_swimlane,
+        "startup_timeout_s": args.startup_timeout_s,
+    }
+
+    for round_id in range(args.rounds):
+        hidden = None
+        start_positions = _round_start_positions(base_positions, chunk_lens, round_id)
+        print(
+            f"[STAGED] prefill round {round_id + 1}/{args.rounds}, "
+            f"start_positions={','.join(str(pos) for pos in start_positions)}",
+            flush=True,
+        )
+        for layer_id in range(MODEL_CONFIG.num_hidden_layers):
+            key = _specialization_key(layer_id)
+            representative = representatives[key]
+            runtime_dir = runtime_dirs.get(key)
+            action = "compile" if runtime_dir is None else "reuse"
+            print(
+                f"[STAGED] layer {layer_id:02d}/{MODEL_CONFIG.num_hidden_layers - 1}: "
+                f"{key[0]}+{key[1]} ({action} L{representative})",
+                flush=True,
+            )
+
+            torch.manual_seed(args.seed + layer_id)
+            specs = build_tensor_specs(
+                layer_id=layer_id,
+                chunk_lens=chunk_lens,
+                start_positions=start_positions,
+                smoke_weights=True,
+            )
+            overrides = dict(caches_by_layer.get(layer_id, {}))
+            if hidden is not None:
+                overrides["x_hc"] = hidden
+            cache_rng_states = cache_rng_states_by_layer.setdefault(layer_id, {})
+            override_inputs(
+                specs,
+                overrides,
+                tracked_names=RNG_CHECKPOINT_NAMES,
+                rng_after_init=cache_rng_states,
+            )
+
+            result = run_jit(
+                fn=l3_prefill_layer,
+                specs=specs,
+                golden_fn=None,
+                compile_only=False,
+                runtime_dir=None if runtime_dir is None else str(runtime_dir),
+                save_data=False,
+                return_outputs=True,
+                compile_cfg=compile_cfg,
+                runtime_cfg=runtime_cfg,
+            )
+            if not result.passed:
+                if result.error:
+                    print(result.error)
+                return False
+            if result.work_dir is None or result.outputs is None:
+                raise RuntimeError(f"layer {layer_id} completed without a runtime directory or outputs")
+            runtime_dirs.setdefault(key, result.work_dir)
+
+            outputs = result.outputs
+            required = {"x_next", *_active_cache_names(layer_id)}
+            missing = required.difference(outputs)
+            if missing:
+                raise RuntimeError(f"layer {layer_id} did not return required outputs: {sorted(missing)}")
+            hidden = outputs["x_next"]
+            caches_by_layer[layer_id] = {
+                name: outputs[name]
+                for name in _active_cache_names(layer_id)
+            }
+
+            del outputs, result, overrides, specs
+            gc.collect()
+
+        if hidden is None:
+            raise RuntimeError("prefill staged layers completed without a hidden state")
+        if hidden.shape[1] % T != 0:
+            raise RuntimeError(
+                f"prefill tail requires whole {T}-token physical tiles, got {hidden.shape[1]} tokens"
+            )
+        normalized_tokens = 0
+        for tile_start in range(0, hidden.shape[1], T):
+            action = "compile" if tail_runtime_dir is None else "reuse"
+            print(
+                f"[STAGED] hc_head+final_rmsnorm tail tile {tile_start // T} ({action})",
+                flush=True,
+            )
+            torch.manual_seed(args.seed + MODEL_CONFIG.num_hidden_layers)
+            specs = build_fwd_tail_tensor_specs(T)
+            override_inputs(
+                specs,
+                {"x_hc": hidden[:, tile_start : tile_start + T].contiguous()},
+            )
+            result = run_jit(
+                fn=l3_prefill_fwd_tail,
+                specs=specs,
+                golden_fn=None,
+                compile_only=False,
+                runtime_dir=None if tail_runtime_dir is None else str(tail_runtime_dir),
+                save_data=False,
+                return_outputs=True,
+                compile_cfg=compile_cfg,
+                runtime_cfg=runtime_cfg,
+            )
+            if not result.passed:
+                if result.error:
+                    print(result.error)
+                return False
+            if result.work_dir is None or result.outputs is None:
+                raise RuntimeError("prefill tail completed without a runtime directory or outputs")
+            tail_runtime_dir = result.work_dir
+            if "hidden_out" not in result.outputs:
+                raise RuntimeError("prefill tail did not return hidden_out")
+            normalized_tokens += result.outputs["hidden_out"].shape[1]
+            del result, specs
+            gc.collect()
+
+        del hidden
+        gc.collect()
+        print(
+            f"[STAGED] prefill round {round_id + 1}/{args.rounds} complete, "
+            f"normalized_physical_tokens={normalized_tokens}",
+            flush=True,
+        )
+    return True
+
+
+def main():
+    parser = argparse.ArgumentParser(description="DeepSeek-V4 Pro staged 61-layer packed-prefill driver.")
+    parser.add_argument("-p", "--platform", type=str, default="a2a3", choices=["a2a3", "a5"])
+    parser.add_argument("--ep", type=int, default=N_RANKS, choices=[2, 4, 8],
+                        help="EP world size / rank count (parsed at import by moe)")
+    parser.add_argument("-d", "--device", type=str,
+                        default=",".join(str(i) for i in range(N_RANKS)),
+                        help=f"comma-separated device ids; need at least {N_RANKS}")
+    parser.add_argument("--chunk-lens", type=str, default=str(T),
+                        help="comma-separated per-request logical chunk lengths")
+    parser.add_argument("--start-positions", type=str, default=None,
+                        help="comma-separated prior context lengths; defaults to all zeros")
+    parser.add_argument("--rounds", type=int, default=2)
+    parser.add_argument("--seed", type=int, default=0,
+                        help="base seed used to regenerate stable per-layer smoke weights")
+    parser.add_argument("--enable-l2-swimlane", type=int, nargs="?", const=1,
+                        default=0, choices=(0, 1, 2))
+    parser.add_argument("--startup-timeout-s", type=float, default=900.0,
+                        help="forked EP worker startup deadline in seconds")
+    parser.add_argument("--compile-only", action="store_true", default=False)
+    parser.add_argument("--dump-passes", action="store_true", default=False)
+    args = parser.parse_args()
+
+    if args.rounds <= 0:
+        parser.error("--rounds must be positive")
+    if not math.isfinite(args.startup_timeout_s) or args.startup_timeout_s <= 0:
+        parser.error("--startup-timeout-s must be positive and finite")
+    if args.ep != N_RANKS:
+        parser.error(f"--ep was imported as {N_RANKS}, got parsed value {args.ep}")
+    device_ids = [int(device) for device in args.device.split(",")]
+    if len(device_ids) < N_RANKS:
+        parser.error(f"need at least {N_RANKS} devices, got {device_ids}")
+
+    chunk_lens = tuple(int(value) for value in args.chunk_lens.split(","))
+    if not chunk_lens or any(chunk_len <= 0 for chunk_len in chunk_lens):
+        parser.error(f"--chunk-lens must contain positive integers, got {chunk_lens}")
+    if args.start_positions is None:
+        base_positions = (0,) * len(chunk_lens)
+    else:
+        base_positions = tuple(int(value) for value in args.start_positions.split(","))
+    if len(base_positions) != len(chunk_lens):
+        parser.error("--start-positions must have the same number of values as --chunk-lens")
+    if any(start_pos < 0 for start_pos in base_positions):
+        parser.error(f"--start-positions must be non-negative, got {base_positions}")
+
+    representatives = _specialization_representatives()
+    passed = (
+        _run_compile_only(
+            args,
+            device_ids,
+            representatives,
+            chunk_lens,
+            base_positions,
+        )
+        if args.compile_only
+        else _run_staged(
+            args,
+            device_ids,
+            representatives,
+            chunk_lens,
+            base_positions,
+        )
+    )
+    if not passed:
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/models/deepseek_v4_pro/prefill_layer.py
+++ b/models/deepseek_v4_pro/prefill_layer.py
@@ -1315,6 +1315,29 @@ if __name__ == "__main__":
     assert len(device_ids) >= N_RANKS, f"need at least {N_RANKS} devices, got {device_ids}"
     chunk_lens = tuple(int(x) for x in args.chunk_lens.split(","))
     start_positions = None if args.start_positions is None else tuple(int(x) for x in args.start_positions.split(","))
+    golden_fn = None if args.smoke_weights else golden_prefill_layer
+    compare_fn = None if args.smoke_weights else {
+        # Real-weight x_next over-thd fractions (frac>5e-3 / frac>1e-2):
+        # --chunk-lens 128,192
+        # TODO: re-measure on Pro real weights. The numbers below are the
+        # Flash measurements (2 SWA layers, 256 experts, routed_scaling 1.5)
+        # and do not describe Pro, whose layer 0 is HCA, not SWA:
+        #   swa(L0) 0.15% / 0.0006%, hca(L9) 1.1% / 0.45%, csa(L8) 3.89% / 0.63%.
+        "x_next": valid_ratio_reldiff(diff_thd=0.01, pct_thd=0.05),
+        "kv_cache": ratio_allclose(atol=1e-4, rtol=1.0 / 128),
+        # Packed CSA runs preserve the standalone child-kernel precision
+        # contracts: sparse BF16 cache rows may differ by one ULP, C8 rows
+        # by one LSB, and only a small fraction of recurrent-state values
+        # cross the strict pointwise FP32 threshold.
+        "csa_compress_state": ratio_allclose(
+            atol=1e-3, rtol=1e-3, max_error_ratio=0.005
+        ),
+        "csa_inner_compress_state": ratio_allclose(
+            atol=1e-3, rtol=1e-3, max_error_ratio=0.005
+        ),
+        "cmp_kv": ratio_allclose(atol=1e-4, rtol=1.0 / 128, max_error_ratio=0.005),
+        "idx_kv_cache": ratio_allclose(atol=1, rtol=0, max_error_ratio=0.01),
+    }
 
     result = run_jit(
         fn=l3_prefill_layer,
@@ -1324,7 +1347,7 @@ if __name__ == "__main__":
             start_positions=start_positions,
             smoke_weights=args.smoke_weights,
         ),
-        golden_fn=golden_prefill_layer,
+        golden_fn=golden_fn,
         compile_only=args.compile_only,
         compile_cfg=dict(
             dump_passes=args.dump_passes,
@@ -1339,28 +1362,7 @@ if __name__ == "__main__":
         ),
         rtol=1e-3,
         atol=1e-3,
-        compare_fn={
-            # Real-weight x_next over-thd fractions (frac>5e-3 / frac>1e-2):
-            # --chunk-lens 128,192
-            # TODO: re-measure on Pro real weights. The numbers below are the
-            # Flash measurements (2 SWA layers, 256 experts, routed_scaling 1.5)
-            # and do not describe Pro, whose layer 0 is HCA, not SWA:
-            #   swa(L0) 0.15% / 0.0006%, hca(L9) 1.1% / 0.45%, csa(L8) 3.89% / 0.63%.
-            "x_next": valid_ratio_reldiff(diff_thd=0.01, pct_thd=0.05),
-            "kv_cache": ratio_allclose(atol=1e-4, rtol=1.0 / 128),
-            # Packed CSA runs preserve the standalone child-kernel precision
-            # contracts: sparse BF16 cache rows may differ by one ULP, C8 rows
-            # by one LSB, and only a small fraction of recurrent-state values
-            # cross the strict pointwise FP32 threshold.
-            "csa_compress_state": ratio_allclose(
-                atol=1e-3, rtol=1e-3, max_error_ratio=0.005
-            ),
-            "csa_inner_compress_state": ratio_allclose(
-                atol=1e-3, rtol=1e-3, max_error_ratio=0.005
-            ),
-            "cmp_kv": ratio_allclose(atol=1e-4, rtol=1.0 / 128, max_error_ratio=0.005),
-            "idx_kv_cache": ratio_allclose(atol=1, rtol=0, max_error_ratio=0.01),
-        },
+        compare_fn=compare_fn,
     )
     if not result.passed:
         if result.error:

--- a/models/deepseek_v4_pro/prefill_layer.py
+++ b/models/deepseek_v4_pro/prefill_layer.py
@@ -878,7 +878,12 @@ def _resolve_batch(chunk_lens, start_positions, torch):
             total_tokens)
 
 
-def build_tensor_specs(layer_id=2, chunk_lens=DEFAULT_CHUNK_LENS, start_positions=None):
+def build_tensor_specs(
+    layer_id=2,
+    chunk_lens=DEFAULT_CHUNK_LENS,
+    start_positions=None,
+    smoke_weights=False,
+):
     """Packed batch tensor specs for the chunked prefill layer.
 
     ``chunk_lens`` lists the current-chunk length per request;
@@ -1090,7 +1095,7 @@ def build_tensor_specs(layer_id=2, chunk_lens=DEFAULT_CHUNK_LENS, start_position
                                    init_value=replicate(tile_offsets_t)))
 
     # MoE weight tensors (per rank). tid2eid keeps its hash-table init.
-    for spec in build_moe_tensor_specs(layer_id=layer_id):
+    for spec in build_moe_tensor_specs(layer_id=layer_id, smoke_weights=smoke_weights):
         if not isinstance(spec, TensorSpec) or spec.name in {"x_hc", "x_next", "input_ids"}:
             continue
         if spec.name == "tid2eid":
@@ -1299,6 +1304,8 @@ if __name__ == "__main__":
                         help="Comma-separated per-request logical chunk lengths.")
     parser.add_argument("--start-positions", type=str, default=None,
                         help="Comma-separated per-request prior context lengths; defaults to all zeros.")
+    parser.add_argument("--smoke-weights", action="store_true", default=False,
+                        help="use lazy constant expert weights for execution-only smoke runs")
     parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
     parser.add_argument("--compile-only", action="store_true", default=False)
     parser.add_argument("--dump-passes", action="store_true", default=False)
@@ -1315,6 +1322,7 @@ if __name__ == "__main__":
             layer_id=args.layer_id,
             chunk_lens=chunk_lens,
             start_positions=start_positions,
+            smoke_weights=args.smoke_weights,
         ),
         golden_fn=golden_prefill_layer,
         compile_only=args.compile_only,

--- a/models/deepseek_v4_pro/staged_fwd_tail.py
+++ b/models/deepseek_v4_pro/staged_fwd_tail.py
@@ -1,0 +1,134 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Per-rank Hyper-Connections head and final RMSNorm for staged bring-up."""
+
+import pypto.language as pl
+import pypto.language.distributed as pld
+
+from config import DECODE_TOKENS, PREFILL_TOKENS, PRO_KERNEL as MODEL_CONFIG
+from hc_head import hc_head
+from moe import N_RANKS
+from rmsnorm import rms_norm
+
+
+# Model configuration.
+D = MODEL_CONFIG.hidden_size
+HC_MULT = MODEL_CONFIG.hc_mult
+HC_DIM = MODEL_CONFIG.hc_dim
+
+
+@pl.jit
+def decode_fwd_tail(
+    x_hc: pl.Tensor[[DECODE_TOKENS, HC_MULT, D], pl.FP32],
+    hc_head_fn: pl.Tensor[[HC_MULT, HC_DIM], pl.FP32],
+    hc_head_scale: pl.Tensor[[1], pl.FP32],
+    hc_head_base: pl.Tensor[[HC_MULT], pl.FP32],
+    final_norm_w: pl.Tensor[[D], pl.BF16],
+    hidden_out: pl.Out[pl.Tensor[[DECODE_TOKENS, D], pl.BF16]],
+):
+    x_head = pl.create_tensor([DECODE_TOKENS, D], dtype=pl.BF16)
+    hc_head(x_hc, hc_head_fn, hc_head_scale, hc_head_base, x_head)
+    rms_norm(x_head, final_norm_w, hidden_out)
+    return hidden_out
+
+
+@pl.jit.host
+def l3_decode_fwd_tail(
+    x_hc: pl.Tensor[[N_RANKS, DECODE_TOKENS, HC_MULT, D], pl.FP32],
+    hc_head_fn: pl.Tensor[[N_RANKS, HC_MULT, HC_DIM], pl.FP32],
+    hc_head_scale: pl.Tensor[[N_RANKS, 1], pl.FP32],
+    hc_head_base: pl.Tensor[[N_RANKS, HC_MULT], pl.FP32],
+    final_norm_w: pl.Tensor[[N_RANKS, D], pl.BF16],
+    hidden_out: pl.Out[pl.Tensor[[N_RANKS, DECODE_TOKENS, D], pl.BF16]],
+):
+    for rank in pl.range(pld.world_size()):
+        decode_fwd_tail(
+            x_hc[rank],
+            hc_head_fn[rank], hc_head_scale[rank], hc_head_base[rank],
+            final_norm_w[rank],
+            hidden_out[rank],
+            device=rank,
+        )
+
+
+@pl.jit
+def prefill_fwd_tail(
+    x_hc: pl.Tensor[[PREFILL_TOKENS, HC_MULT, D], pl.FP32],
+    hc_head_fn: pl.Tensor[[HC_MULT, HC_DIM], pl.FP32],
+    hc_head_scale: pl.Tensor[[1], pl.FP32],
+    hc_head_base: pl.Tensor[[HC_MULT], pl.FP32],
+    final_norm_w: pl.Tensor[[D], pl.BF16],
+    hidden_out: pl.Out[pl.Tensor[[PREFILL_TOKENS, D], pl.BF16]],
+):
+    x_head = pl.create_tensor([PREFILL_TOKENS, D], dtype=pl.BF16)
+    hc_head(x_hc, hc_head_fn, hc_head_scale, hc_head_base, x_head)
+    rms_norm(x_head, final_norm_w, hidden_out)
+    return hidden_out
+
+
+@pl.jit.host
+def l3_prefill_fwd_tail(
+    x_hc: pl.Tensor[[N_RANKS, PREFILL_TOKENS, HC_MULT, D], pl.FP32],
+    hc_head_fn: pl.Tensor[[N_RANKS, HC_MULT, HC_DIM], pl.FP32],
+    hc_head_scale: pl.Tensor[[N_RANKS, 1], pl.FP32],
+    hc_head_base: pl.Tensor[[N_RANKS, HC_MULT], pl.FP32],
+    final_norm_w: pl.Tensor[[N_RANKS, D], pl.BF16],
+    hidden_out: pl.Out[pl.Tensor[[N_RANKS, PREFILL_TOKENS, D], pl.BF16]],
+):
+    for rank in pl.range(pld.world_size()):
+        prefill_fwd_tail(
+            x_hc[rank],
+            hc_head_fn[rank], hc_head_scale[rank], hc_head_base[rank],
+            final_norm_w[rank],
+            hidden_out[rank],
+            device=rank,
+        )
+
+
+def build_tensor_specs(token_count):
+    """Build the replicated tail weights and one rank-stacked activation tile."""
+    import torch
+    from golden import TensorSpec
+
+    if token_count not in (DECODE_TOKENS, PREFILL_TOKENS):
+        raise ValueError(
+            f"tail token count must be decode ({DECODE_TOKENS}) or prefill "
+            f"({PREFILL_TOKENS}), got {token_count}"
+        )
+
+    base = [5.9166, -3.6223, -2.9324, -3.3124]
+    specs = [
+        TensorSpec(
+            "x_hc", [N_RANKS, token_count, HC_MULT, D], torch.float32,
+            init_value=lambda: torch.zeros(N_RANKS, token_count, HC_MULT, D),
+        ),
+        TensorSpec(
+            "hc_head_fn", [N_RANKS, HC_MULT, HC_DIM], torch.float32,
+            init_value=lambda: torch.randn(N_RANKS, HC_MULT, HC_DIM) * 0.0519,
+        ),
+        TensorSpec(
+            "hc_head_scale", [N_RANKS, 1], torch.float32,
+            init_value=lambda: torch.full((N_RANKS, 1), 0.076099, dtype=torch.float32),
+        ),
+        TensorSpec(
+            "hc_head_base", [N_RANKS, HC_MULT], torch.float32,
+            init_value=lambda: torch.tensor(base, dtype=torch.float32)
+            .view(1, HC_MULT)
+            .expand(N_RANKS, -1)
+            .contiguous(),
+        ),
+        TensorSpec(
+            "final_norm_w", [N_RANKS, D], torch.bfloat16,
+            init_value=lambda: (torch.randn(N_RANKS, D) * 0.1 + 1.0).to(torch.bfloat16),
+        ),
+        TensorSpec("hidden_out", [N_RANKS, token_count, D], torch.bfloat16, is_output=True),
+    ]
+    for spec in specs[1:5]:
+        spec.resident = "stacked"
+    return specs

--- a/models/deepseek_v4_pro/staged_fwd_tail.py
+++ b/models/deepseek_v4_pro/staged_fwd_tail.py
@@ -103,6 +103,10 @@ def build_tensor_specs(token_count):
         )
 
     base = [5.9166, -3.6223, -2.9324, -3.3124]
+    if len(base) != HC_MULT:
+        raise ValueError(
+            f"hc_head_base fixture has {len(base)} entries; expected HC_MULT={HC_MULT}"
+        )
     specs = [
         TensorSpec(
             "x_hc", [N_RANKS, token_count, HC_MULT, D], torch.float32,

--- a/models/deepseek_v4_pro/staged_fwd_utils.py
+++ b/models/deepseek_v4_pro/staged_fwd_utils.py
@@ -1,0 +1,68 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Host input chaining helpers for staged DeepSeek-V4 Pro forwards."""
+
+from dataclasses import replace
+
+import torch
+from golden import TensorSpec
+
+
+def override_inputs(specs, values, *, tracked_names=(), rng_after_init=None):
+    """Replace selected inputs while preserving downstream fixture RNG state."""
+    tensor_specs = {spec.name: spec for spec in specs if isinstance(spec, TensorSpec)}
+    tracked_names = frozenset(tracked_names)
+    rng_after_init = {} if rng_after_init is None else rng_after_init
+
+    missing_tracked = tracked_names.difference(tensor_specs)
+    if missing_tracked:
+        raise ValueError(f"cannot track missing tensor specs: {sorted(missing_tracked)}")
+
+    for name, value in values.items():
+        spec = tensor_specs.get(name)
+        if spec is None:
+            raise ValueError(f"cannot override missing tensor spec {name!r}")
+        if list(value.shape) != list(spec.shape) or value.dtype != spec.dtype:
+            raise ValueError(
+                f"{name} override has shape/dtype {list(value.shape)}/{value.dtype}; "
+                f"expected {spec.shape}/{spec.dtype}"
+            )
+        if name in tracked_names:
+            if name not in rng_after_init:
+                raise ValueError(f"missing recorded RNG state for tracked tensor {name!r}")
+            rng_state = rng_after_init[name]
+
+            def init_override(value=value, rng_state=rng_state):
+                torch.random.set_rng_state(rng_state)
+                return value
+
+            spec.init_value = init_override
+        else:
+            spec.init_value = value
+
+    for name in tracked_names.difference(values):
+        spec = tensor_specs[name]
+        source_spec = replace(spec)
+        has_checkpoint = name in rng_after_init
+        checkpoint = rng_after_init.get(name)
+
+        def init_and_checkpoint(
+            name=name,
+            source_spec=source_spec,
+            has_checkpoint=has_checkpoint,
+            checkpoint=checkpoint,
+        ):
+            value = source_spec.create_tensor()
+            if has_checkpoint:
+                torch.random.set_rng_state(checkpoint)
+            else:
+                rng_after_init[name] = torch.random.get_rng_state().clone()
+            return value
+
+        spec.init_value = init_and_checkpoint

--- a/tests/golden/test_runner.py
+++ b/tests/golden/test_runner.py
@@ -21,7 +21,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 import torch
-from golden import ScalarSpec, TensorSpec, run
+from golden import ScalarSpec, TensorSpec, run, run_jit
 from golden.runner import (
     RunResult,
     _backend_for_platform,
@@ -431,6 +431,98 @@ class TestNoValidation:
         # Inputs are still persisted (classic path), outputs are NOT computed/saved.
         assert (compiled_dir / "data" / "in" / "x.pt").is_file()
         assert not (compiled_dir / "data" / "out").exists()
+
+    def test_runtime_only_without_save_does_not_clone_inputs(
+        self, three_kinds_specs, tmp_path,
+    ):
+        """No golden and no persistence must not duplicate generated inputs."""
+        compiled_dir = tmp_path / "build"
+        compiled_dir.mkdir()
+        fake = _FakeCompiled(compiled_dir)
+
+        with (
+            patch("pypto.ir.compile", return_value=fake),
+            patch("pypto.runtime.execute_compiled", return_value=None),
+            patch.object(
+                torch.Tensor,
+                "clone",
+                side_effect=AssertionError("runtime-only inputs must not be cloned"),
+            ),
+        ):
+            result = run(
+                program=object(),
+                specs=three_kinds_specs,
+                golden_fn=None,
+                golden_data=None,
+                save_data=False,
+            )
+
+        assert result.passed, result.error
+
+
+class TestOutputCapture:
+    """Output capture is opt-in and exposes only declared output tensors."""
+
+    def test_run_returns_outputs_when_enabled(self, three_kinds_specs, tmp_path):
+        compiled_dir = tmp_path / "build"
+        compiled_dir.mkdir()
+
+        def fake_execute(_work_dir, tensors, **_kwargs):
+            tensors[1].fill_(7.0)
+            tensors[2].fill_(8.0)
+
+        compile_p, exec_p = _patch_compile_and_execute(
+            compiled_dir,
+            fake_execute=fake_execute,
+        )
+        with compile_p, exec_p:
+            result = run(
+                program=object(),
+                specs=three_kinds_specs,
+                return_outputs=True,
+            )
+
+        assert result.passed, result.error
+        assert result.outputs is not None
+        assert set(result.outputs) == {"y", "state"}
+        assert torch.equal(result.outputs["y"], torch.full((4,), 7.0))
+        assert torch.equal(result.outputs["state"], torch.full((4,), 8.0))
+
+    def test_outputs_default_to_none(self, three_kinds_specs, tmp_path):
+        compiled_dir = tmp_path / "build"
+        compiled_dir.mkdir()
+        compile_p, exec_p = _patch_compile_and_execute(compiled_dir)
+
+        with compile_p, exec_p:
+            result = run(program=object(), specs=three_kinds_specs)
+
+        assert result.passed, result.error
+        assert result.outputs is None
+
+    def test_run_jit_returns_outputs_when_enabled(self, tmp_path):
+        compiled_dir = tmp_path / "build"
+        compiled_dir.mkdir()
+        specs = [
+            TensorSpec("x", [2], torch.float32, init_value=torch.ones),
+            TensorSpec("y", [2], torch.float32, is_output=True),
+        ]
+        compiled = _FakeCompiled(compiled_dir)
+        fake_jit = MagicMock()
+        fake_jit.compile.return_value = compiled
+
+        def fake_execute(_work_dir, tensors, **_kwargs):
+            tensors[1].copy_(tensors[0] + 2)
+
+        with (
+            patch("pypto.runtime.RunConfig", create=True, side_effect=lambda **_kwargs: object()),
+            patch("pypto.runtime.execute_compiled", side_effect=fake_execute),
+        ):
+            result = run_jit(fake_jit, specs, return_outputs=True)
+
+        assert result.passed, result.error
+        assert result.outputs is not None
+        assert set(result.outputs) == {"y"}
+        assert torch.equal(result.outputs["y"], torch.full((2,), 3.0))
 
 
 class TestCompileOnly:
@@ -992,6 +1084,31 @@ class TestConfigForwarding:
         assert captured["dfx"] is dfx
         assert "enable_dump_args" not in captured
 
+    def test_l3_startup_timeout_not_forwarded_to_single_chip(
+        self, three_kinds_specs, tmp_path,
+    ):
+        """The L3 worker control must not leak into execute_compiled."""
+        compiled_dir = tmp_path / "build"
+        compiled_dir.mkdir()
+        captured: dict = {}
+
+        def fake_execute(_work_dir, _tensors, **kwargs):
+            captured.update(kwargs)
+
+        compile_p, exec_p = _patch_compile_and_execute(
+            compiled_dir,
+            fake_execute=fake_execute,
+        )
+        with compile_p, exec_p:
+            result = run(
+                program=object(),
+                specs=three_kinds_specs,
+                runtime_cfg={"startup_timeout_s": 900.0},
+            )
+
+        assert result.passed, result.error
+        assert "startup_timeout_s" not in captured
+
 
 def _set_mtime(path: Path, mtime: float) -> None:
     """Helper to force a file's mtime to a specific value."""
@@ -1247,6 +1364,17 @@ class TestShareInPlace:
         # An already-shared+contiguous tensor is left as the same object.
         assert tensors["a"] is a
 
+    def test_selected_names_leave_resident_source_unshared(self):
+        io = torch.zeros(4, dtype=torch.float32)
+        weight = torch.ones(4, dtype=torch.float32)
+        tensors = {"io": io, "weight": weight}
+
+        _share_in_place(tensors, ["io"])
+
+        assert tensors["io"].is_shared()
+        assert not tensors["weight"].is_shared()
+        assert tensors["weight"] is weight
+
 
 def test_l3_benchmark_reuses_persistent_windows_without_runtime_reset(monkeypatch):
     """L3 benchmark rounds retain CommDomains and rely on kernel-side signal clears."""
@@ -1358,8 +1486,11 @@ class TestResidentPath:
                 calls["events"].append(("dispatch", args[0]))
 
         class _FakeDCP:
-            def prepare(self, *args, **kwargs):
-                calls["prepare"] = (args, kwargs)
+            def prepare(self, *args, inherited_host_tensors=(), **kwargs):
+                calls["prepare"] = (
+                    args,
+                    {**kwargs, "inherited_host_tensors": inherited_host_tensors},
+                )
                 return _FakeRT()
 
         class _Capture:
@@ -1413,10 +1544,12 @@ class TestResidentPath:
             )
 
         assert result is None
-        assert calls["prepare"] == (
-            ("RUNCFG",),
-            {"persistent": True, "reset_persistent_windows": False},
-        )
+        assert calls["prepare"][0] == ("RUNCFG",)
+        assert calls["prepare"][1]["persistent"] is True
+        assert calls["prepare"][1]["reset_persistent_windows"] is False
+        inherited = calls["prepare"][1]["inherited_host_tensors"]
+        assert len(inherited) == 1 and inherited[0] is state_init
+        assert not state_init.is_shared()
         assert [kind for kind, _ in calls["events"]] == [
             "alloc", "dispatch", "dispatch", "dispatch", "dispatch", "dispatch", "free",
         ]
@@ -1456,7 +1589,7 @@ class TestResidentPath:
         """A resident="stacked" spec uploads via alloc_stacked_tensor and frees via free_stacked_tensor."""
         import golden.runner as R
 
-        calls = {"stacked": [], "freed": 0, "dispatched": 0}
+        calls = {"stacked": [], "freed": 0, "dispatched": 0, "inherited": None}
 
         class _FakeRT:
             last_run_timing = None
@@ -1484,7 +1617,8 @@ class TestResidentPath:
                 calls["dispatched"] += 1
 
         class _FakeDCP:
-            def prepare(self):
+            def prepare(self, *, inherited_host_tensors=()):
+                calls["inherited"] = inherited_host_tensors
                 return _FakeRT()
 
         fake_mod = types.ModuleType("pypto.ir.distributed_compiled_program")
@@ -1514,6 +1648,79 @@ class TestResidentPath:
         assert calls["dispatched"] == 1
         assert calls["stacked"] == [((2, 4), None)]  # identity worker_ids
         assert calls["freed"] == 1
+        assert len(calls["inherited"]) == 1
+        assert calls["inherited"][0] is tensors["w"]
+        assert not tensors["w"].is_shared()
+
+    def test_run_l3_resident_shares_only_per_call_io(self, monkeypatch):
+        """Static resident uploads use inherited CPU storage, not shared memory."""
+        import golden.runner as R
+
+        calls = {
+            "inherited": None,
+            "init": None,
+            "ordered": None,
+            "startup_timeout_s": None,
+        }
+
+        class _FakeRT:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return False
+
+            def alloc_tensor(self, _shape, _dtype, *, init=None, worker_id=0):
+                calls["init"] = init
+                return types.SimpleNamespace(worker_id=worker_id)
+
+            def free_tensor(self, _handle, *, worker_id=0):
+                assert worker_id == 0
+
+            def __call__(self, *args, config=None):
+                calls["ordered"] = args
+
+        class _FakeDCP:
+            def prepare(self, *, inherited_host_tensors=(), startup_timeout_s=None):
+                calls["inherited"] = inherited_host_tensors
+                calls["startup_timeout_s"] = startup_timeout_s
+                return _FakeRT()
+
+        fake_mod = types.ModuleType("pypto.ir.distributed_compiled_program")
+        fake_mod.DistributedCompiledProgram = _FakeDCP
+        specs = [
+            TensorSpec("x", [4], torch.float32, init_value=torch.ones),
+            TensorSpec("w", [4], torch.float32, init_value=torch.ones, resident=0),
+            TensorSpec("y", [4], torch.float32, is_output=True),
+        ]
+        tensors = {spec.name: spec.create_tensor() for spec in specs}
+        weight = tensors["w"]
+        monkeypatch.setattr(R, "_l3_ordered_names", lambda _compiled: ["x", "w", "y"])
+        monkeypatch.setattr(R, "_l3_pure_out_names", lambda _compiled: {"y"})
+        monkeypatch.setattr(R, "_l3_run_config", lambda _cfg: "RUNCFG")
+
+        with patch.dict(sys.modules, {"pypto.ir.distributed_compiled_program": fake_mod}):
+            R._run_l3_resident(
+                compiled=_FakeDCP(),
+                tensor_specs=specs,
+                tensors=tensors,
+                scalar_specs_eff={},
+                runtime_cfg={"platform": "a2a3", "startup_timeout_s": 900.0},
+                golden_outputs=None,
+                rtol=1e-5,
+                atol=1e-5,
+                compare_fn={},
+            )
+
+        assert tensors["x"].is_shared()
+        assert tensors["y"].is_shared()
+        assert tensors["w"] is weight
+        assert not weight.is_shared()
+        assert calls["inherited"] == (weight,)
+        assert calls["startup_timeout_s"] == 900.0
+        assert calls["init"] is weight
+        assert calls["ordered"][0] is tensors["x"]
+        assert calls["ordered"][2] is tensors["y"]
 
     def test_run_l3_resident_pure_out_stacked_skips_zero_upload(self, monkeypatch):
         """A write-only stacked resident uses empty per-rank allocations."""
@@ -1669,6 +1876,69 @@ class TestResidentPath:
         # _validate must have seen the read-back device state (7.0), not the stale 0.0.
         assert calls["validated_value"] is not None
         assert torch.equal(calls["validated_value"], torch.full((2, 4), 7.0))
+
+    def test_return_outputs_reads_back_resident_without_golden(self, monkeypatch):
+        """Opt-in capture performs D2H even when golden validation is disabled."""
+        import golden.runner as R
+
+        calls = {"readback": 0}
+
+        class _FakeRT:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return False
+
+            def alloc_stacked_tensor(self, host, worker_ids=None):
+                return types.SimpleNamespace(full_shape=tuple(host.shape))
+
+            def free_stacked_tensor(self, _handle):
+                pass
+
+            def __call__(self, *_args, config=None):
+                pass
+
+            def copy_stacked_from(self, _handle, host):
+                calls["readback"] += 1
+                host.fill_(11.0)
+
+        class _FakeDCP:
+            def prepare(self):
+                return _FakeRT()
+
+        fake_mod = types.ModuleType("pypto.ir.distributed_compiled_program")
+        fake_mod.DistributedCompiledProgram = _FakeDCP
+        spec = TensorSpec(
+            "state",
+            [2, 4],
+            torch.float32,
+            init_value=torch.zeros,
+            is_output=True,
+            resident="stacked",
+        )
+        tensors = {"state": spec.create_tensor()}
+        monkeypatch.setattr(R, "_l3_ordered_names", lambda _compiled: ["state"])
+        monkeypatch.setattr(R, "_l3_pure_out_names", lambda _compiled: set())
+        monkeypatch.setattr(R, "_l3_run_config", lambda _cfg: "RUNCFG")
+
+        with patch.dict(sys.modules, {"pypto.ir.distributed_compiled_program": fake_mod}):
+            R._run_l3_resident(
+                compiled=_FakeDCP(),
+                tensor_specs=[spec],
+                tensors=tensors,
+                scalar_specs_eff={},
+                runtime_cfg={"platform": "a2a3"},
+                golden_outputs=None,
+                rtol=1e-5,
+                atol=1e-5,
+                compare_fn={},
+                return_outputs=True,
+            )
+
+        assert calls["readback"] == 1
+        assert tensors["state"].is_shared()
+        assert torch.equal(tensors["state"], torch.full((2, 4), 11.0))
 
     def test_run_l3_resident_rejects_non_l3(self):
         """The helper itself raises ValueError for a non-L3 compiled object."""

--- a/tests/golden/test_runner.py
+++ b/tests/golden/test_runner.py
@@ -1429,6 +1429,107 @@ class TestResidentPath:
             TensorSpec("y", [4], torch.float32, is_output=True),             # output
         ]
 
+    def test_prepare_l3_worker_filters_unsupported_prepare_timeout(self):
+        """Legacy prepare() signatures ignore the optional startup deadline."""
+        import golden.runner as R
+
+        worker = object()
+
+        class _LegacyDCP:
+            def prepare(self, startup_timeout_s=None, /):
+                return worker
+
+        result = R._prepare_l3_worker(
+            _LegacyDCP(),
+            run_config=None,
+            bench=False,
+            inherited_host_tensors=(),
+            startup_timeout_s=900.0,
+        )
+
+        assert result is worker
+
+    def test_prepare_l3_worker_filters_unsupported_worker_timeout(self):
+        """The fallback preserves inherited tensors on a legacy worker API."""
+        import golden.runner as R
+
+        inherited = (torch.ones(4),)
+        calls = {}
+
+        class _LegacyDCP:
+            def prepare(self):
+                pytest.fail("prepare() cannot inherit resident host tensors")
+
+        class _LegacyDistributedWorker:
+            def __init__(self, compiled, config, *, inherited_host_tensors=()):
+                calls["compiled"] = compiled
+                calls["config"] = config
+                calls["inherited"] = inherited_host_tensors
+
+        compiled = _LegacyDCP()
+        fake_runtime = types.ModuleType("pypto.runtime")
+        fake_runtime.DistributedWorker = _LegacyDistributedWorker
+        with patch.dict(sys.modules, {"pypto.runtime": fake_runtime}):
+            result = R._prepare_l3_worker(
+                compiled,
+                run_config="RUNCFG",
+                bench=False,
+                inherited_host_tensors=inherited,
+                startup_timeout_s=900.0,
+            )
+
+        assert isinstance(result, _LegacyDistributedWorker)
+        assert calls == {
+            "compiled": compiled,
+            "config": None,
+            "inherited": inherited,
+        }
+
+    def test_prepare_l3_worker_passes_supported_worker_timeout(self):
+        """The fallback forwards the deadline when the worker API supports it."""
+        import golden.runner as R
+
+        inherited = (torch.ones(4),)
+        calls = {}
+
+        class _LegacyDCP:
+            def prepare(self):
+                pytest.fail("prepare() cannot inherit resident host tensors")
+
+        class _DistributedWorker:
+            def __init__(
+                self,
+                compiled,
+                config,
+                *,
+                inherited_host_tensors=(),
+                startup_timeout_s=None,
+            ):
+                calls["compiled"] = compiled
+                calls["config"] = config
+                calls["inherited"] = inherited_host_tensors
+                calls["startup_timeout_s"] = startup_timeout_s
+
+        compiled = _LegacyDCP()
+        fake_runtime = types.ModuleType("pypto.runtime")
+        fake_runtime.DistributedWorker = _DistributedWorker
+        with patch.dict(sys.modules, {"pypto.runtime": fake_runtime}):
+            result = R._prepare_l3_worker(
+                compiled,
+                run_config="RUNCFG",
+                bench=False,
+                inherited_host_tensors=inherited,
+                startup_timeout_s=900.0,
+            )
+
+        assert isinstance(result, _DistributedWorker)
+        assert calls == {
+            "compiled": compiled,
+            "config": None,
+            "inherited": inherited,
+            "startup_timeout_s": 900.0,
+        }
+
     def test_resident_routes_to_l3_resident_not_single_chip(self, tmp_path):
         """A resident spec dispatches via _run_l3_resident; execute_compiled never runs."""
         compiled_dir = tmp_path / "build"

--- a/tests/golden/test_staged_fwd_utils.py
+++ b/tests/golden/test_staged_fwd_utils.py
@@ -1,0 +1,89 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+import torch
+
+from golden import TensorSpec
+
+
+MODULE_PATH = Path(__file__).resolve().parents[2] / "models" / "deepseek_v4_pro" / "staged_fwd_utils.py"
+MODULE_SPEC = importlib.util.spec_from_file_location("staged_fwd_utils", MODULE_PATH)
+assert MODULE_SPEC is not None and MODULE_SPEC.loader is not None
+MODULE = importlib.util.module_from_spec(MODULE_SPEC)
+MODULE_SPEC.loader.exec_module(MODULE)
+override_inputs = MODULE.override_inputs
+
+
+def _make_specs(history_draws=0):
+    def init_history():
+        torch.randn(history_draws)
+        return torch.zeros(4)
+
+    return [
+        TensorSpec("state", [4], torch.float32, init_value=torch.randn),
+        TensorSpec("history", [4], torch.float32, init_value=init_history),
+        TensorSpec("weight", [4], torch.float32, init_value=torch.randn),
+    ]
+
+
+def test_override_replays_rng_after_tracked_state_initializer():
+    with torch.random.fork_rng():
+        rng_after_init = {}
+        torch.manual_seed(17)
+        first_specs = _make_specs()
+        override_inputs(first_specs, {}, tracked_names={"state"}, rng_after_init=rng_after_init)
+        first = {spec.name: spec.create_tensor() for spec in first_specs}
+
+        torch.manual_seed(17)
+        second_specs = _make_specs()
+        override_inputs(
+            second_specs,
+            {"state": torch.ones(4)},
+            tracked_names={"state"},
+            rng_after_init=rng_after_init,
+        )
+        second = {spec.name: spec.create_tensor() for spec in second_specs}
+
+    assert torch.equal(second["state"], torch.ones(4))
+    assert torch.equal(second["weight"], first["weight"])
+
+
+def test_override_rejects_shape_mismatch():
+    with pytest.raises(ValueError, match="shape/dtype"):
+        override_inputs(_make_specs(), {"state": torch.ones(3)})
+
+
+def test_override_restores_checkpoint_after_start_dependent_initializer():
+    with torch.random.fork_rng():
+        rng_after_init = {}
+        tracked_names = {"state", "history"}
+        torch.manual_seed(29)
+        first_specs = _make_specs(history_draws=1)
+        override_inputs(first_specs, {}, tracked_names=tracked_names, rng_after_init=rng_after_init)
+        first = {spec.name: spec.create_tensor() for spec in first_specs}
+
+        torch.manual_seed(29)
+        second_specs = _make_specs(history_draws=11)
+        override_inputs(
+            second_specs,
+            {"state": torch.ones(4)},
+            tracked_names=tracked_names,
+            rng_after_init=rng_after_init,
+        )
+        second = {spec.name: spec.create_tensor() for spec in second_specs}
+
+    assert torch.equal(second["weight"], first["weight"])
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
- Add execution-only golden-runner output capture with memory-bounded
  resident tensor uploads and configurable distributed startup deadlines.
- Add staged 61-layer decode and prefill drivers that reuse four compiled
  layer specializations, chain recurrent state across rounds, and run the
  final normalized-hidden-state tail.
- Add low-memory zero-INT8 expert fixtures and stable per-layer synthetic
  initialization across cache overrides.
- Document the EP2 smoke scope, no-fusion task-submit workflow, reduced
  expert topology, and current lack of native MXFP8-MXFP4 or numerical
  validation.

Depends on hw-native-sys/pypto#2340.