### PR TITLE
Add: track DeepSeek V4 performance history

### DIFF
--- a/docs/debug-and-tune/index.md
+++ b/docs/debug-and-tune/index.md
@@ -16,6 +16,7 @@ then move from the broadest evidence to the narrowest:
 | Diagnose compile errors, runtime failures, hangs, or missing dependencies | [Debugging](debugging.md) |
 | Diagnose numerical drift and choose comparison thresholds | [Precision Tuning](precision-tuning.md) |
 | Measure end-to-end time and inspect the task schedule | [Performance Tuning](performance-tuning.md) |
+| Maintain comparable performance history across source revisions | [Performance Tracking](performance-tracking.md) |
 | Choose matmul row, N, and K tiles | [Cube Tile Tuning](cube-tile-tuning.md) |
 | Inspect one generated kernel in the operator simulator | [In-Core Simulator Profiling](incore-simulator-profiling.md) |
 | Partition phases inside a multi-core CCE extern kernel on real hardware | [CCE In-Core Profiling](cce-incore-profiling.md) |

--- a/docs/debug-and-tune/performance-tracking.md
+++ b/docs/debug-and-tune/performance-tracking.md
@@ -125,6 +125,33 @@ Treat an empty or partially valid result set as a failed collection. A
 successful orchestration exit without the required case coverage must not
 republish an older report as though a new measurement succeeded.
 
+## Supplied reference reporting
+
+Use the `Supplied snapshot` in
+`docs/models/deepseek_v4_flash_w8a8_performance.md` as the presentation
+reference for DeepSeek-V4 Flash W8A8 reports. Every performance table uses the
+same five columns and order:
+
+| Operator | Supplied PyPTO | This test | AscendC | This test / AscendC |
+|----------|----------------:|----------:|--------:|---------------------:|
+
+Calculate the ratio from the unrounded official metric after converting both
+values to the same unit, then round only the quotient to three decimal places.
+A value below 1 means the current test is faster than AscendC. Put source,
+device, validation, and status provenance outside the performance table.
+
+The supplied PyPTO and AscendC values are reporting references only. They do
+not replace the previous compatible result, the frozen lane anchor, or the
+regression thresholds. Pin the reference snapshot and its content digest in
+the reporting system without adding it to the benchmark suite contract; a
+presentation-only change must not schedule a device rerun.
+
+The supplied snapshot does not identify its source revision, test time, exact
+command, or aggregation statistic. Its stated EP16/TP1 configuration also
+differs from the maintained EPLB EP8 workload and its TP4 decode cases. Report
+the ratio as a supplied-reference comparison, not as a strict
+same-configuration regression.
+
 ## Regression confirmation
 
 Begin a new lane or epoch in shadow mode. Collect at least ten independent

--- a/docs/debug-and-tune/performance-tracking.md
+++ b/docs/debug-and-tune/performance-tracking.md
@@ -1,0 +1,152 @@
+# Performance Tracking
+
+Performance tracking turns repeated device benchmarks into comparable source
+history. A result is valid only when its source, benchmark contract, toolchain,
+and device identity are all known. A commit SHA alone is not a performance
+identity.
+
+## Separate source and toolchain changes
+
+Maintain independent time series for source changes and dependency changes:
+
+| Lane | Source under test | Fixed resources | Cases |
+|------|-------------------|-----------------|-------|
+| `lib-main-attention` | Each selected `main` snapshot | One designated device | DeepSeek-V4 Flash CSA, HCA, and SWA |
+| `dsv4-eplb-branch` | Observed tips of the maintained EPLB branch | One ordered eight-device set | MoE EP8, Decode Main, and Decode MTP |
+| `toolchain-bridge` | One selected source anchor | Same resources as the owning lane | Cases affected by a dependency update |
+
+The source lanes keep the complete PyPTO dependency chain fixed. A toolchain
+upgrade is measured at the same source anchor before starting a new toolchain
+epoch. Results from different lanes or epochs must not be connected by a
+normal source delta.
+
+## Performance identity
+
+The comparison identity contains:
+
+```text
+lane
++ source tree
++ case contract
++ toolchain epoch
++ device epoch
++ lineage generation
+```
+
+The source commit and branch name remain useful provenance, but the source tree
+identifies the content that ran. The case contract covers the command,
+workload, sampling configuration, metric selection, and validation policy.
+
+Record the complete toolchain dependency chain selected by PyPTO:
+
+```text
+PyPTO commit
+  -> simpler commit
+    -> PTO-ISA commit
+  -> PTOAS version and artifact checksum
+```
+
+Also record Python, Torch, torch-npu, CANN, driver, firmware, relevant runtime
+environment variables, and build provenance. Do not combine a PyPTO update
+with a pypto-lib source comparison.
+
+A device epoch includes the host, ordered logical-to-physical device mapping,
+topology, driver, and firmware. Replacing a device or changing that mapping
+starts a new epoch. An unavailable designated device defers the official run;
+it does not authorize an automatic fallback into the same time series.
+
+## Benchmark contracts
+
+All maintained cases use five warmup rounds, 100 measured rounds, raw samples,
+fixed deterministic fixtures, and fail-closed validation.
+
+### Main attention
+
+Run CSA, HCA, and SWA on `a2a3` with `start_pos=8192`, L2 swimlanes disabled,
+and the suite's designated single device. The official value is the
+`effective_us` median. Both `kv_cache` and `x_out` must pass numerical
+validation before a value is accepted.
+
+### EPLB branch
+
+Run the three cases sequentially in one allocation of the configured ordered
+eight-device set:
+
+1. MoE EP8 with 16 experts per rank, eight tokens, balanced routing, and L2
+   swimlanes disabled. Select the minimum of the eight per-rank medians and
+   require `x_next` numerical validation to pass.
+2. Decode Main / Compare3. Select the minimum of the eight per-rank medians.
+   This is a runtime-only contract until the entry point has a numerical
+   reference.
+3. Decode MTP / Compare4. For each rank, select the median of slot 0 compute
+   samples, then take the minimum rank median. Preserve slot 1 cleanup timing
+   as a diagnostic, but exclude it from the official metric. All declared
+   finite-output checks must pass.
+
+The generic multi-rank headline is not a substitute for these case-specific
+selection rules. Store all rank distributions and identify the selected rank
+and device so a fastest-rank change remains visible.
+
+## Source history
+
+For a squash-merged `main`, each commit is a stable source snapshot. Process
+commits oldest to newest and retain a window overlap so a missed scheduled run
+can be recovered.
+
+A long-lived development branch can be rebased or force-pushed. On every
+observed tip, record the tip and tree commits, merge base, ahead/behind counts,
+observation time, patch-stack digest, and lineage generation. Archive the tip
+under a tracker-owned Git ref before queuing a benchmark.
+
+- A fast-forward tip continues the current lineage.
+- A non-fast-forward tip starts a new lineage generation.
+- An identical tree may reuse an existing measurement through an explicit
+  alias.
+- A changed tree requires a new measurement.
+- A non-fast-forward boundary uses a same-device old/new bridge rather than a
+  normal previous-tip delta.
+
+The tracker observes published branch tips; it never rebases the maintained
+branch itself.
+
+## Storage and finalization
+
+Append one raw record immediately after each case completes. Raw JSONL and logs
+are immutable evidence; retries add records instead of replacing them. A
+separate finalization step folds attempts, prefers a contract-valid successful
+measurement, orders source history, and computes compatible deltas.
+
+Published measurements are frozen. An overlapping rerun of an already
+published source snapshot must not silently change the value used as the next
+snapshot's baseline. Publishing uses the complete measurement identity as its
+idempotency key, not only the source SHA.
+
+Treat an empty or partially valid result set as a failed collection. A
+successful orchestration exit without the required case coverage must not
+republish an older report as though a new measurement succeeded.
+
+## Regression confirmation
+
+Begin a new lane or epoch in shadow mode. Collect at least ten independent
+suite attempts; the 100 samples inside one attempt measure runtime dispersion,
+not host-to-host or attempt-to-attempt noise. Calculate an attempt-level median
+and median absolute deviation for each case before setting gates.
+
+When a candidate exceeds both its calibrated relative and absolute threshold,
+confirm only the affected case in one allocation using:
+
+```text
+parent -> candidate -> candidate -> parent
+```
+
+Report a source regression only when the confirmation uses the same contract,
+toolchain epoch, device epoch, and lineage generation. Precision or contract
+failure is a test failure, not a performance number.
+
+## Branch promotion
+
+When the maintained branch lands on `main`, preserve the final branch tip and
+the resulting main commit. Benchmark both under the same contract, toolchain,
+and device allocation. Seal the branch lane, record the promotion relationship,
+and start a new `main` lane at the landed commit. A metric-semantic change
+requires a new contract version rather than a bridge to the old contract.

--- a/docs/models/deepseek_v4_flash_w8a8_performance.md
+++ b/docs/models/deepseek_v4_flash_w8a8_performance.md
@@ -1,0 +1,43 @@
+# DeepSeek V4-Flash W8A8 performance
+
+This page is the canonical presentation reference for the maintained
+DeepSeek V4-Flash W8A8 performance reports. It does not replace the immutable
+raw measurements or the compatible previous-result baseline used for
+regression tracking.
+
+## Supplied snapshot
+
+The supplied configuration is `TP=1, DP=EP=16, GBS=16x4, SeqLen=8K, MTP=1,
+EPLB`. Lower latency is better.
+
+| Operator | Supplied PyPTO | This test | AscendC | This test / AscendC |
+| --- | ---: | ---: | ---: | ---: |
+| Attention CSA | 357 us | - | 465 us | - |
+| Attention HCA | 261 us | - | 307 us | - |
+| Attention SWA | 243 us | - | 280 us | - |
+| MoE | 477 us | - | 479 us | - |
+| Decode Main | 36.1 ms | - | 37.7 ms | - |
+| Decode MTP | 1,162 us | - | 1,268 us | - |
+
+`This test` is populated from the current contract-valid measurement. The
+ratio is calculated from the unrounded test value after unit conversion and
+is rounded to three decimal places. A ratio below 1 means that the current
+test is faster than AscendC.
+
+The supplied snapshot does not identify its source revision, collection time,
+exact command, or aggregation statistic. Its EP16/TP1 configuration also
+differs from the maintained EPLB EP8 workload and its TP4 decode cases. Treat
+these values as supplied presentation references, not as strict
+same-configuration regression baselines.
+
+## Maintained report format
+
+Every reported result uses the same five columns shown above. Source commit,
+source tree, contract, toolchain and device epochs, selected rank or device,
+validation status, and collection status are recorded outside the table.
+
+The maintained cases and their measurement contracts are defined in
+[Performance Tracking](../debug-and-tune/performance-tracking.md). The tracker
+pins this page and the `Supplied snapshot` section by content digest. A change
+to this presentation reference creates a new reference snapshot; it does not
+schedule an NPU rerun.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -90,6 +90,7 @@ nav:
       - Overview: models/index.md
       - Qwen3-14B: models/qwen3_14b.md
       - DeepSeek V4-Flash (MTP): models/deepseek_v4_flash_mtp.md
+      - DeepSeek V4-Flash W8A8 performance: models/deepseek_v4_flash_w8a8_performance.md
       - DeepSeek V4-Pro: models/deepseek_v4_pro.md
   - Debug and Tune:
       - Overview: debug-and-tune/index.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -96,6 +96,7 @@ nav:
       - Debugging: debug-and-tune/debugging.md
       - Precision tuning: debug-and-tune/precision-tuning.md
       - Performance tuning: debug-and-tune/performance-tuning.md
+      - Performance tracking: debug-and-tune/performance-tracking.md
       - Cube tile tuning: debug-and-tune/cube-tile-tuning.md
       - In-core simulator profiling: debug-and-tune/incore-simulator-profiling.md
       - CCE in-core profiling: debug-and-tune/cce-incore-profiling.md

--- a/tests/perf/test_dsv4_main_attention_perf.py
+++ b/tests/perf/test_dsv4_main_attention_perf.py
@@ -1,0 +1,344 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Device-free tests for the DeepSeek-V4 main-attention performance contract."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from tools.perf.dsv4_main_attention_metrics import (
+    MetricParseError,
+    assemble_suite_result,
+    build_case_result,
+    load_manifest,
+    parse_case_log,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MANIFEST_PATH = REPO_ROOT / "tools/perf/suites/dsv4_main_attention.json"
+PARSER_PATH = REPO_ROOT / "tools/perf/dsv4_main_attention_metrics.py"
+RUNNER_PATH = REPO_ROOT / "tools/perf/run_dsv4_main_attention_perf.sh"
+LAUNCHER_PATH = REPO_ROOT / "tools/perf/deterministic_run.py"
+
+
+@pytest.fixture
+def manifest() -> dict:
+    return load_manifest(MANIFEST_PATH)
+
+
+def _valid_log(*, case_id: str = "attention-csa", samples: list[float] | None = None) -> str:
+    samples = samples or [float(value) for value in range(1, 101)]
+    minimum = min(samples)
+    ordered = sorted(samples)
+    median = (ordered[49] + ordered[50]) / 2
+    mean = sum(samples) / len(samples)
+    maximum = max(samples)
+    threshold = "0.004" if case_id == "attention-csa" else "0.003"
+    return "\n".join(
+        (
+            "[PERF] deterministic_seed seed=1807 python_hash_seed=1807",
+            "[RUN] compile ...",
+            "[RUN] compile done (1.00s)",
+            "[RUN] benchmark ...",
+            "[RUN] benchmark done (1.00s)",
+            f"[RUN]   effective_us (100 rounds) min={minimum:.1f} "
+            f"median={median:.1f} mean={mean:.1f} max={maximum:.1f}",
+            "[RUN]   raw samples: ranks=1 rounds=100 warmup=5",
+            f"[RUN]     rank 1234 raw n=100 eff_us={samples!r}",
+            "[RUN] validate ...",
+            "[RUN]   'kv_cache' PASS  shape=(128, 128, 1, 512) dtype=torch.bfloat16 "
+            "(ratio_allclose(atol=0.0001, rtol=0.0078125))",
+            "[RUN]   'x_out' PASS  shape=(8, 4, 4096) dtype=torch.float32 "
+            f"(ratio_reldiff(diff_thd={threshold}, pct_thd=0.008, max_diff_hd=1))",
+            "[RUN] validate done (0.05s)",
+            "[RUN] PASS (4.00s)",
+        )
+    )
+
+
+def test_manifest_pins_official_contract() -> None:
+    manifest = load_manifest(MANIFEST_PATH)
+
+    assert manifest["contract_id"] == "dsv4-main-attention-v1"
+    assert manifest["ordered_devices"] == [4]
+    assert manifest["sampling"] == {"seed": 1807, "rounds": 100, "warmup": 5, "raw": True}
+    assert [case["case_id"] for case in manifest["cases"]] == [
+        "attention-csa",
+        "attention-hca",
+        "attention-swa",
+    ]
+    assert all(case["metric"]["aggregation"] == "median" for case in manifest["cases"])
+
+
+@pytest.mark.parametrize("case_id", ["attention-csa", "attention-hca", "attention-swa"])
+def test_parse_case_log_accepts_complete_contract(manifest: dict, case_id: str) -> None:
+    result = parse_case_log(
+        _valid_log(case_id=case_id),
+        manifest=manifest,
+        case_id=case_id,
+        device_id=4,
+    )
+
+    assert result["status"] == "pass"
+    assert result["metric_us"] == 50.5
+    assert result["metric"]["aggregation"] == "median"
+    assert result["metric"]["sample_count"] == 100
+    assert result["validation"]["status"] == "pass"
+    assert [output["name"] for output in result["validation"]["outputs"]] == [
+        "kv_cache",
+        "x_out",
+    ]
+    assert result["rank_diagnostics"][0]["device_id"] == 4
+    assert len(result["rank_diagnostics"][0]["samples_us"]) == 100
+
+
+@pytest.mark.parametrize(
+    ("replacement", "match"),
+    [
+        (lambda log: log.replace("seed=1807", "seed=9", 1), "deterministic seed"),
+        (lambda log: log.replace("rounds=100 warmup=5", "rounds=99 warmup=5"), "header mismatch"),
+        (lambda log: log.replace("median=50.5", "median=60.5"), "median mismatch"),
+        (lambda log: log.replace("'x_out' PASS", "'x_out' FAIL"), "validation failed"),
+        (lambda log: log.replace("shape=(8, 4, 4096)", "shape=(8, 4, 1)"), "shape mismatch"),
+        (lambda log: log.replace("dtype=torch.float32", "dtype=torch.float16"), "dtype mismatch"),
+        (lambda log: log.replace("[RUN] PASS (4.00s)", ""), "final PASS"),
+        (
+            lambda log: log + "\n[RUN] benchmark unavailable: late failure",
+            "forbidden marker",
+        ),
+        (lambda log: log + "\n[RUN] late diagnostic", r"last \[RUN\] line"),
+    ],
+)
+def test_parse_case_log_rejects_invalid_or_truncated_logs(
+    manifest: dict,
+    replacement,
+    match: str,
+) -> None:
+    with pytest.raises(MetricParseError, match=match):
+        parse_case_log(
+            replacement(_valid_log()),
+            manifest=manifest,
+            case_id="attention-csa",
+            device_id=4,
+        )
+
+
+def test_parse_case_log_rejects_wrong_device_and_process_failure(manifest: dict) -> None:
+    with pytest.raises(MetricParseError, match="ordered devices"):
+        parse_case_log(
+            _valid_log(),
+            manifest=manifest,
+            case_id="attention-csa",
+            device_id=2,
+        )
+    with pytest.raises(MetricParseError, match="exited with status 7"):
+        parse_case_log(
+            _valid_log(),
+            manifest=manifest,
+            case_id="attention-csa",
+            device_id=4,
+            process_rc=7,
+        )
+
+
+def test_build_case_result_preserves_explicit_failure(manifest: dict) -> None:
+    result, error = build_case_result(
+        _valid_log().replace("[RUN] PASS (4.00s)", ""),
+        manifest=manifest,
+        case_id="attention-csa",
+        device_id=4,
+        process_rc=0,
+    )
+
+    assert error is not None
+    assert result["status"] == "invalid_metric"
+    assert result["metric"] is None
+    assert result["validation"]["status"] == "fail"
+
+
+def test_suite_requires_complete_case_coverage(manifest: dict, tmp_path: Path) -> None:
+    case = parse_case_log(
+        _valid_log(),
+        manifest=manifest,
+        case_id="attention-csa",
+        device_id=4,
+    )
+    result = assemble_suite_result(
+        manifest=manifest,
+        repo_root=REPO_ROOT,
+        device_id=4,
+        started_at_utc="2026-08-13T00:00:00+00:00",
+        finished_at_utc="2026-08-13T00:01:00+00:00",
+        cases=[case],
+    )
+
+    assert result["status"] == "fail"
+    assert result["coverage"]["complete"] is False
+    assert result["source"]["commit"]
+    assert "status_porcelain" in result["source"]
+    assert result["device"]["ordered_devices"] == [4]
+    assert result["device"]["physical_mapping"] == []
+    assert result["device"]["physical_mapping_source"] == "unavailable"
+    assert set(result["toolchain"]["host"]) == {"hostname", "kernel", "architecture"}
+
+
+def test_suite_uses_explicit_ordered_physical_mapping(
+    manifest: dict, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    case = parse_case_log(
+        _valid_log(), manifest=manifest, case_id="attention-csa", device_id=4
+    )
+    mapping = [
+        {
+            "logical_rank": 0,
+            "requested_device_id": 4,
+            "physical_device_id": 104,
+            "serial": "synthetic-card-4",
+        }
+    ]
+    monkeypatch.setenv("PYPTO_DEVICE_MAPPING_JSON", json.dumps(mapping))
+    result = assemble_suite_result(
+        manifest=manifest,
+        repo_root=REPO_ROOT,
+        device_id=4,
+        started_at_utc="2026-08-13T00:00:00+00:00",
+        finished_at_utc="2026-08-13T00:01:00+00:00",
+        cases=[case],
+    )
+
+    assert result["device"]["physical_mapping"] == mapping
+    assert result["device"]["physical_mapping_source"] == "PYPTO_DEVICE_MAPPING_JSON"
+
+
+def test_suite_rejects_mismatched_physical_mapping(
+    manifest: dict, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    case = parse_case_log(
+        _valid_log(), manifest=manifest, case_id="attention-csa", device_id=4
+    )
+    monkeypatch.setenv(
+        "PYPTO_DEVICE_MAPPING_JSON",
+        json.dumps(
+            [
+                {
+                    "logical_rank": 0,
+                    "requested_device_id": 2,
+                    "physical_device_id": 102,
+                    "serial": "wrong-card",
+                }
+            ]
+        ),
+    )
+    with pytest.raises(MetricParseError, match="requested_device_id=4"):
+        assemble_suite_result(
+            manifest=manifest,
+            repo_root=REPO_ROOT,
+            device_id=4,
+            started_at_utc="2026-08-13T00:00:00+00:00",
+            finished_at_utc="2026-08-13T00:01:00+00:00",
+            cases=[case],
+        )
+
+
+def test_parse_cli_writes_failure_case_and_crash_safe_journal(tmp_path: Path) -> None:
+    log_path = tmp_path / "case.log"
+    output_path = tmp_path / "case.json"
+    journal_path = tmp_path / "case-results.jsonl"
+    log_path.write_text(_valid_log().replace("[RUN] PASS (4.00s)", ""), encoding="utf-8")
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(PARSER_PATH),
+            "parse",
+            "--manifest",
+            str(MANIFEST_PATH),
+            "--case",
+            "attention-csa",
+            "--log",
+            str(log_path),
+            "--device",
+            "4",
+            "--process-rc",
+            "0",
+            "--output",
+            str(output_path),
+            "--journal",
+            str(journal_path),
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    case_result = json.loads(output_path.read_text(encoding="utf-8"))
+    journal_result = json.loads(journal_path.read_text(encoding="utf-8"))
+    assert case_result == journal_result
+    assert case_result["status"] == "invalid_metric"
+
+
+def test_deterministic_launcher_replays_python_numpy_and_torch(tmp_path: Path) -> None:
+    entrypoint = tmp_path / "random_values.py"
+    entrypoint.write_text(
+        "import random\n"
+        "import numpy as np\n"
+        "import torch\n"
+        "print(random.random(), np.random.rand(), torch.rand(1).item())\n",
+        encoding="utf-8",
+    )
+    environment = os.environ.copy()
+    environment["PYTHONHASHSEED"] = "1807"
+    command = [sys.executable, str(LAUNCHER_PATH), "--seed", "1807", str(entrypoint)]
+
+    first = subprocess.run(command, env=environment, capture_output=True, text=True, check=True)
+    second = subprocess.run(command, env=environment, capture_output=True, text=True, check=True)
+
+    assert first.stdout == second.stdout
+    assert first.stdout.startswith(
+        "[PERF] deterministic_seed seed=1807 python_hash_seed=1807\n"
+    )
+
+
+def test_runner_dry_run_enforces_card_four_without_device_work() -> None:
+    rejected = subprocess.run(
+        [str(RUNNER_PATH), "--device", "2", "--dry-run"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    accepted = subprocess.run(
+        [str(RUNNER_PATH), "--device", "4", "--dry-run"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert rejected.returncode == 2
+    assert "require --device 4" in rejected.stderr
+    assert accepted.returncode == 0
+    assert "suite-result.json" in accepted.stdout
+    assert accepted.stdout.count("PYTHONHASHSEED=1807") == 3
+
+
+def test_runner_pins_the_archived_repo_before_inherited_pythonpath() -> None:
+    runner = RUNNER_PATH.read_text(encoding="utf-8")
+
+    assert 'export PYTHONPATH="$REPO_ROOT${PYTHONPATH:+:$PYTHONPATH}"' in runner
+    assert "export PYTHONDONTWRITEBYTECODE=1" in runner

--- a/tools/perf/deterministic_run.py
+++ b/tools/perf/deterministic_run.py
@@ -1,0 +1,55 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Run a Python entry point after applying the official performance seed."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import random
+import runpy
+import sys
+from pathlib import Path
+
+import numpy as np
+import torch
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--seed", type=int, required=True)
+    parser.add_argument("entrypoint", type=Path)
+    parser.add_argument("entrypoint_args", nargs=argparse.REMAINDER)
+    args = parser.parse_args()
+
+    hash_seed = os.environ.get("PYTHONHASHSEED")
+    if hash_seed != str(args.seed):
+        raise SystemExit(
+            f"PYTHONHASHSEED must be {args.seed} before Python starts, got {hash_seed!r}"
+        )
+
+    entrypoint = args.entrypoint.resolve()
+    if not entrypoint.is_file():
+        raise SystemExit(f"entry point does not exist: {entrypoint}")
+
+    random.seed(args.seed)
+    np.random.seed(args.seed)
+    torch.manual_seed(args.seed)
+
+    print(
+        f"[PERF] deterministic_seed seed={args.seed} python_hash_seed={hash_seed}",
+        flush=True,
+    )
+    sys.path.insert(0, str(entrypoint.parent))
+    sys.argv = [str(entrypoint), *args.entrypoint_args]
+    runpy.run_path(str(entrypoint), run_name="__main__")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/perf/dsv4_main_attention_metrics.py
+++ b/tools/perf/dsv4_main_attention_metrics.py
@@ -1,0 +1,889 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Parse and assemble the DeepSeek-V4 main-attention performance suite."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import hashlib
+import importlib.metadata
+import importlib.util
+import json
+import math
+import os
+import platform
+import re
+import shutil
+import socket
+import statistics
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Sequence
+from urllib.parse import unquote, urlparse
+
+
+SCHEMA_VERSION = 1
+_NUMBER = r"[0-9]+(?:\.[0-9]+)?"
+_SEED_RE = re.compile(
+    r"^\[PERF\] deterministic_seed seed=(?P<seed>\d+) "
+    r"python_hash_seed=(?P<hash_seed>\d+)$"
+)
+_HEADLINE_RE = re.compile(
+    rf"^\[RUN\]\s+effective_us \((?P<rounds>\d+) rounds\) "
+    rf"min=(?P<minimum>{_NUMBER}) median=(?P<median>{_NUMBER}) "
+    rf"mean=(?P<mean>{_NUMBER}) max=(?P<maximum>{_NUMBER})$"
+)
+_RAW_HEADER_RE = re.compile(
+    r"^\[RUN\]\s+raw samples: ranks=(?P<ranks>\d+) "
+    r"rounds=(?P<rounds>\d+) warmup=(?P<warmup>\d+)$"
+)
+_RAW_RANK_RE = re.compile(
+    r"^\[RUN\]\s+rank (?P<pid>\d+) raw n=(?P<count>\d+) "
+    r"eff_us=(?P<samples>\[.*\])$"
+)
+_VALIDATION_RE = re.compile(
+    r"^\[RUN\]\s+'(?P<name>[^']+)' (?P<status>PASS|FAIL)\s+"
+    r"shape=(?P<shape>\([^)]*\)) dtype=(?P<dtype>[^\s]+)(?: \(.*\))?$"
+)
+_FINAL_PASS_RE = re.compile(rf"^\[RUN\] PASS \({_NUMBER}s\)$")
+_FORBIDDEN_FRAGMENTS = (
+    "fallback_flattened=1",
+    "effective_us unavailable",
+    "benchmark unavailable",
+    "benchmark skipped",
+    "validation skipped",
+    "Traceback (most recent call last)",
+)
+
+
+class MetricParseError(ValueError):
+    """Raised when a log cannot prove the official metric contract."""
+
+
+@dataclass(frozen=True)
+class SampleStats:
+    samples: tuple[float, ...]
+
+    def as_dict(self) -> dict[str, float | int]:
+        return {
+            "sample_count": len(self.samples),
+            "minimum": min(self.samples),
+            "median": statistics.median(self.samples),
+            "mean": statistics.fmean(self.samples),
+            "maximum": max(self.samples),
+        }
+
+
+def load_manifest(path: Path) -> dict[str, Any]:
+    """Load and minimally validate the checked-in suite contract."""
+
+    try:
+        manifest = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise MetricParseError(f"cannot load suite manifest {path}: {error}") from error
+    if not isinstance(manifest, dict):
+        raise MetricParseError("suite manifest must be a JSON object")
+    if manifest.get("schema_version") != SCHEMA_VERSION:
+        raise MetricParseError(
+            f"unsupported manifest schema_version={manifest.get('schema_version')!r}"
+        )
+    for key in ("suite_id", "lane_id", "contract_id", "platform", "ordered_devices"):
+        if key not in manifest:
+            raise MetricParseError(f"suite manifest is missing {key!r}")
+    sampling = manifest.get("sampling")
+    if not isinstance(sampling, dict):
+        raise MetricParseError("suite manifest sampling must be an object")
+    for key in ("seed", "rounds", "warmup", "raw"):
+        if key not in sampling:
+            raise MetricParseError(f"suite manifest sampling is missing {key!r}")
+    cases = manifest.get("cases")
+    if not isinstance(cases, list) or not cases:
+        raise MetricParseError("suite manifest cases must be a non-empty list")
+    case_ids = [case.get("case_id") for case in cases if isinstance(case, dict)]
+    if len(case_ids) != len(cases) or len(set(case_ids)) != len(case_ids):
+        raise MetricParseError("suite manifest case IDs must be present and unique")
+    return manifest
+
+
+def _case_config(manifest: dict[str, Any], case_id: str) -> dict[str, Any]:
+    matches = [case for case in manifest["cases"] if case["case_id"] == case_id]
+    if len(matches) != 1:
+        raise MetricParseError(f"unknown suite case: {case_id}")
+    return matches[0]
+
+
+def _single_match(lines: Sequence[str], pattern: re.Pattern[str], label: str) -> tuple[int, re.Match[str]]:
+    matches = [(index, match) for index, line in enumerate(lines) if (match := pattern.match(line))]
+    if len(matches) != 1:
+        raise MetricParseError(f"expected exactly one {label}, found {len(matches)}")
+    return matches[0]
+
+
+def _parse_samples(payload: str, declared_count: int) -> tuple[float, ...]:
+    try:
+        parsed = ast.literal_eval(payload)
+    except (SyntaxError, ValueError) as error:
+        raise MetricParseError("raw effective-time samples are malformed") from error
+    if not isinstance(parsed, list):
+        raise MetricParseError("raw effective-time samples must be a list")
+    if len(parsed) != declared_count:
+        raise MetricParseError(
+            f"raw sample line declares n={declared_count} but contains {len(parsed)} samples"
+        )
+    samples = []
+    for index, value in enumerate(parsed):
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise MetricParseError(f"raw sample {index} is not numeric")
+        sample = float(value)
+        if not math.isfinite(sample) or sample <= 0.0:
+            raise MetricParseError(f"raw sample {index} must be finite and positive")
+        samples.append(sample)
+    return tuple(samples)
+
+
+def _require_reported_stats(stats: SampleStats, match: re.Match[str]) -> None:
+    actual = stats.as_dict()
+    for name in ("minimum", "median", "mean", "maximum"):
+        reported = float(match.group(name))
+        if not math.isclose(float(actual[name]), reported, rel_tol=0.0, abs_tol=0.11):
+            raise MetricParseError(
+                f"effective_us {name} mismatch: raw={actual[name]:.3f}, summary={reported:.3f}"
+            )
+
+
+def parse_case_log(
+    log_text: str,
+    *,
+    manifest: dict[str, Any],
+    case_id: str,
+    device_id: int,
+    process_rc: int = 0,
+) -> dict[str, Any]:
+    """Parse one case log and return a contract-valid case result."""
+
+    case = _case_config(manifest, case_id)
+    sampling = manifest["sampling"]
+    expected_devices = manifest["ordered_devices"]
+    if expected_devices != [device_id]:
+        raise MetricParseError(
+            f"official metrics require ordered devices {expected_devices}, got {[device_id]}"
+        )
+    if process_rc != 0:
+        raise MetricParseError(f"benchmark process exited with status {process_rc}")
+
+    lines = log_text.splitlines()
+    for fragment in _FORBIDDEN_FRAGMENTS:
+        if any(fragment in line for line in lines):
+            raise MetricParseError(f"benchmark log contains forbidden marker {fragment!r}")
+    if any(line.startswith("[RUN] FAIL") for line in lines):
+        raise MetricParseError("benchmark log contains a final FAIL result")
+
+    seed_index, seed_match = _single_match(lines, _SEED_RE, "deterministic-seed sentinel")
+    expected_seed = int(sampling["seed"])
+    if (int(seed_match.group("seed")), int(seed_match.group("hash_seed"))) != (
+        expected_seed,
+        expected_seed,
+    ):
+        raise MetricParseError(f"deterministic seed must be {expected_seed}")
+
+    headline_index, headline = _single_match(lines, _HEADLINE_RE, "effective_us headline")
+    raw_header_index, raw_header = _single_match(lines, _RAW_HEADER_RE, "raw-sample header")
+    raw_rank_index, raw_rank = _single_match(lines, _RAW_RANK_RE, "raw rank-sample line")
+    final_index, _final = _single_match(lines, _FINAL_PASS_RE, "final PASS line")
+    run_line_indices = [index for index, line in enumerate(lines) if line.startswith("[RUN]")]
+    if not run_line_indices or final_index != run_line_indices[-1]:
+        raise MetricParseError("final PASS must be the last [RUN] line")
+
+    expected_rounds = int(sampling["rounds"])
+    expected_warmup = int(sampling["warmup"])
+    headline_rounds = int(headline.group("rounds"))
+    raw_contract = (
+        int(raw_header.group("ranks")),
+        int(raw_header.group("rounds")),
+        int(raw_header.group("warmup")),
+    )
+    if headline_rounds != expected_rounds:
+        raise MetricParseError(
+            f"effective_us headline requires {expected_rounds} rounds, got {headline_rounds}"
+        )
+    if raw_contract != (1, expected_rounds, expected_warmup):
+        raise MetricParseError(
+            "raw-sample header mismatch: expected ranks/rounds/warmup="
+            f"{(1, expected_rounds, expected_warmup)}, got {raw_contract}"
+        )
+
+    samples = _parse_samples(raw_rank.group("samples"), int(raw_rank.group("count")))
+    if len(samples) != expected_rounds:
+        raise MetricParseError(f"expected {expected_rounds} raw samples, found {len(samples)}")
+    stats = SampleStats(samples)
+    _require_reported_stats(stats, headline)
+
+    validation_matches = [
+        (index, match)
+        for index, line in enumerate(lines)
+        if (match := _VALIDATION_RE.match(line))
+    ]
+    expected_outputs = case["validation_outputs"]
+    expected_by_name = {output["name"]: output for output in expected_outputs}
+    actual_by_name: dict[str, tuple[int, re.Match[str]]] = {}
+    for index, match in validation_matches:
+        name = match.group("name")
+        if name in actual_by_name:
+            raise MetricParseError(f"duplicate validation result for {name!r}")
+        actual_by_name[name] = (index, match)
+    if set(actual_by_name) != set(expected_by_name):
+        raise MetricParseError(
+            "validation output mismatch: "
+            f"expected={sorted(expected_by_name)}, got={sorted(actual_by_name)}"
+        )
+
+    validation_outputs = []
+    validation_indices = []
+    for expected in expected_outputs:
+        index, match = actual_by_name[expected["name"]]
+        validation_indices.append(index)
+        if match.group("status") != "PASS":
+            raise MetricParseError(f"validation failed for {expected['name']!r}")
+        try:
+            shape = ast.literal_eval(match.group("shape"))
+        except (SyntaxError, ValueError) as error:
+            raise MetricParseError(f"invalid validation shape for {expected['name']!r}") from error
+        if tuple(shape) != tuple(expected["shape"]):
+            raise MetricParseError(
+                f"validation shape mismatch for {expected['name']!r}: "
+                f"expected={tuple(expected['shape'])}, got={shape}"
+            )
+        if match.group("dtype") != expected["dtype"]:
+            raise MetricParseError(
+                f"validation dtype mismatch for {expected['name']!r}: "
+                f"expected={expected['dtype']}, got={match.group('dtype')}"
+            )
+        validation_outputs.append(
+            {
+                "name": expected["name"],
+                "status": "pass",
+                "shape": list(shape),
+                "dtype": match.group("dtype"),
+            }
+        )
+
+    if not (
+        seed_index < headline_index < raw_header_index < raw_rank_index
+        < min(validation_indices) <= max(validation_indices) < final_index
+    ):
+        raise MetricParseError("benchmark sections are out of contract order")
+
+    metric = {
+        "name": case["metric"]["name"],
+        "unit": case["metric"]["unit"],
+        "aggregation": case["metric"]["aggregation"],
+        **stats.as_dict(),
+    }
+    rank_diagnostic = {
+        "logical_rank": 0,
+        "device_id": device_id,
+        "pid": int(raw_rank.group("pid")),
+        **stats.as_dict(),
+        "samples_us": list(samples),
+    }
+    return {
+        "case_id": case_id,
+        "status": "pass",
+        "process_rc": process_rc,
+        "contract_id": f"{manifest['contract_id']}:{case_id}",
+        "entrypoint": case["entrypoint"],
+        "metric_us": metric["median"],
+        "metric": metric,
+        "validation": {"status": "pass", "outputs": validation_outputs},
+        "rank_diagnostics": [rank_diagnostic],
+    }
+
+
+def build_case_result(
+    log_text: str,
+    *,
+    manifest: dict[str, Any],
+    case_id: str,
+    device_id: int,
+    process_rc: int,
+) -> tuple[dict[str, Any], MetricParseError | None]:
+    """Return a success or explicit failure record for one case."""
+
+    try:
+        return (
+            parse_case_log(
+                log_text,
+                manifest=manifest,
+                case_id=case_id,
+                device_id=device_id,
+                process_rc=process_rc,
+            ),
+            None,
+        )
+    except MetricParseError as error:
+        case = _case_config(manifest, case_id)
+        status = "fail" if process_rc else "invalid_metric"
+        return (
+            {
+                "case_id": case_id,
+                "status": status,
+                "process_rc": process_rc,
+                "contract_id": f"{manifest['contract_id']}:{case_id}",
+                "entrypoint": case["entrypoint"],
+                "metric_us": None,
+                "metric": None,
+                "validation": {"status": "fail", "outputs": [], "error": str(error)},
+                "rank_diagnostics": [],
+            },
+            error,
+        )
+
+
+def _json_dump(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    try:
+        with temporary.open("w", encoding="utf-8") as output:
+            json.dump(value, output, indent=2, sort_keys=True)
+            output.write("\n")
+            output.flush()
+            os.fsync(output.fileno())
+        os.replace(temporary, path)
+        directory_fd = os.open(path.parent, os.O_RDONLY)
+        try:
+            os.fsync(directory_fd)
+        finally:
+            os.close(directory_fd)
+    finally:
+        try:
+            temporary.unlink()
+        except FileNotFoundError:
+            pass
+
+
+def _append_jsonl(path: Path, value: Any) -> None:
+    payload = (json.dumps(value, sort_keys=True, separators=(",", ":")) + "\n").encode()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o644)
+    try:
+        view = memoryview(payload)
+        while view:
+            written = os.write(descriptor, view)
+            view = view[written:]
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _git(repo: Path, *args: str) -> str | None:
+    try:
+        return subprocess.run(
+            ["git", "-C", str(repo), *args],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+    except (OSError, subprocess.CalledProcessError):
+        return None
+
+
+def _repo_for_path(path: Path) -> Path | None:
+    for candidate in (path, *path.parents):
+        if (candidate / ".git").exists():
+            return candidate
+    return None
+
+
+def _module_sha(module_name: str) -> str:
+    try:
+        spec = importlib.util.find_spec(module_name)
+    except (ImportError, ValueError):
+        return "unavailable"
+    if spec is None:
+        return "unavailable"
+    locations = list(spec.submodule_search_locations or ())
+    origin = None if spec.origin in (None, "built-in") else Path(spec.origin)
+    probe = origin.parent if origin is not None else (Path(locations[0]) if locations else None)
+    if probe is None or (repo := _repo_for_path(probe.resolve())) is None:
+        return "unavailable"
+    return _git(repo, "rev-parse", "HEAD") or "unavailable"
+
+
+def _path_repo_sha(path_value: str | None) -> str:
+    if not path_value:
+        return "unavailable"
+    path = Path(path_value)
+    if not path.exists() or (repo := _repo_for_path(path.resolve())) is None:
+        return "unavailable"
+    return _git(repo, "rev-parse", "HEAD") or "unavailable"
+
+
+def _pto_isa_provenance() -> dict[str, Any]:
+    root_value = os.environ.get("PTO_ISA_ROOT")
+    if not root_value:
+        return {"available": False}
+    root = Path(root_value)
+    status = _git(root, "status", "--porcelain=v1") or ""
+    return {
+        "available": root.is_dir(),
+        "commit": _git(root, "rev-parse", "HEAD"),
+        "tree": _git(root, "rev-parse", "HEAD^{tree}"),
+        "status_sha256": hashlib.sha256(status.encode()).hexdigest(),
+        "clean": status == "",
+    }
+
+
+def _direct_url_info(distribution: importlib.metadata.Distribution) -> dict[str, Any]:
+    try:
+        raw = distribution.read_text("direct_url.json")
+        value = json.loads(raw) if raw else {}
+    except (json.JSONDecodeError, OSError):
+        return {"kind": "unavailable"}
+    if not isinstance(value, dict):
+        return {"kind": "unavailable"}
+    parsed = urlparse(str(value.get("url", "")))
+    archive_info = value.get("archive_info")
+    if isinstance(archive_info, dict):
+        hashes = archive_info.get("hashes")
+        return {
+            "kind": "archive",
+            "artifact": Path(unquote(parsed.path)).name or None,
+            "sha256": hashes.get("sha256") if isinstance(hashes, dict) else None,
+        }
+    vcs_info = value.get("vcs_info")
+    if isinstance(vcs_info, dict):
+        return {
+            "kind": "vcs",
+            "vcs": vcs_info.get("vcs"),
+            "commit": vcs_info.get("commit_id"),
+        }
+    if "dir_info" in value and parsed.scheme == "file":
+        source_path = Path(unquote(parsed.path))
+        return {
+            "kind": "directory",
+            "commit": _git(source_path, "rev-parse", "HEAD"),
+            "tree": _git(source_path, "rev-parse", "HEAD^{tree}"),
+        }
+    return {"kind": "unavailable"}
+
+
+def _distribution_info(name: str) -> dict[str, Any]:
+    try:
+        distribution = importlib.metadata.distribution(name)
+    except importlib.metadata.PackageNotFoundError:
+        return {"available": False}
+    record = distribution.read_text("RECORD") or ""
+    return {
+        "available": True,
+        "version": distribution.version,
+        "record_sha256": hashlib.sha256(record.encode()).hexdigest(),
+        "source": _direct_url_info(distribution),
+    }
+
+
+def _distribution_commit(info: dict[str, Any], module_name: str) -> str:
+    source = info.get("source")
+    if isinstance(source, dict) and source.get("commit"):
+        return str(source["commit"])
+    return _module_sha(module_name)
+
+
+def _ptoas_provenance() -> dict[str, Any]:
+    candidates = []
+    if root := os.environ.get("PTOAS_ROOT"):
+        candidates.extend((Path(root) / "ptoas", Path(root) / "bin" / "ptoas"))
+    if executable := shutil.which("ptoas"):
+        candidates.append(Path(executable))
+    for candidate in candidates:
+        if not candidate.is_file() or not os.access(candidate, os.X_OK):
+            continue
+        try:
+            version = subprocess.run(
+                [str(candidate), "--version"],
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.splitlines()[0]
+            checksum = hashlib.sha256(candidate.read_bytes()).hexdigest()
+            return {
+                "available": True,
+                "executable": candidate.name,
+                "version": version,
+                "sha256": checksum,
+            }
+        except (OSError, subprocess.CalledProcessError, IndexError):
+            continue
+    return {"available": False}
+
+
+def _parse_key_values(path: Path) -> dict[str, str] | None:
+    try:
+        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError:
+        return None
+    values = {}
+    for line in lines:
+        key, separator, value = line.partition("=")
+        if separator:
+            values[key.strip()] = value.strip()
+    return values or None
+
+
+def _sha256_file(path: Path) -> str | None:
+    try:
+        return hashlib.sha256(path.read_bytes()).hexdigest()
+    except OSError:
+        return None
+
+
+def _cann_provenance() -> dict[str, Any]:
+    root_value = next(
+        (
+            os.environ[name]
+            for name in ("ASCEND_HOME_PATH", "CANN_ROOT", "ASCEND_HOME")
+            if os.environ.get(name)
+        ),
+        None,
+    )
+    candidates = []
+    if root_value:
+        root = Path(root_value)
+        candidates.extend(
+            (
+                root / f"{platform.machine()}-linux" / "ascend_toolkit_install.info",
+                root / "ascend_toolkit_install.info",
+            )
+        )
+    candidates.extend(
+        Path("/usr/local/Ascend").glob(
+            f"cann-*/{platform.machine()}-linux/ascend_toolkit_install.info"
+        )
+    )
+    install_info = next((path for path in candidates if path.is_file()), None)
+    values = _parse_key_values(install_info) if install_info else None
+    return {
+        "available": install_info is not None,
+        "version": values.get("version") if values else None,
+        "inner_version": values.get("innerversion") if values else None,
+        "install_info_sha256": _sha256_file(install_info) if install_info else None,
+    }
+
+
+def _system_component(path: Path) -> dict[str, Any]:
+    values = _parse_key_values(path)
+    return {
+        "available": values is not None,
+        "version": (values.get("Version") or values.get("version")) if values else None,
+        "inner_version": (
+            values.get("Innerversion") or values.get("innerversion")
+        ) if values else None,
+        "sha256": _sha256_file(path),
+    }
+
+
+def _capture_npu_smi(output_dir: Path | None) -> dict[str, Any]:
+    if output_dir is None:
+        return {"available": False, "returncode": None, "snapshot_sha256": None}
+    try:
+        result = subprocess.run(
+            ["npu-smi", "info"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            check=False,
+            timeout=30,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return {"available": False, "returncode": None, "snapshot_sha256": None}
+    snapshot = output_dir / "npu-smi-info.txt"
+    snapshot_written = False
+    try:
+        output_dir.mkdir(parents=True, exist_ok=True)
+        with snapshot.open("wb") as output:
+            output.write(result.stdout)
+            output.flush()
+            os.fsync(output.fileno())
+        snapshot_written = True
+    except OSError:
+        pass
+    return {
+        "available": result.returncode == 0,
+        "returncode": result.returncode,
+        "snapshot_sha256": hashlib.sha256(result.stdout).hexdigest(),
+        "snapshot": snapshot.name if snapshot_written else None,
+    }
+
+
+def _physical_mapping(device_ids: list[int]) -> tuple[list[dict[str, Any]], str]:
+    raw = os.environ.get("PYPTO_DEVICE_MAPPING_JSON")
+    if not raw:
+        return [], "unavailable"
+    try:
+        value = json.loads(raw)
+    except json.JSONDecodeError as error:
+        raise MetricParseError(
+            f"PYPTO_DEVICE_MAPPING_JSON is not valid JSON: {error}"
+        ) from error
+    if not isinstance(value, list) or len(value) != len(device_ids):
+        raise MetricParseError(
+            "PYPTO_DEVICE_MAPPING_JSON must be an ordered list with "
+            f"{len(device_ids)} entries"
+        )
+    entries = []
+    for logical_rank, (requested_device_id, entry) in enumerate(
+        zip(device_ids, value, strict=True)
+    ):
+        if not isinstance(entry, dict):
+            raise MetricParseError(
+                f"PYPTO_DEVICE_MAPPING_JSON entry {logical_rank} must be an object"
+            )
+        expected = {
+            "logical_rank": logical_rank,
+            "requested_device_id": requested_device_id,
+        }
+        for field, expected_value in expected.items():
+            if entry.get(field) != expected_value:
+                raise MetricParseError(
+                    f"PYPTO_DEVICE_MAPPING_JSON entry {logical_rank} requires "
+                    f"{field}={expected_value}"
+                )
+        physical_device_id = entry.get("physical_device_id")
+        serial = entry.get("serial")
+        if isinstance(physical_device_id, bool) or not isinstance(
+            physical_device_id, int
+        ):
+            raise MetricParseError(
+                f"PYPTO_DEVICE_MAPPING_JSON entry {logical_rank} requires an integer "
+                "physical_device_id"
+            )
+        if not isinstance(serial, str) or not serial.strip():
+            raise MetricParseError(
+                f"PYPTO_DEVICE_MAPPING_JSON entry {logical_rank} requires a non-empty "
+                "serial"
+            )
+        entries.append(
+            {
+                "logical_rank": logical_rank,
+                "requested_device_id": requested_device_id,
+                "physical_device_id": physical_device_id,
+                "serial": serial,
+            }
+        )
+    physical_ids = [entry["physical_device_id"] for entry in entries]
+    serials = [entry["serial"] for entry in entries]
+    if len(set(physical_ids)) != len(physical_ids) or len(set(serials)) != len(serials):
+        raise MetricParseError(
+            "PYPTO_DEVICE_MAPPING_JSON physical IDs and serials must be unique"
+        )
+    return entries, "PYPTO_DEVICE_MAPPING_JSON"
+
+
+def _source_provenance(repo_root: Path) -> dict[str, Any]:
+    status = _git(repo_root, "status", "--porcelain=v1", "--untracked-files=all") or ""
+    status_bytes = status.encode("utf-8")
+    branch = _git(repo_root, "branch", "--show-current")
+    return {
+        "commit": _git(repo_root, "rev-parse", "HEAD"),
+        "tree": _git(repo_root, "rev-parse", "HEAD^{tree}"),
+        "branch": branch or None,
+        "clean": status == "",
+        "status_sha256": hashlib.sha256(status_bytes).hexdigest(),
+        "status_porcelain": status.splitlines(),
+    }
+
+
+def _toolchain_provenance() -> dict[str, Any]:
+    pypto_info = _distribution_info("pypto")
+    simpler_info = _distribution_info("simpler")
+    return {
+        "epoch": os.environ.get("PYPTO_TOOLCHAIN_EPOCH", "unassigned"),
+        "python": sys.version.split()[0],
+        "pypto_sha": _distribution_commit(pypto_info, "pypto"),
+        "simpler_sha": _distribution_commit(simpler_info, "simpler"),
+        "pto_isa_sha": _path_repo_sha(os.environ.get("PTO_ISA_ROOT")),
+        "pypto": pypto_info,
+        "simpler": simpler_info,
+        "torch": _distribution_info("torch"),
+        "torch_npu": _distribution_info("torch-npu"),
+        "pto_isa": _pto_isa_provenance(),
+        "ptoas": _ptoas_provenance(),
+        "cann": _cann_provenance(),
+        "driver": _system_component(Path("/usr/local/Ascend/driver/version.info")),
+        "firmware": _system_component(Path("/usr/local/Ascend/firmware/version.info")),
+        "host": {
+            "hostname": socket.gethostname(),
+            "kernel": platform.release(),
+            "architecture": platform.machine(),
+        },
+    }
+
+
+def assemble_suite_result(
+    *,
+    manifest: dict[str, Any],
+    repo_root: Path,
+    device_id: int,
+    started_at_utc: str,
+    finished_at_utc: str,
+    cases: list[dict[str, Any]],
+    output_dir: Path | None = None,
+) -> dict[str, Any]:
+    """Assemble the stable tracker-facing suite result."""
+
+    expected_devices = manifest["ordered_devices"]
+    if expected_devices != [device_id]:
+        raise MetricParseError(
+            f"official metrics require ordered devices {expected_devices}, got {[device_id]}"
+        )
+    known_case_ids = [case["case_id"] for case in manifest["cases"]]
+    actual_case_ids = [case.get("case_id") for case in cases]
+    if not actual_case_ids or len(set(actual_case_ids)) != len(actual_case_ids):
+        raise MetricParseError("suite result case IDs must be present and unique")
+    if any(case_id not in known_case_ids for case_id in actual_case_ids):
+        raise MetricParseError(f"suite result contains unknown cases: {actual_case_ids}")
+
+    canonical_manifest = json.dumps(manifest, sort_keys=True, separators=(",", ":")).encode()
+    complete = set(actual_case_ids) == set(known_case_ids)
+    suite_status = (
+        "pass" if complete and all(case.get("status") == "pass" for case in cases) else "fail"
+    )
+    physical_mapping, physical_mapping_source = _physical_mapping([device_id])
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "suite_id": manifest["suite_id"],
+        "lane_id": manifest["lane_id"],
+        "contract_id": manifest["contract_id"],
+        "contract": {
+            "id": manifest["contract_id"],
+            "spec_hash": hashlib.sha256(canonical_manifest).hexdigest(),
+        },
+        "status": suite_status,
+        "coverage": {
+            "complete": complete,
+            "required_case_ids": known_case_ids,
+            "selected_case_ids": actual_case_ids,
+        },
+        "source": _source_provenance(repo_root),
+        "toolchain": _toolchain_provenance(),
+        "device": {
+            "epoch": os.environ.get("PYPTO_DEVICE_EPOCH", "unassigned"),
+            "platform": manifest["platform"],
+            "ordered_devices": [device_id],
+            "mapping_basis": "ordered_logical_rank_to_ordered_device_set",
+            "task_device": os.environ.get("TASK_DEVICE"),
+            "ascend_rt_visible_devices": os.environ.get("ASCEND_RT_VISIBLE_DEVICES"),
+            "npu_smi": _capture_npu_smi(output_dir),
+            "physical_mapping": physical_mapping,
+            "physical_mapping_available": bool(physical_mapping),
+            "physical_mapping_source": physical_mapping_source,
+        },
+        "sampling": {
+            **manifest["sampling"],
+            "python_hash_seed": manifest["sampling"]["seed"],
+        },
+        "started_at_utc": started_at_utc,
+        "finished_at_utc": finished_at_utc,
+        "cases": cases,
+    }
+
+
+def _read_json(path: Path) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        raise MetricParseError(f"cannot load JSON {path}: {error}") from error
+
+
+def _parse_command(args: argparse.Namespace) -> int:
+    manifest = load_manifest(args.manifest)
+    try:
+        log_text = args.log.read_text(encoding="utf-8")
+    except OSError as error:
+        log_text = ""
+        process_rc = args.process_rc or 1
+        read_error = MetricParseError(f"cannot read benchmark log {args.log}: {error}")
+    else:
+        process_rc = args.process_rc
+        read_error = None
+    result, error = build_case_result(
+        log_text,
+        manifest=manifest,
+        case_id=args.case,
+        device_id=args.device,
+        process_rc=process_rc,
+    )
+    if read_error is not None:
+        result["validation"]["error"] = str(read_error)
+        error = read_error
+    _json_dump(args.output, result)
+    if args.journal is not None:
+        _append_jsonl(args.journal, result)
+    if error is not None:
+        print(f"ERROR: {args.case}: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+def _suite_command(args: argparse.Namespace) -> int:
+    manifest = load_manifest(args.manifest)
+    cases = [_read_json(path) for path in args.case_result]
+    result = assemble_suite_result(
+        manifest=manifest,
+        repo_root=args.repo_root.resolve(),
+        device_id=args.device,
+        started_at_utc=args.started_at_utc,
+        finished_at_utc=args.finished_at_utc,
+        cases=cases,
+        output_dir=args.output.parent.resolve(),
+    )
+    _json_dump(args.output, result)
+    return 0 if result["status"] == "pass" else 1
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    parse_parser = subparsers.add_parser("parse", help="parse one case log")
+    parse_parser.add_argument("--manifest", type=Path, required=True)
+    parse_parser.add_argument("--case", required=True)
+    parse_parser.add_argument("--log", type=Path, required=True)
+    parse_parser.add_argument("--device", type=int, required=True)
+    parse_parser.add_argument("--process-rc", type=int, required=True)
+    parse_parser.add_argument("--output", type=Path, required=True)
+    parse_parser.add_argument("--journal", type=Path)
+    parse_parser.set_defaults(handler=_parse_command)
+
+    suite_parser = subparsers.add_parser("suite", help="assemble suite-result.json")
+    suite_parser.add_argument("--manifest", type=Path, required=True)
+    suite_parser.add_argument("--repo-root", type=Path, required=True)
+    suite_parser.add_argument("--device", type=int, required=True)
+    suite_parser.add_argument("--started-at-utc", default=_utc_now())
+    suite_parser.add_argument("--finished-at-utc", default=_utc_now())
+    suite_parser.add_argument("--case-result", type=Path, action="append", required=True)
+    suite_parser.add_argument("--output", type=Path, required=True)
+    suite_parser.set_defaults(handler=_suite_command)
+
+    args = parser.parse_args()
+    try:
+        return args.handler(args)
+    except MetricParseError as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/perf/run_dsv4_main_attention_perf.sh
+++ b/tools/perf/run_dsv4_main_attention_perf.sh
@@ -1,0 +1,239 @@
+#!/usr/bin/env bash
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+set -euo pipefail
+
+readonly SCRIPT_PATH="$(realpath "${BASH_SOURCE[0]}")"
+readonly REPO_ROOT="$(git -C "$(dirname "$SCRIPT_PATH")/../.." rev-parse --show-toplevel)"
+readonly MANIFEST="$REPO_ROOT/tools/perf/suites/dsv4_main_attention.json"
+readonly PARSER="$REPO_ROOT/tools/perf/dsv4_main_attention_metrics.py"
+readonly SEED_LAUNCHER="$REPO_ROOT/tools/perf/deterministic_run.py"
+readonly PLATFORM="a2a3"
+readonly CANONICAL_DEVICE="4"
+readonly SEED="1807"
+readonly ROUNDS="100"
+readonly WARMUP="5"
+
+export PYTHONPATH="$REPO_ROOT${PYTHONPATH:+:$PYTHONPATH}"
+export PYTHONDONTWRITEBYTECODE=1
+
+DEVICE_ID="${TASK_DEVICE:-}"
+OUTPUT_DIR=""
+SELECTED_CASE="all"
+PYTHON_BIN="${PYPTO_PERF_PYTHON:-python}"
+DRY_RUN=0
+
+usage() {
+    cat <<'EOF'
+Usage: tools/perf/run_dsv4_main_attention_perf.sh [OPTIONS]
+
+Run the fixed DeepSeek-V4 Flash CSA/HCA/SWA main-branch performance suite.
+The official contract uses A2/A3 device 4, seed 1807, 5 warmup rounds, 100
+measured rounds, raw samples, the effective_us median, and numerical PASS for
+kv_cache and x_out. The runner never changes Git state or allocates a device.
+
+Options:
+  --device ID          Must be 4. Defaults to TASK_DEVICE.
+  --output-dir DIR     New result directory. Defaults below build_output/.
+  --case NAME          all, attention-csa, attention-hca, or attention-swa.
+  --python PATH        Python executable (default: PYPTO_PERF_PYTHON or python).
+  --dry-run            Print the resolved contract and commands without running.
+  -h, --help           Show this help.
+
+Example inside an existing task-submit allocation:
+  tools/perf/run_dsv4_main_attention_perf.sh --device "$TASK_DEVICE"
+EOF
+}
+
+die() {
+    printf 'ERROR: %s\n' "$*" >&2
+    exit 2
+}
+
+while [[ "$#" -gt 0 ]]; do
+    case "$1" in
+        --device)
+            [[ "$#" -ge 2 ]] || die "--device requires a value"
+            DEVICE_ID="$2"
+            shift 2
+            ;;
+        --output-dir)
+            [[ "$#" -ge 2 ]] || die "--output-dir requires a value"
+            OUTPUT_DIR="$2"
+            shift 2
+            ;;
+        --case)
+            [[ "$#" -ge 2 ]] || die "--case requires a value"
+            SELECTED_CASE="$2"
+            shift 2
+            ;;
+        --python)
+            [[ "$#" -ge 2 ]] || die "--python requires a value"
+            PYTHON_BIN="$2"
+            shift 2
+            ;;
+        --dry-run)
+            DRY_RUN=1
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            die "unknown option: $1"
+            ;;
+    esac
+done
+
+case "$SELECTED_CASE" in
+    all|attention-csa|attention-hca|attention-swa) ;;
+    *) die "unsupported --case: $SELECTED_CASE" ;;
+esac
+[[ -n "$DEVICE_ID" ]] || die "--device is required outside an existing allocation"
+[[ "$DEVICE_ID" == "$CANONICAL_DEVICE" ]] || \
+    die "official main-attention metrics require --device $CANONICAL_DEVICE"
+[[ -f "$MANIFEST" ]] || die "suite manifest not found: $MANIFEST"
+[[ -f "$PARSER" ]] || die "metric parser not found: $PARSER"
+[[ -f "$SEED_LAUNCHER" ]] || die "deterministic launcher not found: $SEED_LAUNCHER"
+
+if [[ -z "$OUTPUT_DIR" ]]; then
+    OUTPUT_DIR="$REPO_ROOT/build_output/dsv4_main_attention_perf/$(date -u '+%Y%m%dT%H%M%SZ')"
+fi
+
+case_entrypoint() {
+    case "$1" in
+        attention-csa) printf '%s\n' "models/deepseek_v4_flash_mtp/decode_csa.py" ;;
+        attention-hca) printf '%s\n' "models/deepseek_v4_flash_mtp/decode_hca.py" ;;
+        attention-swa) printf '%s\n' "models/deepseek_v4_flash_mtp/decode_swa.py" ;;
+        *) die "unknown case: $1" ;;
+    esac
+}
+
+if [[ "$SELECTED_CASE" == "all" ]]; then
+    CASES=(attention-csa attention-hca attention-swa)
+else
+    CASES=("$SELECTED_CASE")
+fi
+
+print_command() {
+    printf '  '
+    printf '%q ' "$@"
+    printf '\n'
+}
+
+build_command() {
+    local case_id="$1"
+    local entrypoint
+    entrypoint="$(case_entrypoint "$case_id")"
+    CASE_COMMAND=(
+        "$PYTHON_BIN" "$SEED_LAUNCHER" --seed "$SEED"
+        "$REPO_ROOT/$entrypoint"
+        -p "$PLATFORM" -d "$DEVICE_ID"
+        --start-pos 8192 --enable-l2-swimlane 0
+    )
+}
+
+if [[ "$DRY_RUN" -eq 1 ]]; then
+    printf 'Suite: dsv4-main-attention\n'
+    printf 'Contract: dsv4-main-attention-v1\n'
+    printf 'Manifest: %s\n' "$MANIFEST"
+    printf 'Output: %s/suite-result.json\n' "$OUTPUT_DIR"
+    printf 'Device/platform: %s/%s\n' "$DEVICE_ID" "$PLATFORM"
+    printf 'Sampling: seed=%s warmup=%s rounds=%s raw=1\n' "$SEED" "$WARMUP" "$ROUNDS"
+    for case_id in "${CASES[@]}"; do
+        printf '%s:\n' "$case_id"
+        build_command "$case_id"
+        print_command env \
+            "PYTHONHASHSEED=$SEED" \
+            PYPTO_BENCH=1 PYPTO_BENCH_RAW=1 \
+            "PYPTO_BENCH_ROUNDS=$ROUNDS" "PYPTO_BENCH_WARMUP=$WARMUP" \
+            PYPTO_RUNTIME_LOG=error SIMPLER_DEVICE_STRACE_ENABLE=1 \
+            PTO2_RING_TASK_WINDOW=262144 PTO2_RING_DEP_POOL=262144 \
+            PTO2_RING_HEAP=2147483648 \
+            "${CASE_COMMAND[@]}"
+    done
+    exit 0
+fi
+
+if [[ "$PYTHON_BIN" == */* ]]; then
+    [[ -x "$PYTHON_BIN" ]] || die "Python executable not found: $PYTHON_BIN"
+else
+    command -v "$PYTHON_BIN" >/dev/null 2>&1 || die "Python executable not found: $PYTHON_BIN"
+fi
+[[ -n "${PYPTO_DEVICE_MAPPING_JSON:-}" ]] || \
+    die "PYPTO_DEVICE_MAPPING_JSON is required for a measured suite"
+[[ ! -e "$OUTPUT_DIR" ]] || die "output directory already exists: $OUTPUT_DIR"
+mkdir -p "$OUTPUT_DIR/logs" "$OUTPUT_DIR/cases" "$OUTPUT_DIR/build"
+OUTPUT_DIR="$(realpath "$OUTPUT_DIR")"
+readonly STARTED_AT_UTC="$(date -u --iso-8601=seconds)"
+export TASK_DEVICE="$DEVICE_ID"
+
+failures=0
+CASE_RESULT_ARGS=()
+for case_id in "${CASES[@]}"; do
+    log_path="$OUTPUT_DIR/logs/$case_id.log"
+    case_result="$OUTPUT_DIR/cases/$case_id.json"
+    build_command "$case_id"
+    printf '[PERF SUITE] %s\n' "$case_id"
+    print_command "${CASE_COMMAND[@]}"
+
+    set +e
+    PYTHONHASHSEED="$SEED" \
+        PYPTO_PERF_SEED="$SEED" \
+        PYPTO_BENCH=1 \
+        PYPTO_BENCH_RAW=1 \
+        PYPTO_BENCH_ROUNDS="$ROUNDS" \
+        PYPTO_BENCH_WARMUP="$WARMUP" \
+        PYPTO_RUNTIME_LOG=error \
+        SIMPLER_DEVICE_STRACE_ENABLE=1 \
+        PTO2_RING_TASK_WINDOW=262144 \
+        PTO2_RING_DEP_POOL=262144 \
+        PTO2_RING_HEAP=2147483648 \
+        PYPTO_PROG_BUILD_DIR="$OUTPUT_DIR/build/$case_id" \
+        "${CASE_COMMAND[@]}" 2>&1 | tee "$log_path"
+    process_rc="${PIPESTATUS[0]}"
+    set -e
+
+    set +e
+    "$PYTHON_BIN" "$PARSER" parse \
+        --manifest "$MANIFEST" \
+        --case "$case_id" \
+        --log "$log_path" \
+        --device "$DEVICE_ID" \
+        --process-rc "$process_rc" \
+        --output "$case_result" \
+        --journal "$OUTPUT_DIR/case-results.jsonl"
+    parser_rc="$?"
+    set -e
+    CASE_RESULT_ARGS+=(--case-result "$case_result")
+    if [[ "$process_rc" -ne 0 || "$parser_rc" -ne 0 ]]; then
+        failures=$((failures + 1))
+    fi
+done
+
+readonly FINISHED_AT_UTC="$(date -u --iso-8601=seconds)"
+set +e
+"$PYTHON_BIN" "$PARSER" suite \
+    --manifest "$MANIFEST" \
+    --repo-root "$REPO_ROOT" \
+    --device "$DEVICE_ID" \
+    --started-at-utc "$STARTED_AT_UTC" \
+    --finished-at-utc "$FINISHED_AT_UTC" \
+    "${CASE_RESULT_ARGS[@]}" \
+    --output "$OUTPUT_DIR/suite-result.json"
+suite_rc="$?"
+set -e
+
+printf 'Suite result: %s\n' "$OUTPUT_DIR/suite-result.json"
+if [[ "$failures" -ne 0 || "$suite_rc" -ne 0 ]]; then
+    printf 'ERROR: %s case(s) failed execution or metric validation.\n' "$failures" >&2
+    exit 1
+fi

--- a/tools/perf/suites/dsv4_main_attention.json
+++ b/tools/perf/suites/dsv4_main_attention.json
@@ -1,0 +1,112 @@
+{
+  "schema_version": 1,
+  "suite_id": "dsv4-main-attention",
+  "lane_id": "lib-main-attention",
+  "contract_id": "dsv4-main-attention-v1",
+  "platform": "a2a3",
+  "ordered_devices": [4],
+  "sampling": {
+    "seed": 1807,
+    "rounds": 100,
+    "warmup": 5,
+    "raw": true
+  },
+  "workload": {
+    "batch": 4,
+    "sequence": 2,
+    "tokens": 8,
+    "start_pos": 8192,
+    "enable_l2_swimlane": 0
+  },
+  "environment": {
+    "PTO2_RING_TASK_WINDOW": "262144",
+    "PTO2_RING_DEP_POOL": "262144",
+    "PTO2_RING_HEAP": "2147483648",
+    "PYPTO_BENCH": "1",
+    "PYPTO_BENCH_RAW": "1",
+    "PYPTO_BENCH_ROUNDS": "100",
+    "PYPTO_BENCH_WARMUP": "5",
+    "PYPTO_RUNTIME_LOG": "error",
+    "SIMPLER_DEVICE_STRACE_ENABLE": "1"
+  },
+  "cases": [
+    {
+      "case_id": "attention-csa",
+      "entrypoint": "models/deepseek_v4_flash_mtp/decode_csa.py",
+      "arguments": [
+        "-p", "a2a3", "-d", "4", "--start-pos", "8192",
+        "--enable-l2-swimlane", "0"
+      ],
+      "metric": {
+        "name": "effective_us",
+        "unit": "us",
+        "aggregation": "median",
+        "rank_policy": "single_rank"
+      },
+      "validation_outputs": [
+        {
+          "name": "kv_cache",
+          "shape": [128, 128, 1, 512],
+          "dtype": "torch.bfloat16"
+        },
+        {
+          "name": "x_out",
+          "shape": [8, 4, 4096],
+          "dtype": "torch.float32"
+        }
+      ]
+    },
+    {
+      "case_id": "attention-hca",
+      "entrypoint": "models/deepseek_v4_flash_mtp/decode_hca.py",
+      "arguments": [
+        "-p", "a2a3", "-d", "4", "--start-pos", "8192",
+        "--enable-l2-swimlane", "0"
+      ],
+      "metric": {
+        "name": "effective_us",
+        "unit": "us",
+        "aggregation": "median",
+        "rank_policy": "single_rank"
+      },
+      "validation_outputs": [
+        {
+          "name": "kv_cache",
+          "shape": [128, 128, 1, 512],
+          "dtype": "torch.bfloat16"
+        },
+        {
+          "name": "x_out",
+          "shape": [8, 4, 4096],
+          "dtype": "torch.float32"
+        }
+      ]
+    },
+    {
+      "case_id": "attention-swa",
+      "entrypoint": "models/deepseek_v4_flash_mtp/decode_swa.py",
+      "arguments": [
+        "-p", "a2a3", "-d", "4", "--start-pos", "8192",
+        "--enable-l2-swimlane", "0"
+      ],
+      "metric": {
+        "name": "effective_us",
+        "unit": "us",
+        "aggregation": "median",
+        "rank_policy": "single_rank"
+      },
+      "validation_outputs": [
+        {
+          "name": "kv_cache",
+          "shape": [128, 128, 1, 512],
+          "dtype": "torch.bfloat16"
+        },
+        {
+          "name": "x_out",
+          "shape": [8, 4, 4096],
+          "dtype": "torch.float32"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
- Add deterministic DeepSeek V4 CSA, HCA, and SWA performance contracts on designated card 4 with five warmups, 100 raw samples, and fail-closed numerical validation.
- Emit suite JSON that pins source tree, toolchain, device mapping, workload, sample-selection, and validation provenance for external history ingestion.
- Document isolated source, toolchain, device, and branch-lineage epochs plus shadow-mode regression calibration.
- Publish the supplied W8A8 PyPTO and AscendC snapshot in the fixed five-column report format and document its comparison limits.