### PR TITLE
Fix: fence DeepSeek V4 MoE window reuse

### DIFF
--- a/models/deepseek_v4_flash_mtp/decode_fwd.py
+++ b/models/deepseek_v4_flash_mtp/decode_fwd.py
@@ -282,9 +282,9 @@ def decode_fwd_inline(
     recv_aux: pld.DistributedTensor[[N_LOCAL * RECV_MAX, AUX_PAD], pl.FP32],
     recv_route: pld.DistributedTensor[[N_LOCAL * RECV_MAX, IDX_PAD], pl.INT32],
     arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
-    data_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
+    data_arrived: pld.DistributedTensor[[N_RANKS, 2], pl.INT32],
     routed_y_buf: pld.DistributedTensor[[N_ROUTES, D], pl.BF16],
-    combine_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
+    combine_arrived: pld.DistributedTensor[[N_RANKS, 2], pl.INT32],
     lm_head_hidden_window: pld.DistributedTensor[[GROUP_LOGIT_ROWS, D], pl.BF16],
     lm_head_hidden_done: pld.DistributedTensor[[LM_HEAD_TP_SIZE, 1], pl.INT32],
     lm_head_logits_window: pld.DistributedTensor[[MAX_LOGIT_ROWS, LM_HEAD_VOCAB], pl.FP32],
@@ -430,7 +430,8 @@ def decode_fwd_inline(
             hidden,
             recv_meta, recv_x, recv_aux, recv_route, arrived, data_arrived,
             routed_y_buf, combine_arrived,
-            pl.cast(0, pl.INT32), nt, my_rank, pl.cast(1, pl.INT32),
+            pl.cast(0, pl.INT32), nt, pl.cast(1, pl.INT32),
+            pl.cast(1, pl.INT32), my_rank, pl.cast(1, pl.INT32),
         )
     with pl.scope():
         attention_swa(
@@ -455,7 +456,8 @@ def decode_fwd_inline(
             hidden,
             recv_meta, recv_x, recv_aux, recv_route, arrived, data_arrived,
             routed_y_buf, combine_arrived,
-            pl.cast(1, pl.INT32), nt, my_rank, pl.cast(2, pl.INT32),
+            pl.cast(1, pl.INT32), nt, pl.cast(1, pl.INT32),
+            pl.cast(1, pl.INT32), my_rank, pl.cast(2, pl.INT32),
         )
     for loop_i in pl.range(HCA_NUM_LAYERS):
         csa_layer: pl.Scalar[pl.INT32] = pl.cast(loop_i * 2 + 2, pl.INT32)
@@ -548,7 +550,8 @@ def decode_fwd_inline(
                 hidden_mid,
                 recv_meta, recv_x, recv_aux, recv_route, arrived, data_arrived,
                 routed_y_buf, combine_arrived,
-                csa_layer, nt, my_rank, csa_moe_epoch,
+                csa_layer, nt, pl.cast(1, pl.INT32),
+                pl.cast(1, pl.INT32), my_rank, csa_moe_epoch,
             )
         hc_attn_fn_hca: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32] = pl.slice(hc_attn_fn, [MIX_HC, HC_DIM], [hca_layer * MIX_HC, 0])
         hc_attn_scale_hca: pl.Tensor[[3], pl.FP32] = pl.slice(hc_attn_scale, [3], [hca_layer * 3])
@@ -617,7 +620,8 @@ def decode_fwd_inline(
                 hidden,
                 recv_meta, recv_x, recv_aux, recv_route, arrived, data_arrived,
                 routed_y_buf, combine_arrived,
-                hca_layer, nt, my_rank, hca_moe_epoch,
+                hca_layer, nt, pl.cast(1, pl.INT32),
+                pl.cast(1, pl.INT32), my_rank, hca_moe_epoch,
             )
     # FWD index (14), not CSA_LAST_LAYER (6): the *_last slices below index per-FWD-layer
     # stacked weights; csa-stacked weights use the literal (CSA_NUM_LAYERS-1).
@@ -707,9 +711,10 @@ def decode_fwd_inline(
             pre_hc_hidden_out,
             recv_meta, recv_x, recv_aux, recv_route, arrived, data_arrived,
             routed_y_buf, combine_arrived,
-            csa_layer_last, nt, my_rank, last_moe_epoch,
+            csa_layer_last, nt, pl.cast(1, pl.INT32),
+            pl.cast(1, pl.INT32), my_rank, last_moe_epoch,
         )
-    clear_moe_signals(pre_hc_hidden_out, arrived, data_arrived, combine_arrived)
+    clear_moe_signals(pre_hc_hidden_out, recv_meta, arrived, data_arrived, combine_arrived)
     x_head: pl.Tensor[[T, D], pl.BF16] = pl.create_tensor([T, D], dtype=pl.BF16)
     with pl.scope():
         hc_head(pre_hc_hidden_out, hc_head_fn, hc_head_scale, hc_head_base, x_head)
@@ -813,9 +818,9 @@ def decode_fwd(
     recv_aux: pld.DistributedTensor[[N_LOCAL * RECV_MAX, AUX_PAD], pl.FP32],
     recv_route: pld.DistributedTensor[[N_LOCAL * RECV_MAX, IDX_PAD], pl.INT32],
     arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
-    data_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
+    data_arrived: pld.DistributedTensor[[N_RANKS, 2], pl.INT32],
     routed_y_buf: pld.DistributedTensor[[N_ROUTES, D], pl.BF16],
-    combine_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
+    combine_arrived: pld.DistributedTensor[[N_RANKS, 2], pl.INT32],
     lm_head_hidden_window: pld.DistributedTensor[[GROUP_LOGIT_ROWS, D], pl.BF16],
     lm_head_hidden_done: pld.DistributedTensor[[LM_HEAD_TP_SIZE, 1], pl.INT32],
     lm_head_logits_window: pld.DistributedTensor[[MAX_LOGIT_ROWS, LM_HEAD_VOCAB], pl.FP32],
@@ -1012,9 +1017,9 @@ def l3_decode_fwd(
     recv_aux_buf = pld.alloc_window_buffer([N_LOCAL * RECV_MAX, AUX_PAD], dtype=pl.FP32)
     recv_route_buf = pld.alloc_window_buffer([N_LOCAL * RECV_MAX, IDX_PAD], dtype=pl.INT32)
     arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
-    data_arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
+    data_arrived_buf = pld.alloc_window_buffer([N_RANKS, 2], dtype=pl.INT32)
     routed_y_buf_buf = pld.alloc_window_buffer([N_ROUTES, D], dtype=pl.BF16)
-    combine_arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
+    combine_arrived_buf = pld.alloc_window_buffer([N_RANKS, 2], dtype=pl.INT32)
     # The LM head owns every window and counter it touches: a peer routes into
     # logits_window while still reading its own hidden_window.
     lm_head_hidden_window_buf = pld.alloc_window_buffer(GROUP_LOGIT_ROWS * D * 2)
@@ -1028,9 +1033,9 @@ def l3_decode_fwd(
         recv_aux: pld.DistributedTensor[[N_LOCAL * RECV_MAX, AUX_PAD], pl.FP32] = pld.window(recv_aux_buf, [N_LOCAL * RECV_MAX, AUX_PAD], dtype=pl.FP32)
         recv_route: pld.DistributedTensor[[N_LOCAL * RECV_MAX, IDX_PAD], pl.INT32] = pld.window(recv_route_buf, [N_LOCAL * RECV_MAX, IDX_PAD], dtype=pl.INT32)
         arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32] = pld.window(arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
-        data_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32] = pld.window(data_arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
+        data_arrived: pld.DistributedTensor[[N_RANKS, 2], pl.INT32] = pld.window(data_arrived_buf, [N_RANKS, 2], dtype=pl.INT32)
         routed_y_buf: pld.DistributedTensor[[N_ROUTES, D], pl.BF16] = pld.window(routed_y_buf_buf, [N_ROUTES, D], dtype=pl.BF16)
-        combine_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32] = pld.window(combine_arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
+        combine_arrived: pld.DistributedTensor[[N_RANKS, 2], pl.INT32] = pld.window(combine_arrived_buf, [N_RANKS, 2], dtype=pl.INT32)
         lm_head_hidden_window = pld.window(lm_head_hidden_window_buf, [GROUP_LOGIT_ROWS, D], dtype=pl.BF16)
         lm_head_hidden_done = pld.window(lm_head_hidden_done_buf, [LM_HEAD_TP_SIZE, 1], dtype=pl.INT32)
         lm_head_logits_window = pld.window(lm_head_logits_window_buf, [MAX_LOGIT_ROWS, LM_HEAD_VOCAB], dtype=pl.FP32)

--- a/models/deepseek_v4_flash_mtp/decode_layer.py
+++ b/models/deepseek_v4_flash_mtp/decode_layer.py
@@ -193,9 +193,9 @@ def decode_layer(
     recv_aux: pld.DistributedTensor[[N_LOCAL * RECV_MAX, AUX_PAD], pl.FP32],
     recv_route: pld.DistributedTensor[[N_LOCAL * RECV_MAX, IDX_PAD], pl.INT32],
     arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
-    data_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
+    data_arrived: pld.DistributedTensor[[N_RANKS, 2], pl.INT32],
     routed_y_buf: pld.DistributedTensor[[N_ROUTES, D], pl.BF16],
-    combine_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
+    combine_arrived: pld.DistributedTensor[[N_RANKS, 2], pl.INT32],
     layer_id: pl.Scalar[pl.INT32],
     my_rank: pl.Scalar[pl.INT32],
 ) -> pl.Tensor[[T, HC_MULT, D], pl.FP32]:
@@ -258,9 +258,10 @@ def decode_layer(
         x_next,
         recv_meta, recv_x, recv_aux, recv_route, arrived, data_arrived,
         routed_y_buf, combine_arrived,
-        layer_id, pl.const(T, pl.INT32), my_rank, pl.const(1, pl.INT32),
+        layer_id, pl.const(T, pl.INT32), pl.const(1, pl.INT32),
+        pl.const(1, pl.INT32), my_rank, pl.const(1, pl.INT32),
     )
-    clear_moe_signals(x_next, arrived, data_arrived, combine_arrived)
+    clear_moe_signals(x_next, recv_meta, arrived, data_arrived, combine_arrived)
     return x_next
 
 
@@ -364,9 +365,9 @@ def l3_decode_layer(
     recv_aux_buf = pld.alloc_window_buffer([N_LOCAL * RECV_MAX, AUX_PAD], dtype=pl.FP32)
     recv_route_buf = pld.alloc_window_buffer([N_LOCAL * RECV_MAX, IDX_PAD], dtype=pl.INT32)
     arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
-    data_arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
+    data_arrived_buf = pld.alloc_window_buffer([N_RANKS, 2], dtype=pl.INT32)
     routed_y_buf_buf = pld.alloc_window_buffer([N_ROUTES, D], dtype=pl.BF16)
-    combine_arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
+    combine_arrived_buf = pld.alloc_window_buffer([N_RANKS, 2], dtype=pl.INT32)
 
     for r in pl.range(pld.world_size()):
         recv_meta = pld.window(recv_meta_buf, [N_RANKS, N_LOCAL], dtype=pl.INT32)
@@ -374,9 +375,9 @@ def l3_decode_layer(
         recv_aux = pld.window(recv_aux_buf, [N_LOCAL * RECV_MAX, AUX_PAD], dtype=pl.FP32)
         recv_route = pld.window(recv_route_buf, [N_LOCAL * RECV_MAX, IDX_PAD], dtype=pl.INT32)
         arrived = pld.window(arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
-        data_arrived = pld.window(data_arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
+        data_arrived = pld.window(data_arrived_buf, [N_RANKS, 2], dtype=pl.INT32)
         routed_y_buf = pld.window(routed_y_buf_buf, [N_ROUTES, D], dtype=pl.BF16)
-        combine_arrived = pld.window(combine_arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
+        combine_arrived = pld.window(combine_arrived_buf, [N_RANKS, 2], dtype=pl.INT32)
         decode_layer(
             x_hc[r],
             hc_attn_fn[r], hc_attn_scale[r], hc_attn_base[r],

--- a/models/deepseek_v4_flash_mtp/decode_mtp.py
+++ b/models/deepseek_v4_flash_mtp/decode_mtp.py
@@ -155,9 +155,9 @@ def mtp_decode_layer_inline(
     recv_aux: pld.DistributedTensor[[N_LOCAL * RECV_MAX, AUX_PAD], pl.FP32],
     recv_route: pld.DistributedTensor[[N_LOCAL * RECV_MAX, IDX_PAD], pl.INT32],
     arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
-    data_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
+    data_arrived: pld.DistributedTensor[[N_RANKS, 2], pl.INT32],
     routed_y_buf: pld.DistributedTensor[[N_ROUTES, D], pl.BF16],
-    combine_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
+    combine_arrived: pld.DistributedTensor[[N_RANKS, 2], pl.INT32],
     lm_head_hidden_window: pld.DistributedTensor[[GROUP_LOGIT_ROWS, D], pl.BF16],
     lm_head_hidden_done: pld.DistributedTensor[[LM_HEAD_TP_SIZE, 1], pl.INT32],
     lm_head_logits_window: pld.DistributedTensor[[MAX_LOGIT_ROWS, LM_HEAD_VOCAB], pl.FP32],
@@ -226,10 +226,12 @@ def mtp_decode_layer_inline(
             next_pre_hc_hidden,
             recv_meta, recv_x, recv_aux, recv_route,
             arrived, data_arrived, routed_y_buf, combine_arrived,
-            pl.cast(MTP_LAYER_ID, pl.INT32), num_tokens, my_rank, pl.cast(MTP_MOE_EPOCH, pl.INT32),
+            pl.cast(MTP_LAYER_ID, pl.INT32), num_tokens,
+            pl.cast(1, pl.INT32), pl.cast(1, pl.INT32), my_rank,
+            pl.cast(MTP_MOE_EPOCH, pl.INT32),
         )
 
-    clear_moe_signals(next_pre_hc_hidden, arrived, data_arrived, combine_arrived)
+    clear_moe_signals(next_pre_hc_hidden, recv_meta, arrived, data_arrived, combine_arrived)
     x_head = pl.create_tensor([T, D], dtype=pl.BF16)
     with pl.scope():
         hc_head(next_pre_hc_hidden, mtp_hc_head_fn, mtp_hc_head_scale, mtp_hc_head_base, x_head)
@@ -314,9 +316,9 @@ def mtp_decode_layer(
     recv_aux: pld.DistributedTensor[[N_LOCAL * RECV_MAX, AUX_PAD], pl.FP32],
     recv_route: pld.DistributedTensor[[N_LOCAL * RECV_MAX, IDX_PAD], pl.INT32],
     arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
-    data_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
+    data_arrived: pld.DistributedTensor[[N_RANKS, 2], pl.INT32],
     routed_y_buf: pld.DistributedTensor[[N_ROUTES, D], pl.BF16],
-    combine_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
+    combine_arrived: pld.DistributedTensor[[N_RANKS, 2], pl.INT32],
     lm_head_hidden_window: pld.DistributedTensor[[GROUP_LOGIT_ROWS, D], pl.BF16],
     lm_head_hidden_done: pld.DistributedTensor[[LM_HEAD_TP_SIZE, 1], pl.INT32],
     lm_head_logits_window: pld.DistributedTensor[[MAX_LOGIT_ROWS, LM_HEAD_VOCAB], pl.FP32],
@@ -477,9 +479,9 @@ def l3_mtp_decode_layer(
     recv_aux_buf = pld.alloc_window_buffer([N_LOCAL * RECV_MAX, AUX_PAD], dtype=pl.FP32)
     recv_route_buf = pld.alloc_window_buffer([N_LOCAL * RECV_MAX, IDX_PAD], dtype=pl.INT32)
     arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
-    data_arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
+    data_arrived_buf = pld.alloc_window_buffer([N_RANKS, 2], dtype=pl.INT32)
     routed_y_buf_buf = pld.alloc_window_buffer([N_ROUTES, D], dtype=pl.BF16)
-    combine_arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
+    combine_arrived_buf = pld.alloc_window_buffer([N_RANKS, 2], dtype=pl.INT32)
     lm_head_hidden_window_buf = pld.alloc_window_buffer([GROUP_LOGIT_ROWS, D], dtype=pl.BF16)
     lm_head_logits_window_buf = pld.alloc_window_buffer(MAX_LOGIT_ROWS * LM_HEAD_VOCAB * 4)
     lm_head_hidden_done_buf = pld.alloc_window_buffer([LM_HEAD_TP_SIZE, 1], dtype=pl.INT32)
@@ -491,9 +493,9 @@ def l3_mtp_decode_layer(
         recv_aux = pld.window(recv_aux_buf, [N_LOCAL * RECV_MAX, AUX_PAD], dtype=pl.FP32)
         recv_route = pld.window(recv_route_buf, [N_LOCAL * RECV_MAX, IDX_PAD], dtype=pl.INT32)
         arrived = pld.window(arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
-        data_arrived = pld.window(data_arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
+        data_arrived = pld.window(data_arrived_buf, [N_RANKS, 2], dtype=pl.INT32)
         routed_y_buf = pld.window(routed_y_buf_buf, [N_ROUTES, D], dtype=pl.BF16)
-        combine_arrived = pld.window(combine_arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
+        combine_arrived = pld.window(combine_arrived_buf, [N_RANKS, 2], dtype=pl.INT32)
         lm_head_hidden_window = pld.window(lm_head_hidden_window_buf, [GROUP_LOGIT_ROWS, D], dtype=pl.BF16)
         lm_head_hidden_done = pld.window(lm_head_hidden_done_buf, [LM_HEAD_TP_SIZE, 1], dtype=pl.INT32)
         lm_head_logits_window = pld.window(lm_head_logits_window_buf, [MAX_LOGIT_ROWS, LM_HEAD_VOCAB], dtype=pl.FP32)

--- a/models/deepseek_v4_flash_mtp/gate.py
+++ b/models/deepseek_v4_flash_mtp/gate.py
@@ -45,6 +45,9 @@ QUANT_TILE = 256
 SCORE_PAD = 256         # padded expert row for sort32 + mrgsort
 TOPK_PAD = 8            # TOPK padded to 32B-aligned width
 SORT_PAD = TOPK_PAD * 2 # (val, idx) interleaved slice width
+DISPATCH_AUX_PAD = 8
+DISPATCH_ROUTE_PAD = 8
+N_ROUTES = T * TOPK
 assert TOPK <= TOPK_PAD
 
 @pl.jit.inline
@@ -61,6 +64,8 @@ def gate(
     x_norm_scale: pl.Tensor[[T, 1], pl.FP32],
     indices: pl.Tensor[[T, TOPK], pl.INT32],
     weights: pl.Tensor[[T, TOPK], pl.FP32],
+    dispatch_aux: pl.Tensor[[N_ROUTES, DISPATCH_AUX_PAD], pl.FP32],
+    dispatch_route: pl.Tensor[[N_ROUTES, DISPATCH_ROUTE_PAD], pl.INT32],
 ):
     # Deferred RMSNorm (qwen3-style): store xg = x*gamma (NOT *inv_rms), because
     # the per-token positive scalar inv_rms factors out of everything downstream:
@@ -232,8 +237,15 @@ def gate(
             for hs_wt_tt in pl.range(GATE_T_TILE):
                 if t1 + hs_wt_tt < active_tokens:
                     for hs_wt_k in pl.range(TOPK):
-                        pl.write(indices, [t1 + hs_wt_tt, hs_wt_k], pl.read(hs_idx_read, [hs_wt_tt, hs_wt_k]))
-                        pl.write(weights, [t1 + hs_wt_tt, hs_wt_k], pl.read(hs_weights_pad, [hs_wt_tt, hs_wt_k]))
+                        token = t1 + hs_wt_tt
+                        route = token * TOPK + hs_wt_k
+                        route_index = pl.read(hs_idx_read, [hs_wt_tt, hs_wt_k])
+                        route_weight = pl.read(hs_weights_pad, [hs_wt_tt, hs_wt_k])
+                        pl.write(indices, [token, hs_wt_k], route_index)
+                        pl.write(weights, [token, hs_wt_k], route_weight)
+                        pl.write(dispatch_aux, [route, 0], pl.read(x_norm_scale, [token, 0]))
+                        pl.write(dispatch_aux, [route, 1], route_weight)
+                        pl.write(dispatch_route, [route, 0], pl.cast(route, pl.INT32))
     else:
         for ts_idx in pl.spmd(active_route_tiles, name_hint="route_sort", allow_early_resolve=True):
             t1 = ts_idx * GATE_T_TILE
@@ -269,8 +281,15 @@ def gate(
             for nm_tt in pl.range(GATE_T_TILE):
                 if t1 + nm_tt < active_tokens:
                     for nm_k in pl.range(TOPK):
-                        pl.write(indices, [t1 + nm_tt, nm_k], pl.read(topk_idx_read, [nm_tt, nm_k]))
-                        pl.write(weights, [t1 + nm_tt, nm_k], pl.read(nm_weights_pad, [nm_tt, nm_k]))
+                        token = t1 + nm_tt
+                        route = token * TOPK + nm_k
+                        route_index = pl.read(topk_idx_read, [nm_tt, nm_k])
+                        route_weight = pl.read(nm_weights_pad, [nm_tt, nm_k])
+                        pl.write(indices, [token, nm_k], route_index)
+                        pl.write(weights, [token, nm_k], route_weight)
+                        pl.write(dispatch_aux, [route, 0], pl.read(x_norm_scale, [token, 0]))
+                        pl.write(dispatch_aux, [route, 1], route_weight)
+                        pl.write(dispatch_route, [route, 0], pl.cast(route, pl.INT32))
 
     # The @pl.inline parser requires inline call expressions to have a return
     # value. weights is convenient because it's already pl.Out and reads as
@@ -292,13 +311,15 @@ def gate_test(
     x_norm_scale: pl.Out[pl.Tensor[[T, 1], pl.FP32]],
     indices: pl.Out[pl.Tensor[[T, TOPK], pl.INT32]],
     weights: pl.Out[pl.Tensor[[T, TOPK], pl.FP32]],
+    dispatch_aux: pl.Out[pl.Tensor[[N_ROUTES, DISPATCH_AUX_PAD], pl.FP32]],
+    dispatch_route: pl.Out[pl.Tensor[[N_ROUTES, DISPATCH_ROUTE_PAD], pl.INT32]],
 ):
     gate(
         x_mixed,
         norm_w, gate_w, gate_bias,
         layer_id, num_tokens,
         tid2eid, input_ids,
-        x_norm_i8, x_norm_scale, indices, weights,
+        x_norm_i8, x_norm_scale, indices, weights, dispatch_aux, dispatch_route,
     )
     return x_norm_i8, x_norm_scale, indices, weights
 
@@ -366,6 +387,16 @@ def golden_gate_core(tensors):
     tensors["x_norm_scale"][:] = x_norm_scale.reshape(T, 1)
     tensors["indices"][:] = indices.to(torch.int32)
     tensors["weights"][:] = weights.to(torch.float32)
+    dispatch_aux = torch.zeros(N_ROUTES, DISPATCH_AUX_PAD, dtype=torch.float32)
+    dispatch_route = torch.zeros(N_ROUTES, DISPATCH_ROUTE_PAD, dtype=torch.int32)
+    for token in range(num_tokens):
+        for topk in range(TOPK):
+            route = token * TOPK + topk
+            dispatch_aux[route, 0] = x_norm_scale[token, 0]
+            dispatch_aux[route, 1] = weights[token, topk]
+            dispatch_route[route, 0] = route
+    tensors["dispatch_aux"][:] = dispatch_aux
+    tensors["dispatch_route"][:] = dispatch_route
 
 
 def build_tensor_specs(layer_id=0, num_tokens=T):
@@ -398,6 +429,8 @@ def build_tensor_specs(layer_id=0, num_tokens=T):
         TensorSpec("x_norm_scale", [T, 1], torch.float32, is_output=True),
         TensorSpec("indices", [T, TOPK], torch.int32, is_output=True),
         TensorSpec("weights", [T, TOPK], torch.float32, is_output=True),
+        TensorSpec("dispatch_aux", [N_ROUTES, DISPATCH_AUX_PAD], torch.float32, is_output=True),
+        TensorSpec("dispatch_route", [N_ROUTES, DISPATCH_ROUTE_PAD], torch.int32, is_output=True),
     ]
 
 

--- a/models/deepseek_v4_flash_mtp/moe.py
+++ b/models/deepseek_v4_flash_mtp/moe.py
@@ -72,18 +72,27 @@ AUX_SCALE = 0
 AUX_W = 1
 IDX_PAD = 8  # INT32 route tile width; route rides a separate window from scale/w
              # (an FP32 tile can't hold it: INDEX->FP32 casts are unsupported).
+# One source can contribute at most T*TOPK rows to one expert. Decode fits four
+# counts per int32 word; prefill uses two so the epoch-prefixed value stays int32.
+META_PACK_BASE = N_ROUTES + 1
+META_COUNTS_PER_WORD = 4 if META_PACK_BASE ** 4 * 64 < 2**31 else 2
+META_PACK_WORDS = N_LOCAL // META_COUNTS_PER_WORD
+META_EPOCH_STRIDE = META_PACK_BASE ** META_COUNTS_PER_WORD
 
 assert N_RANKS in _EP_CHOICES, f"--ep must be one of {_EP_CHOICES} (got {N_RANKS})"
 assert N_EXPERTS_GLOBAL == N_RANKS * N_LOCAL
 assert RECV_MAX == N_RANKS * MAX_PER_SRC
+assert N_LOCAL % META_COUNTS_PER_WORD == 0
+assert META_EPOCH_STRIDE * 64 < 2**31
 
 
 @pl.jit.inline
 def clear_moe_signals(
     completion_anchor: pl.Tensor[[T, HC_MULT, D], pl.FP32],
+    recv_meta: pld.DistributedTensor[[N_RANKS, N_LOCAL], pl.INT32],
     arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
-    data_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
-    combine_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
+    data_arrived: pld.DistributedTensor[[N_RANKS, 2], pl.INT32],
+    combine_arrived: pld.DistributedTensor[[N_RANKS, 2], pl.INT32],
 ):
     """Clear this rank's MoE signal windows after its final MoE completes."""
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="moe_signal_clear"):
@@ -93,9 +102,13 @@ def clear_moe_signals(
         _completion_anchor = pl.read(completion_anchor, [0, 0, 0])
         zero = pl.cast(0, pl.INT32)
         for src in pl.range(N_RANKS):
+            for e in pl.range(N_LOCAL):
+                pl.write(recv_meta, [src, e], zero)
             pl.write(arrived, [src, 0], zero)
             pl.write(data_arrived, [src, 0], zero)
+            pl.write(data_arrived, [src, 1], zero)
             pl.write(combine_arrived, [src, 0], zero)
+            pl.write(combine_arrived, [src, 1], zero)
 
 
 # === Dispatch ================================================================
@@ -107,6 +120,8 @@ def dispatch(
     x_norm_i8: pl.Tensor[[T, D], pl.INT8],
     x_norm_scale: pl.Tensor[[T, 1], pl.FP32],
     weights: pl.Tensor[[T, TOPK], pl.FP32],
+    aux_payload: pl.Tensor[[N_ROUTES, AUX_PAD], pl.FP32],
+    route_payload: pl.Tensor[[N_ROUTES, IDX_PAD], pl.INT32],
     # compact per-expert outputs consumed by expert_routed / combine
     recv_x_out: pl.Tensor[[N_LOCAL, RECV_MAX, D], pl.INT8],
     recv_scale_out: pl.Tensor[[N_LOCAL, RECV_MAX], pl.FP32],
@@ -120,8 +135,10 @@ def dispatch(
     recv_aux: pld.DistributedTensor[[N_LOCAL * RECV_MAX, AUX_PAD], pl.FP32],
     recv_route: pld.DistributedTensor[[N_LOCAL * RECV_MAX, IDX_PAD], pl.INT32],
     arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
-    data_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
+    data_arrived: pld.DistributedTensor[[N_RANKS, 2], pl.INT32],
     num_tokens: pl.Scalar[pl.INT32],
+    draining_payload: pl.Scalar[pl.INT32],
+    packed_meta: pl.Scalar[pl.INT32],
     my_rank: pl.Scalar[pl.INT32],
     # 1-based MoE call id; `arrived`/`data_arrived` are monotonic so waits use `>= moe_epoch`.
     moe_epoch: pl.Scalar[pl.INT32],
@@ -162,45 +179,148 @@ def dispatch(
         # order-independent, so a late notify from an earlier epoch cannot clobber it.
         meta_tile = pl.tile.full([1, N_LOCAL], dtype=pl.INT32, value=0)
         for dst in pl.range(N_RANKS):
-            for e in pl.range(N_LOCAL):
-                pl.tile.write(meta_tile, [0, e], cursor[dst * N_LOCAL + e])
-            pld.tile.remote_store(meta_tile, target=recv_meta, peer=dst, offsets=[my_rank, 0])
-            if dst != my_rank:
-                pld.system.notify(
-                    target=arrived,
-                    peer=dst,
-                    offsets=[my_rank, 0],
-                    value=1,
-                    op=pld.NotifyOp.AtomicAdd,
-                )
+            if packed_meta != 0:
+                # Decode packs four base-(N_ROUTES+1) counts into each signal word.
+                # The epoch prefix lets the receiver wait on the exact addresses it
+                # consumes instead of trusting an unrelated arrival notification.
+                # Before reusing a peer's words, wait until it acknowledged consuming
+                # the previous epoch; otherwise a pipelined later layer can overwrite
+                # an earlier layer's Set value before the receiver reads it.
+                if dst != my_rank:
+                    pld.system.wait(
+                        signal=arrived,
+                        offsets=[dst, 0],
+                        expected=pl.cast(moe_epoch - 1, pl.INT32),
+                        cmp=pld.WaitCmp.Ge,
+                    )
+                    for word in pl.range(META_PACK_WORDS):
+                        packed = pl.cast(0, pl.INT32)
+                        multiplier = pl.cast(1, pl.INT32)
+                        for lane in pl.range(META_COUNTS_PER_WORD):
+                            e = word * META_COUNTS_PER_WORD + lane
+                            packed = packed + cursor[dst * N_LOCAL + e] * multiplier
+                            multiplier = pl.cast(multiplier * META_PACK_BASE, pl.INT32)
+                        encoded_count = pl.cast(moe_epoch * META_EPOCH_STRIDE + packed, pl.INT32)
+                        pld.system.notify(
+                            target=recv_meta,
+                            peer=dst,
+                            offsets=[my_rank, word],
+                            value=encoded_count,
+                            op=pld.NotifyOp.Set,
+                        )
+            else:
+                for e in pl.range(N_LOCAL):
+                    pl.tile.write(meta_tile, [0, e], cursor[dst * N_LOCAL + e])
+                pld.tile.remote_store(meta_tile, target=recv_meta, peer=dst, offsets=[my_rank, 0])
+            if packed_meta == 0:
+                if dst != my_rank:
+                    pld.system.notify(
+                        target=arrived,
+                        peer=dst,
+                        offsets=[my_rank, 0],
+                        value=1,
+                        op=pld.NotifyOp.AtomicAdd,
+                    )
 
-        # Wait for every source's meta flag.
-        for src in pl.range(N_RANKS):
-            if src != my_rank:
-                pld.system.wait(
-                    signal=arrived,
-                    offsets=[src, 0],
-                    expected=moe_epoch,
-                    cmp=pld.WaitCmp.Ge,
-                )
+        if packed_meta != 0:
+            # Each count is its own signal. Waiting on the value that is consumed
+            # removes the unsupported assumption that a separate arrival notify
+            # orders writes to other addresses.
+            meta_epoch_base = pl.cast(moe_epoch * META_EPOCH_STRIDE, pl.INT32)
+            for src in pl.range(N_RANKS):
+                if src != my_rank:
+                    for word in pl.range(META_PACK_WORDS):
+                        pld.system.wait(
+                            signal=recv_meta,
+                            offsets=[src, word],
+                            expected=meta_epoch_base,
+                            cmp=pld.WaitCmp.Ge,
+                        )
+        else:
+            # Wait for every source's packed meta row.
+            for src in pl.range(N_RANKS):
+                if src != my_rank:
+                    pld.system.wait(
+                        signal=arrived,
+                        offsets=[src, 0],
+                        expected=moe_epoch,
+                        cmp=pld.WaitCmp.Ge,
+                    )
 
         # Cumsum recv_meta over sources -> per-expert receive count. The host reads
         # recv_count_out to size the routed-expert tile loop, so producing it here
         # lets routed matmuls submit while the payload is still moving.
-        for e in pl.range(N_LOCAL):
-            acc = pl.const(0, pl.INT32)
+        if packed_meta != 0:
+            meta_epoch_base = pl.cast(moe_epoch * META_EPOCH_STRIDE, pl.INT32)
+            for word in pl.range(META_PACK_WORDS):
+                for lane in pl.range(META_COUNTS_PER_WORD):
+                    e = word * META_COUNTS_PER_WORD + lane
+                    divisor = pl.cast(1, pl.INT32)
+                    if lane == 1:
+                        divisor = pl.cast(META_PACK_BASE, pl.INT32)
+                    if lane == 2:
+                        divisor = pl.cast(META_PACK_BASE ** 2, pl.INT32)
+                    if lane == 3:
+                        divisor = pl.cast(META_PACK_BASE ** 3, pl.INT32)
+                    acc = pl.const(0, pl.INT32)
+                    for src in pl.range(N_RANKS):
+                        if src == my_rank:
+                            count = cursor[my_rank * N_LOCAL + e]
+                        else:
+                            packed = pl.read(recv_meta, [src, word]) - meta_epoch_base
+                            count = pl.cast((packed // divisor) % META_PACK_BASE, pl.INT32)
+                        pl.write(recv_meta_local, [src, e], count)
+                        acc = acc + count
+                    pl.write(recv_count_out, [e, 0], acc)
+
+            # Acknowledge only after every packed word from each source has been
+            # decoded. The source gates its next layer's Set on this counter.
             for src in pl.range(N_RANKS):
-                count = pl.read(recv_meta, [src, e])
-                pl.write(recv_meta_local, [src, e], count)
-                acc = acc + count
-            pl.write(recv_count_out, [e, 0], acc)
+                if src != my_rank:
+                    pld.system.notify(
+                        target=arrived,
+                        peer=src,
+                        offsets=[my_rank, 0],
+                        value=1,
+                        op=pld.NotifyOp.AtomicAdd,
+                    )
+        else:
+            for e in pl.range(N_LOCAL):
+                acc = pl.const(0, pl.INT32)
+                for src in pl.range(N_RANKS):
+                    count = pl.read(recv_meta, [src, e])
+                    pl.write(recv_meta_local, [src, e], count)
+                    acc = acc + count
+                pl.write(recv_count_out, [e, 0], acc)
+
+    # Column 0 counts payload arrivals; column 1 acknowledges consumption. A
+    # peer lane is address-stable across epochs, so it cannot be overwritten
+    # until every expert gather task consumed the previous epoch's rows.
+    with pl.at(
+        level=pl.Level.CORE_GROUP,
+        name_hint="dispatch_reuse_wait",
+        allow_early_resolve=True,
+    ) as _reuse_tid:
+        for dst in pl.range(N_RANKS):
+            if dst != my_rank:
+                pld.system.wait(
+                    signal=data_arrived,
+                    offsets=[dst, 1],
+                    expected=pl.cast((moe_epoch - 1) * N_LOCAL, pl.INT32),
+                    cmp=pld.WaitCmp.Ge,
+                )
 
     # Move the bulk payload (x / aux / route) to each destination lane.
     # Split over LOCAL EXPERT INDEX (N_LOCAL blocks): block loc_e handles expert
     # loc_e on EVERY destination rank, so the blocking cross-rank puts fan out
     # across N_LOCAL cores. One slot counter per destination rank; token-major
     # order matches the meta pass's per-(dst, loc_e) cumulative count.
-    with pl.spmd(N_LOCAL, name_hint="dispatch_push", allow_early_resolve=True):
+    with pl.spmd(
+        N_LOCAL,
+        name_hint="dispatch_push",
+        deps=[_reuse_tid],
+        allow_early_resolve=True,
+    ) as _push_tid:
         loc_e = pl.tile.get_block_idx()
         active_tokens = pl.cast(num_tokens, pl.INDEX)
         if active_tokens < 0:
@@ -234,11 +354,30 @@ def dispatch(
                         src_offsets=[t, 0],
                         shape=[1, D],
                     )
-                    pl.tile.write(aux_tile, [0, AUX_SCALE], pl.read(x_norm_scale, [t, 0]))
-                    pl.tile.write(aux_tile, [0, AUX_W], pl.read(weights, [t, k]))
-                    pld.tile.remote_store(aux_tile, target=recv_aux, peer=dst, offsets=[row, 0])
-                    pl.tile.write(route_tile, [0, 0], pl.cast(t * TOPK + k, pl.INT32))
-                    pld.tile.remote_store(route_tile, target=recv_route, peer=dst, offsets=[row, 0])
+                    route = t * TOPK + k
+                    if draining_payload != 0:
+                        pld.tensor.put(
+                            dst=recv_aux,
+                            peer=dst,
+                            src=aux_payload,
+                            dst_offsets=[row, 0],
+                            src_offsets=[route, 0],
+                            shape=[1, AUX_PAD],
+                        )
+                        pld.tensor.put(
+                            dst=recv_route,
+                            peer=dst,
+                            src=route_payload,
+                            dst_offsets=[row, 0],
+                            src_offsets=[route, 0],
+                            shape=[1, IDX_PAD],
+                        )
+                    else:
+                        pl.tile.write(aux_tile, [0, AUX_SCALE], pl.read(x_norm_scale, [t, 0]))
+                        pl.tile.write(aux_tile, [0, AUX_W], pl.read(weights, [t, k]))
+                        pld.tile.remote_store(aux_tile, target=recv_aux, peer=dst, offsets=[row, 0])
+                        pl.tile.write(route_tile, [0, 0], pl.cast(route, pl.INT32))
+                        pld.tile.remote_store(route_tile, target=recv_route, peer=dst, offsets=[row, 0])
 
         # Payload-arrival notify folded into the push: each block signals every peer
         # after its own puts, so a peer sees N_LOCAL notifies per source per epoch
@@ -274,14 +413,14 @@ def dispatch(
                 )
 
     # Gather lanes into the compact per-expert buffers: one SPMD block per local
-    # expert. deps on _wait_tid for the incoming payload; this rank's own
-    # dst == my_rank puts are already ordered by the local RAW edges on
-    # recv_x / recv_aux / recv_route. deps on _meta_tid for recv_meta_local, which is
-    # manual_dep and so has no auto edge from the cumsum.
+    # expert. _wait_tid covers remote peers, while _push_tid explicitly covers
+    # dst == my_rank. A self-target tensor.put crosses the distributed-window
+    # boundary and must not rely on an inferred local RAW edge. _meta_tid covers
+    # recv_meta_local, which is manual_dep and has no auto edge from the cumsum.
     with pl.spmd(
         N_LOCAL,
         name_hint="dispatch_gather",
-        deps=[_wait_tid, _meta_tid],
+        deps=[_push_tid, _wait_tid, _meta_tid],
         allow_early_resolve=True,
     ) as _gather_tid:
         e = pl.tile.get_block_idx()
@@ -300,6 +439,19 @@ def dispatch(
                 pl.write(recv_r_route_out, [e, out_col], pl.read(recv_route, [in_row, 0]))
             b = b + n
 
+        # This expert lane has consumed every source's payload rows. Together
+        # with the metadata acknowledgement above, these N_LOCAL increments
+        # form the peer-lane reuse fence for the next epoch.
+        for src in pl.range(N_RANKS):
+            if src != my_rank:
+                pld.system.notify(
+                    target=data_arrived,
+                    peer=src,
+                    offsets=[my_rank, 1],
+                    value=1,
+                    op=pld.NotifyOp.AtomicAdd,
+                )
+
 
 # === Combine =================================================================
 # Push recv_y rows back to their origin rank keyed by r_route, barrier, then a
@@ -312,12 +464,28 @@ def combine(
     ffn_out: pl.Tensor[[T, D], pl.BF16],
     recv_meta_local: pl.Tensor[[N_RANKS, N_LOCAL], pl.INT32],
     routed_y_buf: pld.DistributedTensor[[T * TOPK, D], pl.BF16],
-    combine_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
+    combine_arrived: pld.DistributedTensor[[N_RANKS, 2], pl.INT32],
     num_tokens: pl.Scalar[pl.INT32],
     my_rank: pl.Scalar[pl.INT32],
     moe_epoch: pl.Scalar[pl.INT32],
 ):
     recv_y_flat = pl.reshape(recv_y, [N_LOCAL * RECV_MAX, D])
+    # The route-keyed return window is also reused every epoch. Wait until each
+    # peer consumed our previous scatter before overwriting the same route rows.
+    with pl.at(
+        level=pl.Level.CORE_GROUP,
+        name_hint="combine_reuse_wait",
+        allow_early_resolve=True,
+    ) as _combine_reuse_tid:
+        for peer in pl.range(N_RANKS):
+            if peer != my_rank:
+                pld.system.wait(
+                    signal=combine_arrived,
+                    offsets=[peer, 1],
+                    expected=pl.cast(moe_epoch - 1, pl.INT32),
+                    cmp=pld.WaitCmp.Ge,
+                )
+
     # One SPMD block per LOCAL EXPERT: block e pushes expert e's compact rows back to
     # their origin rank (= the source lane src they arrived on) at their route offset.
     # Rows are src-major, so the per-(e, src) base is a loop-carried prefix sum over
@@ -325,7 +493,12 @@ def combine(
     # unique (dst, loc_e) and r_route, so the blocks' puts are write-disjoint.
     # allow_early_resolve: shared_routed pre-stages only when every producer of its
     # fanin is flagged, and combine_wait already is.
-    with pl.spmd(N_LOCAL, name_hint="combine", allow_early_resolve=True):
+    with pl.spmd(
+        N_LOCAL,
+        name_hint="combine",
+        deps=[_combine_reuse_tid],
+        allow_early_resolve=True,
+    ) as _scatter_tid:
         e = pl.tile.get_block_idx()
         e_base_row = e * RECV_MAX
         b = pl.cast(0, pl.INDEX)
@@ -377,8 +550,8 @@ def combine(
                 )
 
     # ffn_out[t] = sh[t] + Sigma_k routed_y_buf[t*TOPK+k]. deps on combine_wait for the
-    # peers' writes; this rank's own puts ride the local RAW edge on routed_y_buf,
-    # which is the only thing ordering them now that the wait is off the scatter.
+    # peers' writes. _scatter_tid explicitly orders this rank's self-target puts;
+    # distributed-window puts must not rely on an inferred local RAW edge.
     active_tokens = pl.cast(num_tokens, pl.INDEX)
     if active_tokens < 0:
         active_tokens = pl.cast(0, pl.INDEX)
@@ -387,7 +560,7 @@ def combine(
     with pl.spmd(
         T,
         name_hint="shared_routed",
-        deps=[_cwait_tid],
+        deps=[_scatter_tid, _cwait_tid],
         allow_early_resolve=True,
     ) as _reduce_tid:
         t = pl.tile.get_block_idx()
@@ -399,6 +572,35 @@ def combine(
             ffn_out[t:t + 1, :] = pl.cast(acc, target_type=pl.BF16, mode="rint")
         else:
             ffn_out[t:t + 1, :] = sh[t:t + 1, :]
+
+    # Publish consumption only after all route rows have been reduced, then
+    # wait for the reciprocal acknowledgement. The final write keeps this
+    # barrier on the ffn_out dependency chain, so signal clearing cannot race it.
+    with pl.at(
+        level=pl.Level.CORE_GROUP,
+        name_hint="combine_consumed",
+        deps=[_reduce_tid],
+        allow_early_resolve=True,
+    ):
+        for peer in pl.range(N_RANKS):
+            if peer != my_rank:
+                pld.system.notify(
+                    target=combine_arrived,
+                    peer=peer,
+                    offsets=[my_rank, 1],
+                    value=1,
+                    op=pld.NotifyOp.AtomicAdd,
+                )
+        for src in pl.range(N_RANKS):
+            if src != my_rank:
+                pld.system.wait(
+                    signal=combine_arrived,
+                    offsets=[src, 1],
+                    expected=moe_epoch,
+                    cmp=pld.WaitCmp.Ge,
+                )
+        anchor = pl.read(ffn_out, [0, 0])
+        pl.write(ffn_out, [0, 0], anchor)
 
 
 @pl.jit.inline(auto_scope=False)
@@ -433,12 +635,17 @@ def moe(
     recv_aux: pld.DistributedTensor[[N_LOCAL * RECV_MAX, AUX_PAD], pl.FP32],
     recv_route: pld.DistributedTensor[[N_LOCAL * RECV_MAX, IDX_PAD], pl.INT32],
     arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
-    data_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
+    data_arrived: pld.DistributedTensor[[N_RANKS, 2], pl.INT32],
     routed_y_buf: pld.DistributedTensor[[N_ROUTES, D], pl.BF16],
-    combine_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
+    combine_arrived: pld.DistributedTensor[[N_RANKS, 2], pl.INT32],
     # scalars last: runtime TaskArgs forbids a tensor arg after a scalar arg.
     layer_id: pl.Scalar[pl.INT32],
     num_tokens: pl.Scalar[pl.INT32],
+    # A draining put prevents aux/route payload notifications from overtaking
+    # their data. ``packed_meta`` selects the epoch/ack protocol that publishes
+    # counts through the exact signal words the receiver consumes.
+    draining_payload: pl.Scalar[pl.INT32],
+    packed_meta: pl.Scalar[pl.INT32],
     my_rank: pl.Scalar[pl.INT32],
     # 1-based MoE call id for the shared flag windows (distinct from layer_id).
     moe_epoch: pl.Scalar[pl.INT32],
@@ -456,10 +663,15 @@ def moe(
     x_norm_scale = pl.create_tensor([T, 1], dtype=pl.FP32, manual_dep=True)
     indices = pl.create_tensor([T, TOPK], dtype=pl.INT32)
     weights = pl.create_tensor([T, TOPK], dtype=pl.FP32)
+    # Gate's existing route tasks also materialize aligned put sources. Keeping
+    # payload production in those tasks avoids the extra producer/fanout that
+    # makes packed prefill hit TENSOR_WAIT_TIMEOUT.
+    aux_payload = pl.create_tensor([N_ROUTES, AUX_PAD], dtype=pl.FP32)
+    route_payload = pl.create_tensor([N_ROUTES, IDX_PAD], dtype=pl.INT32)
     gate(
         x_mixed, norm_w, gate_w, gate_bias,
         layer_id, num_tokens, tid2eid, input_ids,
-        x_norm_i8, x_norm_scale, indices, weights,
+        x_norm_i8, x_norm_scale, indices, weights, aux_payload, route_payload,
     )
 
     sh = pl.create_tensor([T, D], dtype=pl.BF16)
@@ -477,10 +689,10 @@ def moe(
     recv_count_out = pl.create_tensor([N_LOCAL, 1], dtype=pl.INT32)
     recv_meta_local = pl.create_tensor([N_RANKS, N_LOCAL], dtype=pl.INT32, manual_dep=True)
     dispatch(
-        indices, x_norm_i8, x_norm_scale, weights,
+        indices, x_norm_i8, x_norm_scale, weights, aux_payload, route_payload,
         recv_x_out, recv_scale_out, recv_w_out, recv_r_route_out, recv_count_out, recv_meta_local,
         recv_meta, recv_x, recv_aux, recv_route, arrived, data_arrived,
-        num_tokens, my_rank, moe_epoch,
+        num_tokens, draining_payload, packed_meta, my_rank, moe_epoch,
     )
 
     with pl.scope():
@@ -536,15 +748,19 @@ def moe_test(
     recv_aux: pld.DistributedTensor[[N_LOCAL * RECV_MAX, AUX_PAD], pl.FP32],
     recv_route: pld.DistributedTensor[[N_LOCAL * RECV_MAX, IDX_PAD], pl.INT32],
     arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
-    data_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
+    data_arrived: pld.DistributedTensor[[N_RANKS, 2], pl.INT32],
     routed_y_buf: pld.DistributedTensor[[N_ROUTES, D], pl.BF16],
-    combine_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
+    combine_arrived: pld.DistributedTensor[[N_RANKS, 2], pl.INT32],
     # scalars last: runtime TaskArgs forbids a tensor arg after a scalar arg.
     layer_id: pl.Scalar[pl.INT32],
     num_tokens: pl.Scalar[pl.INT32],
     my_rank: pl.Scalar[pl.INT32],
     # 1-based MoE call id; multi-layer callers increment it per reused window.
     moe_epoch: pl.Scalar[pl.INT32],
+    # Clear the shared communication state only after the last MoE that reuses
+    # these windows. A multi-epoch protocol test passes 0 for intermediate calls
+    # and 1 for the final call; the ordinary one-shot wrapper always passes 1.
+    clear_after: pl.Scalar[pl.INT32],
 ) -> pl.Tensor[[T, HC_MULT, D], pl.FP32]:
     moe(
         x_hc, hc_ffn_fn, hc_ffn_scale, hc_ffn_base,
@@ -556,9 +772,11 @@ def moe_test(
         x_next,
         recv_meta, recv_x, recv_aux, recv_route, arrived, data_arrived,
         routed_y_buf, combine_arrived,
-        layer_id, num_tokens, my_rank, moe_epoch,
+        layer_id, num_tokens, pl.const(1, pl.INT32), pl.const(1, pl.INT32),
+        my_rank, moe_epoch,
     )
-    clear_moe_signals(x_next, arrived, data_arrived, combine_arrived)
+    if clear_after != 0:
+        clear_moe_signals(x_next, recv_meta, arrived, data_arrived, combine_arrived)
     return x_next
 
 
@@ -594,9 +812,9 @@ def l3_moe(
     recv_aux_buf = pld.alloc_window_buffer([N_LOCAL * RECV_MAX, AUX_PAD], dtype=pl.FP32)
     recv_route_buf = pld.alloc_window_buffer([N_LOCAL * RECV_MAX, IDX_PAD], dtype=pl.INT32)
     arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
-    data_arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
+    data_arrived_buf = pld.alloc_window_buffer([N_RANKS, 2], dtype=pl.INT32)
     routed_y_buf_buf = pld.alloc_window_buffer([N_ROUTES, D], dtype=pl.BF16)
-    combine_arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
+    combine_arrived_buf = pld.alloc_window_buffer([N_RANKS, 2], dtype=pl.INT32)
 
     for r in pl.range(pld.world_size()):
         recv_meta = pld.window(recv_meta_buf, [N_RANKS, N_LOCAL], dtype=pl.INT32)
@@ -604,9 +822,9 @@ def l3_moe(
         recv_aux = pld.window(recv_aux_buf, [N_LOCAL * RECV_MAX, AUX_PAD], dtype=pl.FP32)
         recv_route = pld.window(recv_route_buf, [N_LOCAL * RECV_MAX, IDX_PAD], dtype=pl.INT32)
         arrived = pld.window(arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
-        data_arrived = pld.window(data_arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
+        data_arrived = pld.window(data_arrived_buf, [N_RANKS, 2], dtype=pl.INT32)
         routed_y_buf = pld.window(routed_y_buf_buf, [N_ROUTES, D], dtype=pl.BF16)
-        combine_arrived = pld.window(combine_arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
+        combine_arrived = pld.window(combine_arrived_buf, [N_RANKS, 2], dtype=pl.INT32)
         moe_test(
             x_hc[r], hc_ffn_fn[r], hc_ffn_scale[r], hc_ffn_base[r],
             norm_w[r], gate_w[r], gate_bias[r], tid2eid[r], input_ids[r],
@@ -617,7 +835,7 @@ def l3_moe(
             x_next[r],
             recv_meta, recv_x, recv_aux, recv_route, arrived, data_arrived,
             routed_y_buf, combine_arrived,
-            layer_id, num_tokens, r, pl.const(1, pl.INT32),
+            layer_id, num_tokens, r, pl.const(1, pl.INT32), pl.const(1, pl.INT32),
             device=r,
         )
 
@@ -667,6 +885,8 @@ def golden_moe(tensors):
         src_x_norm_scale = torch.zeros(T, 1, dtype=torch.float32)
         src_indices = torch.zeros(T, TOPK, dtype=torch.int32)
         src_weights = torch.zeros(T, TOPK, dtype=torch.float32)
+        src_dispatch_aux = torch.zeros(N_ROUTES, AUX_PAD, dtype=torch.float32)
+        src_dispatch_route = torch.zeros(N_ROUTES, IDX_PAD, dtype=torch.int32)
         golden_gate_core({
             "x_mixed":      src_x_mixed,
             "norm_w":       tensors["norm_w"][src],
@@ -680,6 +900,8 @@ def golden_moe(tensors):
             "x_norm_scale": src_x_norm_scale,
             "indices":      src_indices,
             "weights":      src_weights,
+            "dispatch_aux": src_dispatch_aux,
+            "dispatch_route": src_dispatch_route,
         })
         all_post.append(src_post)
         all_comb.append(src_comb)

--- a/models/deepseek_v4_flash_mtp/moe_protocol_stress.py
+++ b/models/deepseek_v4_flash_mtp/moe_protocol_stress.py
@@ -1,0 +1,523 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Persistent two-card regression for the DeepSeek-V4 MoE window protocol.
+
+The ordinary ``moe.py`` test performs one MoE call and validates one launch.
+That does not exercise stale-window or cross-epoch ordering bugs. This test:
+
+* issues ten dependent MoE epochs inside one rank-generic device graph;
+* reuses one set of communication windows and clears it only after the graph;
+* alternates sharply different self/remote expert layouts between host rounds;
+* reuses one persistent prepared worker with window reset disabled; and
+* validates the final three window states against a recursively chained torch golden.
+
+Run on two cards, for example::
+
+    python models/deepseek_v4_flash_mtp/moe_protocol_stress.py \
+        -p a2a3 --ep 2 -d 0,1 --rounds 20
+"""
+
+import argparse
+import dataclasses
+import sys
+import time
+
+import torch
+
+import config
+
+
+def _parse_ep_argv():
+    for i, tok in enumerate(sys.argv):
+        if tok == "--ep" and i + 1 < len(sys.argv):
+            return int(sys.argv[i + 1])
+        if tok.startswith("--ep="):
+            return int(tok.split("=", 1)[1])
+    return 2
+
+
+# ``moe`` and its leaf kernels freeze these values while importing.
+EP = _parse_ep_argv()
+config.EP_WORLD_SIZE = EP
+config.FLASH = dataclasses.replace(config.FLASH, n_routed_experts=config.FLASH.n_routed_experts // 8 * EP)
+if "--prefill" in sys.argv:
+    config.MOE_TOKENS = config.PREFILL_TOKENS
+config.RECV_MAX = EP * config.MOE_TOKENS
+
+import pypto.language as pl
+import pypto.language.distributed as pld
+from pypto.ir.distributed_compiled_program import DistributedConfig
+from pypto.runtime import RunConfig
+
+from golden import ScalarSpec, TensorSpec, ratio_reldiff, validate_golden
+from golden.runner import _l3_ordered_names, _l3_run_config, _share_in_place
+from moe import (
+    AUX_PAD,
+    D,
+    HC_DIM,
+    HC_MULT,
+    IDX_PAD,
+    MIX_HC,
+    MOE_INTER,
+    N_EXPERTS_GLOBAL,
+    N_LOCAL,
+    N_RANKS,
+    N_ROUTES,
+    RECV_MAX,
+    T,
+    TOPK,
+    VOCAB,
+    build_tensor_specs,
+    clear_moe_signals,
+    golden_moe,
+    moe,
+)
+
+
+STRESS_STEPS = 3
+STRESS_TOKENS = (T, T, T)
+STRESS_PAIRS = 4
+STRESS_EPOCHS = 2 * STRESS_PAIRS + 2
+OUTPUT_EPOCHS = (STRESS_EPOCHS - 1, STRESS_EPOCHS - 2, STRESS_EPOCHS)
+
+assert N_RANKS == 2, "the protocol stress regression intentionally targets EP=2"
+assert T >= 2
+assert TOPK % 2 == 0
+assert N_LOCAL >= TOPK
+
+
+@pl.jit(auto_scope=False)
+def moe_protocol_stress_rank(
+    x_hc: pl.Tensor[[T, HC_MULT, D], pl.FP32],
+    hc_ffn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
+    hc_ffn_scale: pl.Tensor[[3], pl.FP32],
+    hc_ffn_base: pl.Tensor[[MIX_HC], pl.FP32],
+    norm_w: pl.Tensor[[D], pl.BF16],
+    gate_w: pl.Tensor[[N_EXPERTS_GLOBAL, D], pl.FP32],
+    gate_bias: pl.Tensor[[N_EXPERTS_GLOBAL], pl.FP32],
+    tid2eid: pl.Tensor[[VOCAB, TOPK], pl.INT32],
+    input_ids_0: pl.Tensor[[T], pl.INT64],
+    input_ids_1: pl.Tensor[[T], pl.INT64],
+    input_ids_2: pl.Tensor[[T], pl.INT64],
+    routed_w1: pl.Tensor[[N_LOCAL, MOE_INTER, D], pl.INT8],
+    routed_w1_scale: pl.Tensor[[N_LOCAL, MOE_INTER], pl.FP32],
+    routed_w3: pl.Tensor[[N_LOCAL, MOE_INTER, D], pl.INT8],
+    routed_w3_scale: pl.Tensor[[N_LOCAL, MOE_INTER], pl.FP32],
+    routed_w2: pl.Tensor[[N_LOCAL, D, MOE_INTER], pl.INT8],
+    routed_w2_scale: pl.Tensor[[N_LOCAL, D], pl.FP32],
+    shared_w1: pl.Tensor[[MOE_INTER, D], pl.INT8],
+    shared_w1_scale: pl.Tensor[[MOE_INTER], pl.FP32],
+    shared_w3: pl.Tensor[[MOE_INTER, D], pl.INT8],
+    shared_w3_scale: pl.Tensor[[MOE_INTER], pl.FP32],
+    shared_w2: pl.Tensor[[D, MOE_INTER], pl.INT8],
+    shared_w2_scale: pl.Tensor[[D], pl.FP32],
+    x_next_0: pl.Out[pl.Tensor[[T, HC_MULT, D], pl.FP32]],
+    x_next_1: pl.Out[pl.Tensor[[T, HC_MULT, D], pl.FP32]],
+    x_next_2: pl.Out[pl.Tensor[[T, HC_MULT, D], pl.FP32]],
+    recv_meta: pld.DistributedTensor[[N_RANKS, N_LOCAL], pl.INT32],
+    recv_x: pld.DistributedTensor[[N_LOCAL * RECV_MAX, D], pl.INT8],
+    recv_aux: pld.DistributedTensor[[N_LOCAL * RECV_MAX, AUX_PAD], pl.FP32],
+    recv_route: pld.DistributedTensor[[N_LOCAL * RECV_MAX, IDX_PAD], pl.INT32],
+    arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
+    data_arrived: pld.DistributedTensor[[N_RANKS, 2], pl.INT32],
+    routed_y_buf: pld.DistributedTensor[[N_ROUTES, D], pl.BF16],
+    combine_arrived: pld.DistributedTensor[[N_RANKS, 2], pl.INT32],
+    layer_id: pl.Scalar[pl.INT32],
+    my_rank: pl.Scalar[pl.INT32],
+):
+    """Issue ten dependent MoE epochs inside one device graph."""
+    num_tokens = pl.const(T, pl.INT32)
+    moe(
+        x_hc, hc_ffn_fn, hc_ffn_scale, hc_ffn_base,
+        norm_w, gate_w, gate_bias, tid2eid, input_ids_0,
+        routed_w1, routed_w1_scale, routed_w3, routed_w3_scale,
+        routed_w2, routed_w2_scale,
+        shared_w1, shared_w1_scale, shared_w3, shared_w3_scale,
+        shared_w2, shared_w2_scale, x_next_0,
+        recv_meta, recv_x, recv_aux, recv_route, arrived, data_arrived,
+        routed_y_buf, combine_arrived,
+        layer_id, num_tokens, pl.const(1, pl.INT32), pl.const(1, pl.INT32),
+        my_rank, pl.const(1, pl.INT32),
+    )
+    for pair in pl.range(STRESS_PAIRS):
+        even_epoch = pl.cast(pair * 2 + 2, pl.INT32)
+        odd_epoch = pl.cast(pair * 2 + 3, pl.INT32)
+        moe(
+            x_next_0, hc_ffn_fn, hc_ffn_scale, hc_ffn_base,
+            norm_w, gate_w, gate_bias, tid2eid, input_ids_1,
+            routed_w1, routed_w1_scale, routed_w3, routed_w3_scale,
+            routed_w2, routed_w2_scale,
+            shared_w1, shared_w1_scale, shared_w3, shared_w3_scale,
+            shared_w2, shared_w2_scale, x_next_1,
+            recv_meta, recv_x, recv_aux, recv_route, arrived, data_arrived,
+            routed_y_buf, combine_arrived,
+            layer_id, num_tokens, pl.const(1, pl.INT32), pl.const(1, pl.INT32),
+            my_rank, even_epoch,
+        )
+        moe(
+            x_next_1, hc_ffn_fn, hc_ffn_scale, hc_ffn_base,
+            norm_w, gate_w, gate_bias, tid2eid, input_ids_2,
+            routed_w1, routed_w1_scale, routed_w3, routed_w3_scale,
+            routed_w2, routed_w2_scale,
+            shared_w1, shared_w1_scale, shared_w3, shared_w3_scale,
+            shared_w2, shared_w2_scale, x_next_0,
+            recv_meta, recv_x, recv_aux, recv_route, arrived, data_arrived,
+            routed_y_buf, combine_arrived,
+            layer_id, num_tokens, pl.const(1, pl.INT32), pl.const(1, pl.INT32),
+            my_rank, odd_epoch,
+        )
+    moe(
+        x_next_0, hc_ffn_fn, hc_ffn_scale, hc_ffn_base,
+        norm_w, gate_w, gate_bias, tid2eid, input_ids_0,
+        routed_w1, routed_w1_scale, routed_w3, routed_w3_scale,
+        routed_w2, routed_w2_scale,
+        shared_w1, shared_w1_scale, shared_w3, shared_w3_scale,
+        shared_w2, shared_w2_scale, x_next_2,
+        recv_meta, recv_x, recv_aux, recv_route, arrived, data_arrived,
+        routed_y_buf, combine_arrived,
+        layer_id, num_tokens, pl.const(1, pl.INT32), pl.const(1, pl.INT32),
+        my_rank, pl.const(STRESS_EPOCHS, pl.INT32),
+    )
+    clear_moe_signals(x_next_2, recv_meta, arrived, data_arrived, combine_arrived)
+
+
+@pl.jit.host
+def l3_moe_protocol_stress(
+    x_hc: pl.Tensor[[N_RANKS, T, HC_MULT, D], pl.FP32],
+    hc_ffn_fn: pl.Tensor[[N_RANKS, MIX_HC, HC_DIM], pl.FP32],
+    hc_ffn_scale: pl.Tensor[[N_RANKS, 3], pl.FP32],
+    hc_ffn_base: pl.Tensor[[N_RANKS, MIX_HC], pl.FP32],
+    norm_w: pl.Tensor[[N_RANKS, D], pl.BF16],
+    gate_w: pl.Tensor[[N_RANKS, N_EXPERTS_GLOBAL, D], pl.FP32],
+    gate_bias: pl.Tensor[[N_RANKS, N_EXPERTS_GLOBAL], pl.FP32],
+    tid2eid: pl.Tensor[[N_RANKS, VOCAB, TOPK], pl.INT32],
+    input_ids: pl.Tensor[[N_RANKS, STRESS_STEPS, T], pl.INT64],
+    routed_w1: pl.Tensor[[N_RANKS, N_LOCAL, MOE_INTER, D], pl.INT8],
+    routed_w1_scale: pl.Tensor[[N_RANKS, N_LOCAL, MOE_INTER], pl.FP32],
+    routed_w3: pl.Tensor[[N_RANKS, N_LOCAL, MOE_INTER, D], pl.INT8],
+    routed_w3_scale: pl.Tensor[[N_RANKS, N_LOCAL, MOE_INTER], pl.FP32],
+    routed_w2: pl.Tensor[[N_RANKS, N_LOCAL, D, MOE_INTER], pl.INT8],
+    routed_w2_scale: pl.Tensor[[N_RANKS, N_LOCAL, D], pl.FP32],
+    shared_w1: pl.Tensor[[N_RANKS, MOE_INTER, D], pl.INT8],
+    shared_w1_scale: pl.Tensor[[N_RANKS, MOE_INTER], pl.FP32],
+    shared_w3: pl.Tensor[[N_RANKS, MOE_INTER, D], pl.INT8],
+    shared_w3_scale: pl.Tensor[[N_RANKS, MOE_INTER], pl.FP32],
+    shared_w2: pl.Tensor[[N_RANKS, D, MOE_INTER], pl.INT8],
+    shared_w2_scale: pl.Tensor[[N_RANKS, D], pl.FP32],
+    x_next: pl.Out[pl.Tensor[[STRESS_STEPS, N_RANKS, T, HC_MULT, D], pl.FP32]],
+    layer_id: pl.Scalar[pl.INT32],
+):
+    """Issue ten epochs against the same distributed windows before clearing."""
+    recv_meta_buf = pld.alloc_window_buffer([N_RANKS, N_LOCAL], dtype=pl.INT32)
+    recv_x_buf = pld.alloc_window_buffer([N_LOCAL * RECV_MAX, D], dtype=pl.INT8)
+    recv_aux_buf = pld.alloc_window_buffer([N_LOCAL * RECV_MAX, AUX_PAD], dtype=pl.FP32)
+    recv_route_buf = pld.alloc_window_buffer([N_LOCAL * RECV_MAX, IDX_PAD], dtype=pl.INT32)
+    arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
+    data_arrived_buf = pld.alloc_window_buffer([N_RANKS, 2], dtype=pl.INT32)
+    routed_y_buf_buf = pld.alloc_window_buffer([N_ROUTES, D], dtype=pl.BF16)
+    combine_arrived_buf = pld.alloc_window_buffer([N_RANKS, 2], dtype=pl.INT32)
+
+    for rank in pl.range(pld.world_size()):
+        recv_meta = pld.window(recv_meta_buf, [N_RANKS, N_LOCAL], dtype=pl.INT32)
+        recv_x = pld.window(recv_x_buf, [N_LOCAL * RECV_MAX, D], dtype=pl.INT8)
+        recv_aux = pld.window(recv_aux_buf, [N_LOCAL * RECV_MAX, AUX_PAD], dtype=pl.FP32)
+        recv_route = pld.window(recv_route_buf, [N_LOCAL * RECV_MAX, IDX_PAD], dtype=pl.INT32)
+        arrived = pld.window(arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
+        data_arrived = pld.window(data_arrived_buf, [N_RANKS, 2], dtype=pl.INT32)
+        routed_y_buf = pld.window(routed_y_buf_buf, [N_ROUTES, D], dtype=pl.BF16)
+        combine_arrived = pld.window(combine_arrived_buf, [N_RANKS, 2], dtype=pl.INT32)
+        moe_protocol_stress_rank(
+            x_hc[rank], hc_ffn_fn[rank], hc_ffn_scale[rank], hc_ffn_base[rank],
+            norm_w[rank], gate_w[rank], gate_bias[rank], tid2eid[rank],
+            input_ids[rank, 0], input_ids[rank, 1], input_ids[rank, 2],
+            routed_w1[rank], routed_w1_scale[rank], routed_w3[rank], routed_w3_scale[rank],
+            routed_w2[rank], routed_w2_scale[rank],
+            shared_w1[rank], shared_w1_scale[rank], shared_w3[rank], shared_w3_scale[rank],
+            shared_w2[rank], shared_w2_scale[rank],
+            x_next[0, rank], x_next[1, rank], x_next[2, rank],
+            recv_meta, recv_x, recv_aux, recv_route, arrived, data_arrived,
+            routed_y_buf, combine_arrived,
+            layer_id, rank,
+            device=rank,
+        )
+
+
+def _route_row(rank, pattern, token):
+    """Return distinct routes split evenly between the local and remote rank."""
+    half = TOPK // 2
+    remote = 1 - rank
+    if pattern == 0:
+        local_base = token % half
+        remote_base = (token * 3) % half
+    else:
+        # Disjoint local-expert bands make the packed per-expert count words very
+        # different from pattern 0 while retaining both self and remote traffic.
+        local_base = N_LOCAL // 2 + token % half
+        remote_base = N_LOCAL - half - (token % half)
+    local = [rank * N_LOCAL + (local_base + k) % N_LOCAL for k in range(half)]
+    remote_routes = [remote * N_LOCAL + (remote_base + k) % N_LOCAL for k in range(half)]
+    return local + remote_routes
+
+
+def _routing_fixtures():
+    """Build A/B/A and B/A/B route sequences for alternating host rounds."""
+    tid2eid = torch.zeros(N_RANKS, VOCAB, TOPK, dtype=torch.int32)
+    variants = []
+    next_row = 0
+    for sequence in ((0, 1, 0), (1, 0, 1)):
+        input_ids = torch.zeros(N_RANKS, STRESS_STEPS, T, dtype=torch.int64)
+        for step, pattern in enumerate(sequence):
+            for rank in range(N_RANKS):
+                for token in range(T):
+                    row = next_row
+                    next_row += 1
+                    tid2eid[rank, row] = torch.tensor(_route_row(rank, pattern, token), dtype=torch.int32)
+                    input_ids[rank, step, token] = row
+        variants.append(input_ids)
+    return tid2eid, variants
+
+
+def _build_stress_specs():
+    tid2eid, input_variants = _routing_fixtures()
+    specs = build_tensor_specs(layer_id=0, num_tokens=T)
+    for spec in specs:
+        if spec.name == "tid2eid":
+            spec.init_value = tid2eid
+        elif spec.name == "input_ids":
+            spec.shape = [N_RANKS, STRESS_STEPS, T]
+            spec.init_value = input_variants[0]
+        elif spec.name == "x_next":
+            spec.shape = [STRESS_STEPS, N_RANKS, T, HC_MULT, D]
+    return [spec for spec in specs if spec.name != "num_tokens"], input_variants
+
+
+def _golden_for(tensors, input_ids, x_hc):
+    expected = torch.zeros(STRESS_STEPS, N_RANKS, T, HC_MULT, D, dtype=torch.float32)
+    epoch_x_hc = x_hc
+    output_slot = {epoch: slot for slot, epoch in enumerate(OUTPUT_EPOCHS)}
+    for epoch in range(1, STRESS_EPOCHS + 1):
+        route_step = 0 if epoch in (1, STRESS_EPOCHS) else (1 if epoch % 2 == 0 else 2)
+        epoch_output = torch.zeros(N_RANKS, T, HC_MULT, D, dtype=torch.float32)
+        values = {name: value for name, value in tensors.items() if name != "x_next"}
+        values["x_hc"] = epoch_x_hc
+        values["input_ids"] = input_ids[:, route_step]
+        values["layer_id"] = 0
+        values["num_tokens"] = T
+        values["x_next"] = epoch_output
+        golden_moe(values)
+        if epoch in output_slot:
+            expected[output_slot[epoch]] = epoch_output
+        epoch_x_hc = epoch_output
+    return expected
+
+
+def _compile(specs, platform, device_ids):
+    dummy_args = [
+        spec.value.item() if isinstance(spec, ScalarSpec)
+        else torch.empty(spec.shape, dtype=spec.dtype)
+        for spec in specs
+    ]
+    return l3_moe_protocol_stress.compile(
+        *dummy_args,
+        config=RunConfig(
+            platform=platform,
+            distributed_config=DistributedConfig(device_ids=device_ids, num_sub_workers=0),
+        ),
+    )
+
+
+def run_stress(
+    platform,
+    device_ids,
+    rounds,
+    seed,
+    reset_windows=False,
+    fixed_variant=None,
+    fixed_routes=None,
+    fixed_activation=None,
+    log_level=None,
+):
+    torch.manual_seed(seed)
+    specs, input_variants = _build_stress_specs()
+    tensor_specs = [spec for spec in specs if isinstance(spec, TensorSpec)]
+    scalar_specs = {spec.name: spec for spec in specs if isinstance(spec, ScalarSpec)}
+    tensors = {spec.name: spec.create_tensor() for spec in tensor_specs}
+    base_x_hc = tensors["x_hc"].clone()
+    activation_variants = [base_x_hc, -base_x_hc]
+
+    print("[STRESS] compile ...", flush=True)
+    compiled = _compile(specs, platform, device_ids)
+    print(f"[STRESS] compile done: {compiled.output_dir}", flush=True)
+
+    print("[STRESS] compute route/activation golden matrix ...", flush=True)
+    goldens = {
+        (route_variant, activation_variant): _golden_for(tensors, ids, x_hc)
+        for route_variant, ids in enumerate(input_variants)
+        for activation_variant, x_hc in enumerate(activation_variants)
+    }
+    _share_in_place(tensors)
+    shared_input_variants = [ids.contiguous().share_memory_() for ids in input_variants]
+    shared_activation_variants = [x.contiguous().share_memory_() for x in activation_variants]
+
+    ordered_names = _l3_ordered_names(compiled)
+    runtime_cfg = {"platform": platform}
+    run_config = _l3_run_config(runtime_cfg)
+    if log_level is not None:
+        from pypto.runtime.log_config import configure_log
+        configure_log(log_level)
+
+    resident_specs = [spec for spec in tensor_specs if spec.is_resident]
+    resident_handles = []
+    started = time.time()
+    with compiled.prepare(
+        run_config,
+        persistent=True,
+        reset_persistent_windows=reset_windows,
+    ) as worker:
+        try:
+            resident_args = {}
+            for spec in resident_specs:
+                if spec.resident != "stacked":
+                    raise ValueError(f"stress runner only supports stacked resident tensors: {spec.name}")
+                handle = worker.alloc_stacked_tensor(tensors[spec.name])
+                resident_handles.append((spec.name, handle))
+                resident_args[spec.name] = handle
+
+            call_overrides = {}
+
+            def arg(name):
+                if name in call_overrides:
+                    return call_overrides[name]
+                if name in resident_args:
+                    return resident_args[name]
+                if name in tensors:
+                    return tensors[name]
+                return scalar_specs[name].value
+
+            for round_id in range(rounds):
+                variant = fixed_variant if fixed_variant is not None else round_id % len(input_variants)
+                route_variant = fixed_routes if fixed_routes is not None else variant
+                activation_variant = fixed_activation if fixed_activation is not None else variant
+                # Bind the selected shared input buffer for this dispatch. Simpler
+                # prebuilds small tensor bindings, so mutating one already-bound
+                # INT64 buffer in place can intentionally reuse its old snapshot;
+                # serving uses stable double-buffered input objects in the same way.
+                call_overrides["input_ids"] = shared_input_variants[route_variant]
+                tensors["input_ids"] = call_overrides["input_ids"]
+                # Alternating a zero-mean fixture and its negation prevents a
+                # stale output from matching the next launch without changing
+                # the calibrated input distribution of the ordinary MoE test.
+                tensors["x_hc"].copy_(shared_activation_variants[activation_variant])
+                ordered = [arg(name) for name in ordered_names]
+                worker(*ordered, config=run_config)
+
+                for step in range(STRESS_STEPS):
+                    output_name = f"x_next_epoch_{OUTPUT_EPOCHS[step]}"
+                    active_tokens = STRESS_TOKENS[step]
+                    actual = tensors["x_next"][step, :, :active_tokens]
+                    expected_full = goldens[(route_variant, activation_variant)][step]
+                    expected = expected_full[:, :active_tokens]
+                    try:
+                        validate_golden(
+                            {output_name: actual},
+                            {output_name: expected},
+                            rtol=1e-3,
+                            atol=1e-3,
+                            compare_fn={output_name: ratio_reldiff(diff_thd=3e-3, pct_thd=0.05)},
+                            inputs={
+                                "input_ids": tensors["input_ids"][:, step, :active_tokens],
+                                "x_hc": tensors["x_hc"][:, :active_tokens],
+                            },
+                        )
+                    except AssertionError:
+                        print(
+                            f"[STRESS] round {round_id + 1} "
+                            f"epoch {OUTPUT_EPOCHS[step]} mismatch diagnostics:"
+                        )
+                        for candidate, candidate_golden in goldens.items():
+                            delta = (actual - candidate_golden[step, :, :active_tokens]).abs()
+                            print(
+                                f"[STRESS]   golden_route_activation={candidate} "
+                                f"mean_abs={delta.mean().item():.6g} max_abs={delta.max().item():.6g}",
+                                flush=True,
+                            )
+                        raise
+                print(
+                    f"[STRESS] round {round_id + 1}/{rounds} "
+                    f"route={route_variant} activation={activation_variant} "
+                    "PASS",
+                    flush=True,
+                )
+        finally:
+            for _, handle in reversed(resident_handles):
+                worker.free_stacked_tensor(handle)
+
+    print(f"[STRESS] PASS: {rounds} persistent rounds in {time.time() - started:.2f}s", flush=True)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-p", "--platform", default="a2a3", choices=["a2a3", "a2a3sim", "a5", "a5sim"])
+    parser.add_argument("--ep", type=int, default=2, choices=[2])
+    parser.add_argument("-d", "--device", default="0,1")
+    parser.add_argument("--rounds", type=int, default=20)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument(
+        "--prefill",
+        action="store_true",
+        help="exercise the 128-token prefill MoE shape instead of decode shape",
+    )
+    parser.add_argument(
+        "--reset-windows",
+        action="store_true",
+        help="runtime-reset communication windows between launches (diagnostic control)",
+    )
+    parser.add_argument(
+        "--fixed-variant",
+        type=int,
+        choices=[0, 1],
+        default=None,
+        help="reuse one input fixture instead of alternating A/B (diagnostic control)",
+    )
+    parser.add_argument(
+        "--fixed-routes",
+        type=int,
+        choices=[0, 1],
+        default=None,
+        help="hold input_ids/routes fixed while activation inputs continue alternating",
+    )
+    parser.add_argument(
+        "--fixed-activation",
+        type=int,
+        choices=[0, 1],
+        default=None,
+        help="hold x_hc fixed while input_ids/routes continue alternating",
+    )
+    parser.add_argument("--log-level", default=None)
+    args = parser.parse_args()
+    device_ids = [int(device) for device in args.device.split(",")]
+    if len(device_ids) != N_RANKS:
+        parser.error(f"need exactly {N_RANKS} devices, got {device_ids}")
+    if args.rounds < 1:
+        parser.error("--rounds must be positive")
+    run_stress(
+        args.platform,
+        device_ids,
+        args.rounds,
+        args.seed,
+        reset_windows=args.reset_windows,
+        fixed_variant=args.fixed_variant,
+        fixed_routes=args.fixed_routes,
+        fixed_activation=args.fixed_activation,
+        log_level=args.log_level,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/models/deepseek_v4_flash_mtp/prefill_fwd.py
+++ b/models/deepseek_v4_flash_mtp/prefill_fwd.py
@@ -303,9 +303,9 @@ def prefill_fwd(
     recv_aux: pld.DistributedTensor[[N_LOCAL * RECV_MAX, AUX_PAD], pl.FP32],
     recv_route: pld.DistributedTensor[[N_LOCAL * RECV_MAX, IDX_PAD], pl.INT32],
     arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
-    data_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
+    data_arrived: pld.DistributedTensor[[N_RANKS, 2], pl.INT32],
     routed_y_buf: pld.DistributedTensor[[N_ROUTES, D], pl.BF16],
-    combine_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
+    combine_arrived: pld.DistributedTensor[[N_RANKS, 2], pl.INT32],
     hc_ffn_fn: pl.Tensor[[FWD_NUM_LAYERS * MIX_HC, HC_DIM], pl.FP32],
     hc_ffn_scale: pl.Tensor[[FWD_NUM_LAYERS * 3], pl.FP32],
     hc_ffn_base: pl.Tensor[[FWD_NUM_LAYERS * MIX_HC], pl.FP32],
@@ -406,7 +406,8 @@ def prefill_fwd(
             hidden,
             recv_meta, recv_x, recv_aux, recv_route, arrived, data_arrived,
             routed_y_buf, combine_arrived,
-            pl.cast(0, pl.INT32), nt, my_rank, pl.cast(1, pl.INT32),
+            pl.cast(0, pl.INT32), nt, pl.cast(1, pl.INT32),
+            pl.cast(1, pl.INT32), my_rank, pl.cast(1, pl.INT32),
         )
 
     # ===================== layer 1 : swa =================================
@@ -468,7 +469,8 @@ def prefill_fwd(
             hidden,
             recv_meta, recv_x, recv_aux, recv_route, arrived, data_arrived,
             routed_y_buf, combine_arrived,
-            pl.cast(1, pl.INT32), nt, my_rank, pl.cast(2, pl.INT32),
+            pl.cast(1, pl.INT32), nt, pl.cast(1, pl.INT32),
+            pl.cast(1, pl.INT32), my_rank, pl.cast(2, pl.INT32),
         )
 
     # ============ loop : csa (even) + hca (odd) pairs, layers 2..41 ======
@@ -563,7 +565,8 @@ def prefill_fwd(
                 hidden_mid,
                 recv_meta, recv_x, recv_aux, recv_route, arrived, data_arrived,
                 routed_y_buf, combine_arrived,
-                csa_layer, nt, my_rank, csa_moe_epoch,
+                csa_layer, nt, pl.cast(1, pl.INT32),
+                pl.cast(1, pl.INT32), my_rank, csa_moe_epoch,
             )
 
         # ---- hca attention weights (per-FWD by hca_layer, compact by loop_i) ----
@@ -634,7 +637,8 @@ def prefill_fwd(
                 hidden,
                 recv_meta, recv_x, recv_aux, recv_route, arrived, data_arrived,
                 routed_y_buf, combine_arrived,
-                hca_layer, nt, my_rank, hca_moe_epoch,
+                hca_layer, nt, pl.cast(1, pl.INT32),
+                pl.cast(1, pl.INT32), my_rank, hca_moe_epoch,
             )
 
     # ================ layer 42 (FWD_LAST_LAYER) : csa -> x_out ===========
@@ -724,9 +728,10 @@ def prefill_fwd(
             pre_hc_hidden_out,
             recv_meta, recv_x, recv_aux, recv_route, arrived, data_arrived,
             routed_y_buf, combine_arrived,
-            csa_layer_last, nt, my_rank, last_moe_epoch,
+            csa_layer_last, nt, pl.cast(1, pl.INT32),
+            pl.cast(1, pl.INT32), my_rank, last_moe_epoch,
         )
-    clear_moe_signals(pre_hc_hidden_out, arrived, data_arrived, combine_arrived)
+    clear_moe_signals(pre_hc_hidden_out, recv_meta, arrived, data_arrived, combine_arrived)
     x_head: pl.Tensor[[T, D], pl.BF16] = pl.create_tensor([T, D], dtype=pl.BF16)
     with pl.scope():
         hc_head(pre_hc_hidden_out, hc_head_fn, hc_head_scale, hc_head_base, x_head)
@@ -833,9 +838,9 @@ def l3_prefill_fwd(
     recv_aux_buf = pld.alloc_window_buffer([N_LOCAL * RECV_MAX, AUX_PAD], dtype=pl.FP32)
     recv_route_buf = pld.alloc_window_buffer([N_LOCAL * RECV_MAX, IDX_PAD], dtype=pl.INT32)
     arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
-    data_arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
+    data_arrived_buf = pld.alloc_window_buffer([N_RANKS, 2], dtype=pl.INT32)
     routed_y_buf_buf = pld.alloc_window_buffer([N_ROUTES, D], dtype=pl.BF16)
-    combine_arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
+    combine_arrived_buf = pld.alloc_window_buffer([N_RANKS, 2], dtype=pl.INT32)
 
     for r in pl.range(pld.world_size()):
         recv_meta: pld.DistributedTensor[[N_RANKS, N_LOCAL], pl.INT32] = pld.window(recv_meta_buf, [N_RANKS, N_LOCAL], dtype=pl.INT32)
@@ -843,9 +848,9 @@ def l3_prefill_fwd(
         recv_aux: pld.DistributedTensor[[N_LOCAL * RECV_MAX, AUX_PAD], pl.FP32] = pld.window(recv_aux_buf, [N_LOCAL * RECV_MAX, AUX_PAD], dtype=pl.FP32)
         recv_route: pld.DistributedTensor[[N_LOCAL * RECV_MAX, IDX_PAD], pl.INT32] = pld.window(recv_route_buf, [N_LOCAL * RECV_MAX, IDX_PAD], dtype=pl.INT32)
         arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32] = pld.window(arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
-        data_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32] = pld.window(data_arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
+        data_arrived: pld.DistributedTensor[[N_RANKS, 2], pl.INT32] = pld.window(data_arrived_buf, [N_RANKS, 2], dtype=pl.INT32)
         routed_y_buf: pld.DistributedTensor[[N_ROUTES, D], pl.BF16] = pld.window(routed_y_buf_buf, [N_ROUTES, D], dtype=pl.BF16)
-        combine_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32] = pld.window(combine_arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
+        combine_arrived: pld.DistributedTensor[[N_RANKS, 2], pl.INT32] = pld.window(combine_arrived_buf, [N_RANKS, 2], dtype=pl.INT32)
         prefill_fwd(
             x_hc[r], hc_attn_fn[r], hc_attn_scale[r], hc_attn_base[r], attn_norm_w[r], wq_a[r],
             wq_b[r], wq_b_scale[r], wkv[r], gamma_cq[r], gamma_ckv[r], kv_cache[r], attn_sink[r],

--- a/models/deepseek_v4_flash_mtp/prefill_layer.py
+++ b/models/deepseek_v4_flash_mtp/prefill_layer.py
@@ -204,9 +204,9 @@ def prefill_layer_core(
     recv_aux: pld.DistributedTensor[[N_LOCAL * RECV_MAX, AUX_PAD], pl.FP32],
     recv_route: pld.DistributedTensor[[N_LOCAL * RECV_MAX, IDX_PAD], pl.INT32],
     arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
-    data_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
+    data_arrived: pld.DistributedTensor[[N_RANKS, 2], pl.INT32],
     routed_y_buf: pld.DistributedTensor[[N_ROUTES, D], pl.BF16],
-    combine_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
+    combine_arrived: pld.DistributedTensor[[N_RANKS, 2], pl.INT32],
     layer_id: pl.Scalar[pl.INT32],
     my_rank: pl.Scalar[pl.INT32],
 ) -> pl.Tensor[[T, HC_MULT, D], pl.FP32]:
@@ -303,12 +303,13 @@ def prefill_layer_core(
                 x_next_tile,
                 recv_meta, recv_x, recv_aux, recv_route, arrived, data_arrived,
                 routed_y_buf, combine_arrived,
-                layer_id, valid_n, my_rank, moe_epoch,
+                layer_id, valid_n, pl.cast(1, pl.INT32), pl.cast(1, pl.INT32),
+                my_rank, moe_epoch,
             )
 
             # Write the one full tile to the fixed output.
             x_next = pl.assemble(x_next, x_next_tile, [tile_base, 0, 0])
-    clear_moe_signals(x_next, arrived, data_arrived, combine_arrived)
+    clear_moe_signals(x_next, recv_meta, arrived, data_arrived, combine_arrived)
     return x_next
 
 
@@ -403,9 +404,9 @@ def l3_prefill_layer(
     recv_aux_buf = pld.alloc_window_buffer([N_LOCAL * RECV_MAX, AUX_PAD], dtype=pl.FP32)
     recv_route_buf = pld.alloc_window_buffer([N_LOCAL * RECV_MAX, IDX_PAD], dtype=pl.INT32)
     arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
-    data_arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
+    data_arrived_buf = pld.alloc_window_buffer([N_RANKS, 2], dtype=pl.INT32)
     routed_y_buf_buf = pld.alloc_window_buffer([N_ROUTES, D], dtype=pl.BF16)
-    combine_arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
+    combine_arrived_buf = pld.alloc_window_buffer([N_RANKS, 2], dtype=pl.INT32)
 
     for rank in pl.range(pld.world_size()):
         recv_meta = pld.window(recv_meta_buf, [N_RANKS, N_LOCAL], dtype=pl.INT32)
@@ -413,9 +414,9 @@ def l3_prefill_layer(
         recv_aux = pld.window(recv_aux_buf, [N_LOCAL * RECV_MAX, AUX_PAD], dtype=pl.FP32)
         recv_route = pld.window(recv_route_buf, [N_LOCAL * RECV_MAX, IDX_PAD], dtype=pl.INT32)
         arrived = pld.window(arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
-        data_arrived = pld.window(data_arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
+        data_arrived = pld.window(data_arrived_buf, [N_RANKS, 2], dtype=pl.INT32)
         routed_y_buf = pld.window(routed_y_buf_buf, [N_ROUTES, D], dtype=pl.BF16)
-        combine_arrived = pld.window(combine_arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
+        combine_arrived = pld.window(combine_arrived_buf, [N_RANKS, 2], dtype=pl.INT32)
         prefill_layer_core(
             x_hc[rank],
             hc_attn_fn[rank], hc_attn_scale[rank], hc_attn_base[rank],

--- a/models/deepseek_v4_flash_mtp/prefill_mtp.py
+++ b/models/deepseek_v4_flash_mtp/prefill_mtp.py
@@ -177,9 +177,9 @@ def mtp_prefill_fwd(
     recv_aux: pld.DistributedTensor[[N_LOCAL * RECV_MAX, AUX_PAD], pl.FP32],
     recv_route: pld.DistributedTensor[[N_LOCAL * RECV_MAX, IDX_PAD], pl.INT32],
     arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
-    data_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
+    data_arrived: pld.DistributedTensor[[N_RANKS, 2], pl.INT32],
     routed_y_buf: pld.DistributedTensor[[N_ROUTES, D], pl.BF16],
-    combine_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
+    combine_arrived: pld.DistributedTensor[[N_RANKS, 2], pl.INT32],
     my_rank: pl.Scalar[pl.INT32],
     num_tokens: pl.Scalar[pl.INT32],
 ) -> pl.Tensor[[T, D], pl.BF16]:
@@ -222,10 +222,12 @@ def mtp_prefill_fwd(
             pre_hc_hidden_out,
             recv_meta, recv_x, recv_aux, recv_route,
             arrived, data_arrived, routed_y_buf, combine_arrived,
-            pl.cast(MTP_LAYER_ID, pl.INT32), nt, my_rank, pl.cast(MTP_MOE_EPOCH, pl.INT32),
+            pl.cast(MTP_LAYER_ID, pl.INT32), nt,
+            pl.cast(1, pl.INT32), pl.cast(1, pl.INT32), my_rank,
+            pl.cast(MTP_MOE_EPOCH, pl.INT32),
         )
 
-    clear_moe_signals(pre_hc_hidden_out, arrived, data_arrived, combine_arrived)
+    clear_moe_signals(pre_hc_hidden_out, recv_meta, arrived, data_arrived, combine_arrived)
     x_head = pl.create_tensor([T, D], dtype=pl.BF16)
     with pl.scope():
         hc_head(pre_hc_hidden_out, mtp_hc_head_fn, mtp_hc_head_scale, mtp_hc_head_base, x_head)
@@ -301,9 +303,9 @@ def l3_mtp_prefill_fwd(
     recv_aux_buf = pld.alloc_window_buffer([N_LOCAL * RECV_MAX, AUX_PAD], dtype=pl.FP32)
     recv_route_buf = pld.alloc_window_buffer([N_LOCAL * RECV_MAX, IDX_PAD], dtype=pl.INT32)
     arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
-    data_arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
+    data_arrived_buf = pld.alloc_window_buffer([N_RANKS, 2], dtype=pl.INT32)
     routed_y_buf_buf = pld.alloc_window_buffer([N_ROUTES, D], dtype=pl.BF16)
-    combine_arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
+    combine_arrived_buf = pld.alloc_window_buffer([N_RANKS, 2], dtype=pl.INT32)
 
     for r in pl.range(pld.world_size()):
         recv_meta = pld.window(recv_meta_buf, [N_RANKS, N_LOCAL], dtype=pl.INT32)
@@ -311,9 +313,9 @@ def l3_mtp_prefill_fwd(
         recv_aux = pld.window(recv_aux_buf, [N_LOCAL * RECV_MAX, AUX_PAD], dtype=pl.FP32)
         recv_route = pld.window(recv_route_buf, [N_LOCAL * RECV_MAX, IDX_PAD], dtype=pl.INT32)
         arrived = pld.window(arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
-        data_arrived = pld.window(data_arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
+        data_arrived = pld.window(data_arrived_buf, [N_RANKS, 2], dtype=pl.INT32)
         routed_y_buf = pld.window(routed_y_buf_buf, [N_ROUTES, D], dtype=pl.BF16)
-        combine_arrived = pld.window(combine_arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
+        combine_arrived = pld.window(combine_arrived_buf, [N_RANKS, 2], dtype=pl.INT32)
         mtp_prefill_fwd(
             hidden_states[r], prev_hidden_states[r],
             enorm_w[r], hnorm_w[r],


### PR DESCRIPTION
- Add epoch-tagged metadata and consumption acknowledgements before
  reusing distributed MoE windows
- Drain dispatch payload transfers and order self-target communication
  explicitly
- Clear all protocol state after the final MoE epoch and add a
  persistent EP2 stress reproducer

Fixes #929