### PR TITLE
Fix: retire DeepSeek V4 Pro prefill MoE signal counts per dispatch

### DIFF
--- a/models/deepseek_v4_pro/prefill_layer.py
+++ b/models/deepseek_v4_pro/prefill_layer.py
@@ -431,6 +431,66 @@ def prefill_layer_core(
             # request's physical span is rounded up to whole-T tiles, so a
             # full-T write is safe even for a partial logical tail tile.
             x_next = pl.assemble(x_next, x_next_tile, [tile_base, 0, 0])
+
+    # Retire this dispatch's MoE signal counts before the next dispatch of the
+    # same graph (benchmark rounds, serving steady state): the windows are
+    # retained across dispatches and the counters are monotonic, so without
+    # this every >=-epoch wait of round 2+ is pre-satisfied by the previous
+    # rounds' counts and the inter-rank reuse throttle goes dead.
+    #
+    # The reset is an atomic SUBTRACTION of exactly the credits this
+    # dispatch's epochs deposit — not a write of zero. A zero-write would race
+    # any credit still in flight (the final epoch's moe_consumed notifies post
+    # after the reduce with no in-dispatch reader, and may land here after a
+    # bare clear, leaking counts into the next round — the flaw in the bare
+    # clear_moe_signals pattern). AtomicAdd commutes: whether a trailing
+    # credit lands before or after the matching subtraction, every row settles
+    # at exactly zero, with at most a transient negative that the signed >=
+    # waits of the next dispatch simply outwait. No quiesce wait is needed;
+    # the anchor read only orders this task behind the final output so the
+    # subtraction cannot run ahead of this dispatch's own >=-epoch waits.
+    # Per-epoch credit slopes (see moe.py): arrived remote rows 1, data_arrived
+    # remote rows N_LOCAL, combine_arrived remote rows N_LOCAL + 1 and self
+    # row 1; the self rows of arrived / data_arrived are never written.
+    last_req = user_batch - 1
+    last_tiles = (pl.tensor.read(chunk_lens, [last_req]) + TOK_TILE - 1) // TOK_TILE
+    total_epochs = pl.cast(pl.tensor.read(chunk_tile_offsets, [last_req]), pl.INDEX) \
+        + pl.cast(last_tiles, pl.INDEX)
+    neg_epochs = pl.cast(0 - total_epochs, pl.INT32)
+    neg_data = pl.cast(0 - total_epochs * N_LOCAL, pl.INT32)
+    neg_combine = pl.cast(0 - total_epochs * (N_LOCAL + 1), pl.INT32)
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="moe_signal_retire"):
+        _x_next_anchor = pl.read(x_next, [0, 0, 0])
+        pld.system.notify(
+            target=combine_arrived,
+            peer=my_rank,
+            offsets=[my_rank, 0],
+            value=neg_epochs,
+            op=pld.NotifyOp.AtomicAdd,
+        )
+        for src in pl.range(N_RANKS):
+            if src != my_rank:
+                pld.system.notify(
+                    target=arrived,
+                    peer=my_rank,
+                    offsets=[src, 0],
+                    value=neg_epochs,
+                    op=pld.NotifyOp.AtomicAdd,
+                )
+                pld.system.notify(
+                    target=data_arrived,
+                    peer=my_rank,
+                    offsets=[src, 0],
+                    value=neg_data,
+                    op=pld.NotifyOp.AtomicAdd,
+                )
+                pld.system.notify(
+                    target=combine_arrived,
+                    peer=my_rank,
+                    offsets=[src, 0],
+                    value=neg_combine,
+                    op=pld.NotifyOp.AtomicAdd,
+                )
     return x_next
 
 


### PR DESCRIPTION
- prefill_layer_core now ends each dispatch by retiring that dispatch's
  MoE signal credits: an atomic subtraction of the exact per-epoch
  counts (arrived 1, data_arrived N_LOCAL, combine_arrived N_LOCAL + 1,
  self combine_arrived 1) from the CommDomain counters, so the next
  dispatch of the same graph starts from zero.
- The A5 benchmark loop and serving steady state dispatch one prepared
  graph repeatedly with persistent windows; the counters are monotonic
  and prefill_layer recomputes moe_epoch from 1 every dispatch, so from
  round 2 on every >=-epoch wait, including the reuse throttle at
  moe.py:114-137, was pre-satisfied and inter-rank flow control died.
  The leading rank overran dispatch/combine windows around dispatch 9
  and the AIV cores trapped (deterministic in the daily A5 sweep).
- Subtraction rather than a zero-write: the final epoch's moe_consumed
  notifies post after the reduce with no in-dispatch reader, so a
  peer's trailing credit can land after a bare clear and leak into the
  next round; AtomicAdd commutes, so every row settles at exactly zero
  with at most a transient negative the next round's signed >= waits
  outwait. The anchor read orders the retire behind this dispatch's own
  >=-epoch waits, so no quiesce wait is needed.
- Verified on 2-card A5: full validation passes; a 20-round benchmark
  (26 consecutive dispatches) completes cleanly (effective_us min=21668
  median=21875 mean=21883 max=22140) where the unfixed kernel trapped
  on the 9th dispatch; ruff, header/language lint, and all 232
  tests/golden unit tests pass.

One file, pure insertion, no harness changes. Longer CI-default 100
round sweeps can still hit a separate pre-existing intermittent device
trap on the composed prefill graph (different engine and kernel pc than
this protocol trap, reproducible without this change) and should be
tracked as its own issue; validation itself is stable.
