### PR TITLE
Add DeepSeek V4 DSpark drafter

### DIFF
--- a/docs/models/index.md
+++ b/docs/models/index.md
@@ -8,7 +8,7 @@ Files ending in `_draft.py` are work in progress and excluded from CI.
 | [qwen3_14b](qwen3_14b.md) | Qwen3-14B BF16 prefill and decode with the serving contract, plus A8W8 and TurboQuant variants and the sampling components | Supported — one-card A2/A3 accuracy job on relevant PRs |
 | [deepseek_v4_flash_mtp](deepseek_v4_flash_mtp.md) | DeepSeek V4-Flash at MTP = 1, batch 4 per card: operators, layer and MTP compositions, prefill/decode full forwards | Supported — eight-card accuracy job on relevant PRs |
 | [deepseek_v4_pro](deepseek_v4_pro.md) | The Ascend A5 variant: the same V4 operator set and compositions at the larger Pro preset, quantized Hybrid MXFP8-MXFP4 | Not supported |
-| `deepseek_v4_flash_dspark` | The V4-Flash operators re-sized to batch 64 per card and S = 8 DSpark speculation; under development, operators only | Not supported |
+| `deepseek_v4_flash_dspark` | V4-Flash target operators plus the three-layer DSpark drafter backbone and sequential rank-256 Markov sampler; dynamic drafter batches 4, 8, 12, and 16 per card | Not supported |
 | `deepseek_v3_2` | DeepSeek V3.2-EXP as a front/back split of one layer | Not supported |
 | `qwen3_32b` | Qwen3-32B single-layer decode in two tensor layouts | Not supported |
 

--- a/models/deepseek_v4_flash_dspark/config.py
+++ b/models/deepseek_v4_flash_dspark/config.py
@@ -244,6 +244,19 @@ DSPARK_SPEC_TOKENS = 7            # drafts the DSpark drafter proposes per reque
 DECODE_SEQ = 1 + DSPARK_SPEC_TOKENS  # S: tokens the target model verifies per step
 DECODE_TOKENS = DECODE_BATCH * DECODE_SEQ
 DECODE_START_POS = 8192
+
+# DSpark drafter constants.  The drafter has seven logical query rows per
+# request, but kernels use an eighth, masked row so every supported batch stays
+# aligned to the existing eight-row HC/attention tiles.
+DSPARK_NUM_LAYERS = 3
+DSPARK_TARGET_LAYER_IDS = (40, 41, 42)
+DSPARK_NOISE_TOKEN_ID = 128799
+DSPARK_MARKOV_RANK = 256
+DSPARK_QUERY_TOKENS = DSPARK_SPEC_TOKENS
+DSPARK_QUERY_TOKENS_PADDED = 8
+DSPARK_SWA_INDEX_WIDTH = 256
+assert DSPARK_QUERY_TOKENS_PADDED >= DSPARK_QUERY_TOKENS
+assert DSPARK_SWA_INDEX_WIDTH >= FLASH.sliding_window + DSPARK_QUERY_TOKENS
 PREFILL_BATCH = 1                 # B: prefill batch for the current kernel programs
 PREFILL_SEQ = 512                 # S: prefill sequence for the current kernel programs
 PREFILL_TOKENS = PREFILL_BATCH * PREFILL_SEQ

--- a/models/deepseek_v4_flash_dspark/dspark_attention_swa.py
+++ b/models/deepseek_v4_flash_dspark/dspark_attention_swa.py
@@ -1,0 +1,579 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""DeepSeek-V4 DSpark non-causal sliding-window attention."""
+
+
+import pypto.language as pl
+
+from config import (
+    FLASH as M,
+    DECODE_BATCH,
+    TP,
+    KV_ORI_BLOCK_NUM,
+    DECODE_SEQ,
+    BLOCK_SIZE,
+    INT8_SCALE_MAX,
+    INT8_AMAX_EPS,
+    KV_CMP_MAX_BLOCKS,
+    KV_ORI_MAX_BLOCKS,
+    DSPARK_SWA_INDEX_WIDTH,
+)
+from hc_pre import hc_pre
+from hc_post import hc_post
+from qkv_proj_rope import kv_proj_rope, qkv_proj_rope, rope_prepare
+from rmsnorm import rms_norm
+from dspark_sparse_attn_swa import sparse_attn_swa
+
+# Dynamic shape variables.
+T_DYN = pl.dynamic("T_DYN")  # T = B * S
+MAIN_B_DYN = pl.dynamic("DSPARK_MAIN_B_DYN")
+MAIN_BATCH_PAD = 16
+
+
+# model config
+B = DECODE_BATCH // TP
+S = DECODE_SEQ
+T = B * S
+BIAS_T_TILE = 8  # sparse_bias row block; T is a multiple of 8 by the batch contract
+EPS = M.rms_norm_eps
+D = M.hidden_size
+H = M.num_attention_heads
+HEAD_DIM = M.head_dim
+ROPE_HEAD_DIM = M.qk_rope_head_dim
+NOPE_HEAD_DIM = M.nope_head_dim
+Q_LORA = M.q_lora_rank
+WIN = DSPARK_SWA_INDEX_WIDTH
+SOFTMAX_SCALE = M.softmax_scale
+HC_MULT = M.hc_mult
+MIX_HC = M.mix_hc
+HC_DIM = M.hc_dim
+HC_SINKHORN_ITER = M.hc_sinkhorn_iters
+HC_EPS = M.hc_eps
+MAX_SEQ_LEN = M.max_position_embeddings
+O_LORA = M.o_lora_rank
+O_GROUPS = M.o_groups
+O_GROUP_IN = H * HEAD_DIM // O_GROUPS
+
+# kernel-local (SWA: ratio-0, no compressor/indexer)
+ORI_MAX_BLOCKS = KV_ORI_MAX_BLOCKS
+ORI_BLOCK_NUM = KV_ORI_BLOCK_NUM
+ORI_BLOCK_NUM_DYN = pl.dynamic("ORI_BLOCK_NUM_DYN")
+TOPK = WIN                          # SWA: sparse_attn topk = window only
+SPARSE_IDX_TOPK = M.index_topk      # sparse_attn module's IDX_TOPK (static shape contract)
+SPARSE_TOPK = WIN + SPARSE_IDX_TOPK
+SPARSE_CMP_MAX_BLOCKS = KV_CMP_MAX_BLOCKS
+
+# tiling
+SPARSE_ROPE_TILE = 16
+SPARSE_ROPE_INTERLEAVE_TILE = 2 * SPARSE_ROPE_TILE
+NEG_INF = -1.0e20
+
+@pl.jit.inline
+def attention_swa(
+    x_hc: pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32],
+    main_x: pl.Tensor[[MAIN_B_DYN, D], pl.BF16],
+    main_slot_mapping: pl.Tensor[[MAIN_B_DYN], pl.INT64],
+    main_position_ids: pl.Tensor[[MAIN_B_DYN], pl.INT32],
+    # hc_pre weights
+    hc_attn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
+    hc_attn_scale: pl.Tensor[[3], pl.FP32],
+    hc_attn_base: pl.Tensor[[MIX_HC], pl.FP32],
+    # qkv_proj_rope weights
+    attn_norm_w: pl.Tensor[[D], pl.BF16],
+    wq_a: pl.Tensor[[D, Q_LORA], pl.BF16],
+    wq_b: pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8],
+    wq_b_scale: pl.Tensor[[H * HEAD_DIM], pl.FP32],
+    wkv: pl.Tensor[[D, HEAD_DIM], pl.BF16],
+    gamma_cq: pl.Tensor[[Q_LORA], pl.BF16],
+    gamma_ckv: pl.Tensor[[HEAD_DIM], pl.BF16],
+    freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    # KV cache (sliding-window only: [0, WIN) ori; no cmp portion)
+    kv_cache: pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    swa_slot_mapping: pl.Tensor[[T_DYN], pl.INT64],
+    swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
+    swa_lens: pl.Tensor[[T_DYN], pl.INT32],
+    position_ids: pl.Tensor[[T_DYN], pl.INT32],
+    # sparse_attn
+    attn_sink: pl.Tensor[[H], pl.FP32],
+    # o_proj
+    wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
+    wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
+    wo_b_scale: pl.Tensor[[D], pl.FP32],
+    x_out: pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32],
+):
+    t_dim = pl.tensor.dim(x_hc, 0)
+    b_dim = t_dim // S
+    bias_blocks = t_dim // BIAS_T_TILE
+    x_mixed = pl.create_tensor([t_dim, D], dtype=pl.BF16)
+    post_t = pl.create_tensor([t_dim, HC_MULT], dtype=pl.FP32)
+    comb_t = pl.create_tensor([t_dim, HC_MULT * HC_MULT], dtype=pl.FP32)
+    hc_pre(x_hc, hc_attn_fn, hc_attn_scale, hc_attn_base, x_mixed, post_t, comb_t)
+
+    rope_cos_t = pl.create_tensor([t_dim, ROPE_HEAD_DIM], dtype=pl.BF16)
+    rope_sin_t = pl.create_tensor([t_dim, ROPE_HEAD_DIM], dtype=pl.BF16)
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="swa_rope_step"):
+        for b in pl.range(b_dim):
+            for s_idx in pl.range(S):
+                t = b * S + s_idx
+                pos_b = pl.cast(pl.read(position_ids, [t]), pl.INDEX)
+                cos_row = pl.cast(freqs_cos[pos_b : pos_b + 1, 0 : ROPE_HEAD_DIM], target_type=pl.FP32)
+                sin_row = pl.cast(freqs_sin[pos_b : pos_b + 1, 0 : ROPE_HEAD_DIM], target_type=pl.FP32)
+                rope_cos_t[t : t + 1, 0 : ROPE_HEAD_DIM] = pl.cast(cos_row, target_type=pl.BF16, mode="rint")
+                rope_sin_t[t : t + 1, 0 : ROPE_HEAD_DIM] = pl.cast(sin_row, target_type=pl.BF16, mode="rint")
+
+    x_normed_t = pl.create_tensor([t_dim, D], dtype=pl.BF16)
+    rms_tid = rms_norm(x_mixed, attn_norm_w, x_normed_t)
+    # Defers kv_proj_matmul one hop behind rms_norm so qr_proj_matmul dispatches first.
+    late_dep = pl.system.task_dummy(deps=[rms_tid])
+    q = pl.create_tensor([t_dim, H, HEAD_DIM], dtype=pl.BF16)
+    kv = pl.create_tensor([t_dim, HEAD_DIM], dtype=pl.BF16)
+    qr = pl.create_tensor([t_dim, Q_LORA], dtype=pl.INT8)
+    qr_scale = pl.create_tensor([t_dim, 1], dtype=pl.FP32)
+    qkv_proj_rope(
+        x_normed_t, wq_a, wq_b, wq_b_scale, wkv,
+        rope_cos_t, rope_sin_t, gamma_cq, gamma_ckv,
+        q, kv, qr, qr_scale, late_dep,
+    )
+
+    # The target hidden projection contributes the current context KV. Pad the
+    # dynamic batch to one legal cube/vector tile, then keep only the live rows.
+    main_x_pad = pl.create_tensor([MAIN_BATCH_PAD, D], dtype=pl.BF16, init_value=0)
+    main_cos = pl.create_tensor([MAIN_BATCH_PAD, ROPE_HEAD_DIM], dtype=pl.BF16, init_value=0)
+    main_sin = pl.create_tensor([MAIN_BATCH_PAD, ROPE_HEAD_DIM], dtype=pl.BF16, init_value=0)
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="dspark_main_kv_prepare") as main_prepare_tid:
+        for request in pl.range(b_dim):
+            main_x_pad[request : request + 1, :] = main_x[request : request + 1, :]
+            position = pl.cast(pl.read(main_position_ids, [request]), pl.INDEX)
+            main_cos[request : request + 1, :] = freqs_cos[position : position + 1, :]
+            main_sin[request : request + 1, :] = freqs_sin[position : position + 1, :]
+    main_cos_il = pl.create_tensor([MAIN_BATCH_PAD, ROPE_HEAD_DIM], dtype=pl.FP32)
+    main_sin_signed = pl.create_tensor([MAIN_BATCH_PAD, ROPE_HEAD_DIM], dtype=pl.FP32)
+    main_swap_idx = pl.create_tensor([MAIN_BATCH_PAD, ROPE_HEAD_DIM], dtype=pl.INT32)
+    rope_prepare(main_cos, main_sin, main_cos_il, main_sin_signed, main_swap_idx)
+    main_kv = pl.create_tensor([MAIN_BATCH_PAD, HEAD_DIM], dtype=pl.BF16)
+    kv_proj_rope(
+        main_x_pad,
+        wkv,
+        gamma_ckv,
+        main_cos_il,
+        main_sin_signed,
+        main_swap_idx,
+        main_kv,
+        main_prepare_tid,
+    )
+
+    # Commit current decode KV and build its additive padding mask in one task.
+    # The SWA attention kernel reads every visible row through metadata-expanded
+    # physical cache indices, so all cache writes must complete before it starts.
+    ori_block_num = pl.tensor.dim(kv_cache, 0)
+    kv_cache_flat = pl.reshape(kv_cache, [ori_block_num * BLOCK_SIZE, HEAD_DIM])
+    sparse_bias = pl.create_tensor([t_dim, WIN], dtype=pl.FP32)
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="swa_cache_insert_valid_bias"):
+        for request in pl.range(b_dim):
+            main_row_i64 = pl.read(main_slot_mapping, [request])
+            if main_row_i64 >= 0:
+                main_row = pl.cast(main_row_i64, pl.INDEX)
+                kv_cache_flat[main_row : main_row + 1, :] = main_kv[request : request + 1, :]
+        for write_t in pl.range(t_dim):
+            write_row_i64 = pl.read(swa_slot_mapping, [write_t])
+            if write_row_i64 >= 0:
+                write_row = pl.cast(write_row_i64, pl.INDEX)
+                kv_cache_flat[write_row : write_row + 1, 0 : HEAD_DIM] = kv[write_t : write_t + 1, 0 : HEAD_DIM]
+        v_col = pl.cast(pl.arange(0, [1, WIN], dtype=pl.INT32), target_type=pl.FP32)
+        for v_blk in pl.range(bias_blocks):
+            v_t0 = v_blk * BIAS_T_TILE
+            v_col_m = pl.col_expand(pl.full([BIAS_T_TILE, WIN], dtype=pl.FP32, value=0.0), v_col)
+            v_lens = pl.cast(pl.reshape(swa_lens[v_t0 : v_t0 + BIAS_T_TILE], [BIAS_T_TILE, 1]), target_type=pl.FP32)
+            v_valid = pl.minimum(
+                pl.maximum(pl.neg(pl.row_expand_sub(v_col_m, v_lens)), 0.0),
+                1.0,
+            )
+            sparse_bias[v_t0 : v_t0 + BIAS_T_TILE, 0:WIN] = pl.mul(pl.sub(v_valid, 1.0), -NEG_INF)
+    attn_out = pl.create_tensor([t_dim, D], dtype=pl.BF16)
+    sparse_attn_swa(
+        q, kv_cache, swa_indices, sparse_bias,
+        attn_sink, rope_cos_t, rope_sin_t,
+        wo_a, wo_b, wo_b_scale, attn_out,
+    )
+
+    hc_post(attn_out, x_hc, post_t, comb_t, x_out)
+    return x_out
+
+
+@pl.jit
+def attention_swa_test(
+    x_hc: pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32],
+    main_x: pl.Tensor[[MAIN_B_DYN, D], pl.BF16],
+    main_slot_mapping: pl.Tensor[[MAIN_B_DYN], pl.INT64],
+    main_position_ids: pl.Tensor[[MAIN_B_DYN], pl.INT32],
+    # hc_pre weights
+    hc_attn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
+    hc_attn_scale: pl.Tensor[[3], pl.FP32],
+    hc_attn_base: pl.Tensor[[MIX_HC], pl.FP32],
+    # qkv_proj_rope weights
+    attn_norm_w: pl.Tensor[[D], pl.BF16],
+    wq_a: pl.Tensor[[D, Q_LORA], pl.BF16],
+    wq_b: pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8],
+    wq_b_scale: pl.Tensor[[H * HEAD_DIM], pl.FP32],
+    wkv: pl.Tensor[[D, HEAD_DIM], pl.BF16],
+    gamma_cq: pl.Tensor[[Q_LORA], pl.BF16],
+    gamma_ckv: pl.Tensor[[HEAD_DIM], pl.BF16],
+    freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    # KV cache (sliding-window only: [0, WIN) ori; no cmp portion)
+    kv_cache: pl.InOut[pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
+    swa_slot_mapping: pl.Tensor[[T_DYN], pl.INT64],
+    swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
+    swa_lens: pl.Tensor[[T_DYN], pl.INT32],
+    position_ids: pl.Tensor[[T_DYN], pl.INT32],
+    # sparse_attn
+    attn_sink: pl.Tensor[[H], pl.FP32],
+    # o_proj
+    wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
+    wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
+    wo_b_scale: pl.Tensor[[D], pl.FP32],
+    x_out: pl.Out[pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32]],
+):
+    x_hc.bind_dynamic(0, T_DYN)
+    main_x.bind_dynamic(0, MAIN_B_DYN)
+    main_slot_mapping.bind_dynamic(0, MAIN_B_DYN)
+    main_position_ids.bind_dynamic(0, MAIN_B_DYN)
+    swa_slot_mapping.bind_dynamic(0, T_DYN)
+    swa_indices.bind_dynamic(0, T_DYN)
+    swa_lens.bind_dynamic(0, T_DYN)
+    position_ids.bind_dynamic(0, T_DYN)
+    x_out.bind_dynamic(0, T_DYN)
+
+    attention_swa(
+        x_hc,
+        main_x, main_slot_mapping, main_position_ids,
+        hc_attn_fn, hc_attn_scale, hc_attn_base,
+        attn_norm_w, wq_a, wq_b, wq_b_scale, wkv,
+        gamma_cq, gamma_ckv,
+        freqs_cos, freqs_sin,
+        kv_cache, swa_slot_mapping, swa_indices, swa_lens, position_ids,
+        attn_sink,
+        wo_a, wo_b, wo_b_scale,
+        x_out,
+    )
+    return x_out
+
+
+def golden_attention_swa(tensors):
+    """End-to-end orchestration for the ratio=0 (SWA) layers.
+    Mirrors Block.hc_pre + Attention.forward (decode branch, ratio==0 path: no compressor,
+    no indexer, no cmp_kv) + Block.hc_post."""
+    import torch
+
+    from hc_pre import golden_hc_pre
+    from qkv_proj_rope import golden_qkv_proj_rope
+    from rmsnorm import golden_rms_norm
+    from decode_sparse_attn_swa import golden_sparse_attn
+
+    tokens = tensors["x_hc"].shape[0]
+    from hc_post import golden_hc_post
+
+    # ---- Block.hc_pre (model.py:691) ----
+    x_mixed = torch.zeros(tokens, D, dtype=torch.bfloat16)
+    post_t = torch.zeros(tokens, HC_MULT)
+    comb_t = torch.zeros(tokens, HC_MULT * HC_MULT)
+    golden_hc_pre({
+        "x": tensors["x_hc"],
+        "hc_fn": tensors["hc_attn_fn"],
+        "hc_scale": tensors["hc_attn_scale"],
+        "hc_base": tensors["hc_attn_base"],
+        "x_mixed": x_mixed,
+        "post": post_t,
+        "comb": comb_t,
+    })
+
+    # ===== Attention.forward (model.py:484-543), ratio==0 branch =====
+    position_ids = tensors["position_ids"].to(torch.int64)
+    rd = ROPE_HEAD_DIM
+
+    freqs_cos = tensors["freqs_cos"]
+    freqs_sin = tensors["freqs_sin"]
+    rope_cos_T = torch.empty(tokens, rd, dtype=freqs_cos.dtype)
+    rope_sin_T = torch.empty(tokens, rd, dtype=freqs_sin.dtype)
+    for t in range(tokens):
+        pos = int(position_ids[t].item())
+        rope_cos_T[t] = freqs_cos[pos]
+        rope_sin_T[t] = freqs_sin[pos]
+
+    # q + win kv (model.py:495-504)
+    q = torch.zeros(tokens, H, HEAD_DIM, dtype=torch.bfloat16)
+    kv = torch.zeros(tokens, HEAD_DIM, dtype=torch.bfloat16)
+    qr = torch.zeros(tokens, Q_LORA, dtype=torch.int8)
+    qr_scale = torch.zeros(tokens, 1, dtype=torch.float32)
+    x_normed = golden_rms_norm(x_mixed, tensors["attn_norm_w"])
+    golden_qkv_proj_rope({
+        "x": x_normed,
+        "wq_a": tensors["wq_a"],
+        "wq_b": tensors["wq_b"],
+        "wq_b_scale": tensors["wq_b_scale"],
+        "wkv": tensors["wkv"],
+        "rope_cos": rope_cos_T,
+        "rope_sin": rope_sin_T,
+        "gamma_cq": tensors["gamma_cq"],
+        "gamma_ckv": tensors["gamma_ckv"],
+        "q": q,
+        "kv": kv,
+        "qr": qr,                                                              # qr unused on SWA path
+        "qr_scale": qr_scale,
+    })
+
+    kv_cache = tensors["kv_cache"]
+    attn_out = torch.zeros(tokens, D, dtype=torch.bfloat16)
+
+    # Current decode KV is visible to SWA through the same physical cache slots
+    # that metadata points at.
+    swa_slot_mapping = tensors["swa_slot_mapping"].to(torch.int64)
+    for t in range(tokens):
+        write_row = int(swa_slot_mapping[t].item())
+        if write_row >= 0:
+            write_blk = write_row // BLOCK_SIZE
+            write_intra = write_row % BLOCK_SIZE
+            kv_cache[write_blk, write_intra, 0] = kv[t]
+
+    golden_sparse_attn({
+        "q": q,
+        "ori_kv": kv_cache,
+        "swa_indices": tensors["swa_indices"],
+        "swa_lens": tensors["swa_lens"],
+        "attn_sink": tensors["attn_sink"],
+        "freqs_cos": rope_cos_T,
+        "freqs_sin": rope_sin_T,
+        "wo_a": tensors["wo_a"],
+        "wo_b": tensors["wo_b"],
+        "wo_b_scale": tensors["wo_b_scale"],
+        "attn_out": attn_out,
+    })
+
+    # ===== Block.hc_post (model.py:694) =====
+    y = torch.zeros(tokens, HC_MULT, D, dtype=torch.float32)
+    golden_hc_post({
+        "x": attn_out,
+        "residual": tensors["x_hc"],
+        "post": post_t,
+        "comb": comb_t,
+        "y": y,
+    })
+
+    tensors["x_out"][:] = y
+
+
+def build_tensor_specs(start_pos=None, batch=B):
+    tokens = batch * S
+    import torch  # type: ignore[import]
+    from utils import (
+        block_table,
+        paged_slot_mapping,
+        position_ids_from_starts,
+        resolve_start_positions,
+        swa_indices_and_lens,
+        swa_decode_start_set,
+    )
+    from golden import TensorSpec
+    from utils import build_rope_tables
+
+    shared_freqs_cos, shared_freqs_sin = build_rope_tables(M, 0, dtype=torch.bfloat16)
+
+    def quant_w_per_output_channel(w):
+        amax = w.float().abs().amax(dim=0).clamp_min(INT8_AMAX_EPS)
+        scale_quant = INT8_SCALE_MAX / amax
+        scaled = w.float() * scale_quant.view(1, H * HEAD_DIM)
+        w_i32 = torch.round(scaled).to(torch.int32)
+        w_i32 = torch.clamp(w_i32, -int(INT8_SCALE_MAX), int(INT8_SCALE_MAX))
+        w_i8 = w_i32.to(torch.float16).to(torch.int8)
+        return w_i8, (1.0 / scale_quant).float()
+
+    def quant_w_per_row(w):
+        amax = w.float().abs().amax(dim=-1).clamp_min(INT8_AMAX_EPS)
+        scale_quant = INT8_SCALE_MAX / amax
+        scaled = w.float() * scale_quant.unsqueeze(-1)
+        w_i32 = torch.round(scaled).to(torch.int32)
+        w_i32 = torch.clamp(w_i32, -int(INT8_SCALE_MAX), int(INT8_SCALE_MAX))
+        w_i8 = w_i32.to(torch.float16).to(torch.int8)
+        return w_i8, (1.0 / scale_quant).float()
+
+    def init_x_hc():
+        return torch.empty(tokens, HC_MULT, D).uniform_(-1, 1)
+    # Real layer-0 (SWA) hc_attn scale/base (fn synthetic at real magnitude). A synthetic
+    # scale=0.5/base=0 leaves hc_pre post~=1 + near-uniform comb, cancelling attn_out and the
+    # hc residual to near-zero in x_out where quant noise blows up the relative tail.
+    def init_hc_attn_fn():
+        return torch.randn(MIX_HC, HC_DIM) * 0.039
+    def init_hc_attn_scale():
+        return torch.tensor([2.076026, 0.018729, 0.245936])
+    def init_hc_attn_base():
+        return torch.tensor([
+            3.9083, -2.0399, -2.2033, -2.017,
+            -2.4443, -10.3158, -8.9943, -6.3581,
+            9.8577, -9.5177, -24.8724, -22.8929,
+            -21.545, 0.7791, -3.386, 1.1948,
+            -20.9605, -0.7702, 1.4218, -4.8994,
+            1.5177, -29.7663, -30.1413, -1.2413,
+        ])
+    def init_attn_norm_w():
+        return torch.ones(D)
+    def init_wq_a():
+        return torch.randn(D, Q_LORA) / D ** 0.5
+    def init_wq_b():
+        return torch.randn(Q_LORA, H * HEAD_DIM) / Q_LORA ** 0.5
+    def init_wkv():
+        return torch.randn(D, HEAD_DIM) / D ** 0.5
+    def init_gamma_cq():
+        return torch.ones(Q_LORA)
+    def init_gamma_ckv():
+        return torch.ones(HEAD_DIM)
+    def init_freqs_cos():
+        return shared_freqs_cos.clone()
+    def init_freqs_sin():
+        return shared_freqs_sin.clone()
+    def init_normalized_cache(shape):
+        cache = torch.randn(*shape)
+        denom = cache.float().pow(2).mean(dim=-1, keepdim=True).sqrt().clamp_min(EPS)
+        return (cache / denom).to(torch.bfloat16)
+
+    def init_kv_cache():
+        return init_normalized_cache((ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM))
+
+    def init_block_table():
+        return block_table(batch=batch, table_blocks=ORI_MAX_BLOCKS, physical_blocks=ORI_BLOCK_NUM)
+
+    def init_attn_sink():
+        return torch.zeros(H)
+    def init_default_start_pos():
+        # Canonical SWA start-position set (sliding-window regimes + 8k long-context).
+        return swa_decode_start_set(batch=batch, window=WIN)
+    def init_start_pos():
+        return resolve_start_positions(
+            start_pos,
+            batch=batch,
+            seq=S,
+            max_seq_len=MAX_SEQ_LEN,
+            default_fn=init_default_start_pos,
+        )
+    def init_position_ids():
+        return position_ids_from_starts(init_start_pos(), seq=S).reshape(-1).contiguous()
+    def init_swa_slot_mapping():
+        return paged_slot_mapping(
+            position_ids_from_starts(init_start_pos(), seq=S),
+            init_block_table(),
+            block_size=BLOCK_SIZE,
+        ).reshape(-1).contiguous()
+    def init_swa_metadata():
+        return swa_indices_and_lens(
+            position_ids_from_starts(init_start_pos(), seq=S),
+            init_block_table(),
+            block_size=BLOCK_SIZE,
+            window=WIN,
+        )
+    def init_swa_indices():
+        return init_swa_metadata()[0].contiguous()
+    def init_swa_lens():
+        return init_swa_metadata()[1].contiguous()
+    def init_wo_a():
+        return torch.randn(O_GROUPS, O_LORA, O_GROUP_IN) / O_GROUP_IN ** 0.5
+    def init_wo_b():
+        return torch.randn(D, O_GROUPS * O_LORA) / (O_GROUPS * O_LORA) ** 0.5
+
+    wq_b_bf16 = init_wq_b().to(torch.bfloat16)
+    wq_b_i8, wq_b_scale = quant_w_per_output_channel(wq_b_bf16)
+    wo_b_bf16 = init_wo_b().to(torch.bfloat16)
+    wo_b_i8, wo_b_scale = quant_w_per_row(wo_b_bf16)
+
+    return [
+        TensorSpec("x_hc", [tokens, HC_MULT, D], torch.float32, init_value=init_x_hc),
+        TensorSpec(
+            "main_x", [batch, D], torch.bfloat16,
+            init_value=lambda: torch.zeros(batch, D, dtype=torch.bfloat16),
+        ),
+        TensorSpec(
+            "main_slot_mapping", [batch], torch.int64,
+            init_value=lambda: torch.full((batch,), -1, dtype=torch.int64),
+        ),
+        TensorSpec(
+            "main_position_ids", [batch], torch.int32,
+            init_value=lambda: torch.zeros(batch, dtype=torch.int32),
+        ),
+        TensorSpec("hc_attn_fn", [MIX_HC, HC_DIM], torch.float32, init_value=init_hc_attn_fn),
+        TensorSpec("hc_attn_scale", [3], torch.float32, init_value=init_hc_attn_scale),
+        TensorSpec("hc_attn_base", [MIX_HC], torch.float32, init_value=init_hc_attn_base),
+        TensorSpec("attn_norm_w", [D], torch.bfloat16, init_value=init_attn_norm_w),
+        TensorSpec("wq_a", [D, Q_LORA], torch.bfloat16, init_value=init_wq_a),
+        TensorSpec("wq_b", [Q_LORA, H * HEAD_DIM], torch.int8, init_value=lambda: wq_b_i8),
+        TensorSpec("wq_b_scale", [H * HEAD_DIM], torch.float32, init_value=lambda: wq_b_scale),
+        TensorSpec("wkv", [D, HEAD_DIM], torch.bfloat16, init_value=init_wkv),
+        TensorSpec("gamma_cq", [Q_LORA], torch.bfloat16, init_value=init_gamma_cq),
+        TensorSpec("gamma_ckv", [HEAD_DIM], torch.bfloat16, init_value=init_gamma_ckv),
+        TensorSpec("freqs_cos", [MAX_SEQ_LEN, ROPE_HEAD_DIM], torch.bfloat16, init_value=init_freqs_cos),
+        TensorSpec("freqs_sin", [MAX_SEQ_LEN, ROPE_HEAD_DIM], torch.bfloat16, init_value=init_freqs_sin),
+        TensorSpec("kv_cache", [ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_kv_cache, is_output=True),
+        TensorSpec("swa_slot_mapping", [tokens], torch.int64, init_value=init_swa_slot_mapping),
+        TensorSpec("swa_indices", [tokens, WIN], torch.int32, init_value=init_swa_indices),
+        TensorSpec("swa_lens", [tokens], torch.int32, init_value=init_swa_lens),
+        TensorSpec("position_ids", [tokens], torch.int32, init_value=init_position_ids),
+        TensorSpec("attn_sink", [H], torch.float32, init_value=init_attn_sink),
+        TensorSpec("wo_a", [O_GROUPS, O_LORA, O_GROUP_IN], torch.bfloat16, init_value=init_wo_a),
+        TensorSpec("wo_b", [D, O_GROUPS * O_LORA], torch.int8, init_value=lambda: wo_b_i8),
+        TensorSpec("wo_b_scale", [D], torch.float32, init_value=lambda: wo_b_scale),
+        TensorSpec("x_out", [tokens, HC_MULT, D], torch.float32, is_output=True),
+    ]
+
+
+if __name__ == "__main__":
+    import argparse
+    from golden import ratio_allclose, ratio_reldiff, run_jit
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-p", "--platform", type=str, default="a2a3",
+                        choices=["a2a3", "a2a3sim", "a5", "a5sim"])
+    parser.add_argument("-d", "--device", type=int, default=0)
+    parser.add_argument("-b", "--batch", type=int, default=B,
+                        help=f"runtime request count; a multiple of 4 up to {B} (the compile-time "
+                             "upper bound). The token axis is pl.dynamic, so one compiled program "
+                             "serves every value.")
+    parser.add_argument("--start-pos", type=int, default=None,
+                        help="Uniform fixture-only start_pos override for all batches; "
+                             "default (unset) uses the canonical per-batch SWA set that includes the 8k point.")
+    parser.add_argument("--enable-l2-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2, 4))
+    parser.add_argument("--runtime-dir", type=str, default=None)
+    parser.add_argument("--golden-data", type=str, default=None)
+    parser.add_argument("--dump-passes", action="store_true", default=False)
+    args = parser.parse_args()
+    if args.batch < 4 or args.batch > B or args.batch % 4 != 0:
+        parser.error(f"--batch must be a multiple of 4 in [4, {B}], got {args.batch}")
+
+    result = run_jit(
+        fn=attention_swa_test,
+        specs=build_tensor_specs(args.start_pos, batch=args.batch),
+        golden_fn=golden_attention_swa,
+        runtime_dir=args.runtime_dir,
+        golden_data=args.golden_data,
+        compile_cfg=dict(dump_passes=args.dump_passes),
+        runtime_cfg=dict(
+            platform=args.platform,
+            device_id=args.device,
+            enable_l2_swimlane=args.enable_l2_swimlane,
+        ),
+        rtol=1e-2,
+        atol=1e-2,
+        compare_fn={
+            # Tightened from CANN's 1e-2 bar: realistic hc_attn gates keep x_out
+            # well-conditioned (0% over 3e-3 across seeds; worst rdiff ~0.16).
+            "x_out": ratio_reldiff(diff_thd=3e-3, pct_thd=0.008, max_diff_hd=1),
+            "kv_cache": ratio_allclose(atol=1e-4, rtol=1.0 / 128),
+        },
+    )
+    if not result.passed:
+        if result.error:
+            print(result.error)
+        raise SystemExit(1)

--- a/models/deepseek_v4_flash_dspark/dspark_backbone.py
+++ b/models/deepseek_v4_flash_dspark/dspark_backbone.py
@@ -1,0 +1,294 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Three-layer DeepSeek-V4-Flash DSpark draft backbone."""
+
+import pypto.language as pl
+import pypto.language.distributed as pld
+
+from config import (
+    BLOCK_SIZE,
+    DSPARK_NUM_LAYERS,
+    DSPARK_QUERY_TOKENS,
+    DSPARK_QUERY_TOKENS_PADDED,
+    DSPARK_SWA_INDEX_WIDTH,
+    FLASH as M,
+    KV_ORI_BLOCK_NUM,
+    KV_ORI_MAX_BLOCKS,
+)
+from dspark_attention_swa import (
+    HEAD_DIM,
+    H,
+    MAX_SEQ_LEN,
+    O_GROUP_IN,
+    O_GROUPS,
+    O_LORA,
+    Q_LORA,
+    ROPE_HEAD_DIM,
+    attention_swa,
+)
+from hc_head import hc_head
+from dspark_metadata import dspark_metadata_core
+from dspark_prepare import dspark_prepare
+from moe import (
+    AUX_PAD,
+    HC_DIM,
+    HC_MULT,
+    IDX_PAD,
+    MIX_HC,
+    MOE_INTER,
+    N_EXPERTS_GLOBAL,
+    N_LOCAL,
+    N_RANKS,
+    N_ROUTES,
+    RECV_MAX,
+    TOPK,
+    VOCAB,
+    clear_moe_signals,
+    moe,
+)
+
+
+B_DYN = pl.dynamic("DSPARK_BACKBONE_B_DYN")
+VOCAB_DYN = pl.dynamic("DSPARK_BACKBONE_VOCAB_DYN")
+D = M.hidden_size
+DRAFT_LAYER_BASE = M.num_hidden_layers
+TILE_D = 512
+
+
+@pl.jit(auto_scope=False)
+def dspark_backbone(
+    target_hidden: pl.Tensor[[B_DYN, DSPARK_NUM_LAYERS, D], pl.BF16],
+    anchor_token_ids: pl.Tensor[[B_DYN], pl.INT64],
+    context_lens: pl.Tensor[[B_DYN], pl.INT32],
+    embed_weight: pl.Tensor[[VOCAB_DYN, D], pl.BF16],
+    main_proj_weight: pl.Tensor[[D, DSPARK_NUM_LAYERS * D], pl.BF16],
+    main_norm_weight: pl.Tensor[[D], pl.BF16],
+    block_tables: pl.Tensor[
+        [DSPARK_NUM_LAYERS, B_DYN, KV_ORI_MAX_BLOCKS], pl.INT32
+    ],
+    hc_attn_fn: pl.Tensor[[DSPARK_NUM_LAYERS, MIX_HC, HC_DIM], pl.FP32],
+    hc_attn_scale: pl.Tensor[[DSPARK_NUM_LAYERS, 3], pl.FP32],
+    hc_attn_base: pl.Tensor[[DSPARK_NUM_LAYERS, MIX_HC], pl.FP32],
+    attn_norm_w: pl.Tensor[[DSPARK_NUM_LAYERS, D], pl.BF16],
+    wq_a: pl.Tensor[[DSPARK_NUM_LAYERS, D, Q_LORA], pl.BF16],
+    wq_b: pl.Tensor[[DSPARK_NUM_LAYERS, Q_LORA, H * HEAD_DIM], pl.INT8],
+    wq_b_scale: pl.Tensor[[DSPARK_NUM_LAYERS, H * HEAD_DIM], pl.FP32],
+    wkv: pl.Tensor[[DSPARK_NUM_LAYERS, D, HEAD_DIM], pl.BF16],
+    gamma_cq: pl.Tensor[[DSPARK_NUM_LAYERS, Q_LORA], pl.BF16],
+    gamma_ckv: pl.Tensor[[DSPARK_NUM_LAYERS, HEAD_DIM], pl.BF16],
+    freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    kv_cache: pl.InOut[
+        pl.Tensor[
+            [DSPARK_NUM_LAYERS, KV_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16
+        ]
+    ],
+    attn_sink: pl.Tensor[[DSPARK_NUM_LAYERS, H], pl.FP32],
+    wo_a: pl.Tensor[
+        [DSPARK_NUM_LAYERS, O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16
+    ],
+    wo_b: pl.Tensor[[DSPARK_NUM_LAYERS, D, O_GROUPS * O_LORA], pl.INT8],
+    wo_b_scale: pl.Tensor[[DSPARK_NUM_LAYERS, D], pl.FP32],
+    hc_ffn_fn: pl.Tensor[[DSPARK_NUM_LAYERS, MIX_HC, HC_DIM], pl.FP32],
+    hc_ffn_scale: pl.Tensor[[DSPARK_NUM_LAYERS, 3], pl.FP32],
+    hc_ffn_base: pl.Tensor[[DSPARK_NUM_LAYERS, MIX_HC], pl.FP32],
+    norm_w: pl.Tensor[[DSPARK_NUM_LAYERS, D], pl.BF16],
+    gate_w: pl.Tensor[[DSPARK_NUM_LAYERS, N_EXPERTS_GLOBAL, D], pl.FP32],
+    gate_bias: pl.Tensor[[DSPARK_NUM_LAYERS, N_EXPERTS_GLOBAL], pl.FP32],
+    tid2eid: pl.Tensor[[DSPARK_NUM_LAYERS, VOCAB, TOPK], pl.INT32],
+    routed_w1: pl.Tensor[
+        [DSPARK_NUM_LAYERS, N_LOCAL, MOE_INTER, D], pl.INT8
+    ],
+    routed_w1_scale: pl.Tensor[
+        [DSPARK_NUM_LAYERS, N_LOCAL, MOE_INTER], pl.FP32
+    ],
+    routed_w3: pl.Tensor[
+        [DSPARK_NUM_LAYERS, N_LOCAL, MOE_INTER, D], pl.INT8
+    ],
+    routed_w3_scale: pl.Tensor[
+        [DSPARK_NUM_LAYERS, N_LOCAL, MOE_INTER], pl.FP32
+    ],
+    routed_w2: pl.Tensor[
+        [DSPARK_NUM_LAYERS, N_LOCAL, D, MOE_INTER], pl.INT8
+    ],
+    routed_w2_scale: pl.Tensor[[DSPARK_NUM_LAYERS, N_LOCAL, D], pl.FP32],
+    shared_w1: pl.Tensor[[DSPARK_NUM_LAYERS, MOE_INTER, D], pl.INT8],
+    shared_w1_scale: pl.Tensor[[DSPARK_NUM_LAYERS, MOE_INTER], pl.FP32],
+    shared_w3: pl.Tensor[[DSPARK_NUM_LAYERS, MOE_INTER, D], pl.INT8],
+    shared_w3_scale: pl.Tensor[[DSPARK_NUM_LAYERS, MOE_INTER], pl.FP32],
+    shared_w2: pl.Tensor[[DSPARK_NUM_LAYERS, D, MOE_INTER], pl.INT8],
+    shared_w2_scale: pl.Tensor[[DSPARK_NUM_LAYERS, D], pl.FP32],
+    hc_head_fn: pl.Tensor[[HC_MULT, HC_DIM], pl.FP32],
+    hc_head_scale: pl.Tensor[[1], pl.FP32],
+    hc_head_base: pl.Tensor[[HC_MULT], pl.FP32],
+    head_hidden: pl.Out[pl.Tensor[[B_DYN, DSPARK_QUERY_TOKENS, D], pl.BF16]],
+    recv_meta: pld.DistributedTensor[[N_RANKS, N_LOCAL], pl.INT32],
+    recv_x: pld.DistributedTensor[[N_LOCAL * RECV_MAX, D], pl.INT8],
+    recv_aux: pld.DistributedTensor[[N_LOCAL * RECV_MAX, AUX_PAD], pl.FP32],
+    recv_route: pld.DistributedTensor[[N_LOCAL * RECV_MAX, IDX_PAD], pl.INT32],
+    arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
+    data_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
+    routed_y_buf: pld.DistributedTensor[[N_ROUTES, D], pl.BF16],
+    combine_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
+    my_rank: pl.Scalar[pl.INT32],
+    num_tokens: pl.Scalar[pl.INT32],
+):
+    target_hidden.bind_dynamic(0, B_DYN)
+    anchor_token_ids.bind_dynamic(0, B_DYN)
+    context_lens.bind_dynamic(0, B_DYN)
+    embed_weight.bind_dynamic(0, VOCAB_DYN)
+    block_tables.bind_dynamic(1, B_DYN)
+    head_hidden.bind_dynamic(0, B_DYN)
+    batch = pl.tensor.dim(target_hidden, 0)
+    tokens = batch * DSPARK_QUERY_TOKENS_PADDED
+    main_x = pl.create_tensor([batch, D], dtype=pl.BF16)
+    query_input_ids = pl.create_tensor(
+        [batch, DSPARK_QUERY_TOKENS_PADDED], dtype=pl.INT64
+    )
+    query_positions = pl.create_tensor(
+        [batch, DSPARK_QUERY_TOKENS_PADDED], dtype=pl.INT32
+    )
+    query_active = pl.create_tensor(
+        [batch, DSPARK_QUERY_TOKENS_PADDED], dtype=pl.INT32
+    )
+    query_hidden = pl.create_tensor(
+        [batch, DSPARK_QUERY_TOKENS_PADDED, HC_MULT, D], dtype=pl.FP32
+    )
+    slot_mapping = pl.create_tensor(
+        [DSPARK_NUM_LAYERS, batch, DSPARK_QUERY_TOKENS_PADDED], dtype=pl.INT64
+    )
+    swa_indices = pl.create_tensor(
+        [DSPARK_NUM_LAYERS, batch, DSPARK_QUERY_TOKENS_PADDED, DSPARK_SWA_INDEX_WIDTH],
+        dtype=pl.INT32,
+    )
+    swa_lens = pl.create_tensor(
+        [DSPARK_NUM_LAYERS, batch, DSPARK_QUERY_TOKENS_PADDED], dtype=pl.INT32
+    )
+    main_slot_mapping = pl.create_tensor(
+        [DSPARK_NUM_LAYERS, batch], dtype=pl.INT64
+    )
+    with pl.scope():
+        dspark_prepare(
+            target_hidden,
+            anchor_token_ids,
+            context_lens,
+            embed_weight,
+            main_proj_weight,
+            main_norm_weight,
+            main_x,
+            query_input_ids,
+            query_positions,
+            query_active,
+            query_hidden,
+        )
+    with pl.scope():
+        dspark_metadata_core(
+            context_lens, block_tables, slot_mapping, swa_indices, swa_lens
+        )
+        for layer in pl.range(DSPARK_NUM_LAYERS):
+            for request in pl.range(batch):
+                position = pl.cast(pl.read(context_lens, [request]), pl.INDEX)
+                logical_block = position // BLOCK_SIZE
+                physical_block = pl.read(block_tables, [layer, request, logical_block])
+                physical_slot = physical_block * BLOCK_SIZE + position % BLOCK_SIZE
+                pl.write(
+                    main_slot_mapping,
+                    [layer, request],
+                    pl.cast(physical_slot, pl.INT64),
+                )
+    x0 = pl.reshape(query_hidden, [tokens, HC_MULT, D])
+    ids = pl.reshape(query_input_ids, [tokens])
+    positions = pl.reshape(query_positions, [tokens])
+    slots = pl.reshape(slot_mapping, [DSPARK_NUM_LAYERS, tokens])
+    indices = pl.reshape(
+        swa_indices, [DSPARK_NUM_LAYERS, tokens, DSPARK_SWA_INDEX_WIDTH]
+    )
+    lens = pl.reshape(swa_lens, [DSPARK_NUM_LAYERS, tokens])
+
+    x1 = pl.create_tensor([tokens, HC_MULT, D], dtype=pl.FP32)
+    x2 = pl.create_tensor([tokens, HC_MULT, D], dtype=pl.FP32)
+    x3 = pl.create_tensor([tokens, HC_MULT, D], dtype=pl.FP32)
+
+    with pl.scope():
+        attention_swa(
+            x0, main_x, main_slot_mapping[0], context_lens,
+            hc_attn_fn[0], hc_attn_scale[0], hc_attn_base[0],
+            attn_norm_w[0], wq_a[0], wq_b[0], wq_b_scale[0], wkv[0],
+            gamma_cq[0], gamma_ckv[0], freqs_cos, freqs_sin, kv_cache[0],
+            slots[0], indices[0], lens[0], positions, attn_sink[0], wo_a[0],
+            wo_b[0], wo_b_scale[0], x1,
+        )
+    with pl.scope():
+        moe(
+            x1, hc_ffn_fn[0], hc_ffn_scale[0], hc_ffn_base[0], norm_w[0],
+            gate_w[0], gate_bias[0], tid2eid[0], ids, routed_w1[0],
+            routed_w1_scale[0], routed_w3[0], routed_w3_scale[0], routed_w2[0],
+            routed_w2_scale[0], shared_w1[0], shared_w1_scale[0], shared_w3[0],
+            shared_w3_scale[0], shared_w2[0], shared_w2_scale[0], x2,
+            recv_meta, recv_x, recv_aux, recv_route, arrived, data_arrived,
+            routed_y_buf, combine_arrived, DRAFT_LAYER_BASE, num_tokens, my_rank, 1,
+        )
+        clear_moe_signals(x2, arrived, data_arrived, combine_arrived)
+
+    # Layers one and two reuse the same buffers only after the previous clear.
+    with pl.scope():
+        attention_swa(
+            x2, main_x, main_slot_mapping[1], context_lens,
+            hc_attn_fn[1], hc_attn_scale[1], hc_attn_base[1],
+            attn_norm_w[1], wq_a[1], wq_b[1], wq_b_scale[1], wkv[1],
+            gamma_cq[1], gamma_ckv[1], freqs_cos, freqs_sin, kv_cache[1],
+            slots[1], indices[1], lens[1], positions, attn_sink[1], wo_a[1],
+            wo_b[1], wo_b_scale[1], x1,
+        )
+    with pl.scope():
+        moe(
+            x1, hc_ffn_fn[1], hc_ffn_scale[1], hc_ffn_base[1], norm_w[1],
+            gate_w[1], gate_bias[1], tid2eid[1], ids, routed_w1[1],
+            routed_w1_scale[1], routed_w3[1], routed_w3_scale[1], routed_w2[1],
+            routed_w2_scale[1], shared_w1[1], shared_w1_scale[1], shared_w3[1],
+            shared_w3_scale[1], shared_w2[1], shared_w2_scale[1], x3,
+            recv_meta, recv_x, recv_aux, recv_route, arrived, data_arrived,
+            routed_y_buf, combine_arrived, DRAFT_LAYER_BASE + 1, num_tokens, my_rank, 2,
+        )
+        clear_moe_signals(x3, arrived, data_arrived, combine_arrived)
+    with pl.scope():
+        attention_swa(
+            x3, main_x, main_slot_mapping[2], context_lens,
+            hc_attn_fn[2], hc_attn_scale[2], hc_attn_base[2],
+            attn_norm_w[2], wq_a[2], wq_b[2], wq_b_scale[2], wkv[2],
+            gamma_cq[2], gamma_ckv[2], freqs_cos, freqs_sin, kv_cache[2],
+            slots[2], indices[2], lens[2], positions, attn_sink[2], wo_a[2],
+            wo_b[2], wo_b_scale[2], x1,
+        )
+    with pl.scope():
+        moe(
+            x1, hc_ffn_fn[2], hc_ffn_scale[2], hc_ffn_base[2], norm_w[2],
+            gate_w[2], gate_bias[2], tid2eid[2], ids, routed_w1[2],
+            routed_w1_scale[2], routed_w3[2], routed_w3_scale[2], routed_w2[2],
+            routed_w2_scale[2], shared_w1[2], shared_w1_scale[2], shared_w3[2],
+            shared_w3_scale[2], shared_w2[2], shared_w2_scale[2], x2,
+            recv_meta, recv_x, recv_aux, recv_route, arrived, data_arrived,
+            routed_y_buf, combine_arrived, DRAFT_LAYER_BASE + 2, num_tokens, my_rank, 3,
+        )
+        clear_moe_signals(x2, arrived, data_arrived, combine_arrived)
+
+    padded_head = pl.create_tensor([tokens, D], dtype=pl.BF16)
+    with pl.scope():
+        hc_head(x2, hc_head_fn, hc_head_scale, hc_head_base, padded_head)
+    output_flat = pl.reshape(head_hidden, [batch * DSPARK_QUERY_TOKENS, D])
+    for task in pl.spmd(batch * DSPARK_QUERY_TOKENS * (D // TILE_D), name_hint="dspark_head_unpack"):
+        output_row = task // (D // TILE_D)
+        d0 = (task % (D // TILE_D)) * TILE_D
+        request = output_row // DSPARK_QUERY_TOKENS
+        query = output_row % DSPARK_QUERY_TOKENS
+        padded_row = request * DSPARK_QUERY_TOKENS_PADDED + query
+        output_flat[output_row : output_row + 1, d0 : d0 + TILE_D] = padded_head[
+            padded_row : padded_row + 1, d0 : d0 + TILE_D
+        ]
+    return head_hidden

--- a/models/deepseek_v4_flash_dspark/dspark_contract.py
+++ b/models/deepseek_v4_flash_dspark/dspark_contract.py
@@ -1,0 +1,150 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Host-side DSpark drafter layout and golden contracts."""
+
+from config import (
+    BLOCK_SIZE,
+    DSPARK_MARKOV_RANK,
+    DSPARK_NOISE_TOKEN_ID,
+    DSPARK_QUERY_TOKENS,
+    DSPARK_QUERY_TOKENS_PADDED,
+    DSPARK_SWA_INDEX_WIDTH,
+    FLASH as M,
+)
+
+
+def validate_dspark_batch(batch: int) -> None:
+    """Validate a dynamic single-card drafter batch."""
+    if batch not in (4, 8, 12, 16):
+        raise ValueError("DSpark drafter batch must be one of {4, 8, 12, 16}")
+
+
+def validate_markov_vocab(vocab_size: int) -> None:
+    """Validate the tiled Markov sampler vocabulary bound."""
+    if vocab_size <= 0 or vocab_size > 131072 or vocab_size % 256 != 0:
+        raise ValueError("DSpark Markov vocab_size must be a multiple of 256 in (0, 131072]")
+
+
+def build_query_layout(anchor_token_ids, context_lens):
+    """Return padded anchor/noise IDs, positions, and the logical-row mask."""
+    import torch
+
+    if anchor_token_ids.ndim != 1 or context_lens.shape != anchor_token_ids.shape:
+        raise ValueError("anchor_token_ids and context_lens must be rank-1 tensors with matching shapes")
+    batch = int(anchor_token_ids.numel())
+    validate_dspark_batch(batch)
+
+    input_ids = torch.full(
+        (batch, DSPARK_QUERY_TOKENS_PADDED),
+        DSPARK_NOISE_TOKEN_ID,
+        dtype=torch.int64,
+        device=anchor_token_ids.device,
+    )
+    input_ids[:, 0] = anchor_token_ids.to(torch.int64)
+    offsets = torch.arange(DSPARK_QUERY_TOKENS_PADDED, device=context_lens.device)
+    positions = context_lens.to(torch.int32)[:, None] + 1 + offsets.to(torch.int32)[None, :]
+    active = offsets[None, :] < DSPARK_QUERY_TOKENS
+    active = active.expand(batch, -1).contiguous()
+    return input_ids, positions.contiguous(), active
+
+
+def build_noncausal_swa_metadata(block_table, context_lens):
+    """Build padded DSpark slots where all seven queries share one visible row."""
+    import torch
+
+    batch = int(context_lens.numel())
+    validate_dspark_batch(batch)
+    if block_table.ndim != 2 or block_table.shape[0] != batch:
+        raise ValueError("block_table must have shape [batch, max_blocks]")
+
+    indices = torch.full(
+        (batch, DSPARK_QUERY_TOKENS_PADDED, DSPARK_SWA_INDEX_WIDTH),
+        -1,
+        dtype=torch.int32,
+        device=block_table.device,
+    )
+    lens = torch.zeros(
+        (batch, DSPARK_QUERY_TOKENS_PADDED), dtype=torch.int32, device=block_table.device
+    )
+    slots = torch.full(
+        (batch, DSPARK_QUERY_TOKENS_PADDED), -1, dtype=torch.int64, device=block_table.device
+    )
+
+    for request in range(batch):
+        context_len = int(context_lens[request])
+        start = max(0, context_len + 1 - M.sliding_window)
+        end = context_len + 1 + DSPARK_QUERY_TOKENS
+        visible = end - start
+        if visible > DSPARK_SWA_INDEX_WIDTH:
+            raise ValueError("DSpark SWA index width is too small for the visible set")
+        for column, logical_position in enumerate(range(start, end)):
+            logical_block = logical_position // BLOCK_SIZE
+            if logical_block >= block_table.shape[1]:
+                raise ValueError("block_table does not cover the DSpark visible positions")
+            physical_block = int(block_table[request, logical_block])
+            physical_slot = physical_block * BLOCK_SIZE + logical_position % BLOCK_SIZE
+            indices[request, :DSPARK_QUERY_TOKENS, column] = physical_slot
+        lens[request, :DSPARK_QUERY_TOKENS] = visible
+        for query in range(DSPARK_QUERY_TOKENS):
+            logical_position = context_len + 1 + query
+            logical_block = logical_position // BLOCK_SIZE
+            physical_block = int(block_table[request, logical_block])
+            slots[request, query] = physical_block * BLOCK_SIZE + logical_position % BLOCK_SIZE
+
+    return (
+        slots.reshape(-1).contiguous(),
+        indices.reshape(-1, DSPARK_SWA_INDEX_WIDTH).contiguous(),
+        lens.reshape(-1).contiguous(),
+    )
+
+
+def golden_main_projection(target_hidden, main_proj_weight, main_norm_weight):
+    """Reference ``main_norm(main_proj(cat(target hidden)))``."""
+    import torch
+
+    batch, target_layers, hidden = target_hidden.shape
+    if target_layers != 3 or hidden != M.hidden_size:
+        raise ValueError("target_hidden must have shape [batch, 3, hidden_size]")
+    projected = target_hidden.float().reshape(batch, 3 * hidden).matmul(main_proj_weight.float().t())
+    inv_rms = torch.rsqrt(projected.square().mean(-1, keepdim=True) + M.rms_norm_eps)
+    return (projected * inv_rms * main_norm_weight.float()).to(torch.bfloat16)
+
+
+def golden_markov_sample(
+    head_hidden,
+    norm_weight,
+    lm_head_weight,
+    markov_w1,
+    markov_w2,
+    anchor_token_ids,
+):
+    """Reference base LM logits plus sequential rank-256 Markov refinement."""
+    import torch
+
+    batch, steps, hidden = head_hidden.shape
+    if steps != DSPARK_QUERY_TOKENS or hidden != M.hidden_size:
+        raise ValueError("head_hidden must have shape [batch, 7, hidden_size]")
+    if markov_w1.shape[1] != DSPARK_MARKOV_RANK or markov_w2.shape[1] != DSPARK_MARKOV_RANK:
+        raise ValueError("Markov weights must use rank 256")
+
+    x = head_hidden.float()
+    x = x * torch.rsqrt(x.square().mean(-1, keepdim=True) + M.rms_norm_eps)
+    x = x * norm_weight.float()
+    base_logits = torch.matmul(x, lm_head_weight.float().t())
+
+    token_ids = torch.empty(batch, steps, dtype=torch.int32, device=head_hidden.device)
+    markov_logits = torch.empty_like(base_logits)
+    previous = anchor_token_ids.long()
+    for step in range(steps):
+        bias = markov_w1[previous].float().matmul(markov_w2.float().t())
+        scores = base_logits[:, step, :] + bias
+        markov_logits[:, step, :] = scores
+        previous = torch.argmax(scores, dim=-1)
+        token_ids[:, step] = previous.to(torch.int32)
+    return token_ids, base_logits, markov_logits

--- a/models/deepseek_v4_flash_dspark/dspark_markov.py
+++ b/models/deepseek_v4_flash_dspark/dspark_markov.py
@@ -1,0 +1,398 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""DSpark final RMSNorm, shared LM head, and sequential Markov sampler."""
+
+import pypto.language as pl
+
+from config import DSPARK_MARKOV_RANK, DSPARK_QUERY_TOKENS, FLASH as M
+
+
+B_DYN = pl.dynamic("DSPARK_MARKOV_B_DYN")
+VOCAB_DYN = pl.dynamic("DSPARK_MARKOV_VOCAB_DYN")
+D = M.hidden_size
+EPS = M.rms_norm_eps
+VOCAB_TILE = 256
+VOCAB_CHUNKS_PAD = 512
+K_TILE = 128
+MARKOV_K_TILE = 128
+MAX_BATCH = 16
+
+
+@pl.jit.inline
+def _normalize_head_hidden(
+    head_hidden: pl.Tensor[[B_DYN, DSPARK_QUERY_TOKENS, D], pl.BF16],
+    norm_weight: pl.Tensor[[D], pl.BF16],
+    normalized: pl.Tensor[[8, MAX_BATCH, D], pl.BF16],
+):
+    batch = pl.tensor.dim(head_hidden, 0)
+    normalized_flat = pl.reshape(normalized, [8 * MAX_BATCH, D])
+    with pl.spmd(batch, name_hint="dspark_head_norm") as norm_tid:
+        request = pl.tile.get_block_idx()
+        sq_sum = pl.full([1, 8], dtype=pl.FP32, value=0.0)
+        for k0 in pl.pipeline(0, D, K_TILE, stage=2):
+            hidden_3d = pl.slice(
+                head_hidden,
+                [1, 8, K_TILE],
+                [request, 0, k0],
+                valid_shape=[1, DSPARK_QUERY_TOKENS, K_TILE],
+            )
+            hidden = pl.cast(pl.reshape(hidden_3d, [8, K_TILE]), pl.FP32)
+            partial = pl.reshape(pl.row_sum(pl.mul(hidden, hidden)), [1, 8])
+            sq_sum = pl.add(sq_sum, partial)
+        inv_rms = pl.rsqrt(pl.add(pl.mul(sq_sum, 1.0 / D), EPS), high_precision=True)
+        inv_rms_col = pl.reshape(inv_rms, [8, 1])
+        for k0 in pl.pipeline(0, D, K_TILE, stage=2):
+            hidden_3d = pl.slice(
+                head_hidden,
+                [1, 8, K_TILE],
+                [request, 0, k0],
+                valid_shape=[1, DSPARK_QUERY_TOKENS, K_TILE],
+            )
+            hidden = pl.cast(pl.reshape(hidden_3d, [8, K_TILE]), pl.FP32)
+            weight = pl.cast(pl.reshape(norm_weight[k0 : k0 + K_TILE], [1, K_TILE]), pl.FP32)
+            value = pl.cast(
+                pl.col_expand_mul(pl.row_expand_mul(hidden, inv_rms_col), weight),
+                pl.BF16,
+                mode="rint",
+            )
+            for step in pl.range(8):
+                row = step * MAX_BATCH + request
+                normalized_flat[row : row + 1, k0 : k0 + K_TILE] = value[
+                    step : step + 1, 0:K_TILE
+                ]
+    return norm_tid
+
+
+@pl.jit.inline
+def _markov_logits_step(
+    normalized: pl.Tensor[[8, MAX_BATCH, D], pl.BF16],
+    lm_head_weight: pl.Tensor[[VOCAB_DYN, D], pl.BF16],
+    markov_w2: pl.Tensor[[VOCAB_DYN, DSPARK_MARKOV_RANK], pl.BF16],
+    markov_embeds: pl.Tensor[[MAX_BATCH, DSPARK_MARKOV_RANK], pl.BF16],
+    logits: pl.Tensor[[MAX_BATCH, VOCAB_DYN], pl.FP32],
+    step: pl.Scalar[pl.INT32],
+    dependency: pl.Scalar[pl.TASK_ID],
+):
+    vocab = pl.tensor.dim(lm_head_weight, 0)
+    vocab_chunks = vocab // VOCAB_TILE
+    with pl.spmd(
+        vocab_chunks, name_hint="dspark_markov_logits", deps=[dependency]
+    ) as logits_tid:
+        chunk = pl.tile.get_block_idx()
+        vocab0 = chunk * VOCAB_TILE
+        step_index = pl.cast(step, pl.INDEX)
+        hidden0 = pl.reshape(
+            normalized[step_index : step_index + 1, 0:MAX_BATCH, 0:K_TILE], [MAX_BATCH, K_TILE]
+        )
+        weight0 = lm_head_weight[vocab0 : vocab0 + VOCAB_TILE, 0:K_TILE]
+        base_acc = pl.matmul(hidden0, weight0, b_trans=True, out_dtype=pl.FP32)
+        for k0 in pl.pipeline(K_TILE, D, K_TILE, stage=2):
+            hidden_k = pl.reshape(
+                normalized[step_index : step_index + 1, 0:MAX_BATCH, k0 : k0 + K_TILE],
+                [MAX_BATCH, K_TILE],
+            )
+            weight_k = lm_head_weight[vocab0 : vocab0 + VOCAB_TILE, k0 : k0 + K_TILE]
+            base_acc = pl.matmul_acc(base_acc, hidden_k, weight_k, b_trans=True)
+        markov_acc = pl.matmul(
+            markov_embeds[:, 0:MARKOV_K_TILE],
+            markov_w2[vocab0 : vocab0 + VOCAB_TILE, 0:MARKOV_K_TILE],
+            b_trans=True,
+            out_dtype=pl.FP32,
+        )
+        markov_acc = pl.matmul_acc(
+            markov_acc,
+            markov_embeds[:, MARKOV_K_TILE:DSPARK_MARKOV_RANK],
+            markov_w2[vocab0 : vocab0 + VOCAB_TILE, MARKOV_K_TILE:DSPARK_MARKOV_RANK],
+            b_trans=True,
+        )
+        logits[0:MAX_BATCH, vocab0 : vocab0 + VOCAB_TILE] = pl.add(base_acc, markov_acc)
+    return logits, logits_tid
+
+
+@pl.jit.inline
+def _markov_embed_step(
+    markov_w1: pl.Tensor[[VOCAB_DYN, DSPARK_MARKOV_RANK], pl.BF16],
+    previous_ids: pl.Tensor[[MAX_BATCH], pl.INT32],
+    markov_embeds: pl.Tensor[[MAX_BATCH, DSPARK_MARKOV_RANK], pl.BF16],
+    dependency: pl.Scalar[pl.TASK_ID],
+):
+    with pl.spmd(
+        MAX_BATCH, name_hint="dspark_markov_embed", deps=[dependency]
+    ) as embed_tid:
+        request = pl.tile.get_block_idx()
+        token = pl.cast(pl.read(previous_ids, [request]), pl.INDEX)
+        markov_embeds[request : request + 1, :] = markov_w1[token : token + 1, :]
+    return markov_embeds, embed_tid
+
+
+@pl.jit.inline
+def _greedy_step(
+    logits: pl.Tensor[[MAX_BATCH, VOCAB_DYN], pl.FP32],
+    sampled_ids: pl.Tensor[[MAX_BATCH], pl.INT32],
+    batch: pl.Scalar[pl.INT32],
+    dependency: pl.Scalar[pl.TASK_ID],
+):
+    vocab = pl.tensor.dim(logits, 1)
+    vocab_chunks = vocab // VOCAB_TILE
+    with pl.spmd(
+        1, name_hint="dspark_markov_greedy", deps=[dependency]
+    ) as greedy_tid:
+        block = pl.tile.get_block_idx()
+        for request in pl.range(block, batch):
+            chunk_maxima = pl.full(
+                [1, VOCAB_CHUNKS_PAD], dtype=pl.FP32, value=-3.402823e38
+            )
+            for chunk in pl.range(vocab_chunks):
+                vocab0 = chunk * VOCAB_TILE
+                scores = logits[request : request + 1, vocab0 : vocab0 + VOCAB_TILE]
+                indices = pl.arange(0, [1, VOCAB_TILE], dtype=pl.UINT32)
+                pairs = pl.sort32(scores, indices)
+                pairs = pl.mrgsort(pairs, block_len=64)
+                pairs = pl.mrgsort(pairs, block_len=256)
+                top_pair = pairs[:, 0:32]
+                top_value = pl.gather(top_pair, mask_pattern=pl.tile.MaskPattern.P0101)
+                pl.write(chunk_maxima, [0, chunk], pl.read(top_value, [0, 0]))
+            chunk_indices = pl.arange(0, [1, VOCAB_CHUNKS_PAD], dtype=pl.UINT32)
+            chunk_pairs = pl.sort32(chunk_maxima, chunk_indices)
+            chunk_pairs = pl.mrgsort(chunk_pairs, block_len=64)
+            chunk_pairs = pl.mrgsort(chunk_pairs, block_len=256)
+            best_value_tensor = pl.gather(
+                chunk_pairs[:, 0:32], mask_pattern=pl.tile.MaskPattern.P0101
+            )
+            best_value = pl.read(best_value_tensor, [0, 0])
+            best_chunk = pl.cast(0, pl.INT32)
+            for chunk in pl.range(vocab_chunks):
+                scan_chunk = vocab_chunks - 1 - chunk
+                if pl.read(chunk_maxima, [0, scan_chunk]) == best_value:
+                    best_chunk = pl.cast(scan_chunk, pl.INT32)
+            chunk_base = best_chunk * pl.cast(VOCAB_TILE, pl.INT32)
+            winning_scores = pl.slice(
+                logits,
+                [1, VOCAB_TILE],
+                [pl.cast(request, pl.INDEX), pl.cast(chunk_base, pl.INDEX)],
+            )
+            best_offset = pl.cast(0, pl.INT32)
+            for offset in pl.range(VOCAB_TILE):
+                scan_offset = VOCAB_TILE - 1 - offset
+                if pl.read(winning_scores, [0, scan_offset]) == best_value:
+                    best_offset = pl.cast(scan_offset, pl.INT32)
+            token_id = best_chunk * pl.cast(VOCAB_TILE, pl.INT32) + best_offset
+            pl.write(sampled_ids, [request], token_id)
+    return sampled_ids, greedy_tid
+
+
+@pl.jit.inline(auto_scope=False)
+def dspark_markov_sample(
+    head_hidden: pl.Tensor[[B_DYN, DSPARK_QUERY_TOKENS, D], pl.BF16],
+    norm_weight: pl.Tensor[[D], pl.BF16],
+    lm_head_weight: pl.Tensor[[VOCAB_DYN, D], pl.BF16],
+    markov_w1: pl.Tensor[[VOCAB_DYN, DSPARK_MARKOV_RANK], pl.BF16],
+    markov_w2: pl.Tensor[[VOCAB_DYN, DSPARK_MARKOV_RANK], pl.BF16],
+    anchor_token_ids: pl.Tensor[[B_DYN], pl.INT64],
+    draft_token_ids: pl.Tensor[[B_DYN, DSPARK_QUERY_TOKENS], pl.INT32],
+):
+    batch = pl.tensor.dim(head_hidden, 0)
+    vocab = pl.tensor.dim(lm_head_weight, 0)
+    normalized = pl.create_tensor([8, MAX_BATCH, D], dtype=pl.BF16, init_value=0)
+    embed0 = pl.create_tensor([MAX_BATCH, DSPARK_MARKOV_RANK], dtype=pl.BF16)
+    embed1 = pl.create_tensor([MAX_BATCH, DSPARK_MARKOV_RANK], dtype=pl.BF16)
+    embed2 = pl.create_tensor([MAX_BATCH, DSPARK_MARKOV_RANK], dtype=pl.BF16)
+    embed3 = pl.create_tensor([MAX_BATCH, DSPARK_MARKOV_RANK], dtype=pl.BF16)
+    embed4 = pl.create_tensor([MAX_BATCH, DSPARK_MARKOV_RANK], dtype=pl.BF16)
+    embed5 = pl.create_tensor([MAX_BATCH, DSPARK_MARKOV_RANK], dtype=pl.BF16)
+    embed6 = pl.create_tensor([MAX_BATCH, DSPARK_MARKOV_RANK], dtype=pl.BF16)
+    sampled0 = pl.create_tensor([MAX_BATCH], dtype=pl.INT32, init_value=0)
+    sampled1 = pl.create_tensor([MAX_BATCH], dtype=pl.INT32, init_value=0)
+    sampled2 = pl.create_tensor([MAX_BATCH], dtype=pl.INT32, init_value=0)
+    sampled3 = pl.create_tensor([MAX_BATCH], dtype=pl.INT32, init_value=0)
+    sampled4 = pl.create_tensor([MAX_BATCH], dtype=pl.INT32, init_value=0)
+    sampled5 = pl.create_tensor([MAX_BATCH], dtype=pl.INT32, init_value=0)
+    sampled6 = pl.create_tensor([MAX_BATCH], dtype=pl.INT32, init_value=0)
+    logits0 = pl.create_tensor([MAX_BATCH, vocab], dtype=pl.FP32)
+    logits1 = pl.create_tensor([MAX_BATCH, vocab], dtype=pl.FP32)
+    logits2 = pl.create_tensor([MAX_BATCH, vocab], dtype=pl.FP32)
+    logits3 = pl.create_tensor([MAX_BATCH, vocab], dtype=pl.FP32)
+    logits4 = pl.create_tensor([MAX_BATCH, vocab], dtype=pl.FP32)
+    logits5 = pl.create_tensor([MAX_BATCH, vocab], dtype=pl.FP32)
+    logits6 = pl.create_tensor([MAX_BATCH, vocab], dtype=pl.FP32)
+    with pl.manual_scope():
+        norm_tid = _normalize_head_hidden(head_hidden, norm_weight, normalized)
+        with pl.spmd(MAX_BATCH, name_hint="dspark_markov_seed") as seed_tid:
+            request = pl.tile.get_block_idx()
+            if request < batch:
+                anchor = pl.cast(pl.read(anchor_token_ids, [request]), pl.INDEX)
+                embed0[request : request + 1, :] = markov_w1[anchor : anchor + 1, :]
+        start_tid = pl.system.task_dummy(deps=[norm_tid, seed_tid])
+        logits0, l0 = _markov_logits_step(
+            normalized, lm_head_weight, markov_w2, embed0, logits0, 0, start_tid
+        )
+        sampled0, g0 = _greedy_step(logits0, sampled0, batch, l0)
+        embed1, e1 = _markov_embed_step(markov_w1, sampled0, embed1, g0)
+        logits1, l1 = _markov_logits_step(
+            normalized, lm_head_weight, markov_w2, embed1, logits1, 1, e1
+        )
+        sampled1, g1 = _greedy_step(logits1, sampled1, batch, l1)
+        embed2, e2 = _markov_embed_step(markov_w1, sampled1, embed2, g1)
+        logits2, l2 = _markov_logits_step(
+            normalized, lm_head_weight, markov_w2, embed2, logits2, 2, e2
+        )
+        sampled2, g2 = _greedy_step(logits2, sampled2, batch, l2)
+        embed3, e3 = _markov_embed_step(markov_w1, sampled2, embed3, g2)
+        logits3, l3 = _markov_logits_step(
+            normalized, lm_head_weight, markov_w2, embed3, logits3, 3, e3
+        )
+        sampled3, g3 = _greedy_step(logits3, sampled3, batch, l3)
+        embed4, e4 = _markov_embed_step(markov_w1, sampled3, embed4, g3)
+        logits4, l4 = _markov_logits_step(
+            normalized, lm_head_weight, markov_w2, embed4, logits4, 4, e4
+        )
+        sampled4, g4 = _greedy_step(logits4, sampled4, batch, l4)
+        embed5, e5 = _markov_embed_step(markov_w1, sampled4, embed5, g4)
+        logits5, l5 = _markov_logits_step(
+            normalized, lm_head_weight, markov_w2, embed5, logits5, 5, e5
+        )
+        sampled5, g5 = _greedy_step(logits5, sampled5, batch, l5)
+        embed6, e6 = _markov_embed_step(markov_w1, sampled5, embed6, g5)
+        logits6, l6 = _markov_logits_step(
+            normalized, lm_head_weight, markov_w2, embed6, logits6, 6, e6
+        )
+        sampled6, g6 = _greedy_step(logits6, sampled6, batch, l6)
+        with pl.spmd(1, name_hint="dspark_markov_pack", deps=[g6]) as pack_tid:
+            block = pl.tile.get_block_idx()
+            for request in pl.range(block, batch):
+                pl.write(draft_token_ids, [request, 0], pl.read(sampled0, [request]))
+                pl.write(draft_token_ids, [request, 1], pl.read(sampled1, [request]))
+                pl.write(draft_token_ids, [request, 2], pl.read(sampled2, [request]))
+                pl.write(draft_token_ids, [request, 3], pl.read(sampled3, [request]))
+                pl.write(draft_token_ids, [request, 4], pl.read(sampled4, [request]))
+                pl.write(draft_token_ids, [request, 5], pl.read(sampled5, [request]))
+                pl.write(draft_token_ids, [request, 6], pl.read(sampled6, [request]))
+    return draft_token_ids
+
+
+@pl.jit
+def dspark_markov_sample_test(
+    head_hidden: pl.Tensor[[B_DYN, DSPARK_QUERY_TOKENS, D], pl.BF16],
+    norm_weight: pl.Tensor[[D], pl.BF16],
+    lm_head_weight: pl.Tensor[[VOCAB_DYN, D], pl.BF16],
+    markov_w1: pl.Tensor[[VOCAB_DYN, DSPARK_MARKOV_RANK], pl.BF16],
+    markov_w2: pl.Tensor[[VOCAB_DYN, DSPARK_MARKOV_RANK], pl.BF16],
+    anchor_token_ids: pl.Tensor[[B_DYN], pl.INT64],
+    draft_token_ids: pl.Out[pl.Tensor[[B_DYN, DSPARK_QUERY_TOKENS], pl.INT32]],
+):
+    head_hidden.bind_dynamic(0, B_DYN)
+    lm_head_weight.bind_dynamic(0, VOCAB_DYN)
+    markov_w1.bind_dynamic(0, VOCAB_DYN)
+    markov_w2.bind_dynamic(0, VOCAB_DYN)
+    anchor_token_ids.bind_dynamic(0, B_DYN)
+    draft_token_ids.bind_dynamic(0, B_DYN)
+    return dspark_markov_sample(
+        head_hidden,
+        norm_weight,
+        lm_head_weight,
+        markov_w1,
+        markov_w2,
+        anchor_token_ids,
+        draft_token_ids,
+    )
+
+
+def golden_dspark_markov_sample(tensors):
+    from dspark_contract import golden_markov_sample
+
+    sampled, _, _ = golden_markov_sample(
+        tensors["head_hidden"],
+        tensors["norm_weight"],
+        tensors["lm_head_weight"],
+        tensors["markov_w1"],
+        tensors["markov_w2"],
+        tensors["anchor_token_ids"],
+    )
+    tensors["draft_token_ids"][:] = sampled
+
+
+def build_tensor_specs(batch=4, vocab_size=1024):
+    import torch
+    from golden import TensorSpec
+
+    from dspark_contract import validate_dspark_batch, validate_markov_vocab
+
+    validate_dspark_batch(batch)
+    validate_markov_vocab(vocab_size)
+
+    def init_anchor_token_ids():
+        return torch.arange(batch, dtype=torch.int64) % vocab_size
+
+    def init_markov_w1():
+        weight = torch.zeros(vocab_size, DSPARK_MARKOV_RANK, dtype=torch.bfloat16)
+        chain_tokens = min(vocab_size - 1, batch + DSPARK_QUERY_TOKENS)
+        for token in range(chain_tokens):
+            weight[token, token] = 1
+        return weight
+
+    def init_markov_w2():
+        weight = torch.zeros(vocab_size, DSPARK_MARKOV_RANK, dtype=torch.bfloat16)
+        chain_tokens = min(vocab_size - 1, batch + DSPARK_QUERY_TOKENS)
+        for token in range(chain_tokens):
+            weight[token + 1, token] = 16
+        return weight
+
+    return [
+        TensorSpec(
+            "head_hidden",
+            [batch, DSPARK_QUERY_TOKENS, D],
+            torch.bfloat16,
+            init_value=lambda: torch.randn(batch, DSPARK_QUERY_TOKENS, D, dtype=torch.bfloat16),
+        ),
+        TensorSpec("norm_weight", [D], torch.bfloat16, init_value=lambda: torch.ones(D, dtype=torch.bfloat16)),
+        TensorSpec(
+            "lm_head_weight",
+            [vocab_size, D],
+            torch.bfloat16,
+            init_value=lambda: torch.zeros(vocab_size, D, dtype=torch.bfloat16),
+        ),
+        TensorSpec(
+            "markov_w1",
+            [vocab_size, DSPARK_MARKOV_RANK],
+            torch.bfloat16,
+            init_value=init_markov_w1,
+        ),
+        TensorSpec(
+            "markov_w2",
+            [vocab_size, DSPARK_MARKOV_RANK],
+            torch.bfloat16,
+            init_value=init_markov_w2,
+        ),
+        TensorSpec("anchor_token_ids", [batch], torch.int64, init_value=init_anchor_token_ids),
+        TensorSpec("draft_token_ids", [batch, DSPARK_QUERY_TOKENS], torch.int32, is_output=True),
+    ]
+
+
+if __name__ == "__main__":
+    import argparse
+    from golden import run_jit
+
+    parser = argparse.ArgumentParser(description="DeepSeek-V4-Flash DSpark Markov sampler validation.")
+    parser.add_argument("-p", "--platform", default="a2a3", choices=["a2a3", "a2a3sim", "a5", "a5sim"])
+    parser.add_argument("-d", "--device", type=int, default=0)
+    parser.add_argument("--batch", type=int, default=4, choices=[4, 8, 12, 16])
+    parser.add_argument("--vocab-size", type=int, default=1024)
+    parser.add_argument("--compile-only", action="store_true")
+    args = parser.parse_args()
+    result = run_jit(
+        fn=dspark_markov_sample_test,
+        specs=build_tensor_specs(args.batch, args.vocab_size),
+        golden_fn=golden_dspark_markov_sample,
+        runtime_cfg=dict(platform=args.platform, device_id=args.device),
+        compile_only=args.compile_only,
+    )
+    if not result.passed:
+        if result.error:
+            print(result.error)
+        raise SystemExit(1)

--- a/models/deepseek_v4_flash_dspark/dspark_metadata.py
+++ b/models/deepseek_v4_flash_dspark/dspark_metadata.py
@@ -1,0 +1,200 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Device-side non-causal SWA metadata for the three DSpark draft layers."""
+
+import pypto.language as pl
+
+from config import (
+    BLOCK_SIZE,
+    DSPARK_NUM_LAYERS,
+    DSPARK_QUERY_TOKENS,
+    DSPARK_QUERY_TOKENS_PADDED,
+    DSPARK_SWA_INDEX_WIDTH,
+    FLASH as M,
+    KV_ORI_MAX_BLOCKS,
+)
+
+
+B_DYN = pl.dynamic("DSPARK_METADATA_B_DYN")
+MAX_BLOCKS = KV_ORI_MAX_BLOCKS
+WIN = M.sliding_window
+
+
+@pl.jit.inline
+def dspark_metadata_core(
+    context_lens: pl.Tensor[[B_DYN], pl.INT32],
+    block_tables: pl.Tensor[[DSPARK_NUM_LAYERS, B_DYN, MAX_BLOCKS], pl.INT32],
+    slot_mapping: pl.Out[
+        pl.Tensor[[DSPARK_NUM_LAYERS, B_DYN, DSPARK_QUERY_TOKENS_PADDED], pl.INT64]
+    ],
+    swa_indices: pl.Out[
+        pl.Tensor[
+            [DSPARK_NUM_LAYERS, B_DYN, DSPARK_QUERY_TOKENS_PADDED, DSPARK_SWA_INDEX_WIDTH],
+            pl.INT32,
+        ]
+    ],
+    swa_lens: pl.Out[
+        pl.Tensor[[DSPARK_NUM_LAYERS, B_DYN, DSPARK_QUERY_TOKENS_PADDED], pl.INT32]
+    ],
+):
+    batch = pl.tensor.dim(context_lens, 0)
+    work_items = DSPARK_NUM_LAYERS * batch * DSPARK_QUERY_TOKENS_PADDED
+    slots_flat = pl.reshape(slot_mapping, [work_items])
+    indices_flat = pl.reshape(swa_indices, [work_items, DSPARK_SWA_INDEX_WIDTH])
+    lens_flat = pl.reshape(swa_lens, [work_items])
+    for task in pl.spmd(work_items, name_hint="dspark_noncausal_swa_metadata"):
+        layer_stride = batch * DSPARK_QUERY_TOKENS_PADDED
+        layer = task // layer_stride
+        request_query = task % layer_stride
+        request = request_query // DSPARK_QUERY_TOKENS_PADDED
+        query = request_query % DSPARK_QUERY_TOKENS_PADDED
+        index_row = pl.full([1, DSPARK_SWA_INDEX_WIDTH], dtype=pl.INT32, value=-1)
+        slot = pl.cast(-1, pl.INT64)
+        visible_len = pl.cast(0, pl.INDEX)
+        if query < DSPARK_QUERY_TOKENS:
+            context_len = pl.cast(pl.read(context_lens, [request]), pl.INDEX)
+            anchor_end = context_len + pl.cast(1, pl.INDEX)
+            history_start = pl.max(anchor_end - WIN, 0)
+            visible_len = anchor_end + DSPARK_QUERY_TOKENS - history_start
+            for column in pl.range(DSPARK_SWA_INDEX_WIDTH):
+                if column < visible_len:
+                    logical_position = history_start + column
+                    logical_block = logical_position // BLOCK_SIZE
+                    physical_block = pl.read(
+                        block_tables,
+                        [layer, request, pl.cast(logical_block, pl.INDEX)],
+                    )
+                    physical_slot = physical_block * BLOCK_SIZE + logical_position % BLOCK_SIZE
+                    pl.write(index_row, [0, column], pl.cast(physical_slot, pl.INT32))
+            query_position = anchor_end + query
+            query_block = query_position // BLOCK_SIZE
+            query_physical_block = pl.read(
+                block_tables, [layer, request, pl.cast(query_block, pl.INDEX)]
+            )
+            slot = pl.cast(
+                query_physical_block * BLOCK_SIZE + query_position % BLOCK_SIZE, pl.INT64
+            )
+        indices_flat[task : task + 1, :] = index_row
+        pl.write(slots_flat, [task], slot)
+        pl.write(lens_flat, [task], pl.cast(visible_len, pl.INT32))
+    return slot_mapping, swa_indices, swa_lens
+
+
+@pl.jit
+def dspark_metadata(
+    context_lens: pl.Tensor[[B_DYN], pl.INT32],
+    block_tables: pl.Tensor[[DSPARK_NUM_LAYERS, B_DYN, MAX_BLOCKS], pl.INT32],
+    slot_mapping: pl.Out[
+        pl.Tensor[[DSPARK_NUM_LAYERS, B_DYN, DSPARK_QUERY_TOKENS_PADDED], pl.INT64]
+    ],
+    swa_indices: pl.Out[
+        pl.Tensor[
+            [DSPARK_NUM_LAYERS, B_DYN, DSPARK_QUERY_TOKENS_PADDED, DSPARK_SWA_INDEX_WIDTH],
+            pl.INT32,
+        ]
+    ],
+    swa_lens: pl.Out[
+        pl.Tensor[[DSPARK_NUM_LAYERS, B_DYN, DSPARK_QUERY_TOKENS_PADDED], pl.INT32]
+    ],
+):
+    context_lens.bind_dynamic(0, B_DYN)
+    block_tables.bind_dynamic(1, B_DYN)
+    slot_mapping.bind_dynamic(1, B_DYN)
+    swa_indices.bind_dynamic(1, B_DYN)
+    swa_lens.bind_dynamic(1, B_DYN)
+    return dspark_metadata_core(
+        context_lens, block_tables, slot_mapping, swa_indices, swa_lens
+    )
+
+
+def golden_dspark_metadata(tensors):
+    from dspark_contract import build_noncausal_swa_metadata
+
+    batch = tensors["context_lens"].numel()
+    for layer in range(DSPARK_NUM_LAYERS):
+        slots, indices, lens = build_noncausal_swa_metadata(
+            tensors["block_tables"][layer], tensors["context_lens"]
+        )
+        tensors["slot_mapping"][layer] = slots.reshape(batch, DSPARK_QUERY_TOKENS_PADDED)
+        tensors["swa_indices"][layer] = indices.reshape(
+            batch, DSPARK_QUERY_TOKENS_PADDED, DSPARK_SWA_INDEX_WIDTH
+        )
+        tensors["swa_lens"][layer] = lens.reshape(batch, DSPARK_QUERY_TOKENS_PADDED)
+
+
+def build_tensor_specs(batch=4):
+    import torch
+    from golden import TensorSpec
+
+    from dspark_contract import validate_dspark_batch
+
+    validate_dspark_batch(batch)
+
+    def init_block_tables():
+        logical = torch.arange(MAX_BLOCKS, dtype=torch.int32)
+        layers = [logical + layer * MAX_BLOCKS for layer in range(DSPARK_NUM_LAYERS)]
+        return torch.stack(layers).unsqueeze(1).expand(-1, batch, -1).contiguous()
+
+    return [
+        TensorSpec(
+            "context_lens",
+            [batch],
+            torch.int32,
+            init_value=lambda: torch.tensor([1, 31, 32, 129], dtype=torch.int32).repeat(
+                (batch + 3) // 4
+            )[:batch],
+        ),
+        TensorSpec(
+            "block_tables",
+            [DSPARK_NUM_LAYERS, batch, MAX_BLOCKS],
+            torch.int32,
+            init_value=init_block_tables,
+        ),
+        TensorSpec(
+            "slot_mapping",
+            [DSPARK_NUM_LAYERS, batch, DSPARK_QUERY_TOKENS_PADDED],
+            torch.int64,
+            is_output=True,
+        ),
+        TensorSpec(
+            "swa_indices",
+            [DSPARK_NUM_LAYERS, batch, DSPARK_QUERY_TOKENS_PADDED, DSPARK_SWA_INDEX_WIDTH],
+            torch.int32,
+            is_output=True,
+        ),
+        TensorSpec(
+            "swa_lens",
+            [DSPARK_NUM_LAYERS, batch, DSPARK_QUERY_TOKENS_PADDED],
+            torch.int32,
+            is_output=True,
+        ),
+    ]
+
+
+if __name__ == "__main__":
+    import argparse
+    from golden import run_jit
+
+    parser = argparse.ArgumentParser(description="DeepSeek-V4-Flash DSpark SWA metadata validation.")
+    parser.add_argument("-p", "--platform", default="a2a3", choices=["a2a3", "a2a3sim", "a5", "a5sim"])
+    parser.add_argument("-d", "--device", type=int, default=0)
+    parser.add_argument("--batch", type=int, default=4, choices=[4, 8, 12, 16])
+    parser.add_argument("--compile-only", action="store_true")
+    args = parser.parse_args()
+    result = run_jit(
+        fn=dspark_metadata,
+        specs=build_tensor_specs(args.batch),
+        golden_fn=golden_dspark_metadata,
+        runtime_cfg=dict(platform=args.platform, device_id=args.device),
+        compile_only=args.compile_only,
+    )
+    if not result.passed:
+        if result.error:
+            print(result.error)
+        raise SystemExit(1)

--- a/models/deepseek_v4_flash_dspark/dspark_prepare.py
+++ b/models/deepseek_v4_flash_dspark/dspark_prepare.py
@@ -1,0 +1,260 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""DSpark target-hidden projection and padded query-block construction."""
+
+import pypto.language as pl
+
+from config import (
+    DSPARK_NOISE_TOKEN_ID,
+    DSPARK_QUERY_TOKENS,
+    DSPARK_QUERY_TOKENS_PADDED,
+    FLASH as M,
+)
+
+
+B_DYN = pl.dynamic("DSPARK_PREPARE_B_DYN")
+VOCAB_DYN = pl.dynamic("DSPARK_PREPARE_VOCAB_DYN")
+
+D = M.hidden_size
+TARGET_LAYERS = 3
+MAIN_K = TARGET_LAYERS * D
+HC_MULT = M.hc_mult
+EPS = M.rms_norm_eps
+D_TILE = 512
+MAIN_N_TILE = 256
+MAIN_K_TILE = 128
+
+
+@pl.jit.inline
+def dspark_prepare(
+    target_hidden: pl.Tensor[[B_DYN, TARGET_LAYERS, D], pl.BF16],
+    anchor_token_ids: pl.Tensor[[B_DYN], pl.INT64],
+    context_lens: pl.Tensor[[B_DYN], pl.INT32],
+    embed_weight: pl.Tensor[[VOCAB_DYN, D], pl.BF16],
+    main_proj_weight: pl.Tensor[[D, MAIN_K], pl.BF16],
+    main_norm_weight: pl.Tensor[[D], pl.BF16],
+    main_x: pl.Tensor[[B_DYN, D], pl.BF16],
+    query_input_ids: pl.Tensor[[B_DYN, DSPARK_QUERY_TOKENS_PADDED], pl.INT64],
+    query_positions: pl.Tensor[[B_DYN, DSPARK_QUERY_TOKENS_PADDED], pl.INT32],
+    query_active: pl.Tensor[[B_DYN, DSPARK_QUERY_TOKENS_PADDED], pl.INT32],
+    query_hidden: pl.Tensor[[B_DYN, DSPARK_QUERY_TOKENS_PADDED, HC_MULT, D], pl.FP32],
+):
+    batch = pl.tensor.dim(target_hidden, 0)
+    target_flat = pl.reshape(target_hidden, [batch, MAIN_K])
+    projected = pl.create_tensor([batch * 2, D], dtype=pl.FP32)
+
+    for task in pl.spmd(batch * (D // MAIN_N_TILE), name_hint="dspark_main_proj"):
+        request = task // (D // MAIN_N_TILE)
+        n0 = (task % (D // MAIN_N_TILE)) * MAIN_N_TILE
+        x0 = target_flat[request : request + 1, 0:MAIN_K_TILE]
+        w0 = main_proj_weight[n0 : n0 + MAIN_N_TILE, 0:MAIN_K_TILE]
+        acc = pl.matmul(x0, w0, b_trans=True, out_dtype=pl.FP32)
+        for k0 in pl.pipeline(MAIN_K_TILE, MAIN_K, MAIN_K_TILE, stage=2):
+            xk = target_flat[request : request + 1, k0 : k0 + MAIN_K_TILE]
+            wk = main_proj_weight[n0 : n0 + MAIN_N_TILE, k0 : k0 + MAIN_K_TILE]
+            acc = pl.matmul_acc(acc, xk, wk, b_trans=True)
+        projected[request * 2 : request * 2 + 1, n0 : n0 + MAIN_N_TILE] = acc
+        projected[request * 2 + 1 : request * 2 + 2, n0 : n0 + MAIN_N_TILE] = acc
+
+    normalized_projected = pl.create_tensor([batch * 2, D], dtype=pl.BF16)
+    for block in pl.spmd(batch * 2 // 8, name_hint="dspark_main_norm"):
+        row0 = block * 8
+        sq_sum = pl.full([1, 8], dtype=pl.FP32, value=0.0)
+        for d0 in pl.pipeline(0, D, D_TILE, stage=2):
+            x = projected[row0 : row0 + 8, d0 : d0 + D_TILE]
+            sq_sum = pl.add(sq_sum, pl.reshape(pl.row_sum(pl.mul(x, x)), [1, 8]))
+        inv_rms = pl.rsqrt(pl.add(pl.mul(sq_sum, 1.0 / D), EPS), high_precision=True)
+        inv_rms_col = pl.reshape(inv_rms, [8, 1])
+        for d0 in pl.pipeline(0, D, D_TILE, stage=2):
+            x = projected[row0 : row0 + 8, d0 : d0 + D_TILE]
+            weight = pl.reshape(main_norm_weight[d0 : d0 + D_TILE], [1, D_TILE])
+            normalized = pl.col_expand_mul(
+                pl.row_expand_mul(x, inv_rms_col), pl.cast(weight, pl.FP32)
+            )
+            normalized_projected[row0 : row0 + 8, d0 : d0 + D_TILE] = pl.cast(
+                normalized, target_type=pl.BF16, mode="rint"
+            )
+
+    for request in pl.spmd(batch * (D // D_TILE), name_hint="dspark_main_norm_unpack"):
+        batch_row = request // (D // D_TILE)
+        d0 = (request % (D // D_TILE)) * D_TILE
+        main_x[batch_row : batch_row + 1, d0 : d0 + D_TILE] = normalized_projected[
+            batch_row * 2 : batch_row * 2 + 1, d0 : d0 + D_TILE
+        ]
+
+    token_count = batch * DSPARK_QUERY_TOKENS_PADDED
+    ids_flat = pl.reshape(query_input_ids, [token_count])
+    positions_flat = pl.reshape(query_positions, [token_count])
+    active_flat = pl.reshape(query_active, [token_count])
+    hidden_flat = pl.reshape(query_hidden, [token_count * HC_MULT, D])
+    for token in pl.spmd(token_count, name_hint="dspark_query_layout"):
+        request = token // DSPARK_QUERY_TOKENS_PADDED
+        query = token % DSPARK_QUERY_TOKENS_PADDED
+        token_id = pl.cast(DSPARK_NOISE_TOKEN_ID, pl.INT64)
+        if query == 0:
+            token_id = pl.read(anchor_token_ids, [request])
+        pl.write(ids_flat, [token], token_id)
+        context_len = pl.read(context_lens, [request])
+        query_position = context_len + pl.cast(1, pl.INT32) + pl.cast(query, pl.INT32)
+        pl.write(positions_flat, [token], query_position)
+        is_active = pl.cast(query < DSPARK_QUERY_TOKENS, pl.INT32)
+        pl.write(active_flat, [token], is_active)
+        embedding_row = pl.cast(token_id, pl.INDEX)
+        for d0 in pl.pipeline(0, D, D_TILE, stage=2):
+            embedding = embed_weight[embedding_row : embedding_row + 1, d0 : d0 + D_TILE]
+            embedding_fp32 = pl.cast(embedding, pl.FP32)
+            for hc in pl.range(HC_MULT):
+                hidden_row = token * HC_MULT + hc
+                hidden_flat[hidden_row : hidden_row + 1, d0 : d0 + D_TILE] = embedding_fp32
+    return main_x, query_hidden
+
+
+@pl.jit
+def dspark_prepare_test(
+    target_hidden: pl.Tensor[[B_DYN, TARGET_LAYERS, D], pl.BF16],
+    anchor_token_ids: pl.Tensor[[B_DYN], pl.INT64],
+    context_lens: pl.Tensor[[B_DYN], pl.INT32],
+    embed_weight: pl.Tensor[[VOCAB_DYN, D], pl.BF16],
+    main_proj_weight: pl.Tensor[[D, MAIN_K], pl.BF16],
+    main_norm_weight: pl.Tensor[[D], pl.BF16],
+    main_x: pl.Out[pl.Tensor[[B_DYN, D], pl.BF16]],
+    query_input_ids: pl.Out[pl.Tensor[[B_DYN, DSPARK_QUERY_TOKENS_PADDED], pl.INT64]],
+    query_positions: pl.Out[pl.Tensor[[B_DYN, DSPARK_QUERY_TOKENS_PADDED], pl.INT32]],
+    query_active: pl.Out[pl.Tensor[[B_DYN, DSPARK_QUERY_TOKENS_PADDED], pl.INT32]],
+    query_hidden: pl.Out[pl.Tensor[[B_DYN, DSPARK_QUERY_TOKENS_PADDED, HC_MULT, D], pl.FP32]],
+):
+    target_hidden.bind_dynamic(0, B_DYN)
+    anchor_token_ids.bind_dynamic(0, B_DYN)
+    context_lens.bind_dynamic(0, B_DYN)
+    main_x.bind_dynamic(0, B_DYN)
+    query_input_ids.bind_dynamic(0, B_DYN)
+    query_positions.bind_dynamic(0, B_DYN)
+    query_active.bind_dynamic(0, B_DYN)
+    query_hidden.bind_dynamic(0, B_DYN)
+    embed_weight.bind_dynamic(0, VOCAB_DYN)
+    return dspark_prepare(
+        target_hidden,
+        anchor_token_ids,
+        context_lens,
+        embed_weight,
+        main_proj_weight,
+        main_norm_weight,
+        main_x,
+        query_input_ids,
+        query_positions,
+        query_active,
+        query_hidden,
+    )
+
+
+def golden_dspark_prepare(tensors):
+    from dspark_contract import build_query_layout, golden_main_projection
+
+    input_ids, positions, active = build_query_layout(
+        tensors["anchor_token_ids"], tensors["context_lens"]
+    )
+    tensors["main_x"][:] = golden_main_projection(
+        tensors["target_hidden"], tensors["main_proj_weight"], tensors["main_norm_weight"]
+    )
+    tensors["query_input_ids"][:] = input_ids
+    tensors["query_positions"][:] = positions
+    tensors["query_active"][:] = active.to(tensors["query_active"].dtype)
+    embedded = tensors["embed_weight"].index_select(0, input_ids.reshape(-1))
+    embedded = embedded.reshape(*input_ids.shape, 1, D).expand(-1, -1, HC_MULT, -1)
+    tensors["query_hidden"][:] = embedded.float()
+
+
+def build_tensor_specs(batch=4, vocab_size=M.vocab_size):
+    import torch
+    from golden import TensorSpec
+
+    from dspark_contract import validate_dspark_batch
+
+    validate_dspark_batch(batch)
+    if vocab_size <= DSPARK_NOISE_TOKEN_ID:
+        raise ValueError("embed vocabulary must contain the DSpark noise token")
+
+    return [
+        TensorSpec(
+            "target_hidden",
+            [batch, TARGET_LAYERS, D],
+            torch.bfloat16,
+            init_value=lambda: torch.randn(batch, TARGET_LAYERS, D, dtype=torch.bfloat16),
+        ),
+        TensorSpec(
+            "anchor_token_ids",
+            [batch],
+            torch.int64,
+            init_value=lambda: torch.arange(batch, dtype=torch.int64),
+        ),
+        TensorSpec(
+            "context_lens",
+            [batch],
+            torch.int32,
+            init_value=lambda: torch.arange(batch, dtype=torch.int32) + 31,
+        ),
+        TensorSpec(
+            "embed_weight",
+            [vocab_size, D],
+            torch.bfloat16,
+            init_value=lambda: torch.zeros(vocab_size, D, dtype=torch.bfloat16),
+        ),
+        TensorSpec(
+            "main_proj_weight",
+            [D, MAIN_K],
+            torch.bfloat16,
+            init_value=lambda: torch.randn(D, MAIN_K, dtype=torch.bfloat16) / MAIN_K ** 0.5,
+        ),
+        TensorSpec(
+            "main_norm_weight",
+            [D],
+            torch.bfloat16,
+            init_value=lambda: torch.ones(D, dtype=torch.bfloat16),
+        ),
+        TensorSpec("main_x", [batch, D], torch.bfloat16, is_output=True),
+        TensorSpec(
+            "query_input_ids", [batch, DSPARK_QUERY_TOKENS_PADDED], torch.int64, is_output=True
+        ),
+        TensorSpec(
+            "query_positions", [batch, DSPARK_QUERY_TOKENS_PADDED], torch.int32, is_output=True
+        ),
+        TensorSpec(
+            "query_active", [batch, DSPARK_QUERY_TOKENS_PADDED], torch.int32, is_output=True
+        ),
+        TensorSpec(
+            "query_hidden",
+            [batch, DSPARK_QUERY_TOKENS_PADDED, HC_MULT, D],
+            torch.float32,
+            is_output=True,
+        ),
+    ]
+
+
+if __name__ == "__main__":
+    import argparse
+    from golden import ratio_allclose, run_jit
+
+    parser = argparse.ArgumentParser(description="DeepSeek-V4-Flash DSpark input preparation validation.")
+    parser.add_argument("-p", "--platform", default="a2a3", choices=["a2a3", "a2a3sim", "a5", "a5sim"])
+    parser.add_argument("-d", "--device", type=int, default=0)
+    parser.add_argument("--batch", type=int, default=4, choices=[4, 8, 12, 16])
+    parser.add_argument("--compile-only", action="store_true")
+    args = parser.parse_args()
+    result = run_jit(
+        fn=dspark_prepare_test,
+        specs=build_tensor_specs(args.batch),
+        golden_fn=golden_dspark_prepare,
+        runtime_cfg=dict(platform=args.platform, device_id=args.device),
+        compile_only=args.compile_only,
+        compare_fn={"main_x": ratio_allclose(atol=2e-2, rtol=2e-2, max_error_ratio=0.02)},
+    )
+    if not result.passed:
+        if result.error:
+            print(result.error)
+        raise SystemExit(1)

--- a/models/deepseek_v4_flash_dspark/dspark_sparse_attn_swa.py
+++ b/models/deepseek_v4_flash_dspark/dspark_sparse_attn_swa.py
@@ -1,0 +1,728 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""DeepSeek-V4 DSpark 256-column non-causal SWA attention."""
+
+
+import pypto.language as pl
+
+from config import (
+    FLASH as M,
+    DECODE_BATCH,
+    TP,
+    DECODE_SEQ,
+    BLOCK_SIZE,
+    KV_ORI_BLOCK_NUM,
+    KV_ORI_MAX_BLOCKS,
+    INT8_SCALE_MAX,
+    INT8_AMAX_EPS,
+    DSPARK_SWA_INDEX_WIDTH,
+)
+
+
+# Dynamic shape variables.
+T_DYN = pl.dynamic("T_DYN")  # T = B * S
+ORI_BLOCK_NUM_DYN = pl.dynamic("ORI_BLOCK_NUM_DYN")
+
+# model config
+B = DECODE_BATCH // TP
+S = DECODE_SEQ
+T = B * S
+D = M.hidden_size
+H = M.num_attention_heads
+HEAD_DIM = M.head_dim
+ROPE_DIM = M.qk_rope_head_dim
+HALF_ROPE = ROPE_DIM // 2
+NOPE_DIM = M.nope_head_dim
+WIN = DSPARK_SWA_INDEX_WIDTH
+MAX_SEQ_LEN = M.max_position_embeddings
+SOFTMAX_SCALE = M.softmax_scale
+O_LORA = M.o_lora_rank
+O_GROUPS = M.o_groups
+HEADS_PER_GROUP = H // O_GROUPS
+O_GROUP_IN = HEADS_PER_GROUP * HEAD_DIM
+NEG_INF = -1.0e20
+
+# paged KV cache
+ORI_MAX_BLOCKS = KV_ORI_MAX_BLOCKS
+ORI_BLOCK_NUM = KV_ORI_BLOCK_NUM
+
+# tiling
+GATHER_SPLITS = 8
+GATHER_ROWS_PER_TASK = WIN // GATHER_SPLITS
+GATHER_RUN = 16          # window sub-tile probed for physical contiguity -> one bulk DMA
+H_TILE = 16
+QK_M_TILE = 32           # qk_pv M rows per QK/PV matmul; QK_M_TILE/H_TILE-way KV L1->L0 reuse
+ATTN_K_TILE = 128
+ROPE_TILE = 16
+ROPE_INTERLEAVE_TILE = 2 * ROPE_TILE
+A_K_TILE = 256           # proj_a cube K frag
+PROJ_A_MM_N_TILE = 128   # proj_a cube N frag
+T_PAD = ((T + 16 - 1) // 16) * 16  # T padded up to the 16-row cube M floor
+MM_T_TILE = T_PAD  # one cube M tile spans every token row of the T_PAD-strided scratch
+ROPE_CS_T_TILE = 8  # rope cos/sin row block; T is a multiple of 8 by the batch contract
+BIAS_T_TILE = 8     # swa_valid_bias row block, same contract
+PROJ_A_ROW_TILE = 16  # proj_a cube M; row-blocked so uninitialized pad rows never enter the matmul
+PA_N_FRAGS = O_LORA // PROJ_A_MM_N_TILE
+B_K_TILE = 256           # proj_b_mm cube K frag
+# proj_b_mm cube N frag; Acc = MM_T_TILE*N*4 = 128KB sits exactly on the a2a3 L0C wall.
+PROJ_B_MM_N_TILE = 256
+PROJ_B_ACT_N_TILE = 512  # proj_b_act vector N frag; keeps the O_GROUPS-way accumulate inside UB
+# Fused amax+quant token tile. 8 keeps the [1, QUANT_TOKEN_TILE] fp32 amax tile
+# 32-byte aligned (8*4=32B, the alloc-tile row floor).
+QUANT_TOKEN_TILE = 8
+PROJ_B_D_TILE = 512      # proj_b_mm D chunk per task; its N frags loop inside the task
+PROJ_B_ACT_T_TILE = 8    # proj_b_act inner token tile for the O_GROUPS-way INT32->FP32 accumulate
+PROJ_B_ACT_TASK_T_TILE = 8   # proj_b_act token block per task
+PROJ_B_ACT_N_REGS = D // PROJ_B_ACT_N_TILE
+TOPK = WIN               # SWA sparse-K width: sliding window only
+SPARSE_BLOCKS = WIN // ATTN_K_TILE
+PADDED_TOPK = SPARSE_BLOCKS * ATTN_K_TILE
+
+assert BLOCK_SIZE % GATHER_RUN == 0, "a contiguous run must not straddle two paged blocks by construction"
+assert WIN % ATTN_K_TILE == 0
+
+
+@pl.jit.inline
+def sparse_attn_swa(
+    q: pl.Tensor[[T_DYN, H, HEAD_DIM], pl.BF16],
+    ori_kv: pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
+    sparse_bias: pl.Tensor[[T_DYN, PADDED_TOPK], pl.FP32],
+    attn_sink: pl.Tensor[[H], pl.FP32],
+    freqs_cos: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
+    wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
+    wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
+    wo_b_scale: pl.Tensor[[D], pl.FP32],
+    attn_out: pl.Tensor[[T_DYN, D], pl.BF16],
+):
+    """Standalone sparse attention with a BF16 projected output."""
+    t_dim = pl.tensor.dim(q, 0)
+    t_heads = t_dim * H
+    t_win = t_dim * WIN
+    t_blk = t_dim * (H // H_TILE) * SPARSE_BLOCKS * H_TILE
+    t_hblocks = t_dim * (H // H_TILE)
+    t_gather = t_dim * GATHER_SPLITS
+    rope_cs_blocks = t_dim // ROPE_CS_T_TILE
+    act_t_blks = t_dim // PROJ_B_ACT_TASK_T_TILE
+    proj_a_rows = (t_dim + PROJ_A_ROW_TILE - 1) // PROJ_A_ROW_TILE
+    ori_block_num = pl.tensor.dim(ori_kv, 0)
+    ori_kv_flat = pl.reshape(ori_kv, [ori_block_num * BLOCK_SIZE, HEAD_DIM])
+    partials = pl.create_tensor([T_PAD, O_GROUPS * D], dtype=pl.INT32)
+    act_scale_dq = pl.create_tensor([O_GROUPS, T_PAD], dtype=pl.FP32)
+    proj_b_tids = pl.array.create(O_GROUPS, pl.TASK_ID)
+    # SWA metadata already lowered each logical window row to a physical cache
+    # slot. Current decode tokens must be inserted into ori_kv by the caller
+    # before this function runs; there is no speculative overlay path here.
+
+    swa_kv_flat = pl.create_tensor([t_win, HEAD_DIM], dtype=pl.BF16)
+    gather_tids = pl.array.create(1, pl.TASK_ID)
+    with pl.spmd(t_gather, name_hint="swa_gather_kv") as gather_tid:
+        g_task = pl.tile.get_block_idx()
+        g_t = g_task // GATHER_SPLITS
+        g_split = g_task - g_t * GATHER_SPLITS
+        g_r0 = g_split * GATHER_ROWS_PER_TASK
+        g_base = g_t * WIN
+        # Probe each sub-tile's first/last slot: endpoints GATHER_RUN-1 apart mean
+        # the whole run sits in one paged block and moves as one bulk copy.
+        for g_sub in pl.range(GATHER_ROWS_PER_TASK // GATHER_RUN):
+            g_sr0 = g_r0 + g_sub * GATHER_RUN
+            g_sdst = g_base + g_sr0
+            g_first = pl.read(swa_indices, [g_t, g_sr0])
+            g_last = pl.read(swa_indices, [g_t, g_sr0 + GATHER_RUN - 1])
+            # A -1 slot anywhere in the run pins g_run_ok below the match value,
+            # so an invalid or block-straddling run takes the per-row path.
+            g_run_ok = (g_last - g_first) + pl.min(g_first, 0) * GATHER_RUN
+            if g_run_ok == GATHER_RUN - 1:
+                g_run_src = pl.cast(g_first, pl.INDEX)
+                swa_kv_flat[g_sdst : g_sdst + GATHER_RUN, 0 : HEAD_DIM] = ori_kv_flat[
+                    g_run_src : g_run_src + GATHER_RUN, 0 : HEAD_DIM
+                ]
+            else:
+                for g_dr in pl.range(GATHER_RUN):
+                    g_dst = g_sdst + g_dr
+                    g_slot_i32 = pl.read(swa_indices, [g_t, g_sr0 + g_dr])
+                    if g_slot_i32 >= 0:
+                        g_slot = pl.cast(g_slot_i32, pl.INDEX)
+                        swa_kv_flat[g_dst : g_dst + 1, 0 : HEAD_DIM] = ori_kv_flat[g_slot : g_slot + 1, 0 : HEAD_DIM]
+                    else:
+                        swa_kv_flat[g_dst : g_dst + 1, 0 : HEAD_DIM] = pl.full(
+                            [1, HEAD_DIM], dtype=pl.BF16, value=0.0)
+    gather_tids[0] = gather_tid
+
+    # qk_pv writes per-tile (mi, li, oi) to GM; merge_norm reads them back. Not
+    # fused on a2a3: the PV output (Acc) -> online rescale (Vec) needs an
+    # unsupported tmov, and a [H_TILE, HEAD_DIM] carry overflows the Vec buffer.
+    q_flat = pl.reshape(q, [t_heads, HEAD_DIM])
+    o_packed_heads = pl.create_tensor([O_GROUPS * T_PAD * HEADS_PER_GROUP, HEAD_DIM], dtype=pl.BF16)
+    o_packed = pl.reshape(o_packed_heads, [O_GROUPS * T_PAD, O_GROUP_IN])
+    sparse_blk_mi = pl.create_tensor([t_blk, 1], dtype=pl.FP32)
+    sparse_blk_li = pl.create_tensor([t_blk, 1], dtype=pl.FP32)
+    sparse_blk_oi = pl.create_tensor([t_blk, HEAD_DIM], dtype=pl.FP32)
+
+    with pl.spmd(t_dim, name_hint="qk_pv", deps=[gather_tids[0]], allow_early_resolve=True) as qk_tid:
+        qk_t = pl.tile.get_block_idx()
+        qk_token_base = qk_t * (H // H_TILE) * SPARSE_BLOCKS * H_TILE
+        for qk_sb in pl.unroll(SPARSE_BLOCKS):
+            qk_s0 = qk_sb * ATTN_K_TILE
+            qk_bias_row = sparse_bias[qk_t : qk_t + 1, qk_s0 : qk_s0 + ATTN_K_TILE]
+            qk_base = qk_t * WIN + qk_s0
+            qk_kv = swa_kv_flat[qk_base : qk_base + ATTN_K_TILE, 0 : HEAD_DIM]
+
+            # Keep both 32-head batches in one token task so they reuse the KV
+            # tile already resident in L1 instead of loading it once per block.
+            for qk_hb in pl.pipeline(H // QK_M_TILE, stage=2):
+                qk_h0 = qk_hb * QK_M_TILE
+                qk_head_row = qk_t * H + qk_h0
+                qk_q_tile = q_flat[qk_head_row : qk_head_row + QK_M_TILE, 0 : HEAD_DIM]
+                qk_raw = pl.matmul(qk_q_tile, qk_kv, b_trans=True, out_dtype=pl.FP32)
+                qk_scaled = pl.mul(qk_raw, SOFTMAX_SCALE)
+                qk_scores = pl.col_expand_add(qk_scaled, qk_bias_row)
+                qk_mi = pl.row_max(qk_scores)
+                # Invalid lanes (NEG_INF bias, zero kv rows) exp to ~0; all-invalid
+                # blocks die in the merge alpha/beta -- no mask multiply needed.
+                qk_exp = pl.exp(pl.row_expand_sub(qk_scores, qk_mi))
+                qk_li = pl.row_sum(qk_exp)
+                qk_exp_bf16 = pl.cast(qk_exp, target_type=pl.BF16, mode="rint")
+                qk_oi = pl.matmul(qk_exp_bf16, qk_kv, out_dtype=pl.FP32)
+                for qk_sub in pl.unroll(QK_M_TILE // H_TILE):
+                    qk_h_idx = qk_hb * (QK_M_TILE // H_TILE) + qk_sub
+                    qk_r0 = qk_sub * H_TILE
+                    qk_blk_base = qk_token_base + qk_h_idx * SPARSE_BLOCKS * H_TILE
+                    qk_row = qk_blk_base + qk_sb * H_TILE
+                    sparse_blk_mi[qk_row : qk_row + H_TILE, 0 : 1] = qk_mi[qk_r0 : qk_r0 + H_TILE, 0 : 1]
+                    sparse_blk_li[qk_row : qk_row + H_TILE, 0 : 1] = qk_li[qk_r0 : qk_r0 + H_TILE, 0 : 1]
+                    sparse_blk_oi[qk_row : qk_row + H_TILE, 0 : HEAD_DIM] = qk_oi[qk_r0 : qk_r0 + H_TILE, 0 : HEAD_DIM]
+
+    # Materialize the head-invariant interleaved cos and signed-sin rows once.
+    # This runs alongside qk_pv and keeps the exact indexed RoPE arithmetic used
+    # by the reference path while the group merge below changes only scheduling
+    # and store granularity.
+    rope_cos_il = pl.create_tensor([T_PAD, ROPE_DIM], dtype=pl.FP32)
+    rope_sin_signed = pl.create_tensor([T_PAD, ROPE_DIM], dtype=pl.FP32)
+    rope_swap_idx = pl.create_tensor([H_TILE, ROPE_DIM], dtype=pl.INT32)
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="rope_cs") as rope_tid:
+        swap_ones = pl.full([H_TILE, ROPE_DIM], dtype=pl.FP32, value=1.0)
+        swap_range_i32 = pl.arange(0, [1, ROPE_DIM], dtype=pl.INT32)
+        swap_range = pl.cast(swap_range_i32, target_type=pl.FP32)
+        swap_col = pl.col_expand_mul(swap_ones, swap_range)
+        swap_half = pl.mul(swap_col, 0.5)
+        swap_dup_i32 = pl.cast(swap_half, target_type=pl.INT32, mode="trunc")
+        swap_dup_f = pl.cast(swap_dup_i32, target_type=pl.FP32)
+        swap_lane = pl.sub(swap_col, pl.mul(swap_dup_f, 2.0))
+        swap_next = pl.add(swap_col, 1.0)
+        swap_stride = pl.mul(swap_lane, 2.0)
+        swap_idx_f = pl.sub(swap_next, swap_stride)
+        rope_swap_idx[:, :] = pl.cast(swap_idx_f, target_type=pl.INT32)
+
+        cs_ones = pl.full([ROPE_CS_T_TILE, ROPE_INTERLEAVE_TILE], dtype=pl.FP32, value=1.0)
+        cs_range_i32 = pl.arange(0, [1, ROPE_INTERLEAVE_TILE], dtype=pl.INT32)
+        cs_range = pl.cast(cs_range_i32, target_type=pl.FP32)
+        cs_col = pl.col_expand_mul(cs_ones, cs_range)
+        cs_half = pl.mul(cs_col, 0.5)
+        cs_dup_i32 = pl.cast(cs_half, target_type=pl.INT32, mode="trunc")
+        cs_dup_f = pl.cast(cs_dup_i32, target_type=pl.FP32)
+        cs_dup_idx = pl.cast(cs_dup_f, target_type=pl.INT32)
+        cs_lane = pl.sub(cs_col, pl.mul(cs_dup_f, 2.0))
+        cs_sign_base = pl.sub(pl.mul(cs_lane, 2.0), 1.0)
+        cs_sign = pl.neg(cs_sign_base)
+        for cp in pl.range(HALF_ROPE // ROPE_TILE):
+            cp_r0 = cp * ROPE_TILE
+            cp_c0 = 2 * cp_r0
+            for cs_rb in pl.range(rope_cs_blocks):
+                cs_t0 = cs_rb * ROPE_CS_T_TILE
+                cs_cos = pl.cast(freqs_cos[cs_t0 : cs_t0 + ROPE_CS_T_TILE, cp_r0 : cp_r0 + ROPE_TILE], target_type=pl.FP32)
+                cs_sin = pl.cast(freqs_sin[cs_t0 : cs_t0 + ROPE_CS_T_TILE, cp_r0 : cp_r0 + ROPE_TILE], target_type=pl.FP32)
+                cs_cos_dup = pl.gather(cs_cos, dim=-1, index=cs_dup_idx)
+                cs_sin_dup = pl.gather(cs_sin, dim=-1, index=cs_dup_idx)
+                cs_sin_signed = pl.mul(cs_sin_dup, cs_sign)
+                rope_cos_il[cs_t0 : cs_t0 + ROPE_CS_T_TILE, cp_c0 : cp_c0 + ROPE_INTERLEAVE_TILE] = cs_cos_dup
+                rope_sin_signed[cs_t0 : cs_t0 + ROPE_CS_T_TILE, cp_c0 : cp_c0 + ROPE_INTERLEAVE_TILE] = cs_sin_signed
+
+    # Flatten the one-block SWA merge over token/head tiles into a single
+    # 32-block grid, which fits in one AIV wave and avoids eight group-grid
+    # submissions. Each block writes two output-projection groups using the
+    # same contiguous per-group stores.
+    with pl.spmd(t_hblocks, name_hint="merge_norm", deps=[qk_tid, rope_tid],
+                 allow_early_resolve=True) as merge_tid:
+        m_idx = pl.tile.get_block_idx()
+        m_t = m_idx // (H // H_TILE)
+        m_h_idx = m_idx - m_t * (H // H_TILE)
+        m_h0 = m_h_idx * H_TILE
+        m_blk_base = m_t * H + m_h0
+        m_mi = sparse_blk_mi[m_blk_base : m_blk_base + H_TILE, 0:1]
+        m_li = sparse_blk_li[m_blk_base : m_blk_base + H_TILE, 0:1]
+        m_oi = sparse_blk_oi[m_blk_base : m_blk_base + H_TILE, 0:HEAD_DIM]
+
+        n_sink = pl.reshape(attn_sink[m_h0 : m_h0 + H_TILE], [H_TILE, 1])
+        n_sink_delta = pl.sub(n_sink, m_mi)
+        n_sink_exp = pl.exp(n_sink_delta)
+        n_denom = pl.add(m_li, n_sink_exp)
+        n_normalized = pl.row_expand_div(m_oi, n_denom)
+        n_full = n_normalized[0:H_TILE, 0:HEAD_DIM]
+        n_bf16 = pl.cast(n_full, target_type=pl.BF16, mode="rint")
+
+        m_rope = n_full[:, NOPE_DIM:HEAD_DIM]
+        m_swapped = pl.gather(m_rope, dim=-1, index=rope_swap_idx[:, :])
+        m_cos_il = rope_cos_il[m_t : m_t + 1, 0:ROPE_DIM]
+        m_sin_signed = rope_sin_signed[m_t : m_t + 1, 0:ROPE_DIM]
+        m_rope_cos = pl.col_expand_mul(m_rope, m_cos_il)
+        m_swap_sin = pl.col_expand_mul(m_swapped, m_sin_signed)
+        m_rot = pl.add(m_rope_cos, m_swap_sin)
+        n_rope_bf16 = pl.cast(m_rot, target_type=pl.BF16, mode="rint")
+
+        m_g0 = m_h0 // HEADS_PER_GROUP
+        for m_sg in pl.unroll(H_TILE // HEADS_PER_GROUP):
+            m_src_h0 = m_sg * HEADS_PER_GROUP
+            n_pack_row = (m_g0 + m_sg) * T_PAD + m_t
+            n_dst_head = n_pack_row * HEADS_PER_GROUP
+            o_packed_heads[n_dst_head : n_dst_head + HEADS_PER_GROUP, 0:NOPE_DIM] = n_bf16[
+                m_src_h0 : m_src_h0 + HEADS_PER_GROUP, 0:NOPE_DIM
+            ]
+            o_packed_heads[n_dst_head : n_dst_head + HEADS_PER_GROUP, NOPE_DIM:HEAD_DIM] = n_rope_bf16[
+                m_src_h0 : m_src_h0 + HEADS_PER_GROUP, 0:ROPE_DIM
+            ]
+
+    # ========================================================================
+    # Back-to-back grouped output projection (manual scope, PER-GROUP INT8 quant).
+    #
+    # Per-GROUP amax localizes the quant reduction to each O_LORA group (vs the
+    # per-ROW-amax form, where a full-8192-row reduction is a hard barrier between
+    # proj_a and proj_b), so the three stages PIPELINE per group with qwen3-style
+    # fine-grained deps: proj_b[*, g] waits only on quant[g], which waits only on
+    # proj_a[g, *] -- so proj_b's cube for group g runs while proj_a/quant of later
+    # groups are still in flight (a genuine proj_a<->proj_b back-to-back GEMM).
+    #
+    # manual_scope SUPPRESSES auto-dep, so every edge is explicit: proj_a[g]
+    # reads only its o_packed slab -> deps=[merge_tid]; quant[g] deps on group
+    # g's proj_a task; proj_b depends directly on quant[g] and writes a disjoint
+    # group partial. proj_b_act combines those partials with their group row scales,
+    # applies the per-channel weight scale, and is the consolidated attn_out writer.
+    # ========================================================================
+    o_r_pad = pl.create_tensor([T_PAD, O_GROUPS * O_LORA], dtype=pl.FP32)
+    o_r_i8_pad = pl.create_tensor([T_PAD, O_GROUPS * O_LORA], dtype=pl.INT8)
+    # [G, T] keeps each group's per-row scale as one contiguous row;
+    # column reads would become unsupported strided GM->VecTile loads.
+    # Per-group INT32 partials: proj_b_mm (pure cube) writes group g's contribution to
+    # output channel n at partials[:, g*D + n]; proj_b_act (pure vector) sums the
+    # O_GROUPS partials with their per-group act scales. No atomic-add -> no zero-seed.
+    # Package each group's fragments into one grid. The group TaskId is the
+    # exact dependency granularity needed by quant/proj_b, while 80 individual
+    # orchestration submissions disappear from the critical projection tail.
+    with pl.manual_scope():
+        for g in pl.parallel(O_GROUPS):
+            row_base_o = g * T_PAD
+            out_col_g = g * O_LORA
+
+            with pl.spmd(proj_a_rows * PA_N_FRAGS, name_hint="proj_a_mm", deps=[merge_tid],
+                         allow_early_resolve=True) as pa_tid:
+                pa_unit = pl.tile.get_block_idx()
+                pa_rb = pa_unit // PA_N_FRAGS  # row block outermost
+                nf = pa_unit - pa_rb * PA_N_FRAGS
+                pa_r0 = pa_rb * PROJ_A_ROW_TILE
+                pa_rows = pl.min(PROJ_A_ROW_TILE, t_dim - pa_r0)
+                pa_src0 = row_base_o + pa_r0
+                n0 = nf * PROJ_A_MM_N_TILE
+                xa0_chunk = pl.slice(o_packed, [PROJ_A_ROW_TILE, A_K_TILE], [pa_src0, 0], valid_shape=[pa_rows, A_K_TILE])
+                wa0_chunk = wo_a[g : g + 1, n0 : n0 + PROJ_A_MM_N_TILE, 0:A_K_TILE]
+                acc_a = pl.matmul(xa0_chunk, wa0_chunk, b_trans=True, out_dtype=pl.FP32)
+                for kb in pl.pipeline(1, O_GROUP_IN // A_K_TILE, stage=2):
+                    k0 = kb * A_K_TILE
+                    xa_k_chunk = pl.slice(o_packed, [PROJ_A_ROW_TILE, A_K_TILE], [pa_src0, k0], valid_shape=[pa_rows, A_K_TILE])
+                    wa_k_chunk = wo_a[g : g + 1, n0 : n0 + PROJ_A_MM_N_TILE, k0 : k0 + A_K_TILE]
+                    acc_a = pl.matmul_acc(acc_a, xa_k_chunk, wa_k_chunk, b_trans=True)
+                # acc_a is 3D (wo_a keeps its group axis), which subscript-write cannot express.
+                o_r_pad = pl.assemble(o_r_pad, acc_a, [pa_r0, out_col_g + n0])
+
+            col_g = g * O_LORA
+            with pl.at(level=pl.Level.CORE_GROUP, name_hint="quant", deps=[pa_tid], allow_early_resolve=True) as q_tid:
+                for qt in pl.pipeline(0, t_dim, QUANT_TOKEN_TILE, stage=2):
+                    oc_amax = o_r_pad[qt : qt + QUANT_TOKEN_TILE, col_g : col_g + O_LORA]
+                    g_abs = pl.abs(oc_amax)
+                    g_row_max = pl.row_max(g_abs)
+                    g_row_max = pl.reshape(g_row_max, [1, QUANT_TOKEN_TILE])
+                    g_amax_floor = pl.full([1, QUANT_TOKEN_TILE], dtype=pl.FP32, value=INT8_AMAX_EPS)
+                    g_amax = pl.maximum(g_amax_floor, g_row_max)
+                    g_scale_num = pl.full([1, QUANT_TOKEN_TILE], dtype=pl.FP32, value=INT8_SCALE_MAX)
+                    g_sq_row = pl.div(g_scale_num, g_amax)
+                    g_scale_dq = pl.mul(g_amax, 1.0 / INT8_SCALE_MAX)
+                    act_scale_dq[g : g + 1, qt : qt + QUANT_TOKEN_TILE] = g_scale_dq
+                    g_sq_col = pl.reshape(g_sq_row, [QUANT_TOKEN_TILE, 1])
+                    oc_q = o_r_pad[qt : qt + QUANT_TOKEN_TILE, col_g : col_g + O_LORA]
+                    oq_scaled = pl.row_expand_mul(oc_q, g_sq_col)
+                    oq_i32 = pl.cast(oq_scaled, target_type=pl.INT32, mode="rint")
+                    oq_half = pl.cast(oq_i32, target_type=pl.FP16, mode="round")
+                    oq_i8 = pl.cast(oq_half, target_type=pl.INT8, mode="trunc")
+                    o_r_i8_pad[qt : qt + QUANT_TOKEN_TILE, col_g : col_g + O_LORA] = oq_i8
+                # Zero the rows past the runtime token count; proj_b_mm reads the full T_PAD extent.
+                for zt in pl.range(t_dim, T_PAD, QUANT_TOKEN_TILE):
+                    zero_half = pl.full([QUANT_TOKEN_TILE, O_LORA], dtype=pl.FP16, value=0.0)
+                    o_r_i8_pad[zt : zt + QUANT_TOKEN_TILE, col_g : col_g + O_LORA] = pl.cast(
+                        zero_half, target_type=pl.INT8, mode="trunc")
+
+            with pl.spmd(D // PROJ_B_D_TILE, name_hint="proj_b_mm", deps=[q_tid], allow_early_resolve=True) as pb_tid:
+                dc = pl.tile.get_block_idx()
+                d0 = dc * PROJ_B_D_TILE
+                for nf in pl.range(PROJ_B_D_TILE // PROJ_B_MM_N_TILE):
+                    n0 = d0 + nf * PROJ_B_MM_N_TILE
+                    acc_b = pl.create_tensor([MM_T_TILE, PROJ_B_MM_N_TILE], dtype=pl.INT32)
+                    for kb in pl.pipeline(0, O_LORA // B_K_TILE, stage=2):
+                        k0 = col_g + kb * B_K_TILE
+                        if kb == 0:
+                            b_act = o_r_i8_pad[:, col_g : col_g + B_K_TILE]
+                            b_weight = wo_b[n0 : n0 + PROJ_B_MM_N_TILE, col_g : col_g + B_K_TILE]
+                            acc_b = pl.matmul(b_act, b_weight, b_trans=True, out_dtype=pl.INT32)
+                        else:
+                            b_act = o_r_i8_pad[:, k0 : k0 + B_K_TILE]
+                            b_weight = wo_b[n0 : n0 + PROJ_B_MM_N_TILE, k0 : k0 + B_K_TILE]
+                            acc_b = pl.matmul_acc(acc_b, b_act, b_weight, b_trans=True)
+                    partials[0:MM_T_TILE, g * D + n0 : g * D + n0 + PROJ_B_MM_N_TILE] = acc_b
+            proj_b_tids[g] = pb_tid
+
+    # Consolidate the eight grouped INT32 partials in one vector epilogue. Keep
+    # the direct per-group task dependencies so there is no synthetic join task
+    # between the output-projection cubes and dequantization.
+    with pl.spmd(act_t_blks * PROJ_B_ACT_N_REGS, name_hint="proj_b_act",
+                 deps=[proj_b_tids[i] for i in range(O_GROUPS)], allow_early_resolve=True) as _act_tid:
+        act_idx = pl.tile.get_block_idx()
+        tblk = act_idx // PROJ_B_ACT_N_REGS  # token block outermost
+        nreg = act_idx - tblk * PROJ_B_ACT_N_REGS
+        ob_n0 = nreg * PROJ_B_ACT_N_TILE
+        t0 = tblk * PROJ_B_ACT_TASK_T_TILE
+        wb_scale = wo_b_scale[ob_n0 : ob_n0 + PROJ_B_ACT_N_TILE]
+        wb_scale_chunk = pl.reshape(wb_scale, [1, PROJ_B_ACT_N_TILE])
+        for b_tb in pl.range(t0, t0 + PROJ_B_ACT_TASK_T_TILE, PROJ_B_ACT_T_TILE):
+            acc = pl.full([PROJ_B_ACT_T_TILE, PROJ_B_ACT_N_TILE], dtype=pl.FP32, value=0.0)
+            for act_g in pl.pipeline(O_GROUPS, stage=2):
+                p_col0 = act_g * D + ob_n0
+                p_g = partials[b_tb : b_tb + PROJ_B_ACT_T_TILE, p_col0 : p_col0 + PROJ_B_ACT_N_TILE]
+                g_scale_row = act_scale_dq[act_g : act_g + 1, b_tb : b_tb + PROJ_B_ACT_T_TILE]
+                g_scale = pl.reshape(g_scale_row, [PROJ_B_ACT_T_TILE, 1])
+                p_g_f32 = pl.cast(p_g, target_type=pl.FP32, mode="none")
+                p_g_scaled = pl.row_expand_mul(p_g_f32, g_scale)
+                acc = pl.add(acc, p_g_scaled)
+            out_t = pl.col_expand_mul(acc, wb_scale_chunk)
+            out_bf16 = pl.cast(out_t, target_type=pl.BF16, mode="rint")
+            attn_out[b_tb : b_tb + PROJ_B_ACT_T_TILE, ob_n0 : ob_n0 + PROJ_B_ACT_N_TILE] = out_bf16
+    return attn_out
+
+
+@pl.jit
+def sparse_attn_test(
+    q: pl.Tensor[[T_DYN, H, HEAD_DIM], pl.BF16],
+    ori_kv: pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
+    swa_lens: pl.Tensor[[T_DYN], pl.INT32],
+    attn_sink: pl.Tensor[[H], pl.FP32],
+    freqs_cos: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
+    wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
+    wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
+    wo_b_scale: pl.Tensor[[D], pl.FP32],
+    attn_out: pl.Out[pl.Tensor[[T_DYN, D], pl.BF16]],
+):
+    q.bind_dynamic(0, T_DYN)
+    swa_indices.bind_dynamic(0, T_DYN)
+    swa_lens.bind_dynamic(0, T_DYN)
+    freqs_cos.bind_dynamic(0, T_DYN)
+    freqs_sin.bind_dynamic(0, T_DYN)
+    attn_out.bind_dynamic(0, T_DYN)
+    t_dim = pl.tensor.dim(q, 0)
+    bias_blocks = t_dim // BIAS_T_TILE
+    sparse_bias = pl.create_tensor([t_dim, PADDED_TOPK], dtype=pl.FP32)
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="swa_valid_bias"):
+        v_col = pl.cast(pl.arange(0, [1, ATTN_K_TILE], dtype=pl.INT32), target_type=pl.FP32)
+        for vb in pl.range(bias_blocks):
+            v_t0 = vb * BIAS_T_TILE
+            v_col_m = pl.col_expand(pl.full([BIAS_T_TILE, ATTN_K_TILE], dtype=pl.FP32, value=0.0), v_col)
+            v_lens = pl.cast(pl.reshape(swa_lens[v_t0 : v_t0 + BIAS_T_TILE], [BIAS_T_TILE, 1]), target_type=pl.FP32)
+            v_valid = pl.minimum(
+                pl.maximum(pl.neg(pl.row_expand_sub(v_col_m, v_lens)), 0.0),
+                1.0,
+            )
+            sparse_bias[v_t0 : v_t0 + BIAS_T_TILE, 0:ATTN_K_TILE] = pl.mul(pl.sub(v_valid, 1.0), -NEG_INF)
+    sparse_attn_swa(
+        q,
+        ori_kv,
+        swa_indices,
+        sparse_bias,
+        attn_sink,
+        freqs_cos,
+        freqs_sin,
+        wo_a,
+        wo_b,
+        wo_b_scale,
+        attn_out,
+    )
+    return attn_out
+
+
+def golden_sparse_attn(tensors):
+    """Torch reference: sparse_attn decode path followed by grouped o_proj."""
+    import torch
+
+    q = tensors["q"].float()
+    ori_kv = tensors["ori_kv"].float()
+    ori_kv_flat = ori_kv.reshape(ori_kv.shape[0] * BLOCK_SIZE, HEAD_DIM)
+    swa_indices = tensors["swa_indices"]
+    swa_lens = tensors["swa_lens"]
+    attn_sink = tensors["attn_sink"].float()
+    cos = tensors["freqs_cos"].float()
+    sin = tensors["freqs_sin"].float()
+    wo_a = tensors["wo_a"].float()
+    wo_b_i8 = tensors["wo_b"]
+    wo_b_scale = tensors["wo_b_scale"].float()
+
+    tokens = q.shape[0]
+    batch = tokens // S
+    o = torch.zeros(tokens, H, HEAD_DIM)
+
+    # Per-query-token attention. swa_indices is the authoritative physical
+    # cache-row list; invalid tail columns are -1 and swa_lens gives the valid
+    # prefix length.
+    for t in range(tokens):
+        valid_len = int(swa_lens[t].item())
+        valid_slots = [int(v) for v in swa_indices[t, :valid_len].tolist() if int(v) >= 0]
+        if not valid_slots:
+            continue
+
+        q_t = q[t]
+
+        block_mi = []
+        block_li = []
+        block_oi = []
+        for sb in range(SPARSE_BLOCKS):
+            start = sb * ATTN_K_TILE
+            end = min(start + ATTN_K_TILE, WIN)
+            slots = swa_indices[t, start:end].tolist()
+            valid_tile = torch.tensor(
+                [start + i < valid_len and int(slot) >= 0 for i, slot in enumerate(slots)],
+                dtype=torch.bool,
+            )
+            if end - start < ATTN_K_TILE:
+                valid_tile = torch.cat([
+                    valid_tile,
+                    torch.zeros(ATTN_K_TILE - (end - start), dtype=torch.bool),
+                ])
+            valid_tile = valid_tile.to(device=ori_kv.device)
+            kv_tile = torch.zeros(ATTN_K_TILE, HEAD_DIM, dtype=ori_kv.dtype, device=ori_kv.device)
+            for r, slot in enumerate(slots):
+                if r >= ATTN_K_TILE:
+                    break
+                slot_i = int(slot)
+                if slot_i >= 0:
+                    kv_tile[r] = ori_kv_flat[slot_i]
+            scores = (q_t @ kv_tile.T) * SOFTMAX_SCALE
+            scores = scores.masked_fill(~valid_tile.unsqueeze(0), NEG_INF)
+            mi = scores.max(dim=-1, keepdim=True).values
+            exp_scores = torch.exp(scores - mi).masked_fill(~valid_tile.unsqueeze(0), 0.0)
+            li = exp_scores.sum(dim=-1, keepdim=True)
+            oi = exp_scores.to(torch.bfloat16).float() @ kv_tile.to(torch.bfloat16).float()
+            block_mi.append(mi)
+            block_li.append(li)
+            block_oi.append(oi)
+
+        score_max = block_mi[0]
+        li = block_li[0]
+        oi_num = block_oi[0]
+        for mi_cur, li_cur, oi_cur in zip(block_mi[1:], block_li[1:], block_oi[1:]):
+            score_max_new = torch.maximum(score_max, mi_cur)
+            alpha = torch.exp(score_max - score_max_new)
+            beta = torch.exp(mi_cur - score_max_new)
+            li = alpha * li + beta * li_cur
+            oi_num = alpha * oi_num + beta * oi_cur
+            score_max = score_max_new
+
+        denom = li + torch.exp(attn_sink.unsqueeze(-1) - score_max)
+        o[t] = oi_num / denom
+
+    rope_pair = o[..., NOPE_DIM:].unflatten(-1, (-1, 2))
+    rope_even = rope_pair[..., 0]
+    rope_odd = rope_pair[..., 1]
+    cos_half = cos[:, :HALF_ROPE].unsqueeze(1)
+    sin_half = sin[:, :HALF_ROPE].unsqueeze(1)
+    inv_even = (rope_even * cos_half + rope_odd * sin_half).to(torch.bfloat16).float()
+    inv_odd = (rope_odd * cos_half - rope_even * sin_half).to(torch.bfloat16).float()
+    o_rope = torch.stack([inv_even, inv_odd], dim=-1).flatten(-2)
+    o = torch.cat([o[..., :NOPE_DIM], o_rope], dim=-1).to(torch.bfloat16)
+
+    seq_per_batch = tokens // batch
+    o_model = o.float().view(batch, seq_per_batch, O_GROUPS, O_GROUP_IN)
+    o_r = torch.einsum("bsgd,grd->bsgr", o_model, wo_a)
+    # PER-GROUP INT8 activation quant (one amax per O_LORA group, not per full row):
+    # this localizes the reduction so proj_a[g]->quant[g]->proj_b[g] can pipeline
+    # back-to-back. Each group's INT32 partial is dequantized by its OWN per-row
+    # activation scale before the groups are summed (the per-group scale cannot
+    # factor out of the K-sum), then the per-channel weight scale is applied.
+    o_r_g = o_r.reshape(tokens, O_GROUPS, O_LORA)
+    amax_g = o_r_g.abs().amax(dim=-1, keepdim=True).clamp_min(INT8_AMAX_EPS)   # [tokens, G, 1]
+    scale_q_g = INT8_SCALE_MAX / amax_g
+    o_r_i8_g = torch.round(o_r_g * scale_q_g).to(torch.int32).to(torch.float16).to(torch.int8)
+    scale_dq_g = 1.0 / scale_q_g                                              # [tokens, G, 1]
+    wo_b_g = wo_b_i8.reshape(D, O_GROUPS, O_LORA)
+    out = torch.zeros(tokens, D, dtype=torch.float32)
+    for g in range(O_GROUPS):
+        p_g = o_r_i8_g[:, g].to(torch.int32) @ wo_b_g[:, g].to(torch.int32).T   # [tokens, D]
+        out = out + p_g.float() * scale_dq_g[:, g]                             # per-row group scale
+    out = out * wo_b_scale.unsqueeze(0)                                        # per-channel weight scale
+
+    tensors["attn_out"][:] = out.to(torch.bfloat16)
+
+def build_tensor_specs(
+    causal_regression_fixture: bool = False,
+    short_window_fixture: bool = False,
+    batch: int = B,
+):
+    """Build deterministic demo tensors for the merged standalone harness."""
+    tokens = batch * S
+    import torch
+    from golden import TensorSpec
+    from utils import block_table, quant_w_per_channel
+
+    def init_q():
+        """Initialize the query tensor used by the decode attention stage."""
+        q = torch.rand(tokens, H, HEAD_DIM) - 0.5
+        if causal_regression_fixture:
+            q[0].fill_(1.0)
+        return q
+
+    def init_ori_kv():
+        """Initialize the sliding-window KV cache pages."""
+        kv = torch.rand(ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM) - 0.5
+        if causal_regression_fixture:
+            kv[0, WIN - 1, 0].fill_(8.0)
+        return kv
+
+    def init_attn_sink():
+        """Initialize the per-head sink logits to zero."""
+        return torch.zeros(H)
+
+    def init_ori_block_table():
+        """Build the demo block table for the sliding-window cache pages."""
+        return block_table(batch=batch, table_blocks=ORI_MAX_BLOCKS, physical_blocks=ORI_BLOCK_NUM)
+
+    def init_swa_lens():
+        lens = torch.full((tokens,), WIN, dtype=torch.int32)
+        if short_window_fixture:
+            lens.fill_(17)
+        return lens
+
+    def init_swa_indices():
+        """Build physical cache-row indices for the standalone SWA fixture."""
+        tbl = init_ori_block_table()
+        indices = torch.full((tokens, WIN), -1, dtype=torch.int32)
+        lens = init_swa_lens()
+        for t in range(tokens):
+            b = t // S
+            valid_len = int(lens[t].item())
+            for w in range(valid_len):
+                logical_blk = w // BLOCK_SIZE
+                intra = w % BLOCK_SIZE
+                blk = int(tbl[b, logical_blk].item())
+                if blk >= 0:
+                    indices[t, w] = blk * BLOCK_SIZE + intra
+        return indices
+
+    def init_cos():
+        """Build the split-half cosine table used by the inverse-RoPE reference."""
+        angles = torch.arange(tokens * HALF_ROPE).reshape(tokens, HALF_ROPE) * 1e-3
+        cos_half = torch.cos(angles)
+        return torch.cat([cos_half, cos_half], dim=-1)
+
+    def init_sin():
+        """Build the split-half sine table used by the inverse-RoPE reference."""
+        angles = torch.arange(tokens * HALF_ROPE).reshape(tokens, HALF_ROPE) * 1e-3
+        sin_half = torch.sin(angles)
+        return torch.cat([sin_half, sin_half], dim=-1)
+
+    def init_wo_a():
+        """Initialize the grouped first-stage output-projection weights."""
+        return (torch.rand(O_GROUPS, O_LORA, O_GROUP_IN) - 0.5) / (O_GROUP_IN ** 0.5)
+
+    wo_b_bf16 = ((torch.rand(D, O_GROUPS * O_LORA) - 0.5) / ((O_GROUPS * O_LORA) ** 0.5)).to(torch.bfloat16)
+    wo_b_i8, wo_b_scale = quant_w_per_channel(wo_b_bf16)
+
+    def init_wo_b():
+        """Initialize the second-stage output-projection weights in per-channel INT8 form."""
+        return wo_b_i8
+
+    def init_wo_b_scale():
+        """Initialize the dequant scales paired with the INT8 second-stage weights."""
+        return wo_b_scale
+
+    return [
+        TensorSpec("q", [tokens, H, HEAD_DIM], torch.bfloat16, init_value=init_q),
+        TensorSpec("ori_kv", [ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_ori_kv),
+        TensorSpec("swa_indices", [tokens, WIN], torch.int32, init_value=init_swa_indices),
+        TensorSpec("swa_lens", [tokens], torch.int32, init_value=init_swa_lens),
+        TensorSpec("attn_sink", [H], torch.float32, init_value=init_attn_sink),
+        TensorSpec("freqs_cos", [tokens, ROPE_DIM], torch.bfloat16, init_value=init_cos),
+        TensorSpec("freqs_sin", [tokens, ROPE_DIM], torch.bfloat16, init_value=init_sin),
+        TensorSpec("wo_a", [O_GROUPS, O_LORA, O_GROUP_IN], torch.bfloat16, init_value=init_wo_a),
+        TensorSpec("wo_b", [D, O_GROUPS * O_LORA], torch.int8, init_value=init_wo_b),
+        TensorSpec("wo_b_scale", [D], torch.float32, init_value=init_wo_b_scale),
+        TensorSpec("attn_out", [tokens, D], torch.bfloat16, is_output=True),
+    ]
+
+
+if __name__ == "__main__":
+    import argparse
+    from golden import ratio_allclose, run_jit
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-p", "--platform", type=str, default="a2a3", choices=["a2a3", "a2a3sim", "a5", "a5sim"])
+    parser.add_argument("-d", "--device", type=int, default=0)
+    parser.add_argument("-b", "--batch", type=int, default=B,
+                        help=f"runtime request count; a multiple of 4 up to {B} (the compile-time "
+                             "upper bound). The token axis is pl.dynamic, so one compiled program "
+                             "serves every value.")
+    parser.add_argument("--causal-regression-fixture", action="store_true", default=False,
+                        help="Amplify the S=2 future-window-slot regression.")
+    parser.add_argument("--short-window-fixture", action="store_true", default=False,
+                        help="Use a short-window topk row with valid prefix + -1 padding.")
+    parser.add_argument("--golden-data", type=str, default=None)
+    parser.add_argument("--enable-l2-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2, 4))
+    parser.add_argument("--enable-dep-gen", action="store_true", default=False,
+                        help="Capture PTO2 dependency edges (deps.json); the swimlane "
+                             "converter draws fanout/fanin arrows from the sibling file.")
+    parser.add_argument("--enable-pmu", nargs="?", const=2, default=0, type=int, choices=[0, 1, 2, 4])
+    parser.add_argument("--dump-passes", action="store_true", default=False)
+    args = parser.parse_args()
+    if args.batch < 4 or args.batch > B or args.batch % 4 != 0:
+        parser.error(f"--batch must be a multiple of 4 in [4, {B}], got {args.batch}")
+
+    print(f"TOPK={TOPK} SPARSE_BLOCKS={SPARSE_BLOCKS} PADDED_TOPK={PADDED_TOPK}", flush=True)
+
+    result = run_jit(
+        fn=sparse_attn_test,
+        specs=build_tensor_specs(
+            args.causal_regression_fixture,
+            args.short_window_fixture,
+            batch=args.batch,
+        ),
+        golden_fn=golden_sparse_attn,
+        golden_data=args.golden_data,
+        compile_cfg=dict(dump_passes=args.dump_passes),
+        runtime_cfg=dict(
+            platform=args.platform,
+            device_id=args.device,
+            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_dep_gen=args.enable_dep_gen,
+            enable_pmu=args.enable_pmu,
+        ),
+        rtol=1e-3,
+        atol=1e-3,
+        compare_fn={
+            "attn_out": ratio_allclose(atol=1e-4, rtol=1.0 / 128),
+        },
+    )
+    if not result.passed:
+        if result.error:
+            print(result.error)
+        raise SystemExit(1)

--- a/tests/contract/test_dspark_drafter_contract.py
+++ b/tests/contract/test_dspark_drafter_contract.py
@@ -1,0 +1,139 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Contract tests for the DeepSeek-V4-Flash DSpark drafter."""
+
+import sys
+from pathlib import Path
+
+import pytest
+import torch
+
+
+MODEL_DIR = Path(__file__).resolve().parents[2] / "models" / "deepseek_v4_flash_dspark"
+sys.path.insert(0, str(MODEL_DIR))
+
+from config import (  # noqa: E402
+    BLOCK_SIZE,
+    DSPARK_MARKOV_RANK,
+    DSPARK_NOISE_TOKEN_ID,
+    DSPARK_QUERY_TOKENS,
+    DSPARK_QUERY_TOKENS_PADDED,
+    DSPARK_SWA_INDEX_WIDTH,
+    FLASH as M,
+)
+from dspark_contract import (  # noqa: E402
+    build_noncausal_swa_metadata,
+    build_query_layout,
+    golden_markov_sample,
+    validate_dspark_batch,
+    validate_markov_vocab,
+)
+
+
+@pytest.mark.parametrize("batch", [4, 8, 12, 16])
+def test_query_layout_is_anchor_first_and_padded(batch):
+    anchor = torch.arange(batch, dtype=torch.int64) + 100
+    context_lens = torch.arange(batch, dtype=torch.int32) + 31
+
+    input_ids, positions, active = build_query_layout(anchor, context_lens)
+
+    assert input_ids.shape == (batch, DSPARK_QUERY_TOKENS_PADDED)
+    assert torch.equal(input_ids[:, 0], anchor)
+    assert torch.all(input_ids[:, 1:] == DSPARK_NOISE_TOKEN_ID)
+    assert torch.all(active[:, :DSPARK_QUERY_TOKENS])
+    assert not torch.any(active[:, DSPARK_QUERY_TOKENS:])
+    assert torch.equal(positions[:, 0], context_lens + 1)
+    assert torch.equal(positions[:, -1], context_lens + DSPARK_QUERY_TOKENS_PADDED)
+
+
+@pytest.mark.parametrize("batch", [0, 1, 5, 20])
+def test_batch_contract_rejects_unsupported_sizes(batch):
+    with pytest.raises(ValueError, match="batch must be one of"):
+        validate_dspark_batch(batch)
+
+
+def test_markov_vocab_contract_covers_checkpoint_vocab():
+    validate_markov_vocab(M.vocab_size)
+    for vocab_size in (0, 255, 129281, 131328):
+        with pytest.raises(ValueError, match="vocab_size"):
+            validate_markov_vocab(vocab_size)
+
+
+def _block_table(batch, physical_base=0, max_blocks=64):
+    rows = torch.arange(max_blocks, dtype=torch.int32) + physical_base
+    return rows.repeat(batch, 1)
+
+
+def test_noncausal_swa_exposes_all_query_rows_and_masks_padding():
+    batch = 4
+    context_lens = torch.tensor([1, 31, 32, 129], dtype=torch.int32)
+    slots, indices, lens = build_noncausal_swa_metadata(
+        _block_table(batch), context_lens
+    )
+    indices = indices.reshape(batch, DSPARK_QUERY_TOKENS_PADDED, DSPARK_SWA_INDEX_WIDTH)
+    lens = lens.reshape(batch, DSPARK_QUERY_TOKENS_PADDED)
+    slots = slots.reshape(batch, DSPARK_QUERY_TOKENS_PADDED)
+
+    for request, context_len in enumerate(context_lens.tolist()):
+        visible_len = min(context_len + 1, M.sliding_window) + DSPARK_QUERY_TOKENS
+        expected_query_slots = slots[request, :DSPARK_QUERY_TOKENS]
+        for query in range(DSPARK_QUERY_TOKENS):
+            row = indices[request, query, :visible_len]
+            assert torch.equal(row[-DSPARK_QUERY_TOKENS:], expected_query_slots)
+            assert int(lens[request, query]) == visible_len
+        assert int(lens[request, -1]) == 0
+        assert torch.all(indices[request, -1] == -1)
+        assert int(slots[request, -1]) == -1
+
+
+def test_swa_metadata_honors_page_mapping_and_layer_cache_isolation():
+    batch = 4
+    context_lens = torch.full((batch,), 65, dtype=torch.int32)
+    table0 = _block_table(batch)
+    table0[:, 1], table0[:, 2] = table0[:, 2].clone(), table0[:, 1].clone()
+    table1 = table0 + 100
+
+    slots0, indices0, _ = build_noncausal_swa_metadata(table0, context_lens)
+    slots1, indices1, _ = build_noncausal_swa_metadata(table1, context_lens)
+
+    # Position 32 is redirected through the swapped logical page.
+    assert int(indices0[0, 32]) == 2 * BLOCK_SIZE
+    # A different layer's page table produces disjoint physical cache slots.
+    valid0 = indices0[0][indices0[0] >= 0]
+    valid1 = indices1[0][indices1[0] >= 0]
+    assert int(valid1.min() - valid0.min()) == 100 * BLOCK_SIZE
+    assert int(slots1[0] - slots0[0]) == 100 * BLOCK_SIZE
+
+
+def test_markov_sampling_is_sequential_but_base_logits_are_not():
+    batch = 4
+    vocab = 16
+    head_hidden = torch.zeros(batch, DSPARK_QUERY_TOKENS, M.hidden_size, dtype=torch.bfloat16)
+    norm_weight = torch.ones(M.hidden_size, dtype=torch.bfloat16)
+    lm_head_weight = torch.zeros(vocab, M.hidden_size, dtype=torch.bfloat16)
+    markov_w1 = torch.zeros(vocab, DSPARK_MARKOV_RANK, dtype=torch.bfloat16)
+    markov_w2 = torch.zeros(vocab, DSPARK_MARKOV_RANK, dtype=torch.bfloat16)
+    for token in range(vocab):
+        markov_w1[token, token] = 1
+        markov_w2[(token + 1) % vocab, token] = 10
+
+    anchor0 = torch.tensor([0, 1, 2, 3], dtype=torch.int64)
+    anchor1 = anchor0 + 1
+    ids0, base0, logits0 = golden_markov_sample(
+        head_hidden, norm_weight, lm_head_weight, markov_w1, markov_w2, anchor0
+    )
+    ids1, base1, logits1 = golden_markov_sample(
+        head_hidden, norm_weight, lm_head_weight, markov_w1, markov_w2, anchor1
+    )
+
+    assert torch.equal(ids0[:, 0], (anchor0 + 1).to(torch.int32))
+    assert torch.equal(ids0[:, 1], (anchor0 + 2).to(torch.int32))
+    assert torch.equal(base0, base1)
+    assert not torch.equal(logits0, logits1)
+    assert not torch.equal(ids0, ids1)


### PR DESCRIPTION
## Summary
- add the three-layer DSpark draft backbone with non-causal SWA metadata and layer-local KV caches
- add the sequential rank-256 Markov sampler with explicit task and tensor dependencies
- add dynamic-batch contract coverage for query layout, vocabulary bounds, and cache isolation
- validate the Markov sampler on real NPU at batches 4 and 16; full multi-rank backbone and serving integration remain follow-up work

## Related Issues
Related to #935