### PR TITLE
Perf: warm DeepSeek V4 attention weights into L2 via SDMA CMO

### DIFF
--- a/models/deepseek_v4_flash_mtp/decode_csa.py
+++ b/models/deepseek_v4_flash_mtp/decode_csa.py
@@ -213,6 +213,27 @@ def attention_csa(
 
     x_normed_t = pl.create_tensor([T, D], dtype=pl.BF16)
     rms_tid = rms_norm(x_mixed, attn_norm_w, x_normed_t)
+    # SDMA CMO L2 warm of this layer's attention weights, in deadline order.
+    wq_a_flat = pl.reshape(wq_a, [D * Q_LORA])
+    wkv_flat = pl.reshape(wkv, [D * HEAD_DIM])
+    idx_wq_b_flat = pl.reshape(idx_wq_b, [Q_LORA * IDX_N_HEADS * IDX_HEAD_DIM])
+    weights_proj_flat = pl.reshape(weights_proj, [D * IDX_N_HEADS])
+    inner_wkv_flat = pl.reshape(inner_wkv, [INNER_OUT_DIM * D])
+    inner_wgate_flat = pl.reshape(inner_wgate, [INNER_OUT_DIM * D])
+    wq_b_flat = pl.reshape(wq_b, [Q_LORA * H * HEAD_DIM])
+    wo_a_flat = pl.reshape(wo_a, [O_GROUPS * O_LORA * O_GROUP_IN])
+    wo_b_flat = pl.reshape(wo_b, [D * O_GROUPS * O_LORA])
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefetch_attn_w", deps=[rms_tid]):
+        warm_ctx = pl.prefetch.make_context()
+        pl.prefetch.async_prefetch(wq_a_flat, warm_ctx)
+        pl.prefetch.async_prefetch(wkv_flat, warm_ctx)
+        pl.prefetch.async_prefetch(idx_wq_b_flat, warm_ctx)
+        pl.prefetch.async_prefetch(weights_proj_flat, warm_ctx)
+        pl.prefetch.async_prefetch(inner_wkv_flat, warm_ctx)
+        pl.prefetch.async_prefetch(inner_wgate_flat, warm_ctx)
+        pl.prefetch.async_prefetch(wq_b_flat, warm_ctx)
+        pl.prefetch.async_prefetch(wo_a_flat, warm_ctx)
+        pl.prefetch.async_prefetch(wo_b_flat, warm_ctx)
     # rms_norm fans out to qr_proj_matmul (critical path), kv_proj_matmul, kv_score_proj
     # and weights_proj. The latter three take this barrier instead of racing the first:
     # the dummy resolves one hop after rms_norm, so qr_proj_matmul is dispatched first.

--- a/models/deepseek_v4_flash_mtp/decode_hca.py
+++ b/models/deepseek_v4_flash_mtp/decode_hca.py
@@ -178,6 +178,19 @@ def attention_hca(
 
     x_normed = pl.create_tensor([T, D], dtype=pl.BF16)
     rms_tid = rms_norm(x_mixed, attn_norm_w, x_normed)
+    # SDMA CMO L2 warm of this layer's attention weights, in deadline order.
+    wq_a_flat = pl.reshape(wq_a, [D * Q_LORA])
+    wkv_flat = pl.reshape(wkv, [D * HEAD_DIM])
+    wq_b_flat = pl.reshape(wq_b, [Q_LORA * H * HEAD_DIM])
+    wo_a_flat = pl.reshape(wo_a, [O_GROUPS * O_LORA * O_GROUP_IN])
+    wo_b_flat = pl.reshape(wo_b, [D * O_GROUPS * O_LORA])
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefetch_attn_w", deps=[rms_tid]):
+        warm_ctx = pl.prefetch.make_context()
+        pl.prefetch.async_prefetch(wq_a_flat, warm_ctx)
+        pl.prefetch.async_prefetch(wkv_flat, warm_ctx)
+        pl.prefetch.async_prefetch(wq_b_flat, warm_ctx)
+        pl.prefetch.async_prefetch(wo_a_flat, warm_ctx)
+        pl.prefetch.async_prefetch(wo_b_flat, warm_ctx)
     # Defers kv_proj_matmul one hop behind rms_norm so qr_proj_matmul dispatches first.
     late_dep = pl.system.task_dummy(deps=[rms_tid])
     q = pl.create_tensor([T, H, HEAD_DIM], dtype=pl.BF16)

--- a/models/deepseek_v4_flash_mtp/decode_swa.py
+++ b/models/deepseek_v4_flash_mtp/decode_swa.py
@@ -124,6 +124,19 @@ def attention_swa(
 
     x_normed_t = pl.create_tensor([T, D], dtype=pl.BF16)
     rms_tid = rms_norm(x_mixed, attn_norm_w, x_normed_t)
+    # SDMA CMO L2 warm of this layer's attention weights, in deadline order.
+    wq_a_flat = pl.reshape(wq_a, [D * Q_LORA])
+    wkv_flat = pl.reshape(wkv, [D * HEAD_DIM])
+    wq_b_flat = pl.reshape(wq_b, [Q_LORA * H * HEAD_DIM])
+    wo_a_flat = pl.reshape(wo_a, [O_GROUPS * O_LORA * O_GROUP_IN])
+    wo_b_flat = pl.reshape(wo_b, [D * O_GROUPS * O_LORA])
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefetch_attn_w", deps=[rms_tid]):
+        warm_ctx = pl.prefetch.make_context()
+        pl.prefetch.async_prefetch(wq_a_flat, warm_ctx)
+        pl.prefetch.async_prefetch(wkv_flat, warm_ctx)
+        pl.prefetch.async_prefetch(wq_b_flat, warm_ctx)
+        pl.prefetch.async_prefetch(wo_a_flat, warm_ctx)
+        pl.prefetch.async_prefetch(wo_b_flat, warm_ctx)
     # Defers kv_proj_matmul one hop behind rms_norm so qr_proj_matmul dispatches first.
     late_dep = pl.system.task_dummy(deps=[rms_tid])
     q = pl.create_tensor([T, H, HEAD_DIM], dtype=pl.BF16)


### PR DESCRIPTION
- Each decode attention layer streams its whole weight set from HBM
  once per forward, and in decode_fwd that traffic lands cold: the MoE
  between two layers pushes 427.8 MB through L2, so nothing an
  attention layer read survives to the next one. One SDMA CMO warm per
  layer now covers every weight the layer reads, in consumer deadline
  order (decode_swa.py, decode_hca.py, decode_csa.py).
- Anchored on rms_norm: at layer entry the cores are still busy with
  hc_pre and rope, so the warm overlaps them; anchoring later (after
  qproj_matmul or the KV-cache writeback) measured worse.
- One scope, one context: splitting the warm across two pl.at scopes
  puts two SDMA streams in flight, halving aggregate throughput (153
  vs 285 GB/s) and turning a 1.1% gain into a 0.7% loss. All weights
  or none: warming only wo_a (+0.41%) or wo_b (+0.83%) is worse than
  none - the warm costs a near-fixed ~20 us in its segment while the
  saving scales with coverage.
- Measured on decode_fwd ep2, a2a3, cards 4/6, 100 rounds after 20
  warmup, fast rank: p50 40132.0 -> 39287.9 us (-2.10%), mean -2.13%,
  min -2.66%. Per-layer blocks return to standalone speed (SWA attn
  273.6 -> 258.2, CSA attn 384.7 -> 357.2, HCA attn 290.5 -> 268.8);
  MoE is unaffected, as expected - the warm covers attention weights
  only.
- CSA also carries the indexer weights, warming 157.9 MB vs 146.9 MB
  for SWA/HCA, both inside the 192 MiB L2 - the constraint that sets
  the sign: a 268.4 MB warm set (1.33x L2) evicts itself and costs 3%.
- The warm is a cache hint only: async_prefetch has no destination, so
  dropping the scope changes no value. decode_fwd --ep 2 --compile-only
  passes.
