### PR TITLE
Revert: restore the standalone DeepSeek-V4 MoE combine scatter

### DIFF
--- a/models/deepseek_v4_flash_mtp/decode_fwd.py
+++ b/models/deepseek_v4_flash_mtp/decode_fwd.py
@@ -92,7 +92,6 @@ from config import DECODE_START_POS, FLASH as MODEL_CONFIG
 from decode_input_pack import VOCAB_DYN as EMBED_VOCAB_DYN, pack_x_hc
 from decode_metadata import N_CACHE_GROUPS, build_decode_metadata
 from moe import (
-    COMB_PAD,
     AUX_PAD,
     IDX_PAD,
     MOE_INTER,
@@ -287,7 +286,7 @@ def decode_fwd_inline(
     arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
     data_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
     routed_y_buf: pld.DistributedTensor[[N_ROUTES, D], pl.BF16],
-    combine_arrived: pld.DistributedTensor[[N_RANKS, COMB_PAD], pl.INT32],
+    combine_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
     lm_head_hidden_window: pld.DistributedTensor[[GROUP_LOGIT_ROWS, D], pl.BF16],
     lm_head_hidden_done: pld.DistributedTensor[[LM_HEAD_TP_SIZE, 1], pl.INT32],
     lm_head_logits_window: pld.DistributedTensor[[MAX_LOGIT_ROWS, LM_HEAD_VOCAB], pl.FP32],
@@ -845,7 +844,7 @@ def decode_fwd(
     arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
     data_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
     routed_y_buf: pld.DistributedTensor[[N_ROUTES, D], pl.BF16],
-    combine_arrived: pld.DistributedTensor[[N_RANKS, COMB_PAD], pl.INT32],
+    combine_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
     lm_head_hidden_window: pld.DistributedTensor[[GROUP_LOGIT_ROWS, D], pl.BF16],
     lm_head_hidden_done: pld.DistributedTensor[[LM_HEAD_TP_SIZE, 1], pl.INT32],
     lm_head_logits_window: pld.DistributedTensor[[MAX_LOGIT_ROWS, LM_HEAD_VOCAB], pl.FP32],
@@ -1044,7 +1043,7 @@ def l3_decode_fwd(
     arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
     data_arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
     routed_y_buf_buf = pld.alloc_window_buffer([N_ROUTES, D], dtype=pl.BF16)
-    combine_arrived_buf = pld.alloc_window_buffer([N_RANKS, COMB_PAD], dtype=pl.INT32)
+    combine_arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
     # The LM head owns every window and counter it touches: a peer routes into
     # logits_window while still reading its own hidden_window.
     lm_head_hidden_window_buf = pld.alloc_window_buffer(GROUP_LOGIT_ROWS * D * 2)
@@ -1060,7 +1059,7 @@ def l3_decode_fwd(
         arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32] = pld.window(arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
         data_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32] = pld.window(data_arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
         routed_y_buf: pld.DistributedTensor[[N_ROUTES, D], pl.BF16] = pld.window(routed_y_buf_buf, [N_ROUTES, D], dtype=pl.BF16)
-        combine_arrived: pld.DistributedTensor[[N_RANKS, COMB_PAD], pl.INT32] = pld.window(combine_arrived_buf, [N_RANKS, COMB_PAD], dtype=pl.INT32)
+        combine_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32] = pld.window(combine_arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
         lm_head_hidden_window = pld.window(lm_head_hidden_window_buf, [GROUP_LOGIT_ROWS, D], dtype=pl.BF16)
         lm_head_hidden_done = pld.window(lm_head_hidden_done_buf, [LM_HEAD_TP_SIZE, 1], dtype=pl.INT32)
         lm_head_logits_window = pld.window(lm_head_logits_window_buf, [MAX_LOGIT_ROWS, LM_HEAD_VOCAB], dtype=pl.FP32)

--- a/models/deepseek_v4_flash_mtp/decode_fwd_mtp.py
+++ b/models/deepseek_v4_flash_mtp/decode_fwd_mtp.py
@@ -129,7 +129,7 @@ def decode_fwd_mtp_l2(
     arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
     data_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
     routed_y_buf: pld.DistributedTensor[[N_ROUTES, D], pl.BF16],
-    combine_arrived: pld.DistributedTensor[[N_RANKS, COMB_PAD], pl.INT32],
+    combine_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
     lm_head_hidden_window: pld.DistributedTensor[[GROUP_LOGIT_ROWS, D], pl.BF16],
     lm_head_hidden_done: pld.DistributedTensor[[LM_HEAD_TP_SIZE, 1], pl.INT32],
     lm_head_logits_window: pld.DistributedTensor[[MAX_LOGIT_ROWS, LM_HEAD_VOCAB], pl.FP32],
@@ -203,7 +203,7 @@ def decode_fwd_mtp_l2(
     mtp_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
     mtp_data_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
     mtp_routed_y_buf: pld.DistributedTensor[[N_ROUTES, D], pl.BF16],
-    mtp_combine_arrived: pld.DistributedTensor[[N_RANKS, COMB_PAD], pl.INT32],
+    mtp_combine_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
     mtp_lm_head_hidden_window: pld.DistributedTensor[[GROUP_LOGIT_ROWS, D], pl.BF16],
     mtp_lm_head_hidden_done: pld.DistributedTensor[[LM_HEAD_TP_SIZE, 1], pl.INT32],
     mtp_lm_head_logits_window: pld.DistributedTensor[[MAX_LOGIT_ROWS, LM_HEAD_VOCAB], pl.FP32],
@@ -508,7 +508,7 @@ def l3_decode_fwd_mtp(
     arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
     data_arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
     routed_y_buf_buf = pld.alloc_window_buffer([N_ROUTES, D], dtype=pl.BF16)
-    combine_arrived_buf = pld.alloc_window_buffer([N_RANKS, COMB_PAD], dtype=pl.INT32)
+    combine_arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
     lm_head_hidden_window_buf = pld.alloc_window_buffer(GROUP_LOGIT_ROWS * D * 2)
     lm_head_logits_window_buf = pld.alloc_window_buffer(MAX_LOGIT_ROWS * LM_HEAD_VOCAB * 4)
     lm_head_hidden_done_buf = pld.alloc_window_buffer([LM_HEAD_TP_SIZE, 1], dtype=pl.INT32)
@@ -520,7 +520,7 @@ def l3_decode_fwd_mtp(
     mtp_arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
     mtp_data_arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
     mtp_routed_y_buf_buf = pld.alloc_window_buffer([N_ROUTES, D], dtype=pl.BF16)
-    mtp_combine_arrived_buf = pld.alloc_window_buffer([N_RANKS, COMB_PAD], dtype=pl.INT32)
+    mtp_combine_arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
     mtp_lm_head_hidden_window_buf = pld.alloc_window_buffer([GROUP_LOGIT_ROWS, D], dtype=pl.BF16)
     mtp_lm_head_logits_window_buf = pld.alloc_window_buffer(MAX_LOGIT_ROWS * LM_HEAD_VOCAB * 4)
     mtp_lm_head_hidden_done_buf = pld.alloc_window_buffer([LM_HEAD_TP_SIZE, 1], dtype=pl.INT32)
@@ -533,7 +533,7 @@ def l3_decode_fwd_mtp(
         arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32] = pld.window(arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
         data_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32] = pld.window(data_arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
         routed_y_buf: pld.DistributedTensor[[N_ROUTES, D], pl.BF16] = pld.window(routed_y_buf_buf, [N_ROUTES, D], dtype=pl.BF16)
-        combine_arrived: pld.DistributedTensor[[N_RANKS, COMB_PAD], pl.INT32] = pld.window(combine_arrived_buf, [N_RANKS, COMB_PAD], dtype=pl.INT32)
+        combine_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32] = pld.window(combine_arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
         lm_head_hidden_window = pld.window(lm_head_hidden_window_buf, [GROUP_LOGIT_ROWS, D], dtype=pl.BF16)
         lm_head_hidden_done = pld.window(lm_head_hidden_done_buf, [LM_HEAD_TP_SIZE, 1], dtype=pl.INT32)
         lm_head_logits_window = pld.window(lm_head_logits_window_buf, [MAX_LOGIT_ROWS, LM_HEAD_VOCAB], dtype=pl.FP32)
@@ -545,7 +545,7 @@ def l3_decode_fwd_mtp(
         mtp_arrived = pld.window(mtp_arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
         mtp_data_arrived = pld.window(mtp_data_arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
         mtp_routed_y_buf = pld.window(mtp_routed_y_buf_buf, [N_ROUTES, D], dtype=pl.BF16)
-        mtp_combine_arrived = pld.window(mtp_combine_arrived_buf, [N_RANKS, COMB_PAD], dtype=pl.INT32)
+        mtp_combine_arrived = pld.window(mtp_combine_arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
         mtp_lm_head_hidden_window = pld.window(mtp_lm_head_hidden_window_buf, [GROUP_LOGIT_ROWS, D], dtype=pl.BF16)
         mtp_lm_head_hidden_done = pld.window(mtp_lm_head_hidden_done_buf, [LM_HEAD_TP_SIZE, 1], dtype=pl.INT32)
         mtp_lm_head_logits_window = pld.window(mtp_lm_head_logits_window_buf, [MAX_LOGIT_ROWS, LM_HEAD_VOCAB], dtype=pl.FP32)

--- a/models/deepseek_v4_flash_mtp/decode_layer.py
+++ b/models/deepseek_v4_flash_mtp/decode_layer.py
@@ -79,7 +79,6 @@ from decode_csa import (
 )
 from config import DECODE_START_POS, FLASH as MODEL_CONFIG
 from moe import (
-    COMB_PAD,
     AUX_PAD,
     IDX_PAD,
     MOE_INTER,
@@ -196,7 +195,7 @@ def decode_layer(
     arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
     data_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
     routed_y_buf: pld.DistributedTensor[[N_ROUTES, D], pl.BF16],
-    combine_arrived: pld.DistributedTensor[[N_RANKS, COMB_PAD], pl.INT32],
+    combine_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
     layer_id: pl.Scalar[pl.INT32],
     my_rank: pl.Scalar[pl.INT32],
 ) -> pl.Tensor[[T, HC_MULT, D], pl.FP32]:
@@ -367,7 +366,7 @@ def l3_decode_layer(
     arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
     data_arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
     routed_y_buf_buf = pld.alloc_window_buffer([N_ROUTES, D], dtype=pl.BF16)
-    combine_arrived_buf = pld.alloc_window_buffer([N_RANKS, COMB_PAD], dtype=pl.INT32)
+    combine_arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
 
     for r in pl.range(pld.world_size()):
         recv_meta = pld.window(recv_meta_buf, [N_RANKS, N_LOCAL], dtype=pl.INT32)
@@ -377,7 +376,7 @@ def l3_decode_layer(
         arrived = pld.window(arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
         data_arrived = pld.window(data_arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
         routed_y_buf = pld.window(routed_y_buf_buf, [N_ROUTES, D], dtype=pl.BF16)
-        combine_arrived = pld.window(combine_arrived_buf, [N_RANKS, COMB_PAD], dtype=pl.INT32)
+        combine_arrived = pld.window(combine_arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
         decode_layer(
             x_hc[r],
             hc_attn_fn[r], hc_attn_scale[r], hc_attn_base[r],

--- a/models/deepseek_v4_flash_mtp/decode_mtp.py
+++ b/models/deepseek_v4_flash_mtp/decode_mtp.py
@@ -52,7 +52,6 @@ from lm_head import (
 )
 from lookup_embedding import VOCAB_DYN as EMBED_VOCAB_DYN, lookup_embedding
 from moe import (
-    COMB_PAD,
     AUX_PAD,
     D,
     HC_DIM,
@@ -158,7 +157,7 @@ def mtp_decode_layer_inline(
     arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
     data_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
     routed_y_buf: pld.DistributedTensor[[N_ROUTES, D], pl.BF16],
-    combine_arrived: pld.DistributedTensor[[N_RANKS, COMB_PAD], pl.INT32],
+    combine_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
     lm_head_hidden_window: pld.DistributedTensor[[GROUP_LOGIT_ROWS, D], pl.BF16],
     lm_head_hidden_done: pld.DistributedTensor[[LM_HEAD_TP_SIZE, 1], pl.INT32],
     lm_head_logits_window: pld.DistributedTensor[[MAX_LOGIT_ROWS, LM_HEAD_VOCAB], pl.FP32],
@@ -317,7 +316,7 @@ def mtp_decode_layer(
     arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
     data_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
     routed_y_buf: pld.DistributedTensor[[N_ROUTES, D], pl.BF16],
-    combine_arrived: pld.DistributedTensor[[N_RANKS, COMB_PAD], pl.INT32],
+    combine_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
     lm_head_hidden_window: pld.DistributedTensor[[GROUP_LOGIT_ROWS, D], pl.BF16],
     lm_head_hidden_done: pld.DistributedTensor[[LM_HEAD_TP_SIZE, 1], pl.INT32],
     lm_head_logits_window: pld.DistributedTensor[[MAX_LOGIT_ROWS, LM_HEAD_VOCAB], pl.FP32],
@@ -492,7 +491,7 @@ def l3_mtp_decode_layer(
     arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
     data_arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
     routed_y_buf_buf = pld.alloc_window_buffer([N_ROUTES, D], dtype=pl.BF16)
-    combine_arrived_buf = pld.alloc_window_buffer([N_RANKS, COMB_PAD], dtype=pl.INT32)
+    combine_arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
     lm_head_hidden_window_buf = pld.alloc_window_buffer([GROUP_LOGIT_ROWS, D], dtype=pl.BF16)
     lm_head_logits_window_buf = pld.alloc_window_buffer(MAX_LOGIT_ROWS * LM_HEAD_VOCAB * 4)
     lm_head_hidden_done_buf = pld.alloc_window_buffer([LM_HEAD_TP_SIZE, 1], dtype=pl.INT32)
@@ -506,7 +505,7 @@ def l3_mtp_decode_layer(
         arrived = pld.window(arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
         data_arrived = pld.window(data_arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
         routed_y_buf = pld.window(routed_y_buf_buf, [N_ROUTES, D], dtype=pl.BF16)
-        combine_arrived = pld.window(combine_arrived_buf, [N_RANKS, COMB_PAD], dtype=pl.INT32)
+        combine_arrived = pld.window(combine_arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
         lm_head_hidden_window = pld.window(lm_head_hidden_window_buf, [GROUP_LOGIT_ROWS, D], dtype=pl.BF16)
         lm_head_hidden_done = pld.window(lm_head_hidden_done_buf, [LM_HEAD_TP_SIZE, 1], dtype=pl.INT32)
         lm_head_logits_window = pld.window(lm_head_logits_window_buf, [MAX_LOGIT_ROWS, LM_HEAD_VOCAB], dtype=pl.FP32)

--- a/models/deepseek_v4_flash_mtp/expert_routed.py
+++ b/models/deepseek_v4_flash_mtp/expert_routed.py
@@ -6,25 +6,17 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-# ci: devices=1  # CI: single-rank L3 run; the fused scatter needs a window
-"""DeepSeek-V4 MoE routed local expert compute (decode, EP).
+"""DeepSeek-V4 MoE routed local expert compute (decode, EP single-card).
 
 Only the routed-expert path lives here. The shared expert was split out
 into ``expert_shared.py``; both kernels are composed in ``moe.py``.
-
-The MoE combine scatter is fused into this kernel: ``exp_w2_act`` pushes each
-activated row to its origin rank's ``routed_y_buf`` and bumps that rank's
-arrival counter, so a row starts crossing the fabric while the rest of the
-expert grid is still in the W2 GEMM. ``moe.combine`` keeps only the arrival
-wait and the dense reduce.
 """
 
 
 import pypto.language as pl
-import pypto.language.distributed as pld
 
 from config import (FLASH as M, DECODE_BATCH, DECODE_SEQ, INT8_SCALE_MAX, INT8_AMAX_EPS,
-                    EP_WORLD_SIZE, MOE_TOKENS, RECV_MAX)
+                    EP_WORLD_SIZE, RECV_MAX)
 
 
 # model config
@@ -55,44 +47,35 @@ W2_INNER = 2
 W2_ACT_INNER = 8
 TILES_PER_EXPERT = RECV_MAX // RECV_TILE
 
-# Fused-combine route ids index routed_y_buf, which is one route row per (token,
-# topk slot) on the origin rank.
-N_ROUTES = MOE_TOKENS * M.num_experts_per_tok
-
-# combine_arrived columns. The scatter's pushes live in tasks nested in two
-# pl.parallel loops and so have no single TaskId a barrier could depend on; the
-# handshake therefore counts ROWS, not tasks. COMB_ARRIVED is bumped once per row
-# a peer pushes here; COMB_EXPECT is how many rows this rank expects back. Every
-# row dispatched to a peer returns from that peer, so the expectation is the
-# dispatcher's own per-destination route count -- known locally, before any
-# expert runs. Both columns are cumulative across moe_epoch (cleared once per
-# forward). Defined here rather than in moe because this file writes
-# COMB_ARRIVED on peers and moe imports this module, not the other way round.
-COMB_ARRIVED = 0
-COMB_EXPECT = 1
-COMB_PAD = 2
-
 assert RECV_MAX % RECV_TILE == 0, "RECV_MAX must be a whole number of RECV_TILE row-tiles"
-# The fused scatter pushes whole [1, D] rows, so one exp_w2_act block must own
-# the full row width; a column-split grid would scatter partial rows instead.
-assert D == W2_ACT_INNER * D_OUT_TILE_ACT, \
-    "fused combine needs a single exp_w2_act column block spanning D"
 
 
 @pl.jit.inline(auto_scope=False)
-def _expert_h_quant(
-    recv_x_flat: pl.Tensor[[N_LOCAL_EXPERTS * RECV_MAX, D], pl.INT8],
+def expert_routed(
+    recv_x: pl.Tensor[[N_LOCAL_EXPERTS, RECV_MAX, D], pl.INT8],
     recv_scale_dq: pl.Tensor[[N_LOCAL_EXPERTS, RECV_MAX], pl.FP32],
+    recv_weights: pl.Tensor[[N_LOCAL_EXPERTS, RECV_MAX], pl.FP32],
     recv_expert_count: pl.Tensor[[N_LOCAL_EXPERTS, 1], pl.INT32],
     routed_w1: pl.Tensor[[N_LOCAL_EXPERTS, MOE_INTER, D], pl.INT8],
     routed_w1_scale: pl.Tensor[[N_LOCAL_EXPERTS, MOE_INTER], pl.FP32],
     routed_w3: pl.Tensor[[N_LOCAL_EXPERTS, MOE_INTER, D], pl.INT8],
     routed_w3_scale: pl.Tensor[[N_LOCAL_EXPERTS, MOE_INTER], pl.FP32],
-    h_i8: pl.Tensor[[N_LOCAL_EXPERTS * RECV_MAX, MOE_INTER], pl.INT8],
-    h_scale_dq: pl.Tensor[[N_LOCAL_EXPERTS * RECV_MAX, 1], pl.FP32],
+    routed_w2: pl.Tensor[[N_LOCAL_EXPERTS, D, MOE_INTER], pl.INT8],
+    routed_w2_scale: pl.Tensor[[N_LOCAL_EXPERTS, D], pl.FP32],
+    recv_y: pl.Tensor[[N_LOCAL_EXPERTS, RECV_MAX, D], pl.BF16],
 ):
-    """W1/W3 GEMMs, SwiGLU, and the A8 requant feeding the W2 phase."""
+    recv_y_flat = pl.reshape(recv_y, [N_LOCAL_EXPERTS * RECV_MAX, D])
+    recv_x_flat = pl.reshape(recv_x, [N_LOCAL_EXPERTS * RECV_MAX, D])
+
     with pl.scope():
+        # Keep only the requantized SwiGLU result across the W1/W3 and W2 phases.
+        # The full INT32 gate/up tensors would occupy 512 MiB at EP8; h_i8 and its
+        # per-row dequant scale occupy about 64 MiB instead.
+        h_i8 = pl.create_tensor([N_LOCAL_EXPERTS * RECV_MAX, MOE_INTER], dtype=pl.INT8)
+        h_scale_dq = pl.create_tensor(
+            [N_LOCAL_EXPERTS * RECV_MAX, 1], dtype=pl.FP32, manual_dep=True
+        )
+
         # Produce one gate/up row tile at a time, immediately activate and quantize
         # it, then release the INT32/FP32 temporaries at the tile scope boundary.
         for local_i in pl.parallel(N_LOCAL_EXPERTS):
@@ -216,164 +199,62 @@ def _expert_h_quant(
                                 eh_q_half, target_type=pl.INT8, mode="trunc"
                             )
 
+        with pl.scope():
+            for local_e in pl.parallel(N_LOCAL_EXPERTS):
+                e_flat_base = local_e * RECV_MAX
 
-@pl.jit.inline(auto_scope=False)
-def _expert_w2(
-    h_i8: pl.Tensor[[N_LOCAL_EXPERTS * RECV_MAX, MOE_INTER], pl.INT8],
-    h_scale_dq: pl.Tensor[[N_LOCAL_EXPERTS * RECV_MAX, 1], pl.FP32],
-    recv_weights: pl.Tensor[[N_LOCAL_EXPERTS, RECV_MAX], pl.FP32],
-    recv_expert_count: pl.Tensor[[N_LOCAL_EXPERTS, 1], pl.INT32],
-    recv_r_route: pl.Tensor[[N_LOCAL_EXPERTS, RECV_MAX], pl.INT32],
-    recv_src: pl.Tensor[[N_LOCAL_EXPERTS, RECV_MAX], pl.INT32],
-    routed_w2: pl.Tensor[[N_LOCAL_EXPERTS, D, MOE_INTER], pl.INT8],
-    routed_w2_scale: pl.Tensor[[N_LOCAL_EXPERTS, D], pl.FP32],
-    recv_y_flat: pl.Tensor[[N_LOCAL_EXPERTS * RECV_MAX, D], pl.BF16],
-    routed_y_buf: pld.DistributedTensor[[N_ROUTES, D], pl.BF16],
-    combine_arrived: pld.DistributedTensor[[EP_WORLD_SIZE, COMB_PAD], pl.INT32],
-    my_rank: pl.Scalar[pl.INT32],
-):
-    """W2 GEMM, routing-weight-scaled dequant, and the fused combine scatter.
+                e_rows = pl.read(recv_expert_count, [local_e, 0])
+                e_tiles = (e_rows + RECV_TILE - 1) // RECV_TILE
 
-    Each activated row goes straight from on-core memory to the origin rank's
-    routed_y_buf slot, so it starts crossing the fabric while the rest of the
-    expert grid is still in the W2 GEMM. recv_y is written too: it is this
-    kernel's declared output and what the standalone test validates, but moe
-    never reads it."""
-    with pl.scope():
-        for local_e in pl.parallel(N_LOCAL_EXPERTS):
-            e_flat_base = local_e * RECV_MAX
+                for tt in pl.parallel(e_tiles):
+                    tt0 = tt * RECV_TILE
+                    flat_tt0 = e_flat_base + tt0
+                    h_tile_i8 = h_i8[flat_tt0 : flat_tt0 + RECV_TILE]
+                    h_tile_scale_dq = h_scale_dq[flat_tt0 : flat_tt0 + RECV_TILE]
 
-            e_rows = pl.read(recv_expert_count, [local_e, 0])
-            e_tiles = (e_rows + RECV_TILE - 1) // RECV_TILE
+                    y_i32 = pl.create_tensor([RECV_TILE, D], dtype=pl.INT32)
+                    with pl.spmd(
+                        D // (W2_INNER * D_OUT_TILE),
+                        name_hint="exp_w2_mm",
+                        allow_early_resolve=True,
+                    ):
+                        wb_idx = pl.tile.get_block_idx()
+                        d_base = wb_idx * (W2_INNER * D_OUT_TILE)
+                        for dg in pl.range(W2_INNER):
+                            d0 = d_base + dg * D_OUT_TILE
+                            y_acc = pl.create_tensor([1, RECV_TILE, D_OUT_TILE], dtype=pl.INT32)
+                            for k0 in pl.pipeline(0, MOE_INTER, INTER_K, stage=2):
+                                h_k = h_tile_i8[:, k0 : k0 + INTER_K]
+                                w2_k = routed_w2[local_e : local_e + 1, d0 : d0 + D_OUT_TILE, k0 : k0 + INTER_K]
+                                if k0 == 0:
+                                    y_acc = pl.matmul(h_k, w2_k, b_trans=True, out_dtype=pl.INT32)
+                                else:
+                                    y_acc = pl.matmul_acc(y_acc, h_k, w2_k, b_trans=True)
+                            y_i32[:, d0 : d0 + D_OUT_TILE] = pl.reshape(y_acc, [RECV_TILE, D_OUT_TILE])
 
-            for tt in pl.parallel(e_tiles):
-                tt0 = tt * RECV_TILE
-                flat_tt0 = e_flat_base + tt0
-                valid_rows = pl.min(RECV_TILE, e_rows - tt0)
-                h_tile_i8 = h_i8[flat_tt0 : flat_tt0 + RECV_TILE]
-                h_tile_scale_dq = h_scale_dq[flat_tt0 : flat_tt0 + RECV_TILE]
-
-                y_i32 = pl.create_tensor([RECV_TILE, D], dtype=pl.INT32)
-                with pl.spmd(
-                    D // (W2_INNER * D_OUT_TILE),
-                    name_hint="exp_w2_mm",
-                    allow_early_resolve=True,
-                ):
-                    wb_idx = pl.tile.get_block_idx()
-                    d_base = wb_idx * (W2_INNER * D_OUT_TILE)
-                    for dg in pl.range(W2_INNER):
-                        d0 = d_base + dg * D_OUT_TILE
-                        y_acc = pl.create_tensor([1, RECV_TILE, D_OUT_TILE], dtype=pl.INT32)
-                        for k0 in pl.pipeline(0, MOE_INTER, INTER_K, stage=2):
-                            h_k = h_tile_i8[:, k0 : k0 + INTER_K]
-                            w2_k = routed_w2[local_e : local_e + 1, d0 : d0 + D_OUT_TILE, k0 : k0 + INTER_K]
-                            if k0 == 0:
-                                y_acc = pl.matmul(h_k, w2_k, b_trans=True, out_dtype=pl.INT32)
-                            else:
-                                y_acc = pl.matmul_acc(y_acc, h_k, w2_k, b_trans=True)
-                        y_i32[:, d0 : d0 + D_OUT_TILE] = pl.reshape(y_acc, [RECV_TILE, D_OUT_TILE])
-
-                recv_y_tile = pl.create_tensor([RECV_TILE, D], dtype=pl.BF16)
-                with pl.spmd(
-                    D // (W2_ACT_INNER * D_OUT_TILE_ACT),
-                    name_hint="exp_w2_act",
-                    allow_early_resolve=True,
-                ):
-                    db_idx = pl.tile.get_block_idx()
-                    act_d_base = db_idx * (W2_ACT_INNER * D_OUT_TILE_ACT)
-                    w_col_blk = pl.reshape(
-                        recv_weights[local_e : local_e + 1, tt0 : tt0 + RECV_TILE],
-                        [RECV_TILE, 1],
-                    )
-                    row_scale_blk = pl.mul(h_tile_scale_dq, w_col_blk)
-                    for dg in pl.pipeline(W2_ACT_INNER, stage=2):
-                        act_d0 = act_d_base + dg * D_OUT_TILE_ACT
-                        y_2d_i32 = y_i32[:, act_d0 : act_d0 + D_OUT_TILE_ACT]
-                        w2_scale_chunk = routed_w2_scale[local_e : local_e + 1, act_d0 : act_d0 + D_OUT_TILE_ACT]
-                        y_2d = pl.cast(y_2d_i32, target_type=pl.FP32, mode="none")
-                        y_2d = pl.col_expand_mul(pl.row_expand_mul(y_2d, row_scale_blk), w2_scale_chunk)
-                        recv_y_tile[:, act_d0 : act_d0 + D_OUT_TILE_ACT] = pl.cast(
-                            y_2d, target_type=pl.BF16, mode="rint"
+                    recv_y_tile = pl.create_tensor([RECV_TILE, D], dtype=pl.BF16)
+                    with pl.spmd(
+                        D // (W2_ACT_INNER * D_OUT_TILE_ACT),
+                        name_hint="exp_w2_act",
+                        allow_early_resolve=True,
+                    ):
+                        db_idx = pl.tile.get_block_idx()
+                        act_d_base = db_idx * (W2_ACT_INNER * D_OUT_TILE_ACT)
+                        w_col_blk = pl.reshape(
+                            recv_weights[local_e : local_e + 1, tt0 : tt0 + RECV_TILE],
+                            [RECV_TILE, 1],
                         )
-                    # Rows in one tile belong to different origin ranks, so the
-                    # scatter is per row: lane (local_e, tt0 + i) carries the origin
-                    # rank and its r_route slot in routed_y_buf. Tail rows
-                    # (i >= valid_rows) hold no route and are never pushed. Pushing
-                    # whole [1, D] rows after the column loop rather than each
-                    # D_OUT_TILE_ACT chunk keeps the transfer at one row per store --
-                    # per-chunk stores cost ~10us/task in fragmentation alone.
-                    #
-                    # put, not remote_store: remote_store does not drain before the
-                    # notify issues (PTOAS#872), so the peer could satisfy its row
-                    # count and let shared_routed read a row still in flight. Program
-                    # order within the task does not supply the missing fence -- only
-                    # the draining transfer does. deepseek_v4_pro/lm_head.py makes the
-                    # same choice for the same reason. Rows bound for this rank skip
-                    # the notify: combine_wait ignores its own slot and they ride the
-                    # local RAW edge on routed_y_buf instead.
-                    for i in pl.range(valid_rows):
-                        r_route = pl.cast(pl.read(recv_r_route, [local_e, tt0 + i]), pl.INDEX)
-                        origin = pl.read(recv_src, [local_e, tt0 + i])
-                        pld.tensor.put(
-                            dst=routed_y_buf,
-                            peer=origin,
-                            src=recv_y_tile,
-                            dst_offsets=[r_route, 0],
-                            src_offsets=[i, 0],
-                            shape=[1, D],
-                        )
-                        if origin != my_rank:
-                            pld.system.notify(
-                                target=combine_arrived,
-                                peer=origin,
-                                offsets=[my_rank, COMB_ARRIVED],
-                                value=1,
-                                op=pld.NotifyOp.AtomicAdd,
+                        row_scale_blk = pl.mul(h_tile_scale_dq, w_col_blk)
+                        for dg in pl.pipeline(W2_ACT_INNER, stage=2):
+                            act_d0 = act_d_base + dg * D_OUT_TILE_ACT
+                            y_2d_i32 = y_i32[:, act_d0 : act_d0 + D_OUT_TILE_ACT]
+                            w2_scale_chunk = routed_w2_scale[local_e : local_e + 1, act_d0 : act_d0 + D_OUT_TILE_ACT]
+                            y_2d = pl.cast(y_2d_i32, target_type=pl.FP32, mode="none")
+                            y_2d = pl.col_expand_mul(pl.row_expand_mul(y_2d, row_scale_blk), w2_scale_chunk)
+                            recv_y_tile[:, act_d0 : act_d0 + D_OUT_TILE_ACT] = pl.cast(
+                                y_2d, target_type=pl.BF16, mode="rint"
                             )
-                recv_y_flat = pl.assemble(recv_y_flat, recv_y_tile, [flat_tt0, 0])
-
-
-@pl.jit.inline(auto_scope=False)
-def expert_routed(
-    recv_x: pl.Tensor[[N_LOCAL_EXPERTS, RECV_MAX, D], pl.INT8],
-    recv_scale_dq: pl.Tensor[[N_LOCAL_EXPERTS, RECV_MAX], pl.FP32],
-    recv_weights: pl.Tensor[[N_LOCAL_EXPERTS, RECV_MAX], pl.FP32],
-    recv_expert_count: pl.Tensor[[N_LOCAL_EXPERTS, 1], pl.INT32],
-    recv_r_route: pl.Tensor[[N_LOCAL_EXPERTS, RECV_MAX], pl.INT32],
-    recv_src: pl.Tensor[[N_LOCAL_EXPERTS, RECV_MAX], pl.INT32],
-    routed_w1: pl.Tensor[[N_LOCAL_EXPERTS, MOE_INTER, D], pl.INT8],
-    routed_w1_scale: pl.Tensor[[N_LOCAL_EXPERTS, MOE_INTER], pl.FP32],
-    routed_w3: pl.Tensor[[N_LOCAL_EXPERTS, MOE_INTER, D], pl.INT8],
-    routed_w3_scale: pl.Tensor[[N_LOCAL_EXPERTS, MOE_INTER], pl.FP32],
-    routed_w2: pl.Tensor[[N_LOCAL_EXPERTS, D, MOE_INTER], pl.INT8],
-    routed_w2_scale: pl.Tensor[[N_LOCAL_EXPERTS, D], pl.FP32],
-    recv_y: pl.Tensor[[N_LOCAL_EXPERTS, RECV_MAX, D], pl.BF16],
-    routed_y_buf: pld.DistributedTensor[[N_ROUTES, D], pl.BF16],
-    combine_arrived: pld.DistributedTensor[[EP_WORLD_SIZE, COMB_PAD], pl.INT32],
-    my_rank: pl.Scalar[pl.INT32],
-):
-    recv_y_flat = pl.reshape(recv_y, [N_LOCAL_EXPERTS * RECV_MAX, D])
-    recv_x_flat = pl.reshape(recv_x, [N_LOCAL_EXPERTS * RECV_MAX, D])
-
-    with pl.scope():
-        # Keep only the requantized SwiGLU result across the W1/W3 and W2 phases.
-        # The full INT32 gate/up tensors would occupy 512 MiB at EP8; h_i8 and its
-        # per-row dequant scale occupy about 64 MiB instead.
-        h_i8 = pl.create_tensor([N_LOCAL_EXPERTS * RECV_MAX, MOE_INTER], dtype=pl.INT8)
-        h_scale_dq = pl.create_tensor(
-            [N_LOCAL_EXPERTS * RECV_MAX, 1], dtype=pl.FP32, manual_dep=True
-        )
-        _expert_h_quant(
-            recv_x_flat, recv_scale_dq, recv_expert_count,
-            routed_w1, routed_w1_scale, routed_w3, routed_w3_scale,
-            h_i8, h_scale_dq,
-        )
-        _expert_w2(
-            h_i8, h_scale_dq, recv_weights, recv_expert_count,
-            recv_r_route, recv_src,
-            routed_w2, routed_w2_scale, recv_y_flat,
-            routed_y_buf, combine_arrived, my_rank,
-        )
+                    recv_y_flat = pl.assemble(recv_y_flat, recv_y_tile, [flat_tt0, 0])
 
     return recv_y
 
@@ -384,8 +265,6 @@ def expert_routed_test(
     recv_scale_dq: pl.Tensor[[N_LOCAL_EXPERTS, RECV_MAX], pl.FP32],
     recv_weights: pl.Tensor[[N_LOCAL_EXPERTS, RECV_MAX], pl.FP32],
     recv_expert_count: pl.Tensor[[N_LOCAL_EXPERTS, 1], pl.INT32],
-    recv_r_route: pl.Tensor[[N_LOCAL_EXPERTS, RECV_MAX], pl.INT32],
-    recv_src: pl.Tensor[[N_LOCAL_EXPERTS, RECV_MAX], pl.INT32],
     routed_w1: pl.Tensor[[N_LOCAL_EXPERTS, MOE_INTER, D], pl.INT8],
     routed_w1_scale: pl.Tensor[[N_LOCAL_EXPERTS, MOE_INTER], pl.FP32],
     routed_w3: pl.Tensor[[N_LOCAL_EXPERTS, MOE_INTER, D], pl.INT8],
@@ -393,60 +272,14 @@ def expert_routed_test(
     routed_w2: pl.Tensor[[N_LOCAL_EXPERTS, D, MOE_INTER], pl.INT8],
     routed_w2_scale: pl.Tensor[[N_LOCAL_EXPERTS, D], pl.FP32],
     recv_y: pl.Out[pl.Tensor[[N_LOCAL_EXPERTS, RECV_MAX, D], pl.BF16]],
-    routed_y_buf: pld.DistributedTensor[[N_ROUTES, D], pl.BF16],
-    combine_arrived: pld.DistributedTensor[[EP_WORLD_SIZE, COMB_PAD], pl.INT32],
-    my_rank: pl.Scalar[pl.INT32],
 ):
     expert_routed(
         recv_x, recv_scale_dq, recv_weights, recv_expert_count,
-        recv_r_route, recv_src,
         routed_w1, routed_w1_scale, routed_w3, routed_w3_scale,
         routed_w2, routed_w2_scale,
-        recv_y, routed_y_buf, combine_arrived, my_rank,
+        recv_y,
     )
     return recv_y
-
-
-@pl.jit.host
-def l3_expert_routed(
-    recv_x: pl.Tensor[[1, N_LOCAL_EXPERTS, RECV_MAX, D], pl.INT8],
-    recv_scale_dq: pl.Tensor[[1, N_LOCAL_EXPERTS, RECV_MAX], pl.FP32],
-    recv_weights: pl.Tensor[[1, N_LOCAL_EXPERTS, RECV_MAX], pl.FP32],
-    recv_expert_count: pl.Tensor[[1, N_LOCAL_EXPERTS, 1], pl.INT32],
-    recv_r_route: pl.Tensor[[1, N_LOCAL_EXPERTS, RECV_MAX], pl.INT32],
-    recv_src: pl.Tensor[[1, N_LOCAL_EXPERTS, RECV_MAX], pl.INT32],
-    routed_w1: pl.Tensor[[1, N_LOCAL_EXPERTS, MOE_INTER, D], pl.INT8],
-    routed_w1_scale: pl.Tensor[[1, N_LOCAL_EXPERTS, MOE_INTER], pl.FP32],
-    routed_w3: pl.Tensor[[1, N_LOCAL_EXPERTS, MOE_INTER, D], pl.INT8],
-    routed_w3_scale: pl.Tensor[[1, N_LOCAL_EXPERTS, MOE_INTER], pl.FP32],
-    routed_w2: pl.Tensor[[1, N_LOCAL_EXPERTS, D, MOE_INTER], pl.INT8],
-    routed_w2_scale: pl.Tensor[[1, N_LOCAL_EXPERTS, D], pl.FP32],
-    recv_y: pl.Out[pl.Tensor[[1, N_LOCAL_EXPERTS, RECV_MAX, D], pl.BF16]],
-):
-    """Single-rank harness for the routed expert.
-
-    Validates recv_y -- the routing-weight-scaled SwiGLU output -- and runs the
-    fused scatter for its compile and lowering coverage. It cannot check where
-    the scatter LANDS: with one rank every push targets peer == my_rank, so no
-    arrival notify fires and combine_wait's `src != my_rank` loop is empty. A
-    readback of routed_y_buf here would be asserting on local store ordering that
-    nothing guarantees. Scatter placement is covered by moe.py's EP8 test, which
-    has real peers and a real arrival handshake.
-    """
-    routed_y_buf_buf = pld.alloc_window_buffer([N_ROUTES, D], dtype=pl.BF16)
-    combine_arrived_buf = pld.alloc_window_buffer([EP_WORLD_SIZE, COMB_PAD], dtype=pl.INT32)
-
-    for r in pl.range(pld.world_size()):
-        routed_y_buf = pld.window(routed_y_buf_buf, [N_ROUTES, D], dtype=pl.BF16)
-        combine_arrived = pld.window(combine_arrived_buf, [EP_WORLD_SIZE, COMB_PAD], dtype=pl.INT32)
-        expert_routed_test(
-            recv_x[r], recv_scale_dq[r], recv_weights[r], recv_expert_count[r],
-            recv_r_route[r], recv_src[r],
-            routed_w1[r], routed_w1_scale[r], routed_w3[r], routed_w3_scale[r],
-            routed_w2[r], routed_w2_scale[r],
-            recv_y[r], routed_y_buf, combine_arrived, r,
-            device=r,
-        )
 
 
 def golden_expert_routed(tensors):
@@ -492,19 +325,6 @@ def golden_expert_routed(tensors):
         recv_y[e, :n_rows, :] = h @ w2[e].T
 
     tensors["recv_y"][:] = recv_y.to(torch.bfloat16)
-
-
-def golden_l3_expert_routed(tensors):
-    """Rank-dim wrapper for the single-rank harness.
-
-    golden_expert_routed itself stays un-batched: moe.py's golden calls it
-    per destination rank with plain [E, ...] tensors.
-    """
-    unbatched = {k: (v[0] if hasattr(v, "ndim") and v.ndim > 1 else v)
-                 for k, v in tensors.items()}
-    unbatched["recv_y"] = tensors["recv_y"][0]
-    golden_expert_routed(unbatched)
-    tensors["recv_y"][0] = unbatched["recv_y"]
 
 
 def gen_routed_weight(shape, dequant_std):
@@ -611,92 +431,47 @@ def build_tensor_specs():
     def init_recv_weights():
         return recv_weights_pre
 
-    # Route ids for the fused scatter: every valid row gets a distinct
-    # routed_y_buf slot, matching dispatch's one-route-per-(token, topk) layout.
-    # Tail rows keep route 0 and are never pushed (the kernel stops at
-    # recv_expert_count). Single rank, so every row's origin is rank 0.
-    recv_r_route_pre = torch.zeros(N_LOCAL_EXPERTS, RECV_MAX, dtype=torch.int32)
-    next_route = 0
-    for e in range(N_LOCAL_EXPERTS):
-        for slot in range(int(counts[e].item())):
-            recv_r_route_pre[e, slot] = next_route
-            next_route += 1
-    assert next_route <= N_ROUTES, f"fixture needs {next_route} routes, buffer holds {N_ROUTES}"
-
-    def init_recv_r_route():
-        return recv_r_route_pre.unsqueeze(0)
-
-    def init_recv_src():
-        return torch.zeros(1, N_LOCAL_EXPERTS, RECV_MAX, dtype=torch.int32)
-
     # Synthesize (int8, per-channel scale) by simulating the real MXFP4 routed-expert
     # quant grid (see gen_routed_weight). The kernel + golden both consume int8+scale.
     w1_i8, w1_s = gen_routed_weight((N_LOCAL_EXPERTS, MOE_INTER, D), ROUTED_DEQUANT_STD["w1"])
     w3_i8, w3_s = gen_routed_weight((N_LOCAL_EXPERTS, MOE_INTER, D), ROUTED_DEQUANT_STD["w3"])
     w2_i8, w2_s = gen_routed_weight((N_LOCAL_EXPERTS, D, MOE_INTER), ROUTED_DEQUANT_STD["w2"])
 
-    # Every tensor carries a leading rank dim: l3_expert_routed slices x[r] per
-    # card, the same shape contract as l3_moe (one rank here).
-    def r1(t):
-        return t.unsqueeze(0)
-
     return [
-        TensorSpec("recv_x", [1, N_LOCAL_EXPERTS, RECV_MAX, D], torch.int8,
-                   init_value=lambda: r1(init_recv_x())),
-        TensorSpec("recv_scale_dq", [1, N_LOCAL_EXPERTS, RECV_MAX], torch.float32,
-                   init_value=lambda: r1(init_recv_scale_dq())),
-        TensorSpec("recv_weights", [1, N_LOCAL_EXPERTS, RECV_MAX], torch.float32,
-                   init_value=lambda: r1(init_recv_weights())),
-        TensorSpec("recv_expert_count", [1, N_LOCAL_EXPERTS, 1], torch.int32,
-                   init_value=lambda: r1(init_recv_expert_count())),
-        TensorSpec("recv_r_route", [1, N_LOCAL_EXPERTS, RECV_MAX], torch.int32,
-                   init_value=init_recv_r_route),
-        TensorSpec("recv_src", [1, N_LOCAL_EXPERTS, RECV_MAX], torch.int32,
-                   init_value=init_recv_src),
-        TensorSpec("routed_w1", [1, N_LOCAL_EXPERTS, MOE_INTER, D], torch.int8,
-                   init_value=lambda: r1(w1_i8)),
-        TensorSpec("routed_w1_scale", [1, N_LOCAL_EXPERTS, MOE_INTER], torch.float32,
-                   init_value=lambda: r1(w1_s)),
-        TensorSpec("routed_w3", [1, N_LOCAL_EXPERTS, MOE_INTER, D], torch.int8,
-                   init_value=lambda: r1(w3_i8)),
-        TensorSpec("routed_w3_scale", [1, N_LOCAL_EXPERTS, MOE_INTER], torch.float32,
-                   init_value=lambda: r1(w3_s)),
-        TensorSpec("routed_w2", [1, N_LOCAL_EXPERTS, D, MOE_INTER], torch.int8,
-                   init_value=lambda: r1(w2_i8)),
-        TensorSpec("routed_w2_scale", [1, N_LOCAL_EXPERTS, D], torch.float32,
-                   init_value=lambda: r1(w2_s)),
-        TensorSpec("recv_y", [1, N_LOCAL_EXPERTS, RECV_MAX, D], torch.bfloat16, is_output=True),
+        TensorSpec("recv_x", [N_LOCAL_EXPERTS, RECV_MAX, D], torch.int8, init_value=init_recv_x),
+        TensorSpec("recv_scale_dq", [N_LOCAL_EXPERTS, RECV_MAX], torch.float32, init_value=init_recv_scale_dq),
+        TensorSpec("recv_weights", [N_LOCAL_EXPERTS, RECV_MAX], torch.float32, init_value=init_recv_weights),
+        TensorSpec("recv_expert_count", [N_LOCAL_EXPERTS, 1], torch.int32, init_value=init_recv_expert_count),
+        TensorSpec("routed_w1", [N_LOCAL_EXPERTS, MOE_INTER, D], torch.int8, init_value=lambda: w1_i8),
+        TensorSpec("routed_w1_scale", [N_LOCAL_EXPERTS, MOE_INTER], torch.float32, init_value=lambda: w1_s),
+        TensorSpec("routed_w3", [N_LOCAL_EXPERTS, MOE_INTER, D], torch.int8, init_value=lambda: w3_i8),
+        TensorSpec("routed_w3_scale", [N_LOCAL_EXPERTS, MOE_INTER], torch.float32, init_value=lambda: w3_s),
+        TensorSpec("routed_w2", [N_LOCAL_EXPERTS, D, MOE_INTER], torch.int8, init_value=lambda: w2_i8),
+        TensorSpec("routed_w2_scale", [N_LOCAL_EXPERTS, D], torch.float32, init_value=lambda: w2_s),
+        TensorSpec("recv_y", [N_LOCAL_EXPERTS, RECV_MAX, D], torch.bfloat16, is_output=True),
     ]
 
 
 if __name__ == "__main__":
     import argparse
     from golden import ratio_reldiff, run_jit
-    from pypto.ir.distributed_compiled_program import DistributedConfig
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
     parser.add_argument("--enable-l2-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2))
-    parser.add_argument("--compile-only", action="store_true", default=False)
     parser.add_argument("--dump-passes", action="store_true", default=False)
     args = parser.parse_args()
 
     result = run_jit(
-        fn=l3_expert_routed,
+        fn=expert_routed_test,
         specs=build_tensor_specs(),
-        golden_fn=golden_l3_expert_routed,
-        compile_only=args.compile_only,
-        compile_cfg=dict(
-            dump_passes=args.dump_passes,
-            distributed_config=DistributedConfig(
-                device_ids=[args.device],
-                num_sub_workers=0,
-            ),
-        ),
+        golden_fn=golden_expert_routed,
+        compile_cfg=dict(dump_passes=args.dump_passes),
         runtime_cfg=dict(
             platform=args.platform,
+            device_id=args.device,
             enable_l2_swimlane=args.enable_l2_swimlane,
         ),
         rtol=1e-3,

--- a/models/deepseek_v4_flash_mtp/moe.py
+++ b/models/deepseek_v4_flash_mtp/moe.py
@@ -45,7 +45,7 @@ from hc_pre import hc_pre
 from hc_post import hc_post
 from gate import gate
 from expert_shared import expert_shared
-from expert_routed import COMB_ARRIVED, COMB_EXPECT, COMB_PAD, expert_routed
+from expert_routed import expert_routed
 
 
 T = MOE_TOKENS
@@ -72,9 +72,6 @@ AUX_SCALE = 0
 AUX_W = 1
 IDX_PAD = 8  # INT32 route tile width; route rides a separate window from scale/w
              # (an FP32 tile can't hold it: INDEX->FP32 casts are unsupported).
-IDX_ROUTE = 0
-IDX_SRC = 1  # origin rank, so the fused combine can push a row back without the
-             # per-(src, expert) prefix sum the standalone scatter walked.
 
 assert N_RANKS in _EP_CHOICES, f"--ep must be one of {_EP_CHOICES} (got {N_RANKS})"
 assert N_EXPERTS_GLOBAL == N_RANKS * N_LOCAL
@@ -86,7 +83,7 @@ def clear_moe_signals(
     completion_anchor: pl.Tensor[[T, HC_MULT, D], pl.FP32],
     arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
     data_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
-    combine_arrived: pld.DistributedTensor[[N_RANKS, COMB_PAD], pl.INT32],
+    combine_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
 ):
     """Clear this rank's MoE signal windows after its final MoE completes."""
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="moe_signal_clear"):
@@ -98,8 +95,7 @@ def clear_moe_signals(
         for src in pl.range(N_RANKS):
             pl.write(arrived, [src, 0], zero)
             pl.write(data_arrived, [src, 0], zero)
-            pl.write(combine_arrived, [src, COMB_ARRIVED], zero)
-            pl.write(combine_arrived, [src, COMB_EXPECT], zero)
+            pl.write(combine_arrived, [src, 0], zero)
 
 
 # === Dispatch ================================================================
@@ -116,7 +112,6 @@ def dispatch(
     recv_scale_out: pl.Tensor[[N_LOCAL, RECV_MAX], pl.FP32],
     recv_w_out: pl.Tensor[[N_LOCAL, RECV_MAX], pl.FP32],
     recv_r_route_out: pl.Tensor[[N_LOCAL, RECV_MAX], pl.INT32],
-    recv_src_out: pl.Tensor[[N_LOCAL, RECV_MAX], pl.INT32],
     recv_count_out: pl.Tensor[[N_LOCAL, 1], pl.INT32],
     recv_meta_local: pl.Tensor[[N_RANKS, N_LOCAL], pl.INT32],
     # windows
@@ -126,7 +121,6 @@ def dispatch(
     recv_route: pld.DistributedTensor[[N_LOCAL * RECV_MAX, IDX_PAD], pl.INT32],
     arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
     data_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
-    combine_arrived: pld.DistributedTensor[[N_RANKS, COMB_PAD], pl.INT32],
     num_tokens: pl.Scalar[pl.INT32],
     my_rank: pl.Scalar[pl.INT32],
     # 1-based MoE call id; `arrived`/`data_arrived` are monotonic so waits use `>= moe_epoch`.
@@ -180,18 +174,6 @@ def dispatch(
                     op=pld.NotifyOp.AtomicAdd,
                 )
 
-        # Every row sent to dst comes back from dst in the combine, so this epoch's
-        # route count to dst is exactly how many combine rows to expect from it.
-        # Accumulate (not overwrite): the counter it is compared against is
-        # cumulative until clear_moe_signals. Self rows never notify, so skip them.
-        for dst in pl.range(N_RANKS):
-            if dst != my_rank:
-                rows = pl.const(0, pl.INT32)
-                for e in pl.range(N_LOCAL):
-                    rows = rows + cursor[dst * N_LOCAL + e]
-                prev = pl.read(combine_arrived, [dst, COMB_EXPECT])
-                pl.write(combine_arrived, [dst, COMB_EXPECT], prev + rows)
-
         # Wait for every source's meta flag.
         for src in pl.range(N_RANKS):
             if src != my_rank:
@@ -234,8 +216,6 @@ def dispatch(
         # Pad tiles zeroed once; used cols overwritten per push, then remote_store.
         aux_tile = pl.tile.full([1, AUX_PAD], dtype=pl.FP32, value=0.0)
         route_tile = pl.tile.full([1, IDX_PAD], dtype=pl.INT32, value=0)
-        # Origin rank is push-invariant; only the route column moves per row.
-        pl.tile.write(route_tile, [0, IDX_SRC], my_rank)
         for t in pl.range(active_tokens):
             for k in pl.range(TOPK):
                 eid = pl.read(indices, [t, k])
@@ -257,7 +237,7 @@ def dispatch(
                     pl.tile.write(aux_tile, [0, AUX_SCALE], pl.read(x_norm_scale, [t, 0]))
                     pl.tile.write(aux_tile, [0, AUX_W], pl.read(weights, [t, k]))
                     pld.tile.remote_store(aux_tile, target=recv_aux, peer=dst, offsets=[row, 0])
-                    pl.tile.write(route_tile, [0, IDX_ROUTE], pl.cast(t * TOPK + k, pl.INT32))
+                    pl.tile.write(route_tile, [0, 0], pl.cast(t * TOPK + k, pl.INT32))
                     pld.tile.remote_store(route_tile, target=recv_route, peer=dst, offsets=[row, 0])
 
         # Payload-arrival notify folded into the push: each block signals every peer
@@ -323,60 +303,80 @@ def dispatch(
                 recv_x_out_flat[out_row : out_row + 1, :] = recv_x[in_row : in_row + 1, :]
                 pl.write(recv_scale_out, [e, out_col], pl.read(recv_aux, [in_row, AUX_SCALE]))
                 pl.write(recv_w_out, [e, out_col], pl.read(recv_aux, [in_row, AUX_W]))
-                pl.write(recv_r_route_out, [e, out_col], pl.read(recv_route, [in_row, IDX_ROUTE]))
-                pl.write(recv_src_out, [e, out_col], pl.read(recv_route, [in_row, IDX_SRC]))
+                pl.write(recv_r_route_out, [e, out_col], pl.read(recv_route, [in_row, 0]))
             b = b + n
 
-    return _push_tid, _meta_tid
+    return _push_tid
 
 
 # === Combine =================================================================
-# The scatter itself is fused into expert_routed's exp_w2_act (see
-# expert_routed): a row leaves for its origin rank as soon as it is
-# activated. What remains here is the arrival handshake and the dense reduce
-# ffn_out[t] = sh[t] + Sigma_k routed_y_buf[t*TOPK+k].
+# Push recv_y rows back to their origin rank keyed by r_route, barrier, then a
+# dense reduce ffn_out[t] = sh[t] + Sigma_k routed_y_buf[t*TOPK+k].
 @pl.jit.inline
 def combine(
     recv_y: pl.Tensor[[N_LOCAL, RECV_MAX, D], pl.BF16],
+    recv_r_route_out: pl.Tensor[[N_LOCAL, RECV_MAX], pl.INT32],
     sh: pl.Tensor[[T, D], pl.BF16],
     ffn_out: pl.Tensor[[T, D], pl.BF16],
+    recv_meta_local: pl.Tensor[[N_RANKS, N_LOCAL], pl.INT32],
     routed_y_buf: pld.DistributedTensor[[T * TOPK, D], pl.BF16],
-    combine_arrived: pld.DistributedTensor[[N_RANKS, COMB_PAD], pl.INT32],
+    combine_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
     num_tokens: pl.Scalar[pl.INT32],
     my_rank: pl.Scalar[pl.INT32],
+    moe_epoch: pl.Scalar[pl.INT32],
     dispatch_push_tid: pl.Scalar[pl.TASK_ID],
-    dispatch_meta_tid: pl.Scalar[pl.TASK_ID],
 ):
     recv_y_flat = pl.reshape(recv_y, [N_LOCAL * RECV_MAX, D])
+    # One SPMD block per LOCAL EXPERT: block e pushes expert e's compact rows back to
+    # their origin rank (= the source lane src they arrived on) at their route offset.
+    # Rows are src-major, so the per-(e, src) base is a loop-carried prefix sum over
+    # src inside the block (same shape as dispatch_gather). Each route maps to a
+    # unique (dst, loc_e) and r_route, so the blocks' puts are write-disjoint.
+    # Keep the scatter TaskId so the arrival handshake cannot occupy AIV cores
+    # until every routed_y_buf put from this rank has completed.
+    with pl.spmd(N_LOCAL, name_hint="combine") as _combine_tid:
+        e = pl.tile.get_block_idx()
+        e_base_row = e * RECV_MAX
+        b = pl.cast(0, pl.INDEX)
+        for src in pl.range(N_RANKS):
+            n = pl.cast(pl.read(recv_meta_local, [src, e]), pl.INDEX)
+            for slot in pl.range(n):
+                out_col = b + slot
+                r_route = pl.cast(pl.read(recv_r_route_out, [e, out_col]), pl.INDEX)
+                pld.tensor.put(
+                    dst=routed_y_buf,
+                    peer=src,
+                    src=recv_y_flat,
+                    dst_offsets=[r_route, 0],
+                    src_offsets=[e_base_row + out_col, 0],
+                    shape=[1, D],
+                )
+            b = b + n
 
-    # Wait on ROWS, not tasks. The scatter lives in exp_w2_act tasks nested in two
-    # pl.parallel loops, which have no single TaskId to depend on. Counting the rows
-    # each peer owes us needs no barrier at all: every push bumps COMB_ARRIVED on
-    # its origin rank via a draining put, and dispatch_meta published the matching
-    # total in COMB_EXPECT before any expert ran. The dispatch_meta dep is
-    # load-bearing for that publish; nothing else orders this task after it.
-    #
-    # The recv_y read is a SCHEDULING hint, not the barrier. Correctness rests
-    # entirely on the row count above -- as a barrier this read is unsound, since it
-    # orders the task after most of the expert grid but measurably not all of it.
-    # What it buys is a late start: with only the dispatch deps this task is
-    # dispatched at the head of the expert phase and spins ~430 us holding an AIV
-    # core group that the expert tiles need (measured; baseline sat at ~64 us).
-    #
-    # This rank's own rows never notify; they ride the local RAW edge on
-    # routed_y_buf.
+    # Publish only after the complete scatter grid. Keeping this cross-rank wait
+    # out of the speculative early-dispatch chain prevents it and shared_routed
+    # from reserving the AIV cores needed by the scatter itself.
     with pl.at(
         level=pl.Level.CORE_GROUP,
         name_hint="combine_wait",
-        deps=[dispatch_push_tid, dispatch_meta_tid],
+        deps=[_combine_tid, dispatch_push_tid],
     ) as _cwait_tid:
-        _recv_y_anchor = pl.read(recv_y_flat, [0, 0])
+        for peer in pl.range(N_RANKS):
+            if peer != my_rank:
+                pld.system.notify(
+                    target=combine_arrived,
+                    peer=peer,
+                    offsets=[my_rank, 0],
+                    value=1,
+                    op=pld.NotifyOp.AtomicAdd,
+                )
+
         for src in pl.range(N_RANKS):
             if src != my_rank:
                 pld.system.wait(
                     signal=combine_arrived,
-                    offsets=[src, COMB_ARRIVED],
-                    expected=pl.read(combine_arrived, [src, COMB_EXPECT]),
+                    offsets=[src, 0],
+                    expected=moe_epoch,
                     cmp=pld.WaitCmp.Ge,
                 )
 
@@ -438,7 +438,7 @@ def moe(
     arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
     data_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
     routed_y_buf: pld.DistributedTensor[[N_ROUTES, D], pl.BF16],
-    combine_arrived: pld.DistributedTensor[[N_RANKS, COMB_PAD], pl.INT32],
+    combine_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
     # scalars last: runtime TaskArgs forbids a tensor arg after a scalar arg.
     layer_id: pl.Scalar[pl.INT32],
     num_tokens: pl.Scalar[pl.INT32],
@@ -477,35 +477,30 @@ def moe(
     recv_scale_out = pl.create_tensor([N_LOCAL, RECV_MAX], dtype=pl.FP32, manual_dep=True)
     recv_w_out = pl.create_tensor([N_LOCAL, RECV_MAX], dtype=pl.FP32, manual_dep=True)
     recv_r_route_out = pl.create_tensor([N_LOCAL, RECV_MAX], dtype=pl.INT32, manual_dep=True)
-    recv_src_out = pl.create_tensor([N_LOCAL, RECV_MAX], dtype=pl.INT32, manual_dep=True)
     recv_count_out = pl.create_tensor([N_LOCAL, 1], dtype=pl.INT32)
     recv_meta_local = pl.create_tensor([N_RANKS, N_LOCAL], dtype=pl.INT32, manual_dep=True)
-    dispatch_push_tid, dispatch_meta_tid = dispatch(
+    dispatch_push_tid = dispatch(
         indices, x_norm_i8, x_norm_scale, weights,
-        recv_x_out, recv_scale_out, recv_w_out, recv_r_route_out, recv_src_out,
-        recv_count_out, recv_meta_local,
-        recv_meta, recv_x, recv_aux, recv_route, arrived, data_arrived, combine_arrived,
+        recv_x_out, recv_scale_out, recv_w_out, recv_r_route_out, recv_count_out, recv_meta_local,
+        recv_meta, recv_x, recv_aux, recv_route, arrived, data_arrived,
         num_tokens, my_rank, moe_epoch,
     )
 
     with pl.scope():
-        # recv_y is the routed experts' declared output and what the standalone
-        # test validates; moe itself never reads it, because the fused scatter has
-        # already pushed every row to its origin rank's routed_y_buf.
         recv_y = pl.create_tensor([N_LOCAL, RECV_MAX, D], dtype=pl.BF16)
         expert_routed(
             recv_x_out, recv_scale_out, recv_w_out, recv_count_out,
-            recv_r_route_out, recv_src_out,
             routed_w1, routed_w1_scale, routed_w3, routed_w3_scale,
             routed_w2, routed_w2_scale,
-            recv_y, routed_y_buf, combine_arrived, my_rank,
+            recv_y,
         )
 
         ffn_out = pl.create_tensor([T, D], dtype=pl.BF16)
         combine(
-            recv_y, sh, ffn_out,
+            recv_y, recv_r_route_out, sh,
+            ffn_out, recv_meta_local,
             routed_y_buf, combine_arrived,
-            num_tokens, my_rank, dispatch_push_tid, dispatch_meta_tid,
+            num_tokens, my_rank, moe_epoch, dispatch_push_tid,
         )
 
         hc_post(ffn_out, x_hc, post_ffn, comb_ffn, x_next)
@@ -546,7 +541,7 @@ def moe_test(
     arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
     data_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
     routed_y_buf: pld.DistributedTensor[[N_ROUTES, D], pl.BF16],
-    combine_arrived: pld.DistributedTensor[[N_RANKS, COMB_PAD], pl.INT32],
+    combine_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
     # scalars last: runtime TaskArgs forbids a tensor arg after a scalar arg.
     layer_id: pl.Scalar[pl.INT32],
     num_tokens: pl.Scalar[pl.INT32],
@@ -604,7 +599,7 @@ def l3_moe(
     arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
     data_arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
     routed_y_buf_buf = pld.alloc_window_buffer([N_ROUTES, D], dtype=pl.BF16)
-    combine_arrived_buf = pld.alloc_window_buffer([N_RANKS, COMB_PAD], dtype=pl.INT32)
+    combine_arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
 
     for r in pl.range(pld.world_size()):
         recv_meta = pld.window(recv_meta_buf, [N_RANKS, N_LOCAL], dtype=pl.INT32)
@@ -614,7 +609,7 @@ def l3_moe(
         arrived = pld.window(arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
         data_arrived = pld.window(data_arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
         routed_y_buf = pld.window(routed_y_buf_buf, [N_ROUTES, D], dtype=pl.BF16)
-        combine_arrived = pld.window(combine_arrived_buf, [N_RANKS, COMB_PAD], dtype=pl.INT32)
+        combine_arrived = pld.window(combine_arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
         moe_test(
             x_hc[r], hc_ffn_fn[r], hc_ffn_scale[r], hc_ffn_base[r],
             norm_w[r], gate_w[r], gate_bias[r], tid2eid[r], input_ids[r],

--- a/models/deepseek_v4_flash_mtp/prefill_cp_fwd_draft.py
+++ b/models/deepseek_v4_flash_mtp/prefill_cp_fwd_draft.py
@@ -95,7 +95,6 @@ import config
 config.MOE_TOKENS = config.PREFILL_TOKENS
 
 from moe import (
-    COMB_PAD,
     AUX_PAD,
     D,
     HC_DIM,
@@ -485,7 +484,7 @@ def _fwd_moe_tail(
     arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
     data_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
     routed_y_buf: pld.DistributedTensor[[N_ROUTES, D], pl.BF16],
-    combine_arrived: pld.DistributedTensor[[N_RANKS, COMB_PAD], pl.INT32],
+    combine_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
     stage_done: pld.DistributedTensor[[CP_SIZE, 1], pl.INT32],
     hidden_out: pl.Out[
         pl.Tensor[
@@ -861,7 +860,7 @@ def prefill_cp_fwd(
     arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
     data_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
     routed_y_buf: pld.DistributedTensor[[N_ROUTES, D], pl.BF16],
-    combine_arrived: pld.DistributedTensor[[N_RANKS, COMB_PAD], pl.INT32],
+    combine_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
     # Layer stage synchronization window.
     stage_done: pld.DistributedTensor[[CP_SIZE, 1], pl.INT32],
     # Phase 3 final-tail weights (HC head + final RMSNorm). The HC head
@@ -1941,7 +1940,7 @@ def l3_prefill_cp_fwd(
     arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
     data_arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
     routed_y_buf_buf = pld.alloc_window_buffer([N_ROUTES, D], dtype=pl.BF16)
-    combine_arrived_buf = pld.alloc_window_buffer([N_RANKS, COMB_PAD], dtype=pl.INT32)
+    combine_arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
 
     # Domain 3: layer stage synchronization (monotonic counter, 1..20).
     stage_done_buf = pld.alloc_window_buffer([CP_SIZE, 1], dtype=pl.INT32)
@@ -2052,7 +2051,7 @@ def l3_prefill_cp_fwd(
         )
         routed_y_buf = pld.window(routed_y_buf_buf, [N_ROUTES, D], dtype=pl.BF16)
         combine_arrived = pld.window(
-            combine_arrived_buf, [N_RANKS, COMB_PAD], dtype=pl.INT32
+            combine_arrived_buf, [N_RANKS, 1], dtype=pl.INT32
         )
         stage_done = pld.window(stage_done_buf, [CP_SIZE, 1], dtype=pl.INT32)
         # Domain 4: HCA compact windows.

--- a/models/deepseek_v4_flash_mtp/prefill_cp_layer.py
+++ b/models/deepseek_v4_flash_mtp/prefill_cp_layer.py
@@ -27,7 +27,6 @@ config.MOE_TOKENS = config.PREFILL_TOKENS
 # Import moe first. It applies the EP override before dependent modules bake
 # config-derived MoE shapes.
 from moe import (
-    COMB_PAD,
     AUX_PAD,
     D,
     HC_DIM,
@@ -307,7 +306,7 @@ def _prefill_layer_cp_moe_tail(
     arrived: pld.DistributedTensor[[META_WINDOW_ROWS, 1], pl.INT32],
     data_arrived: pld.DistributedTensor[[META_WINDOW_ROWS, 1], pl.INT32],
     routed_y_buf: pld.DistributedTensor[[ROUTED_WINDOW_ROWS, D], pl.BF16],
-    combine_arrived: pld.DistributedTensor[[META_WINDOW_ROWS, COMB_PAD], pl.INT32],
+    combine_arrived: pld.DistributedTensor[[META_WINDOW_ROWS, 1], pl.INT32],
     # Layer stage synchronization window.
     stage_done: pld.DistributedTensor[[CP_SIZE, 1], pl.INT32],
     stage_tokens: pl.Tensor[[NUM_MOE_WAVES + 1, 1, 8], pl.FP32],
@@ -492,7 +491,7 @@ def prefill_layer_cp_swa(
     arrived: pld.DistributedTensor[[META_WINDOW_ROWS, 1], pl.INT32],
     data_arrived: pld.DistributedTensor[[META_WINDOW_ROWS, 1], pl.INT32],
     routed_y_buf: pld.DistributedTensor[[ROUTED_WINDOW_ROWS, D], pl.BF16],
-    combine_arrived: pld.DistributedTensor[[META_WINDOW_ROWS, COMB_PAD], pl.INT32],
+    combine_arrived: pld.DistributedTensor[[META_WINDOW_ROWS, 1], pl.INT32],
     # Layer stage synchronization window.
     stage_done: pld.DistributedTensor[[CP_SIZE, 1], pl.INT32],
     # Layer output.
@@ -694,7 +693,7 @@ def prefill_layer_cp_hca(
     arrived: pld.DistributedTensor[[META_WINDOW_ROWS, 1], pl.INT32],
     data_arrived: pld.DistributedTensor[[META_WINDOW_ROWS, 1], pl.INT32],
     routed_y_buf: pld.DistributedTensor[[ROUTED_WINDOW_ROWS, D], pl.BF16],
-    combine_arrived: pld.DistributedTensor[[META_WINDOW_ROWS, COMB_PAD], pl.INT32],
+    combine_arrived: pld.DistributedTensor[[META_WINDOW_ROWS, 1], pl.INT32],
     # Layer stage synchronization window.
     stage_done: pld.DistributedTensor[[CP_SIZE, 1], pl.INT32],
     # Layer output.
@@ -958,7 +957,7 @@ def prefill_layer_cp_csa(
     arrived: pld.DistributedTensor[[META_WINDOW_ROWS, 1], pl.INT32],
     data_arrived: pld.DistributedTensor[[META_WINDOW_ROWS, 1], pl.INT32],
     routed_y_buf: pld.DistributedTensor[[ROUTED_WINDOW_ROWS, D], pl.BF16],
-    combine_arrived: pld.DistributedTensor[[META_WINDOW_ROWS, COMB_PAD], pl.INT32],
+    combine_arrived: pld.DistributedTensor[[META_WINDOW_ROWS, 1], pl.INT32],
     # Layer stage synchronization window.
     stage_done: pld.DistributedTensor[[CP_SIZE, 1], pl.INT32],
     # Layer output.
@@ -1131,7 +1130,7 @@ def l3_prefill_layer_cp_swa(
     arrived_buf = pld.alloc_window_buffer([META_WINDOW_ROWS, 1], dtype=pl.INT32)
     data_arrived_buf = pld.alloc_window_buffer([META_WINDOW_ROWS, 1], dtype=pl.INT32)
     routed_y_buf_buf = pld.alloc_window_buffer([ROUTED_WINDOW_ROWS, D], dtype=pl.BF16)
-    combine_arrived_buf = pld.alloc_window_buffer([META_WINDOW_ROWS, COMB_PAD], dtype=pl.INT32)
+    combine_arrived_buf = pld.alloc_window_buffer([META_WINDOW_ROWS, 1], dtype=pl.INT32)
 
     # Domain 3: layer stage synchronization (monotonic counter, 1..5).
     stage_done_buf = pld.alloc_window_buffer([CP_SIZE, 1], dtype=pl.INT32)
@@ -1156,7 +1155,7 @@ def l3_prefill_layer_cp_swa(
         )
         routed_y_buf = pld.window(routed_y_buf_buf, [ROUTED_WINDOW_ROWS, D], dtype=pl.BF16)
         combine_arrived = pld.window(
-            combine_arrived_buf, [META_WINDOW_ROWS, COMB_PAD], dtype=pl.INT32
+            combine_arrived_buf, [META_WINDOW_ROWS, 1], dtype=pl.INT32
         )
         stage_done = pld.window(stage_done_buf, [CP_SIZE, 1], dtype=pl.INT32)
         # SWA attention weights are shared across ranks (passed directly, not
@@ -1371,7 +1370,7 @@ def l3_prefill_layer_cp_hca(
     arrived_buf = pld.alloc_window_buffer([META_WINDOW_ROWS, 1], dtype=pl.INT32)
     data_arrived_buf = pld.alloc_window_buffer([META_WINDOW_ROWS, 1], dtype=pl.INT32)
     routed_y_buf_buf = pld.alloc_window_buffer([ROUTED_WINDOW_ROWS, D], dtype=pl.BF16)
-    combine_arrived_buf = pld.alloc_window_buffer([META_WINDOW_ROWS, COMB_PAD], dtype=pl.INT32)
+    combine_arrived_buf = pld.alloc_window_buffer([META_WINDOW_ROWS, 1], dtype=pl.INT32)
 
     # Domain 4: layer stage synchronization (monotonic counter, 1..5).
     stage_done_buf = pld.alloc_window_buffer([CP_SIZE, 1], dtype=pl.INT32)
@@ -1422,7 +1421,7 @@ def l3_prefill_layer_cp_hca(
         )
         routed_y_buf = pld.window(routed_y_buf_buf, [ROUTED_WINDOW_ROWS, D], dtype=pl.BF16)
         combine_arrived = pld.window(
-            combine_arrived_buf, [META_WINDOW_ROWS, COMB_PAD], dtype=pl.INT32
+            combine_arrived_buf, [META_WINDOW_ROWS, 1], dtype=pl.INT32
         )
         stage_done = pld.window(stage_done_buf, [CP_SIZE, 1], dtype=pl.INT32)
         # HCA attention weights are shared across ranks (passed directly, not
@@ -1691,7 +1690,7 @@ def l3_prefill_layer_cp_csa(
     arrived_buf = pld.alloc_window_buffer([META_WINDOW_ROWS, 1], dtype=pl.INT32)
     data_arrived_buf = pld.alloc_window_buffer([META_WINDOW_ROWS, 1], dtype=pl.INT32)
     routed_y_buf_buf = pld.alloc_window_buffer([ROUTED_WINDOW_ROWS, D], dtype=pl.BF16)
-    combine_arrived_buf = pld.alloc_window_buffer([META_WINDOW_ROWS, COMB_PAD], dtype=pl.INT32)
+    combine_arrived_buf = pld.alloc_window_buffer([META_WINDOW_ROWS, 1], dtype=pl.INT32)
 
     # Domain 3: layer stage synchronization (monotonic counter, 1..5).
     stage_done_buf = pld.alloc_window_buffer([CP_SIZE, 1], dtype=pl.INT32)
@@ -1760,7 +1759,7 @@ def l3_prefill_layer_cp_csa(
         )
         routed_y_buf = pld.window(routed_y_buf_buf, [ROUTED_WINDOW_ROWS, D], dtype=pl.BF16)
         combine_arrived = pld.window(
-            combine_arrived_buf, [META_WINDOW_ROWS, COMB_PAD], dtype=pl.INT32
+            combine_arrived_buf, [META_WINDOW_ROWS, 1], dtype=pl.INT32
         )
         stage_done = pld.window(stage_done_buf, [CP_SIZE, 1], dtype=pl.INT32)
 

--- a/models/deepseek_v4_flash_mtp/prefill_fwd.py
+++ b/models/deepseek_v4_flash_mtp/prefill_fwd.py
@@ -39,7 +39,6 @@ config.MOE_TOKENS = config.PREFILL_TOKENS
 # Import moe first: it applies the EP/FLASH override before the attention modules
 # bake config-derived MoE shapes (matches prefill_layer's import order).
 from moe import (
-    COMB_PAD,
     AUX_PAD,
     D,
     HC_DIM,
@@ -309,7 +308,7 @@ def prefill_fwd(
     arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
     data_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
     routed_y_buf: pld.DistributedTensor[[N_ROUTES, D], pl.BF16],
-    combine_arrived: pld.DistributedTensor[[N_RANKS, COMB_PAD], pl.INT32],
+    combine_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
     hc_ffn_fn: pl.Tensor[[FWD_NUM_LAYERS * MIX_HC, HC_DIM], pl.FP32],
     hc_ffn_scale: pl.Tensor[[FWD_NUM_LAYERS * 3], pl.FP32],
     hc_ffn_base: pl.Tensor[[FWD_NUM_LAYERS * MIX_HC], pl.FP32],
@@ -896,7 +895,7 @@ def l3_prefill_fwd(
     arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
     data_arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
     routed_y_buf_buf = pld.alloc_window_buffer([N_ROUTES, D], dtype=pl.BF16)
-    combine_arrived_buf = pld.alloc_window_buffer([N_RANKS, COMB_PAD], dtype=pl.INT32)
+    combine_arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
 
     for r in pl.range(pld.world_size()):
         recv_meta: pld.DistributedTensor[[N_RANKS, N_LOCAL], pl.INT32] = pld.window(recv_meta_buf, [N_RANKS, N_LOCAL], dtype=pl.INT32)
@@ -906,7 +905,7 @@ def l3_prefill_fwd(
         arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32] = pld.window(arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
         data_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32] = pld.window(data_arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
         routed_y_buf: pld.DistributedTensor[[N_ROUTES, D], pl.BF16] = pld.window(routed_y_buf_buf, [N_ROUTES, D], dtype=pl.BF16)
-        combine_arrived: pld.DistributedTensor[[N_RANKS, COMB_PAD], pl.INT32] = pld.window(combine_arrived_buf, [N_RANKS, COMB_PAD], dtype=pl.INT32)
+        combine_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32] = pld.window(combine_arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
         x_hc_rank = x_hc[r]
         hidden_rank = hidden_out[r]
         ori_slot_rank = ori_slot_mapping[r]

--- a/models/deepseek_v4_flash_mtp/prefill_layer.py
+++ b/models/deepseek_v4_flash_mtp/prefill_layer.py
@@ -25,7 +25,6 @@ config.MOE_TOKENS = config.PREFILL_TOKENS
 # Import moe first. It applies the EP2 FLASH override before dependent
 # modules bake config-derived MoE shapes.
 from moe import (
-    COMB_PAD,
     AUX_PAD,
     D,
     HC_DIM,
@@ -207,7 +206,7 @@ def prefill_layer_core(
     arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
     data_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
     routed_y_buf: pld.DistributedTensor[[N_ROUTES, D], pl.BF16],
-    combine_arrived: pld.DistributedTensor[[N_RANKS, COMB_PAD], pl.INT32],
+    combine_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
     layer_id: pl.Scalar[pl.INT32],
     my_rank: pl.Scalar[pl.INT32],
 ) -> pl.Tensor[[T, HC_MULT, D], pl.FP32]:
@@ -406,7 +405,7 @@ def l3_prefill_layer(
     arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
     data_arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
     routed_y_buf_buf = pld.alloc_window_buffer([N_ROUTES, D], dtype=pl.BF16)
-    combine_arrived_buf = pld.alloc_window_buffer([N_RANKS, COMB_PAD], dtype=pl.INT32)
+    combine_arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
 
     for rank in pl.range(pld.world_size()):
         recv_meta = pld.window(recv_meta_buf, [N_RANKS, N_LOCAL], dtype=pl.INT32)
@@ -416,7 +415,7 @@ def l3_prefill_layer(
         arrived = pld.window(arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
         data_arrived = pld.window(data_arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
         routed_y_buf = pld.window(routed_y_buf_buf, [N_ROUTES, D], dtype=pl.BF16)
-        combine_arrived = pld.window(combine_arrived_buf, [N_RANKS, COMB_PAD], dtype=pl.INT32)
+        combine_arrived = pld.window(combine_arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
         prefill_layer_core(
             x_hc[rank],
             hc_attn_fn[rank], hc_attn_scale[rank], hc_attn_base[rank],

--- a/models/deepseek_v4_flash_mtp/prefill_mtp.py
+++ b/models/deepseek_v4_flash_mtp/prefill_mtp.py
@@ -40,7 +40,6 @@ from lm_head import (
     lm_head_test,
 )
 from moe import (
-    COMB_PAD,
     AUX_PAD,
     D,
     HC_DIM,
@@ -180,7 +179,7 @@ def mtp_prefill_fwd(
     arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
     data_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
     routed_y_buf: pld.DistributedTensor[[N_ROUTES, D], pl.BF16],
-    combine_arrived: pld.DistributedTensor[[N_RANKS, COMB_PAD], pl.INT32],
+    combine_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
     my_rank: pl.Scalar[pl.INT32],
     num_tokens: pl.Scalar[pl.INT32],
 ) -> pl.Tensor[[T, D], pl.BF16]:
@@ -316,7 +315,7 @@ def l3_mtp_prefill_fwd(
     arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
     data_arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
     routed_y_buf_buf = pld.alloc_window_buffer([N_ROUTES, D], dtype=pl.BF16)
-    combine_arrived_buf = pld.alloc_window_buffer([N_RANKS, COMB_PAD], dtype=pl.INT32)
+    combine_arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
 
     for r in pl.range(pld.world_size()):
         recv_meta = pld.window(recv_meta_buf, [N_RANKS, N_LOCAL], dtype=pl.INT32)
@@ -326,7 +325,7 @@ def l3_mtp_prefill_fwd(
         arrived = pld.window(arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
         data_arrived = pld.window(data_arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
         routed_y_buf = pld.window(routed_y_buf_buf, [N_ROUTES, D], dtype=pl.BF16)
-        combine_arrived = pld.window(combine_arrived_buf, [N_RANKS, COMB_PAD], dtype=pl.INT32)
+        combine_arrived = pld.window(combine_arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
         mtp_prefill_fwd(
             hidden_states[r], prev_hidden_states[r],
             enorm_w[r], hnorm_w[r],


### PR DESCRIPTION
Reverts #975, returning all eleven files to their pre-#975 state.

- Move the routed-output scatter back out of exp_w2_act into combine's
  own SPMD grid, one block per local expert, walking the per-(src,
  expert) prefix sum to place each row rather than pushing it as soon as
  it is activated.
- Return the arrival handshake to counting tasks instead of rows:
  combine_wait depends on the scatter grid's TaskId again, each block
  notifies its peers, combine_arrived narrows back to [N_RANKS, 1], and
  the COMB_ARRIVED / COMB_EXPECT columns go away.
- Drop recv_src_out and the IDX_SRC origin-rank column that dispatch
  recorded next to each route id.
- Restore the non-fused _expert_w2 and expert_routed pair and the
  multi-rank expert_routed entry.

The row-count handshake carried no epoch dimension: COMB_ARRIVED and
COMB_EXPECT both accumulated until clear_moe_signals, which runs once per
program rather than once per wave, so in a multi-layer forward or the
four-wave CP path a faster rank's next-epoch rows could satisfy a slower
rank's current expectation and let shared_routed read a missing or
overwritten route. Restoring the barrier-based ordering gives that back
at the cost of the core-time and drain gains #975 measured, which never
resolved into an end-to-end wall-time difference anyway.