### PR TITLE
Perf: halve the routed-expert w2 spmd block length

### DIFF
--- a/models/deepseek_v4_flash_mtp/expert_routed.py
+++ b/models/deepseek_v4_flash_mtp/expert_routed.py
@@ -43,7 +43,7 @@ D_OUT_TILE = 256
 # line (perf_hint PH001 flagged the prior 256B store as sub-line).
 QUANT_TILE = 512
 D_OUT_TILE_ACT = 512
-W2_INNER = 4
+W2_INNER = 2
 W2_ACT_INNER = 8
 TILES_PER_EXPERT = RECV_MAX // RECV_TILE
 


### PR DESCRIPTION
- Set W2_INNER to 2 in the DeepSeek V4 Flash MTP routed expert,
  doubling the exp_w2_mm spmd block count to D / (2 * D_OUT_TILE) so
  each block covers half the output columns.

decode_fwd fastest-rank median 34550.1 -> 34027.9 us at ep2 (-1.5%)
and 36364.9 -> 35756.9 us at ep8 (-1.7%).