### PR TITLE
Refactor: rename and rescope the dspark decode attention entries

### DIFF
--- a/models/deepseek_v4_flash_dspark/decode_csa.py
+++ b/models/deepseek_v4_flash_dspark/decode_csa.py
@@ -70,9 +70,9 @@ from decode_o_proj import (
     LOCAL_T,
     LOCAL_T_PAD,
     O_WINDOW_ROWS,
-    attention_token_head_all_to_all_step,
-    decode_sharded_o_projection,
-    o_projection_reduce_scatter_step,
+    decode_o_proj,
+    o_group_a2a,
+    o_proj_reduce_scatter,
 )
 from decode_sparse_attn_csa import (
     ATTN_K_TILE,
@@ -496,7 +496,7 @@ def decode_csa_output(
     )
 
     attention_local_flat = pl.create_tensor([ATTENTION_WINDOW_ROWS, O_GROUP_IN], dtype=pl.BF16)
-    attention_local_flat, attention_signal = attention_token_head_all_to_all_step(
+    attention_local_flat, attention_signal = o_group_a2a(
         attention_grouped, attention_local_flat,
         attention_window, attention_signal,
         group_base, tp_rank, local_t,
@@ -504,18 +504,17 @@ def decode_csa_output(
 
     attention_local_groups = pl.reshape(attention_local_flat, [LOCAL_O_GROUPS, GROUP_T_PAD, O_GROUP_IN])
     o_partial = pl.create_tensor([GROUP_T_PAD, D], dtype=pl.FP32)
-    o_partial, projection_tid = decode_sharded_o_projection(
+    o_partial, projection_tid = decode_o_proj(
         attention_local_groups,
         wo_a, wo_b, wo_b_scale,
         local_t, o_partial,
     )
 
-    with pl.spmd(1, name_hint="tp_o_reduce_scatter", deps=[projection_tid]) as _reduce_scatter_tid:
-        o_local, o_signal = o_projection_reduce_scatter_step(
-            o_partial, o_local,
-            o_window, o_signal,
-            group_base, tp_rank, local_t,
-        )
+    o_local, o_signal = o_proj_reduce_scatter(
+        o_partial, o_local,
+        o_window, o_signal,
+        group_base, tp_rank, local_t, projection_tid,
+    )
     return o_local, attention_signal, o_signal
 
 

--- a/models/deepseek_v4_flash_dspark/decode_csa.py
+++ b/models/deepseek_v4_flash_dspark/decode_csa.py
@@ -89,6 +89,11 @@ from decode_sparse_attn_csa import (
 # Dynamic shape variables.
 B_DYN = pl.dynamic("B_DYN")  # per-request axis
 T_DYN = pl.dynamic("T_DYN")  # T = B * S
+ORI_BLOCK_NUM_DYN = pl.dynamic("ORI_BLOCK_NUM_DYN")
+CMP_BLOCK_NUM_DYN = pl.dynamic("CMP_BLOCK_NUM_DYN")
+IDX_CACHE_BLOCK_NUM_DYN = pl.dynamic("IDX_CACHE_BLOCK_NUM_DYN")
+MAIN_STATE_BLOCK_NUM_DYN = pl.dynamic("CSA_STATE_BLOCK_NUM_DYN")
+INNER_STATE_BLOCK_NUM_DYN = pl.dynamic("INNER_STATE_BLOCK_NUM_DYN")
 
 # model config
 B = DECODE_BATCH // TP_SIZE
@@ -125,69 +130,24 @@ MAIN_STATE_BLOCK_SIZE = C4A_COMPRESSOR_BLOCK_SIZE
 MAIN_STATE_PHYSICAL_BLOCKS = CSA_STATE_PHYSICAL_BLOCKS
 MAIN_STATE_MAX_BLOCKS = (MAX_SEQ_LEN + MAIN_STATE_BLOCK_SIZE - 1) // MAIN_STATE_BLOCK_SIZE
 MAIN_STATE_BLOCK_NUM = MAIN_STATE_PHYSICAL_BLOCKS
-MAIN_STATE_BLOCK_NUM_DYN = pl.dynamic("CSA_STATE_BLOCK_NUM_DYN")
 INNER_OUT_DIM = COFF * IDX_HEAD_DIM
 INNER_STATE_DIM = 2 * INNER_OUT_DIM
 INNER_STATE_BLOCK_SIZE = C4A_COMPRESSOR_BLOCK_SIZE
 INNER_STATE_PHYSICAL_BLOCKS = CSA_INNER_STATE_PHYSICAL_BLOCKS
 INNER_STATE_MAX_BLOCKS = (MAX_SEQ_LEN + INNER_STATE_BLOCK_SIZE - 1) // INNER_STATE_BLOCK_SIZE
 INNER_STATE_BLOCK_NUM = INNER_STATE_PHYSICAL_BLOCKS
-INNER_STATE_BLOCK_NUM_DYN = pl.dynamic("INNER_STATE_BLOCK_NUM_DYN")
-IDX_CACHE_BLOCK_NUM_DYN = pl.dynamic("IDX_CACHE_BLOCK_NUM_DYN")
 ORI_MAX_BLOCKS = KV_ORI_MAX_BLOCKS
 ORI_BLOCK_NUM = KV_ORI_BLOCK_NUM
-ORI_BLOCK_NUM_DYN = pl.dynamic("ORI_BLOCK_NUM_DYN")
 CMP_MAX_BLOCKS = KV_CMP_MAX_BLOCKS
 CMP_BLOCK_NUM = KV_CMP_BLOCK_NUM
-CMP_BLOCK_NUM_DYN = pl.dynamic("CMP_BLOCK_NUM_DYN")
 
 # tiling
 CSA_WB_TOKEN_TILE = 8
-
-# fixture
-FIXTURE_CMP_ENTRIES = (
-    (ATTN_K_TILE - 1, BLOCK_SIZE // 4 - 1),
-    (2 * ATTN_K_TILE - 1, BLOCK_SIZE),
-    (3 * ATTN_K_TILE - 1, 2 * BLOCK_SIZE),
-    (4 * ATTN_K_TILE - 1, 4 * BLOCK_SIZE - 3),
-)
-FIXTURE_FILTERED_POSITIONS = (1, ATTN_K_TILE + 1, 2 * ATTN_K_TILE + 1, 3 * ATTN_K_TILE + 1)
-FIXTURE_CMP_SLOTS = tuple(slot for _, slot in FIXTURE_CMP_ENTRIES)
-FIXTURE_CMP_LOGICAL_BLOCKS = (max(FIXTURE_CMP_SLOTS) + 1 + BLOCK_SIZE - 1) // BLOCK_SIZE
-FIXTURE_CMP_BOUND = 4 * BLOCK_SIZE - 2
-FIXTURE_FILTERED_SLOT = FIXTURE_CMP_BOUND
-FIXTURE_POSITION_ID = COMPRESS_RATIO * FIXTURE_CMP_BOUND - 1
-FIXTURE_WINDOW_HEAD = (FIXTURE_POSITION_ID - WIN + 1) % BLOCK_SIZE
-FIXTURE_WINDOW_BLOCKS = (FIXTURE_WINDOW_HEAD + WIN + BLOCK_SIZE - 1) // BLOCK_SIZE
-FIXTURE_CMP_BLOCKS = (LOCAL_T // S) * FIXTURE_CMP_LOGICAL_BLOCKS
-FIXTURE_OUTPUT_SENTINEL = -7.0
 
 if T != LOCAL_T:
     raise ValueError(f"CSA token capacity {T} must equal TP local token capacity {LOCAL_T}")
 if T_PAD != LOCAL_T_PAD:
     raise ValueError(f"CSA token capacity {T_PAD} must equal TP local token capacity {LOCAL_T_PAD}")
-if LOCAL_T < 2 * ROPE_CS_T_TILE:
-    raise ValueError("CSA fixture token capacity must leave one RoPE row tile for subcapacity")
-if LOCAL_T % ROPE_CS_T_TILE != 0:
-    raise ValueError("CSA fixture token capacity must align to the RoPE row tile")
-if (LOCAL_T - ROPE_CS_T_TILE) % S != 0:
-    raise ValueError("CSA fixture subcapacity must preserve whole decode requests")
-if max(position for position, _ in FIXTURE_CMP_ENTRIES) >= INDEXER_SCORE_LEN:
-    raise ValueError("CSA fixture compressed positions exceed the indexer score row")
-if max(position for position, _ in FIXTURE_CMP_ENTRIES) >= 4 * ATTN_K_TILE:
-    raise ValueError("CSA fixture compressed positions exceed the four sparse tiles")
-if max(FIXTURE_FILTERED_POSITIONS) >= CMP_TOPK:
-    raise ValueError("CSA fixture filtered positions exceed the compressed top-k row")
-if FIXTURE_FILTERED_SLOT >= FIXTURE_CMP_LOGICAL_BLOCKS * BLOCK_SIZE:
-    raise ValueError("CSA filtered slot must remain inside the fixture block table")
-if FIXTURE_WINDOW_BLOCKS > ORI_BLOCK_NUM:
-    raise ValueError("CSA fixture window exceeds the original KV cache capacity")
-if FIXTURE_CMP_LOGICAL_BLOCKS > CMP_MAX_BLOCKS:
-    raise ValueError("CSA fixture compressed slots exceed the compressed block table")
-if FIXTURE_CMP_BLOCKS > CMP_BLOCK_NUM:
-    raise ValueError("CSA fixture compressed-cache pool exceeds its physical capacity")
-if O_LORA < 4 * HEADS_PER_GROUP:
-    raise ValueError("CSA fixture output projection needs four observable rows per local head")
 
 
 @pl.jit
@@ -375,12 +335,7 @@ def decode_csa_tp1(
     rope_sin_t = pl.create_tensor([t_dim, ROPE_HEAD_DIM], dtype=pl.BF16)
     step_cos = pl.create_tensor([B, HALF_ROPE], dtype=pl.FP32)
     step_sin = pl.create_tensor([B, HALF_ROPE], dtype=pl.FP32)
-    # Interleave-duplicated / sign-folded step rope rows for the indexer subsystem.
-    # The indexer's qr_rope re-ran the j>>1 dup-gather on each of its 16 spmd blocks
-    # (32 rows each) and its compressor once more; pl.gather lowers to a per-row
-    # TGATHER loop, so that was ~1056 row-gathers per layer to rebuild one small
-    # position-invariant table. Built once here instead (B rows, off the critical
-    # path -- this scope has no producer) and read as a plain load downstream.
+    # Interleave-duplicated / sign-folded step rope rows for the indexer, built once over B rows.
     step_cos_il = pl.create_tensor([B, ROPE_HEAD_DIM], dtype=pl.FP32)
     step_sin_signed = pl.create_tensor([B, ROPE_HEAD_DIM], dtype=pl.FP32)
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="csa_rope_step"):
@@ -395,8 +350,10 @@ def decode_csa_tp1(
                 sin_row = pl.cast(freqs_sin[pos_b : pos_b + 1, 0 : ROPE_HEAD_DIM], target_type=pl.FP32)
                 rope_cos_t[t : t + 1, 0 : ROPE_HEAD_DIM] = pl.cast(cos_row, target_type=pl.BF16)
                 rope_sin_t[t : t + 1, 0 : ROPE_HEAD_DIM] = pl.cast(sin_row, target_type=pl.BF16)
-            step_cos[b : b + 1, 0 : HALF_ROPE] = pl.cast(freqs_cos[step_pos_b : step_pos_b + 1, 0 : HALF_ROPE], target_type=pl.FP32)
-            step_sin[b : b + 1, 0 : HALF_ROPE] = pl.cast(freqs_sin[step_pos_b : step_pos_b + 1, 0 : HALF_ROPE], target_type=pl.FP32)
+            step_cos_row = freqs_cos[step_pos_b : step_pos_b + 1, 0 : HALF_ROPE]
+            step_sin_row = freqs_sin[step_pos_b : step_pos_b + 1, 0 : HALF_ROPE]
+            step_cos[b : b + 1, 0 : HALF_ROPE] = pl.cast(step_cos_row, target_type=pl.FP32)
+            step_sin[b : b + 1, 0 : HALF_ROPE] = pl.cast(step_sin_row, target_type=pl.FP32)
 
     rope_interleave(step_cos, step_sin, step_cos_il, step_sin_signed)
 
@@ -411,16 +368,17 @@ def decode_csa_tp1(
             first_pos_b = pl.read(position_ids, [first_t])
             cmp_offset_b = COMPRESS_RATIO - (first_pos_b % COMPRESS_RATIO)
             cmp_pos_b = pl.cast(first_pos_b + cmp_offset_b - COMPRESS_RATIO, pl.INDEX)
-            cmp_cos[b : b + 1, 0 : HALF_ROPE] = pl.cast(freqs_cos[cmp_pos_b : cmp_pos_b + 1, 0 : HALF_ROPE], target_type=pl.FP32)
-            cmp_sin[b : b + 1, 0 : HALF_ROPE] = pl.cast(freqs_sin[cmp_pos_b : cmp_pos_b + 1, 0 : HALF_ROPE], target_type=pl.FP32)
+            cmp_cos_row = freqs_cos[cmp_pos_b : cmp_pos_b + 1, 0 : HALF_ROPE]
+            cmp_sin_row = freqs_sin[cmp_pos_b : cmp_pos_b + 1, 0 : HALF_ROPE]
+            cmp_cos[b : b + 1, 0 : HALF_ROPE] = pl.cast(cmp_cos_row, target_type=pl.FP32)
+            cmp_sin[b : b + 1, 0 : HALF_ROPE] = pl.cast(cmp_sin_row, target_type=pl.FP32)
 
     rope_interleave(cmp_cos, cmp_sin, cmp_cos_il, cmp_sin_signed)
 
     x_normed_t = pl.create_tensor([t_dim, D], dtype=pl.BF16)
     rms_tid = rms_norm(x_mixed, attn_norm_w, x_normed_t)
-    # rms_norm fans out to qr_proj_matmul (critical path), kv_proj_matmul, kv_score_proj
-    # and weights_proj. The latter three take this barrier instead of racing the first:
-    # the dummy resolves one hop after rms_norm, so qr_proj_matmul is dispatched first.
+    # Dispatch barrier: kv_proj_matmul, kv_score_proj and weights_proj resolve one hop
+    # after rms_norm, leaving qr_proj_matmul first.
     late_dep = pl.system.task_dummy(deps=[rms_tid])
     q = pl.create_tensor([t_dim, H, HEAD_DIM], dtype=pl.BF16)
     kv = pl.create_tensor([t_dim, HEAD_DIM], dtype=pl.BF16)
@@ -467,9 +425,8 @@ def decode_csa_tp1(
         kv_seq_lens, 0, late_dep,
     )
 
-    # sparse_attn_csa now folds the compressed-slot masking + valid-block flags in from
-    # the raw indexer topk + position, so pass those directly.
-
+    # sparse_attn_csa folds the compressed-slot masking + valid-block flags in from the
+    # raw indexer topk + position.
     position_ids_t1 = pl.reshape(position_ids, [t_dim, 1])
     attn_out = pl.create_tensor([t_dim, D], dtype=pl.BF16)
     o_packed_heads = pl.create_tensor([O_GROUPS * T_PAD, O_GROUP_IN], dtype=pl.BF16)
@@ -579,6 +536,48 @@ def decode_csa_tp1_test(
     return x_out
 
 
+# fixture
+FIXTURE_CMP_ENTRIES = (
+    (ATTN_K_TILE - 1, BLOCK_SIZE // 4 - 1),
+    (2 * ATTN_K_TILE - 1, BLOCK_SIZE),
+    (3 * ATTN_K_TILE - 1, 2 * BLOCK_SIZE),
+    (4 * ATTN_K_TILE - 1, 4 * BLOCK_SIZE - 3),
+)
+FIXTURE_FILTERED_POSITIONS = (1, ATTN_K_TILE + 1, 2 * ATTN_K_TILE + 1, 3 * ATTN_K_TILE + 1)
+FIXTURE_CMP_SLOTS = tuple(slot for _, slot in FIXTURE_CMP_ENTRIES)
+FIXTURE_CMP_LOGICAL_BLOCKS = (max(FIXTURE_CMP_SLOTS) + 1 + BLOCK_SIZE - 1) // BLOCK_SIZE
+FIXTURE_CMP_BOUND = 4 * BLOCK_SIZE - 2
+FIXTURE_FILTERED_SLOT = FIXTURE_CMP_BOUND
+FIXTURE_POSITION_ID = COMPRESS_RATIO * FIXTURE_CMP_BOUND - 1
+FIXTURE_WINDOW_HEAD = (FIXTURE_POSITION_ID - WIN + 1) % BLOCK_SIZE
+FIXTURE_WINDOW_BLOCKS = (FIXTURE_WINDOW_HEAD + WIN + BLOCK_SIZE - 1) // BLOCK_SIZE
+FIXTURE_CMP_BLOCKS = (LOCAL_T // S) * FIXTURE_CMP_LOGICAL_BLOCKS
+FIXTURE_OUTPUT_SENTINEL = -7.0
+
+if LOCAL_T < 2 * ROPE_CS_T_TILE:
+    raise ValueError("CSA fixture token capacity must leave one RoPE row tile for subcapacity")
+if LOCAL_T % ROPE_CS_T_TILE != 0:
+    raise ValueError("CSA fixture token capacity must align to the RoPE row tile")
+if (LOCAL_T - ROPE_CS_T_TILE) % S != 0:
+    raise ValueError("CSA fixture subcapacity must preserve whole decode requests")
+if max(position for position, _ in FIXTURE_CMP_ENTRIES) >= INDEXER_SCORE_LEN:
+    raise ValueError("CSA fixture compressed positions exceed the indexer score row")
+if max(position for position, _ in FIXTURE_CMP_ENTRIES) >= 4 * ATTN_K_TILE:
+    raise ValueError("CSA fixture compressed positions exceed the four sparse tiles")
+if max(FIXTURE_FILTERED_POSITIONS) >= CMP_TOPK:
+    raise ValueError("CSA fixture filtered positions exceed the compressed top-k row")
+if FIXTURE_FILTERED_SLOT >= FIXTURE_CMP_LOGICAL_BLOCKS * BLOCK_SIZE:
+    raise ValueError("CSA filtered slot must remain inside the fixture block table")
+if FIXTURE_WINDOW_BLOCKS > ORI_BLOCK_NUM:
+    raise ValueError("CSA fixture window exceeds the original KV cache capacity")
+if FIXTURE_CMP_LOGICAL_BLOCKS > CMP_MAX_BLOCKS:
+    raise ValueError("CSA fixture compressed slots exceed the compressed block table")
+if FIXTURE_CMP_BLOCKS > CMP_BLOCK_NUM:
+    raise ValueError("CSA fixture compressed-cache pool exceeds its physical capacity")
+if O_LORA < 4 * HEADS_PER_GROUP:
+    raise ValueError("CSA fixture output projection needs four observable rows per local head")
+
+
 def build_tp_tensor_specs(local_t):
     """Build deterministic tensor-parallel CSA output inputs."""
     import torch
@@ -636,21 +635,12 @@ def build_tp_tensor_specs(local_t):
                     row = cmp_slot % BLOCK_SIZE
                     cmp_kv[rank, physical_block, row, 0, :] = 0.0
                     cmp_kv[rank, physical_block, row, 0, 0] = 0.25
-                    cmp_kv[rank, physical_block, row, 0, 1] = (
-                        (rank + 1) * 0.03125
-                        + (request + 1) * 0.0078125
-                        + (entry_index + 1) * 0.001953125
-                    )
-                    cmp_kv[rank, physical_block, row, 0, NOPE_DIM] = (
-                        (rank + 1) * 0.0625
-                        + (request + 1) * 0.015625
-                        + (entry_index + 1) * 0.00390625
-                    )
-                    cmp_kv[rank, physical_block, row, 0, NOPE_DIM + 1] = (
-                        -(logical_block + 1) * 0.0625
-                        + (rank + 1) * 0.0078125
-                        + (request + 1) * 0.001953125
-                    )
+                    col1_value = (rank + 1) * 0.03125 + (request + 1) * 0.0078125 + (entry_index + 1) * 0.001953125
+                    nope_value = (rank + 1) * 0.0625 + (request + 1) * 0.015625 + (entry_index + 1) * 0.00390625
+                    block_value = -(logical_block + 1) * 0.0625 + (rank + 1) * 0.0078125 + (request + 1) * 0.001953125
+                    cmp_kv[rank, physical_block, row, 0, 1] = col1_value
+                    cmp_kv[rank, physical_block, row, 0, NOPE_DIM] = nope_value
+                    cmp_kv[rank, physical_block, row, 0, NOPE_DIM + 1] = block_value
         return cmp_kv
 
     def init_cmp_block_table():
@@ -659,9 +649,8 @@ def build_tp_tensor_specs(local_t):
             for request in range(local_batch):
                 request_block_base = request * FIXTURE_CMP_LOGICAL_BLOCKS
                 for logical_block in range(FIXTURE_CMP_LOGICAL_BLOCKS):
-                    table[rank, request, logical_block] = (
-                        request_block_base + FIXTURE_CMP_LOGICAL_BLOCKS - 1 - logical_block
-                    )
+                    physical_block = request_block_base + FIXTURE_CMP_LOGICAL_BLOCKS - 1 - logical_block
+                    table[rank, request, logical_block] = physical_block
         return table
 
     def init_idx_topk():
@@ -704,19 +693,12 @@ def build_tp_tensor_specs(local_t):
             for local_group in range(LOCAL_O_GROUPS):
                 shard_scale = (rank + 1) * (local_group + 1) * 0.125
                 for head in range(HEADS_PER_GROUP):
-                    wo_a[rank, local_group, head, head * HEAD_DIM] = shard_scale * (head + 1)
-                    wo_a[
-                        rank, local_group, HEADS_PER_GROUP + head,
-                        head * HEAD_DIM + 1,
-                    ] = shard_scale * (head + 1) * 0.75
-                    wo_a[
-                        rank, local_group, 2 * HEADS_PER_GROUP + head,
-                        head * HEAD_DIM + NOPE_DIM,
-                    ] = -shard_scale * (head + 1) * 0.5
-                    wo_a[
-                        rank, local_group, 3 * HEADS_PER_GROUP + head,
-                        head * HEAD_DIM + NOPE_DIM + 1,
-                    ] = shard_scale * (head + 1) * 0.25
+                    head_col = head * HEAD_DIM
+                    head_scale = shard_scale * (head + 1)
+                    wo_a[rank, local_group, head, head_col] = head_scale
+                    wo_a[rank, local_group, HEADS_PER_GROUP + head, head_col + 1] = head_scale * 0.75
+                    wo_a[rank, local_group, 2 * HEADS_PER_GROUP + head, head_col + NOPE_DIM] = -head_scale * 0.5
+                    wo_a[rank, local_group, 3 * HEADS_PER_GROUP + head, head_col + NOPE_DIM + 1] = head_scale * 0.25
         return wo_a
 
     def init_wo_b():
@@ -1083,9 +1065,7 @@ def build_tensor_specs(start_pos=None, batch=B):
     def init_x_hc():
         return torch.empty(tokens, HC_MULT, D).uniform_(-1, 1)
 
-    # Real layer-8 (CSA, ratio-4) hc_attn scale/base (fn synthetic at real magnitude). A
-    # synthetic scale=0.5/base=0 leaves hc_pre post~=1 + near-uniform comb, cancelling attn_out
-    # and the hc residual to near-zero in x_out where W8A8 noise blows up the relative tail.
+    # Real layer-8 (CSA, ratio-4) hc_attn scale/base; fn is synthetic at the real magnitude.
     def init_hc_attn_fn():
         return torch.randn(MIX_HC, HC_DIM) * 0.0519
 
@@ -1417,12 +1397,13 @@ if __name__ == "__main__":
     from pypto.ir.distributed_compiled_program import DistributedConfig
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("-p", "--platform", type=str, default="a2a3",
-                        choices=["a2a3", "a2a3sim", "a5", "a5sim"])
-    parser.add_argument("--tp", type=int, default=TP_SIZE, choices=list(_TP_CHOICES),
-                        help="tensor-parallel world size")
-    parser.add_argument("-d", "--device", type=str, default=",".join(str(rank) for rank in range(TP_SIZE)),
-                        help=f"comma-separated device ids; need exactly {TP_SIZE}")
+    default_devices = ",".join(str(rank) for rank in range(TP_SIZE))
+    parser.add_argument("-p", "--platform", type=str, default="a2a3", choices=["a2a3", "a2a3sim", "a5", "a5sim"])
+    parser.add_argument("--tp", type=int, default=TP_SIZE, choices=list(_TP_CHOICES), help="tensor-parallel world size")
+    parser.add_argument(
+        "-d", "--device", type=str, default=default_devices,
+        help=f"comma-separated device ids; need exactly {TP_SIZE}",
+    )
     parser.add_argument("--case", choices=("all", "max", "subcapacity"), default="all")
     parser.add_argument("--compile-only", action="store_true", default=False)
     parser.add_argument("--dump-passes", action="store_true", default=False)

--- a/models/deepseek_v4_flash_dspark/decode_csa.py
+++ b/models/deepseek_v4_flash_dspark/decode_csa.py
@@ -71,6 +71,7 @@ from decode_o_proj import (
     LOCAL_T_PAD,
     O_WINDOW_ROWS,
     decode_o_proj,
+    decode_o_proj_tp1,
     o_group_a2a,
     o_proj_reduce_scatter,
 )
@@ -83,7 +84,6 @@ from decode_sparse_attn_csa import (
     SOFTMAX_SCALE,
     T_PAD,
     sparse_attn_csa,
-    sparse_attn_csa_heads,
 )
 
 # Dynamic shape variables.
@@ -190,8 +190,129 @@ if O_LORA < 4 * HEADS_PER_GROUP:
     raise ValueError("CSA fixture output projection needs four observable rows per local head")
 
 
+@pl.jit
+def decode_csa(
+    q: pl.Tensor[[T_DYN, H, HEAD_DIM], pl.BF16],
+    ori_kv: pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    window_swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
+    cmp_kv: pl.Tensor[[CMP_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    cmp_block_table: pl.Tensor[[B_DYN, CMP_MAX_BLOCKS], pl.INT32],
+    idx_topk: pl.Tensor[[T_DYN, INDEXER_SCORE_LEN], pl.INT32],
+    position_ids: pl.Tensor[[T_DYN, 1], pl.INT32],
+    attn_sink: pl.Tensor[[H], pl.FP32],
+    freqs_cos: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
+    wo_a: pl.Tensor[[LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
+    wo_b: pl.Tensor[[D, LOCAL_O_WIDTH], pl.INT8],
+    wo_b_scale: pl.Tensor[[D], pl.FP32],
+    o_local: pl.InOut[pl.Tensor[[LOCAL_T_PAD, D], pl.BF16]],
+    attention_window: pld.DistributedTensor[[ATTENTION_WINDOW_ROWS, O_GROUP_IN], pl.BF16],
+    attention_signal: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
+    o_window: pld.DistributedTensor[[O_WINDOW_ROWS, D], pl.FP32],
+    o_signal: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
+    group_base: pl.Scalar[pl.INT32],
+    tp_rank: pl.Scalar[pl.INT32],
+    local_t: pl.Scalar[pl.INT32],
+):
+    """Run rank-local CSA heads, output A2A, sharded O projection, and RS."""
+    q.bind_dynamic(0, T_DYN)
+    ori_kv.bind_dynamic(0, ORI_BLOCK_NUM_DYN)
+    window_swa_indices.bind_dynamic(0, T_DYN)
+    cmp_kv.bind_dynamic(0, CMP_BLOCK_NUM_DYN)
+    cmp_block_table.bind_dynamic(0, B_DYN)
+    idx_topk.bind_dynamic(0, T_DYN)
+    position_ids.bind_dynamic(0, T_DYN)
+    freqs_cos.bind_dynamic(0, T_DYN)
+    freqs_sin.bind_dynamic(0, T_DYN)
+
+    attention_grouped = pl.create_tensor([O_GROUPS * LOCAL_T_PAD, O_GROUP_IN], dtype=pl.BF16)
+    attention_grouped, _ = sparse_attn_csa(
+        q, ori_kv, window_swa_indices,
+        cmp_kv, cmp_block_table, idx_topk,
+        position_ids, attn_sink, freqs_cos, freqs_sin,
+        attention_grouped,
+    )
+
+    attention_local_flat = pl.create_tensor([ATTENTION_WINDOW_ROWS, O_GROUP_IN], dtype=pl.BF16)
+    attention_local_flat, attention_signal = o_group_a2a(
+        attention_grouped, attention_local_flat,
+        attention_window, attention_signal,
+        group_base, tp_rank, local_t,
+    )
+
+    attention_local_groups = pl.reshape(attention_local_flat, [LOCAL_O_GROUPS, GROUP_T_PAD, O_GROUP_IN])
+    o_partial = pl.create_tensor([GROUP_T_PAD, D], dtype=pl.FP32)
+    o_partial, projection_tid = decode_o_proj(
+        attention_local_groups,
+        wo_a, wo_b, wo_b_scale,
+        local_t, o_partial,
+    )
+
+    o_local, o_signal = o_proj_reduce_scatter(
+        o_partial, o_local,
+        o_window, o_signal,
+        group_base, tp_rank, local_t, projection_tid,
+    )
+    return o_local, attention_signal, o_signal
+
+
+@pl.jit.host
+def l3_decode_csa(
+    q: pl.Tensor[[TP_SIZE, T_DYN, H, HEAD_DIM], pl.BF16],
+    ori_kv: pl.Tensor[[TP_SIZE, ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    window_swa_indices: pl.Tensor[[TP_SIZE, T_DYN, WIN], pl.INT32],
+    cmp_kv: pl.Tensor[[TP_SIZE, CMP_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    cmp_block_table: pl.Tensor[[TP_SIZE, B_DYN, CMP_MAX_BLOCKS], pl.INT32],
+    idx_topk: pl.Tensor[[TP_SIZE, T_DYN, INDEXER_SCORE_LEN], pl.INT32],
+    position_ids: pl.Tensor[[TP_SIZE, T_DYN, 1], pl.INT32],
+    attn_sink: pl.Tensor[[TP_SIZE, H], pl.FP32],
+    freqs_cos: pl.Tensor[[TP_SIZE, T_DYN, ROPE_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[TP_SIZE, T_DYN, ROPE_DIM], pl.BF16],
+    wo_a: pl.Tensor[[TP_SIZE, LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
+    wo_b: pl.Tensor[[TP_SIZE, D, LOCAL_O_WIDTH], pl.INT8],
+    wo_b_scale: pl.Tensor[[TP_SIZE, D], pl.FP32],
+    o_local: pl.InOut[pl.Tensor[[TP_SIZE, LOCAL_T_PAD, D], pl.BF16]],
+    local_t: pl.Scalar[pl.INT32],
+):
+    """Launch the CSA output path on one TP group."""
+    q.bind_dynamic(1, T_DYN)
+    ori_kv.bind_dynamic(1, ORI_BLOCK_NUM_DYN)
+    window_swa_indices.bind_dynamic(1, T_DYN)
+    cmp_kv.bind_dynamic(1, CMP_BLOCK_NUM_DYN)
+    cmp_block_table.bind_dynamic(1, B_DYN)
+    idx_topk.bind_dynamic(1, T_DYN)
+    position_ids.bind_dynamic(1, T_DYN)
+    freqs_cos.bind_dynamic(1, T_DYN)
+    freqs_sin.bind_dynamic(1, T_DYN)
+
+    attention_window_buf = pld.alloc_window_buffer([ATTENTION_WINDOW_ROWS, O_GROUP_IN], dtype=pl.BF16)
+    attention_signal_buf = pld.alloc_window_buffer([TP_SIZE, 1], dtype=pl.INT32)
+    o_window_buf = pld.alloc_window_buffer([O_WINDOW_ROWS, D], dtype=pl.FP32)
+    o_signal_buf = pld.alloc_window_buffer([TP_SIZE, 1], dtype=pl.INT32)
+
+    for rank in pl.range(pld.world_size()):
+        attention_window = pld.window(attention_window_buf, [ATTENTION_WINDOW_ROWS, O_GROUP_IN], dtype=pl.BF16)
+        attention_signal = pld.window(attention_signal_buf, [TP_SIZE, 1], dtype=pl.INT32)
+        o_window = pld.window(o_window_buf, [O_WINDOW_ROWS, D], dtype=pl.FP32)
+        o_signal = pld.window(o_signal_buf, [TP_SIZE, 1], dtype=pl.INT32)
+        decode_csa(
+            q[rank],
+            ori_kv[rank], window_swa_indices[rank],
+            cmp_kv[rank], cmp_block_table[rank], idx_topk[rank],
+            position_ids[rank], attn_sink[rank],
+            freqs_cos[rank], freqs_sin[rank],
+            wo_a[rank], wo_b[rank], wo_b_scale[rank],
+            o_local[rank],
+            attention_window, attention_signal,
+            o_window, o_signal,
+            0, rank, local_t,
+            device=rank,
+        )
+
+
+
 @pl.jit.inline
-def attention_csa(
+def decode_csa_tp1(
     x_hc: pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32],
     hc_attn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
     hc_attn_scale: pl.Tensor[[3], pl.FP32],
@@ -351,11 +472,17 @@ def attention_csa(
 
     position_ids_t1 = pl.reshape(position_ids, [t_dim, 1])
     attn_out = pl.create_tensor([t_dim, D], dtype=pl.BF16)
-    sparse_attn_csa(
+    o_packed_heads = pl.create_tensor([O_GROUPS * T_PAD, O_GROUP_IN], dtype=pl.BF16)
+    o_packed_heads, heads_dep = sparse_attn_csa(
         q, kv_cache, window_swa_indices,
         cmp_kv, cmp_block_table, idx_topk_full, position_ids_t1,
         attn_sink, rope_cos_t, rope_sin_t,
-        wo_a, wo_b, wo_b_scale, attn_out,
+        o_packed_heads,
+    )
+    attn_out = decode_o_proj_tp1(
+        o_packed_heads,
+        wo_a, wo_b, wo_b_scale,
+        attn_out, heads_dep,
     )
 
     hc_post(attn_out, x_hc, post_t, comb_t, x_out)
@@ -363,7 +490,7 @@ def attention_csa(
 
 
 @pl.jit
-def attention_csa_test(
+def decode_csa_tp1_test(
     x_hc: pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32],
     hc_attn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
     hc_attn_scale: pl.Tensor[[3], pl.FP32],
@@ -430,7 +557,7 @@ def attention_csa_test(
     idx_block_table.bind_dynamic(0, B_DYN)
     x_out.bind_dynamic(0, T_DYN)
 
-    attention_csa(
+    decode_csa_tp1(
         x_hc,
         hc_attn_fn, hc_attn_scale, hc_attn_base,
         attn_norm_w, wq_a, wq_b, wq_b_scale, wkv, gamma_cq, gamma_ckv,
@@ -452,128 +579,305 @@ def attention_csa_test(
     return x_out
 
 
-@pl.jit
-def decode_csa_output(
-    q: pl.Tensor[[T_DYN, H, HEAD_DIM], pl.BF16],
-    ori_kv: pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
-    window_swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
-    cmp_kv: pl.Tensor[[CMP_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
-    cmp_block_table: pl.Tensor[[B_DYN, CMP_MAX_BLOCKS], pl.INT32],
-    idx_topk: pl.Tensor[[T_DYN, INDEXER_SCORE_LEN], pl.INT32],
-    position_ids: pl.Tensor[[T_DYN, 1], pl.INT32],
-    attn_sink: pl.Tensor[[H], pl.FP32],
-    freqs_cos: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
-    freqs_sin: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
-    wo_a: pl.Tensor[[LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
-    wo_b: pl.Tensor[[D, LOCAL_O_WIDTH], pl.INT8],
-    wo_b_scale: pl.Tensor[[D], pl.FP32],
-    o_local: pl.InOut[pl.Tensor[[LOCAL_T_PAD, D], pl.BF16]],
-    attention_window: pld.DistributedTensor[[ATTENTION_WINDOW_ROWS, O_GROUP_IN], pl.BF16],
-    attention_signal: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
-    o_window: pld.DistributedTensor[[O_WINDOW_ROWS, D], pl.FP32],
-    o_signal: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
-    group_base: pl.Scalar[pl.INT32],
-    tp_rank: pl.Scalar[pl.INT32],
-    local_t: pl.Scalar[pl.INT32],
-):
-    """Run rank-local CSA heads, output A2A, sharded O projection, and RS."""
-    q.bind_dynamic(0, T_DYN)
-    ori_kv.bind_dynamic(0, ORI_BLOCK_NUM_DYN)
-    window_swa_indices.bind_dynamic(0, T_DYN)
-    cmp_kv.bind_dynamic(0, CMP_BLOCK_NUM_DYN)
-    cmp_block_table.bind_dynamic(0, B_DYN)
-    idx_topk.bind_dynamic(0, T_DYN)
-    position_ids.bind_dynamic(0, T_DYN)
-    freqs_cos.bind_dynamic(0, T_DYN)
-    freqs_sin.bind_dynamic(0, T_DYN)
+def build_tp_tensor_specs(local_t):
+    """Build deterministic tensor-parallel CSA output inputs."""
+    import torch
 
-    attention_grouped = pl.create_tensor([O_GROUPS * LOCAL_T_PAD, O_GROUP_IN], dtype=pl.BF16)
-    attention_grouped, _ = sparse_attn_csa_heads(
-        q, ori_kv, window_swa_indices,
-        cmp_kv, cmp_block_table, idx_topk,
-        position_ids, attn_sink, freqs_cos, freqs_sin,
-        attention_grouped,
-    )
+    from golden import ScalarSpec, TensorSpec
 
-    attention_local_flat = pl.create_tensor([ATTENTION_WINDOW_ROWS, O_GROUP_IN], dtype=pl.BF16)
-    attention_local_flat, attention_signal = o_group_a2a(
-        attention_grouped, attention_local_flat,
-        attention_window, attention_signal,
-        group_base, tp_rank, local_t,
-    )
-
-    attention_local_groups = pl.reshape(attention_local_flat, [LOCAL_O_GROUPS, GROUP_T_PAD, O_GROUP_IN])
-    o_partial = pl.create_tensor([GROUP_T_PAD, D], dtype=pl.FP32)
-    o_partial, projection_tid = decode_o_proj(
-        attention_local_groups,
-        wo_a, wo_b, wo_b_scale,
-        local_t, o_partial,
-    )
-
-    o_local, o_signal = o_proj_reduce_scatter(
-        o_partial, o_local,
-        o_window, o_signal,
-        group_base, tp_rank, local_t, projection_tid,
-    )
-    return o_local, attention_signal, o_signal
-
-
-@pl.jit.host
-def l3_decode_csa_output(
-    q: pl.Tensor[[TP_SIZE, T_DYN, H, HEAD_DIM], pl.BF16],
-    ori_kv: pl.Tensor[[TP_SIZE, ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
-    window_swa_indices: pl.Tensor[[TP_SIZE, T_DYN, WIN], pl.INT32],
-    cmp_kv: pl.Tensor[[TP_SIZE, CMP_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
-    cmp_block_table: pl.Tensor[[TP_SIZE, B_DYN, CMP_MAX_BLOCKS], pl.INT32],
-    idx_topk: pl.Tensor[[TP_SIZE, T_DYN, INDEXER_SCORE_LEN], pl.INT32],
-    position_ids: pl.Tensor[[TP_SIZE, T_DYN, 1], pl.INT32],
-    attn_sink: pl.Tensor[[TP_SIZE, H], pl.FP32],
-    freqs_cos: pl.Tensor[[TP_SIZE, T_DYN, ROPE_DIM], pl.BF16],
-    freqs_sin: pl.Tensor[[TP_SIZE, T_DYN, ROPE_DIM], pl.BF16],
-    wo_a: pl.Tensor[[TP_SIZE, LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
-    wo_b: pl.Tensor[[TP_SIZE, D, LOCAL_O_WIDTH], pl.INT8],
-    wo_b_scale: pl.Tensor[[TP_SIZE, D], pl.FP32],
-    o_local: pl.InOut[pl.Tensor[[TP_SIZE, LOCAL_T_PAD, D], pl.BF16]],
-    local_t: pl.Scalar[pl.INT32],
-):
-    """Launch the CSA output path on one TP group."""
-    q.bind_dynamic(1, T_DYN)
-    ori_kv.bind_dynamic(1, ORI_BLOCK_NUM_DYN)
-    window_swa_indices.bind_dynamic(1, T_DYN)
-    cmp_kv.bind_dynamic(1, CMP_BLOCK_NUM_DYN)
-    cmp_block_table.bind_dynamic(1, B_DYN)
-    idx_topk.bind_dynamic(1, T_DYN)
-    position_ids.bind_dynamic(1, T_DYN)
-    freqs_cos.bind_dynamic(1, T_DYN)
-    freqs_sin.bind_dynamic(1, T_DYN)
-
-    attention_window_buf = pld.alloc_window_buffer([ATTENTION_WINDOW_ROWS, O_GROUP_IN], dtype=pl.BF16)
-    attention_signal_buf = pld.alloc_window_buffer([TP_SIZE, 1], dtype=pl.INT32)
-    o_window_buf = pld.alloc_window_buffer([O_WINDOW_ROWS, D], dtype=pl.FP32)
-    o_signal_buf = pld.alloc_window_buffer([TP_SIZE, 1], dtype=pl.INT32)
-
-    for rank in pl.range(pld.world_size()):
-        attention_window = pld.window(attention_window_buf, [ATTENTION_WINDOW_ROWS, O_GROUP_IN], dtype=pl.BF16)
-        attention_signal = pld.window(attention_signal_buf, [TP_SIZE, 1], dtype=pl.INT32)
-        o_window = pld.window(o_window_buf, [O_WINDOW_ROWS, D], dtype=pl.FP32)
-        o_signal = pld.window(o_signal_buf, [TP_SIZE, 1], dtype=pl.INT32)
-        decode_csa_output(
-            q[rank],
-            ori_kv[rank], window_swa_indices[rank],
-            cmp_kv[rank], cmp_block_table[rank], idx_topk[rank],
-            position_ids[rank], attn_sink[rank],
-            freqs_cos[rank], freqs_sin[rank],
-            wo_a[rank], wo_b[rank], wo_b_scale[rank],
-            o_local[rank],
-            attention_window, attention_signal,
-            o_window, o_signal,
-            0, rank, local_t,
-            device=rank,
+    if (local_t < ROPE_CS_T_TILE or local_t > LOCAL_T
+            or local_t % ROPE_CS_T_TILE != 0 or local_t % S != 0):
+        raise ValueError(
+            f"local_t must be a multiple of {ROPE_CS_T_TILE} "
+            f"in [{ROPE_CS_T_TILE}, {LOCAL_T}], got {local_t}"
         )
+    local_batch = local_t // S
+    cmp_block_table_shape = [TP_SIZE, local_batch, CMP_MAX_BLOCKS]
+
+    def init_q():
+        q = torch.zeros(TP_SIZE, local_t, H, HEAD_DIM, dtype=torch.bfloat16)
+        rank = torch.arange(TP_SIZE, dtype=torch.float32).reshape(TP_SIZE, 1, 1)
+        token = torch.arange(local_t, dtype=torch.float32).reshape(1, local_t, 1)
+        head = torch.arange(H, dtype=torch.float32).reshape(1, 1, H)
+        q[..., 0] = (rank + token * 0.25 + head * 0.0625).to(torch.bfloat16)
+        return q
+
+    def init_ori_kv():
+        shape = (TP_SIZE, FIXTURE_WINDOW_BLOCKS, BLOCK_SIZE, 1, HEAD_DIM)
+        ori_kv = torch.zeros(shape, dtype=torch.bfloat16)
+        rank = torch.arange(TP_SIZE, dtype=torch.float32).reshape(TP_SIZE, 1, 1)
+        block = torch.arange(FIXTURE_WINDOW_BLOCKS, dtype=torch.float32).reshape(1, FIXTURE_WINDOW_BLOCKS, 1)
+        row = torch.arange(BLOCK_SIZE, dtype=torch.float32).reshape(1, 1, BLOCK_SIZE)
+        ori_kv[:, :, :, 0, 0] = 0.25
+        ori_kv[:, :, :, 0, 1] = (
+            (rank + 1.0) * 0.0625
+            + (block + 1.0) * 0.015625
+            + (row + 1.0) * 0.0001220703125
+        ).to(torch.bfloat16)
+        return ori_kv
+
+    def init_window_swa_indices():
+        logical_row = FIXTURE_WINDOW_HEAD + torch.arange(WIN, dtype=torch.int32)
+        logical_block = logical_row // BLOCK_SIZE
+        physical_block = FIXTURE_WINDOW_BLOCKS - 1 - logical_block
+        physical_row = logical_row % BLOCK_SIZE
+        window_row = physical_block * BLOCK_SIZE + physical_row
+        return window_row.reshape(1, 1, WIN).expand(TP_SIZE, local_t, WIN).clone()
+
+    def init_cmp_kv():
+        shape = (TP_SIZE, FIXTURE_CMP_BLOCKS, BLOCK_SIZE, 1, HEAD_DIM)
+        cmp_kv = torch.full(shape, float("nan"), dtype=torch.bfloat16)
+        for rank in range(TP_SIZE):
+            for request in range(local_batch):
+                request_block_base = request * FIXTURE_CMP_LOGICAL_BLOCKS
+                for entry_index, cmp_slot in enumerate(FIXTURE_CMP_SLOTS):
+                    logical_block = cmp_slot // BLOCK_SIZE
+                    physical_block = request_block_base + FIXTURE_CMP_LOGICAL_BLOCKS - 1 - logical_block
+                    row = cmp_slot % BLOCK_SIZE
+                    cmp_kv[rank, physical_block, row, 0, :] = 0.0
+                    cmp_kv[rank, physical_block, row, 0, 0] = 0.25
+                    cmp_kv[rank, physical_block, row, 0, 1] = (
+                        (rank + 1) * 0.03125
+                        + (request + 1) * 0.0078125
+                        + (entry_index + 1) * 0.001953125
+                    )
+                    cmp_kv[rank, physical_block, row, 0, NOPE_DIM] = (
+                        (rank + 1) * 0.0625
+                        + (request + 1) * 0.015625
+                        + (entry_index + 1) * 0.00390625
+                    )
+                    cmp_kv[rank, physical_block, row, 0, NOPE_DIM + 1] = (
+                        -(logical_block + 1) * 0.0625
+                        + (rank + 1) * 0.0078125
+                        + (request + 1) * 0.001953125
+                    )
+        return cmp_kv
+
+    def init_cmp_block_table():
+        table = torch.full(cmp_block_table_shape, -1, dtype=torch.int32)
+        for rank in range(TP_SIZE):
+            for request in range(local_batch):
+                request_block_base = request * FIXTURE_CMP_LOGICAL_BLOCKS
+                for logical_block in range(FIXTURE_CMP_LOGICAL_BLOCKS):
+                    table[rank, request, logical_block] = (
+                        request_block_base + FIXTURE_CMP_LOGICAL_BLOCKS - 1 - logical_block
+                    )
+        return table
+
+    def init_idx_topk():
+        topk = torch.full((TP_SIZE, local_t, INDEXER_SCORE_LEN), -1, dtype=torch.int32)
+        for position, cmp_slot in FIXTURE_CMP_ENTRIES:
+            topk[:, :, position] = cmp_slot
+        for position in FIXTURE_FILTERED_POSITIONS:
+            topk[:, :, position] = FIXTURE_FILTERED_SLOT
+        return topk
+
+    def init_position_ids():
+        return torch.full((TP_SIZE, local_t, 1), FIXTURE_POSITION_ID, dtype=torch.int32)
+
+    def init_attn_sink():
+        head = torch.arange(H, dtype=torch.int32).remainder(HEADS_PER_GROUP).to(torch.float32)
+        sink = 4.0 + head * 0.125
+        return sink.reshape(1, H).expand(TP_SIZE, H).clone()
+
+    def init_freqs_cos():
+        rank = torch.arange(TP_SIZE, dtype=torch.int32).reshape(TP_SIZE, 1, 1)
+        token = torch.arange(local_t, dtype=torch.int32).reshape(1, local_t, 1)
+        column = torch.arange(ROPE_DIM, dtype=torch.int32).reshape(1, 1, ROPE_DIM)
+        phase = (rank + token + column).remainder(4)
+        phase[:, :, HALF_ROPE:] = (phase[:, :, HALF_ROPE:] + 1).remainder(4)
+        values = torch.tensor((1.0, 0.0, -1.0, 0.0), dtype=torch.bfloat16)
+        return values[phase]
+
+    def init_freqs_sin():
+        rank = torch.arange(TP_SIZE, dtype=torch.int32).reshape(TP_SIZE, 1, 1)
+        token = torch.arange(local_t, dtype=torch.int32).reshape(1, local_t, 1)
+        column = torch.arange(ROPE_DIM, dtype=torch.int32).reshape(1, 1, ROPE_DIM)
+        phase = (rank + token + column).remainder(4)
+        phase[:, :, HALF_ROPE:] = (phase[:, :, HALF_ROPE:] + 1).remainder(4)
+        values = torch.tensor((0.0, 1.0, 0.0, -1.0), dtype=torch.bfloat16)
+        return values[phase]
+
+    def init_wo_a():
+        wo_a = torch.zeros(TP_SIZE, LOCAL_O_GROUPS, O_LORA, O_GROUP_IN, dtype=torch.bfloat16)
+        for rank in range(TP_SIZE):
+            for local_group in range(LOCAL_O_GROUPS):
+                shard_scale = (rank + 1) * (local_group + 1) * 0.125
+                for head in range(HEADS_PER_GROUP):
+                    wo_a[rank, local_group, head, head * HEAD_DIM] = shard_scale * (head + 1)
+                    wo_a[
+                        rank, local_group, HEADS_PER_GROUP + head,
+                        head * HEAD_DIM + 1,
+                    ] = shard_scale * (head + 1) * 0.75
+                    wo_a[
+                        rank, local_group, 2 * HEADS_PER_GROUP + head,
+                        head * HEAD_DIM + NOPE_DIM,
+                    ] = -shard_scale * (head + 1) * 0.5
+                    wo_a[
+                        rank, local_group, 3 * HEADS_PER_GROUP + head,
+                        head * HEAD_DIM + NOPE_DIM + 1,
+                    ] = shard_scale * (head + 1) * 0.25
+        return wo_a
+
+    def init_wo_b():
+        base = torch.arange(D * LOCAL_O_WIDTH, dtype=torch.int32).reshape(D, LOCAL_O_WIDTH)
+        rank = torch.arange(TP_SIZE, dtype=torch.int32).reshape(TP_SIZE, 1, 1)
+        return (base.unsqueeze(0) + rank).remainder(7).sub(3).to(torch.int8)
+
+    def init_wo_b_scale():
+        channel_scale = torch.arange(D, dtype=torch.int32).remainder(4).to(torch.float32) * 0.25 + 0.5
+        return channel_scale.reshape(1, D).expand(TP_SIZE, D).clone()
+
+    return [
+        TensorSpec("q", [TP_SIZE, local_t, H, HEAD_DIM], torch.bfloat16, init_value=init_q),
+        TensorSpec(
+            "ori_kv", [TP_SIZE, FIXTURE_WINDOW_BLOCKS, BLOCK_SIZE, 1, HEAD_DIM],
+            torch.bfloat16, init_value=init_ori_kv,
+        ),
+        TensorSpec("window_swa_indices", [TP_SIZE, local_t, WIN], torch.int32, init_value=init_window_swa_indices),
+        TensorSpec(
+            "cmp_kv", [TP_SIZE, FIXTURE_CMP_BLOCKS, BLOCK_SIZE, 1, HEAD_DIM],
+            torch.bfloat16, init_value=init_cmp_kv,
+        ),
+        TensorSpec("cmp_block_table", cmp_block_table_shape, torch.int32, init_value=init_cmp_block_table),
+        TensorSpec("idx_topk", [TP_SIZE, local_t, INDEXER_SCORE_LEN], torch.int32, init_value=init_idx_topk),
+        TensorSpec("position_ids", [TP_SIZE, local_t, 1], torch.int32, init_value=init_position_ids),
+        TensorSpec("attn_sink", [TP_SIZE, H], torch.float32, init_value=init_attn_sink),
+        TensorSpec("freqs_cos", [TP_SIZE, local_t, ROPE_DIM], torch.bfloat16, init_value=init_freqs_cos),
+        TensorSpec("freqs_sin", [TP_SIZE, local_t, ROPE_DIM], torch.bfloat16, init_value=init_freqs_sin),
+        TensorSpec("wo_a", [TP_SIZE, LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], torch.bfloat16, init_value=init_wo_a),
+        TensorSpec("wo_b", [TP_SIZE, D, LOCAL_O_WIDTH], torch.int8, init_value=init_wo_b),
+        TensorSpec("wo_b_scale", [TP_SIZE, D], torch.float32, init_value=init_wo_b_scale),
+        TensorSpec(
+            "o_local", [TP_SIZE, LOCAL_T_PAD, D], torch.bfloat16,
+            init_value=FIXTURE_OUTPUT_SENTINEL, is_output=True,
+        ),
+        ScalarSpec("local_t", torch.int32, local_t),
+    ]
 
 
+def golden_decode_csa(tensors):
+    """Compute the controlled CSA heads, sharded O projection, and reduced rows."""
+    import torch
 
-def golden_attention_csa(tensors):
+    local_t = int(tensors["local_t"])
+    group_t = TP_SIZE * local_t
+    observed_dims = torch.tensor((0, 1, NOPE_DIM, NOPE_DIM + 1), dtype=torch.int64)
+    q = tensors["q"].float()
+
+    window_indices = tensors["window_swa_indices"].long()
+    window_valid = window_indices >= 0
+    safe_window_indices = window_indices.clamp_min(0)
+    ori_rows = tensors["ori_kv"][:, :, :, 0].reshape(TP_SIZE, -1, HEAD_DIM)
+    ori_values = ori_rows[..., observed_dims].float()
+    window_sum = torch.zeros(TP_SIZE, local_t, len(observed_dims), dtype=torch.float32)
+    for rank in range(TP_SIZE):
+        gathered = ori_values[rank][safe_window_indices[rank]]
+        window_sum[rank] = (
+            gathered * window_valid[rank].unsqueeze(-1)
+        ).sum(dim=1)
+    window_count = window_valid.sum(dim=-1).to(torch.float32)
+
+    raw = tensors["idx_topk"][:, :, :CMP_TOPK].to(torch.int64)
+    bound = ((tensors["position_ids"][:, :, 0].to(torch.int64) + 1) // COMPRESS_RATIO).unsqueeze(-1)
+    keep = (raw >= 0) & (raw < bound)
+    cmp_rows = tensors["cmp_kv"][:, :, :, 0]
+    cmp_sum = torch.zeros_like(window_sum)
+    cmp_count = torch.zeros(TP_SIZE, local_t, dtype=torch.float32)
+    for rank in range(TP_SIZE):
+        for token in range(local_t):
+            request = token // S
+            valid_slots = raw[rank, token][keep[rank, token]]
+            cmp_count[rank, token] = valid_slots.numel()
+            for cmp_slot_tensor in valid_slots:
+                cmp_slot = int(cmp_slot_tensor.item())
+                logical_block = cmp_slot // BLOCK_SIZE
+                physical_block = int(tensors["cmp_block_table"][rank, request, logical_block].item())
+                cmp_sum[rank, token] += cmp_rows[
+                    rank, physical_block, cmp_slot % BLOCK_SIZE, observed_dims
+                ].float()
+
+    kv_sum = window_sum + cmp_sum
+    valid_count = window_count + cmp_count
+    scores = q[..., 0] * 0.25 * SOFTMAX_SCALE
+    sink = tensors["attn_sink"].float().reshape(TP_SIZE, 1, H)
+    denominator = valid_count.unsqueeze(-1) + torch.exp(sink - scores)
+    head_observed = kv_sum.unsqueeze(2) / denominator.unsqueeze(-1)
+    head_value = torch.zeros(TP_SIZE, local_t, H, HEAD_DIM, dtype=torch.float32)
+    head_value[..., observed_dims] = head_observed
+
+    rope_pair = head_value[..., NOPE_DIM:].unflatten(-1, (-1, 2))
+    rope_even = rope_pair[..., 0]
+    rope_odd = rope_pair[..., 1]
+    cos_half = tensors["freqs_cos"][..., :HALF_ROPE].float().unsqueeze(2)
+    sin_half = tensors["freqs_sin"][..., :HALF_ROPE].float().unsqueeze(2)
+    inverse_even = (rope_even * cos_half + rope_odd * sin_half).to(torch.bfloat16).float()
+    inverse_odd = (rope_odd * cos_half - rope_even * sin_half).to(torch.bfloat16).float()
+    inverse_rope = torch.stack((inverse_even, inverse_odd), dim=-1).flatten(-2)
+    head_value = torch.cat((head_value[..., :NOPE_DIM], inverse_rope), dim=-1).to(torch.bfloat16)
+
+    attention_grouped = head_value.reshape(
+        TP_SIZE, local_t, O_GROUPS, HEADS_PER_GROUP, HEAD_DIM,
+    )
+    attention_grouped = attention_grouped.permute(0, 2, 1, 3, 4)
+    attention_grouped = attention_grouped.reshape(
+        TP_SIZE, O_GROUPS, local_t, O_GROUP_IN,
+    )
+
+    attention_local = torch.zeros(TP_SIZE, LOCAL_O_GROUPS, group_t, O_GROUP_IN, dtype=torch.bfloat16)
+    for destination_rank in range(TP_SIZE):
+        for local_group in range(LOCAL_O_GROUPS):
+            global_group = destination_rank * LOCAL_O_GROUPS + local_group
+            group_rows = attention_grouped[:, global_group].reshape(group_t, O_GROUP_IN)
+            attention_local[destination_rank, local_group] = group_rows
+
+    partials = torch.zeros(TP_SIZE, group_t, D, dtype=torch.float32)
+    for rank in range(TP_SIZE):
+        attention = attention_local[rank].float()
+        o_a = torch.einsum("gti,gri->gtr", attention, tensors["wo_a"][rank].float())
+        row_amax = o_a.abs().amax(dim=-1, keepdim=True).clamp_min(INT8_AMAX_EPS)
+        scale_q = INT8_SCALE_MAX / row_amax
+        o_a_i8 = torch.round(o_a * scale_q).to(torch.int32).to(torch.float16).to(torch.int8)
+        scale_dq = 1.0 / scale_q
+        wo_b = tensors["wo_b"][rank].reshape(D, LOCAL_O_GROUPS, O_LORA)
+        for local_group in range(LOCAL_O_GROUPS):
+            group_i32 = o_a_i8[local_group].to(torch.int32)
+            weight_i32 = wo_b[:, local_group].to(torch.int32)
+            group_partial = group_i32 @ weight_i32.T
+            partials[rank] += group_partial.float() * scale_dq[local_group]
+        partials[rank] *= tensors["wo_b_scale"][rank].float().reshape(1, D)
+
+    reduced = partials.sum(dim=0)
+    tensors["o_local"].fill_(FIXTURE_OUTPUT_SENTINEL)
+    for rank in range(TP_SIZE):
+        row_start = rank * local_t
+        tensors["o_local"][rank, :local_t] = reduced[row_start : row_start + local_t].to(torch.bfloat16)
+
+
+def build_o_local_compare(local_t):
+    """Compare valid token rows and require the poisoned capacity tail to survive."""
+    import torch
+
+    from golden import ratio_allclose
+
+    prefix_compare = ratio_allclose(
+        atol=1e-4, rtol=1.0 / 128, max_error_ratio=0.005,
+        valid_rows=local_t, valid_axis=1,
+    )
+
+    def compare(actual, expected, **kwargs):
+        actual_tail = actual[:, local_t:]
+        expected_tail = expected[:, local_t:]
+        if not torch.equal(actual_tail, expected_tail):
+            mismatch_count = int((actual_tail != expected_tail).sum().item())
+            return False, f"    inactive token tail mismatch count={mismatch_count}"
+        return prefix_compare(actual, expected, **kwargs)
+
+    compare.__name__ = f"csa_output_prefix_and_tail(local_t={local_t})"
+    return compare
+
+
+def golden_decode_csa_tp1(tensors):
     """Torch reference for the ratio-4 compression-step CSA orchestration."""
     import torch
 
@@ -1106,304 +1410,6 @@ def build_tensor_specs(start_pos=None, batch=B):
     ]
 
 
-def build_tp_tensor_specs(local_t):
-    """Build deterministic tensor-parallel CSA output inputs."""
-    import torch
-
-    from golden import ScalarSpec, TensorSpec
-
-    if (local_t < ROPE_CS_T_TILE or local_t > LOCAL_T
-            or local_t % ROPE_CS_T_TILE != 0 or local_t % S != 0):
-        raise ValueError(
-            f"local_t must be a multiple of {ROPE_CS_T_TILE} "
-            f"in [{ROPE_CS_T_TILE}, {LOCAL_T}], got {local_t}"
-        )
-    local_batch = local_t // S
-    cmp_block_table_shape = [TP_SIZE, local_batch, CMP_MAX_BLOCKS]
-
-    def init_q():
-        q = torch.zeros(TP_SIZE, local_t, H, HEAD_DIM, dtype=torch.bfloat16)
-        rank = torch.arange(TP_SIZE, dtype=torch.float32).reshape(TP_SIZE, 1, 1)
-        token = torch.arange(local_t, dtype=torch.float32).reshape(1, local_t, 1)
-        head = torch.arange(H, dtype=torch.float32).reshape(1, 1, H)
-        q[..., 0] = (rank + token * 0.25 + head * 0.0625).to(torch.bfloat16)
-        return q
-
-    def init_ori_kv():
-        shape = (TP_SIZE, FIXTURE_WINDOW_BLOCKS, BLOCK_SIZE, 1, HEAD_DIM)
-        ori_kv = torch.zeros(shape, dtype=torch.bfloat16)
-        rank = torch.arange(TP_SIZE, dtype=torch.float32).reshape(TP_SIZE, 1, 1)
-        block = torch.arange(FIXTURE_WINDOW_BLOCKS, dtype=torch.float32).reshape(1, FIXTURE_WINDOW_BLOCKS, 1)
-        row = torch.arange(BLOCK_SIZE, dtype=torch.float32).reshape(1, 1, BLOCK_SIZE)
-        ori_kv[:, :, :, 0, 0] = 0.25
-        ori_kv[:, :, :, 0, 1] = (
-            (rank + 1.0) * 0.0625
-            + (block + 1.0) * 0.015625
-            + (row + 1.0) * 0.0001220703125
-        ).to(torch.bfloat16)
-        return ori_kv
-
-    def init_window_swa_indices():
-        logical_row = FIXTURE_WINDOW_HEAD + torch.arange(WIN, dtype=torch.int32)
-        logical_block = logical_row // BLOCK_SIZE
-        physical_block = FIXTURE_WINDOW_BLOCKS - 1 - logical_block
-        physical_row = logical_row % BLOCK_SIZE
-        window_row = physical_block * BLOCK_SIZE + physical_row
-        return window_row.reshape(1, 1, WIN).expand(TP_SIZE, local_t, WIN).clone()
-
-    def init_cmp_kv():
-        shape = (TP_SIZE, FIXTURE_CMP_BLOCKS, BLOCK_SIZE, 1, HEAD_DIM)
-        cmp_kv = torch.full(shape, float("nan"), dtype=torch.bfloat16)
-        for rank in range(TP_SIZE):
-            for request in range(local_batch):
-                request_block_base = request * FIXTURE_CMP_LOGICAL_BLOCKS
-                for entry_index, cmp_slot in enumerate(FIXTURE_CMP_SLOTS):
-                    logical_block = cmp_slot // BLOCK_SIZE
-                    physical_block = request_block_base + FIXTURE_CMP_LOGICAL_BLOCKS - 1 - logical_block
-                    row = cmp_slot % BLOCK_SIZE
-                    cmp_kv[rank, physical_block, row, 0, :] = 0.0
-                    cmp_kv[rank, physical_block, row, 0, 0] = 0.25
-                    cmp_kv[rank, physical_block, row, 0, 1] = (
-                        (rank + 1) * 0.03125
-                        + (request + 1) * 0.0078125
-                        + (entry_index + 1) * 0.001953125
-                    )
-                    cmp_kv[rank, physical_block, row, 0, NOPE_DIM] = (
-                        (rank + 1) * 0.0625
-                        + (request + 1) * 0.015625
-                        + (entry_index + 1) * 0.00390625
-                    )
-                    cmp_kv[rank, physical_block, row, 0, NOPE_DIM + 1] = (
-                        -(logical_block + 1) * 0.0625
-                        + (rank + 1) * 0.0078125
-                        + (request + 1) * 0.001953125
-                    )
-        return cmp_kv
-
-    def init_cmp_block_table():
-        table = torch.full(cmp_block_table_shape, -1, dtype=torch.int32)
-        for rank in range(TP_SIZE):
-            for request in range(local_batch):
-                request_block_base = request * FIXTURE_CMP_LOGICAL_BLOCKS
-                for logical_block in range(FIXTURE_CMP_LOGICAL_BLOCKS):
-                    table[rank, request, logical_block] = (
-                        request_block_base + FIXTURE_CMP_LOGICAL_BLOCKS - 1 - logical_block
-                    )
-        return table
-
-    def init_idx_topk():
-        topk = torch.full((TP_SIZE, local_t, INDEXER_SCORE_LEN), -1, dtype=torch.int32)
-        for position, cmp_slot in FIXTURE_CMP_ENTRIES:
-            topk[:, :, position] = cmp_slot
-        for position in FIXTURE_FILTERED_POSITIONS:
-            topk[:, :, position] = FIXTURE_FILTERED_SLOT
-        return topk
-
-    def init_position_ids():
-        return torch.full((TP_SIZE, local_t, 1), FIXTURE_POSITION_ID, dtype=torch.int32)
-
-    def init_attn_sink():
-        head = torch.arange(H, dtype=torch.int32).remainder(HEADS_PER_GROUP).to(torch.float32)
-        sink = 4.0 + head * 0.125
-        return sink.reshape(1, H).expand(TP_SIZE, H).clone()
-
-    def init_freqs_cos():
-        rank = torch.arange(TP_SIZE, dtype=torch.int32).reshape(TP_SIZE, 1, 1)
-        token = torch.arange(local_t, dtype=torch.int32).reshape(1, local_t, 1)
-        column = torch.arange(ROPE_DIM, dtype=torch.int32).reshape(1, 1, ROPE_DIM)
-        phase = (rank + token + column).remainder(4)
-        phase[:, :, HALF_ROPE:] = (phase[:, :, HALF_ROPE:] + 1).remainder(4)
-        values = torch.tensor((1.0, 0.0, -1.0, 0.0), dtype=torch.bfloat16)
-        return values[phase]
-
-    def init_freqs_sin():
-        rank = torch.arange(TP_SIZE, dtype=torch.int32).reshape(TP_SIZE, 1, 1)
-        token = torch.arange(local_t, dtype=torch.int32).reshape(1, local_t, 1)
-        column = torch.arange(ROPE_DIM, dtype=torch.int32).reshape(1, 1, ROPE_DIM)
-        phase = (rank + token + column).remainder(4)
-        phase[:, :, HALF_ROPE:] = (phase[:, :, HALF_ROPE:] + 1).remainder(4)
-        values = torch.tensor((0.0, 1.0, 0.0, -1.0), dtype=torch.bfloat16)
-        return values[phase]
-
-    def init_wo_a():
-        wo_a = torch.zeros(TP_SIZE, LOCAL_O_GROUPS, O_LORA, O_GROUP_IN, dtype=torch.bfloat16)
-        for rank in range(TP_SIZE):
-            for local_group in range(LOCAL_O_GROUPS):
-                shard_scale = (rank + 1) * (local_group + 1) * 0.125
-                for head in range(HEADS_PER_GROUP):
-                    wo_a[rank, local_group, head, head * HEAD_DIM] = shard_scale * (head + 1)
-                    wo_a[
-                        rank, local_group, HEADS_PER_GROUP + head,
-                        head * HEAD_DIM + 1,
-                    ] = shard_scale * (head + 1) * 0.75
-                    wo_a[
-                        rank, local_group, 2 * HEADS_PER_GROUP + head,
-                        head * HEAD_DIM + NOPE_DIM,
-                    ] = -shard_scale * (head + 1) * 0.5
-                    wo_a[
-                        rank, local_group, 3 * HEADS_PER_GROUP + head,
-                        head * HEAD_DIM + NOPE_DIM + 1,
-                    ] = shard_scale * (head + 1) * 0.25
-        return wo_a
-
-    def init_wo_b():
-        base = torch.arange(D * LOCAL_O_WIDTH, dtype=torch.int32).reshape(D, LOCAL_O_WIDTH)
-        rank = torch.arange(TP_SIZE, dtype=torch.int32).reshape(TP_SIZE, 1, 1)
-        return (base.unsqueeze(0) + rank).remainder(7).sub(3).to(torch.int8)
-
-    def init_wo_b_scale():
-        channel_scale = torch.arange(D, dtype=torch.int32).remainder(4).to(torch.float32) * 0.25 + 0.5
-        return channel_scale.reshape(1, D).expand(TP_SIZE, D).clone()
-
-    return [
-        TensorSpec("q", [TP_SIZE, local_t, H, HEAD_DIM], torch.bfloat16, init_value=init_q),
-        TensorSpec(
-            "ori_kv", [TP_SIZE, FIXTURE_WINDOW_BLOCKS, BLOCK_SIZE, 1, HEAD_DIM],
-            torch.bfloat16, init_value=init_ori_kv,
-        ),
-        TensorSpec("window_swa_indices", [TP_SIZE, local_t, WIN], torch.int32, init_value=init_window_swa_indices),
-        TensorSpec(
-            "cmp_kv", [TP_SIZE, FIXTURE_CMP_BLOCKS, BLOCK_SIZE, 1, HEAD_DIM],
-            torch.bfloat16, init_value=init_cmp_kv,
-        ),
-        TensorSpec("cmp_block_table", cmp_block_table_shape, torch.int32, init_value=init_cmp_block_table),
-        TensorSpec("idx_topk", [TP_SIZE, local_t, INDEXER_SCORE_LEN], torch.int32, init_value=init_idx_topk),
-        TensorSpec("position_ids", [TP_SIZE, local_t, 1], torch.int32, init_value=init_position_ids),
-        TensorSpec("attn_sink", [TP_SIZE, H], torch.float32, init_value=init_attn_sink),
-        TensorSpec("freqs_cos", [TP_SIZE, local_t, ROPE_DIM], torch.bfloat16, init_value=init_freqs_cos),
-        TensorSpec("freqs_sin", [TP_SIZE, local_t, ROPE_DIM], torch.bfloat16, init_value=init_freqs_sin),
-        TensorSpec("wo_a", [TP_SIZE, LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], torch.bfloat16, init_value=init_wo_a),
-        TensorSpec("wo_b", [TP_SIZE, D, LOCAL_O_WIDTH], torch.int8, init_value=init_wo_b),
-        TensorSpec("wo_b_scale", [TP_SIZE, D], torch.float32, init_value=init_wo_b_scale),
-        TensorSpec(
-            "o_local", [TP_SIZE, LOCAL_T_PAD, D], torch.bfloat16,
-            init_value=FIXTURE_OUTPUT_SENTINEL, is_output=True,
-        ),
-        ScalarSpec("local_t", torch.int32, local_t),
-    ]
-
-
-def golden_decode_csa_output(tensors):
-    """Compute the controlled CSA heads, sharded O projection, and reduced rows."""
-    import torch
-
-    local_t = int(tensors["local_t"])
-    group_t = TP_SIZE * local_t
-    observed_dims = torch.tensor((0, 1, NOPE_DIM, NOPE_DIM + 1), dtype=torch.int64)
-    q = tensors["q"].float()
-
-    window_indices = tensors["window_swa_indices"].long()
-    window_valid = window_indices >= 0
-    safe_window_indices = window_indices.clamp_min(0)
-    ori_rows = tensors["ori_kv"][:, :, :, 0].reshape(TP_SIZE, -1, HEAD_DIM)
-    ori_values = ori_rows[..., observed_dims].float()
-    window_sum = torch.zeros(TP_SIZE, local_t, len(observed_dims), dtype=torch.float32)
-    for rank in range(TP_SIZE):
-        gathered = ori_values[rank][safe_window_indices[rank]]
-        window_sum[rank] = (
-            gathered * window_valid[rank].unsqueeze(-1)
-        ).sum(dim=1)
-    window_count = window_valid.sum(dim=-1).to(torch.float32)
-
-    raw = tensors["idx_topk"][:, :, :CMP_TOPK].to(torch.int64)
-    bound = ((tensors["position_ids"][:, :, 0].to(torch.int64) + 1) // COMPRESS_RATIO).unsqueeze(-1)
-    keep = (raw >= 0) & (raw < bound)
-    cmp_rows = tensors["cmp_kv"][:, :, :, 0]
-    cmp_sum = torch.zeros_like(window_sum)
-    cmp_count = torch.zeros(TP_SIZE, local_t, dtype=torch.float32)
-    for rank in range(TP_SIZE):
-        for token in range(local_t):
-            request = token // S
-            valid_slots = raw[rank, token][keep[rank, token]]
-            cmp_count[rank, token] = valid_slots.numel()
-            for cmp_slot_tensor in valid_slots:
-                cmp_slot = int(cmp_slot_tensor.item())
-                logical_block = cmp_slot // BLOCK_SIZE
-                physical_block = int(tensors["cmp_block_table"][rank, request, logical_block].item())
-                cmp_sum[rank, token] += cmp_rows[
-                    rank, physical_block, cmp_slot % BLOCK_SIZE, observed_dims
-                ].float()
-
-    kv_sum = window_sum + cmp_sum
-    valid_count = window_count + cmp_count
-    scores = q[..., 0] * 0.25 * SOFTMAX_SCALE
-    sink = tensors["attn_sink"].float().reshape(TP_SIZE, 1, H)
-    denominator = valid_count.unsqueeze(-1) + torch.exp(sink - scores)
-    head_observed = kv_sum.unsqueeze(2) / denominator.unsqueeze(-1)
-    head_value = torch.zeros(TP_SIZE, local_t, H, HEAD_DIM, dtype=torch.float32)
-    head_value[..., observed_dims] = head_observed
-
-    rope_pair = head_value[..., NOPE_DIM:].unflatten(-1, (-1, 2))
-    rope_even = rope_pair[..., 0]
-    rope_odd = rope_pair[..., 1]
-    cos_half = tensors["freqs_cos"][..., :HALF_ROPE].float().unsqueeze(2)
-    sin_half = tensors["freqs_sin"][..., :HALF_ROPE].float().unsqueeze(2)
-    inverse_even = (rope_even * cos_half + rope_odd * sin_half).to(torch.bfloat16).float()
-    inverse_odd = (rope_odd * cos_half - rope_even * sin_half).to(torch.bfloat16).float()
-    inverse_rope = torch.stack((inverse_even, inverse_odd), dim=-1).flatten(-2)
-    head_value = torch.cat((head_value[..., :NOPE_DIM], inverse_rope), dim=-1).to(torch.bfloat16)
-
-    attention_grouped = head_value.reshape(
-        TP_SIZE, local_t, O_GROUPS, HEADS_PER_GROUP, HEAD_DIM,
-    )
-    attention_grouped = attention_grouped.permute(0, 2, 1, 3, 4)
-    attention_grouped = attention_grouped.reshape(
-        TP_SIZE, O_GROUPS, local_t, O_GROUP_IN,
-    )
-
-    attention_local = torch.zeros(TP_SIZE, LOCAL_O_GROUPS, group_t, O_GROUP_IN, dtype=torch.bfloat16)
-    for destination_rank in range(TP_SIZE):
-        for local_group in range(LOCAL_O_GROUPS):
-            global_group = destination_rank * LOCAL_O_GROUPS + local_group
-            group_rows = attention_grouped[:, global_group].reshape(group_t, O_GROUP_IN)
-            attention_local[destination_rank, local_group] = group_rows
-
-    partials = torch.zeros(TP_SIZE, group_t, D, dtype=torch.float32)
-    for rank in range(TP_SIZE):
-        attention = attention_local[rank].float()
-        o_a = torch.einsum("gti,gri->gtr", attention, tensors["wo_a"][rank].float())
-        row_amax = o_a.abs().amax(dim=-1, keepdim=True).clamp_min(INT8_AMAX_EPS)
-        scale_q = INT8_SCALE_MAX / row_amax
-        o_a_i8 = torch.round(o_a * scale_q).to(torch.int32).to(torch.float16).to(torch.int8)
-        scale_dq = 1.0 / scale_q
-        wo_b = tensors["wo_b"][rank].reshape(D, LOCAL_O_GROUPS, O_LORA)
-        for local_group in range(LOCAL_O_GROUPS):
-            group_i32 = o_a_i8[local_group].to(torch.int32)
-            weight_i32 = wo_b[:, local_group].to(torch.int32)
-            group_partial = group_i32 @ weight_i32.T
-            partials[rank] += group_partial.float() * scale_dq[local_group]
-        partials[rank] *= tensors["wo_b_scale"][rank].float().reshape(1, D)
-
-    reduced = partials.sum(dim=0)
-    tensors["o_local"].fill_(FIXTURE_OUTPUT_SENTINEL)
-    for rank in range(TP_SIZE):
-        row_start = rank * local_t
-        tensors["o_local"][rank, :local_t] = reduced[row_start : row_start + local_t].to(torch.bfloat16)
-
-
-def build_o_local_compare(local_t):
-    """Compare valid token rows and require the poisoned capacity tail to survive."""
-    import torch
-
-    from golden import ratio_allclose
-
-    prefix_compare = ratio_allclose(
-        atol=1e-4, rtol=1.0 / 128, max_error_ratio=0.005,
-        valid_rows=local_t, valid_axis=1,
-    )
-
-    def compare(actual, expected, **kwargs):
-        actual_tail = actual[:, local_t:]
-        expected_tail = expected[:, local_t:]
-        if not torch.equal(actual_tail, expected_tail):
-            mismatch_count = int((actual_tail != expected_tail).sum().item())
-            return False, f"    inactive token tail mismatch count={mismatch_count}"
-        return prefix_compare(actual, expected, **kwargs)
-
-    compare.__name__ = f"csa_output_prefix_and_tail(local_t={local_t})"
-    return compare
-
-
 if __name__ == "__main__":
     import argparse
 
@@ -1440,9 +1446,9 @@ if __name__ == "__main__":
     for case in selected_cases:
         local_t = case_local_t[case]
         result = run_jit(
-            fn=l3_decode_csa_output,
+            fn=l3_decode_csa,
             specs=build_tp_tensor_specs(local_t),
-            golden_fn=golden_decode_csa_output,
+            golden_fn=golden_decode_csa,
             compile_only=args.compile_only,
             compile_cfg=dict(
                 dump_passes=args.dump_passes,

--- a/models/deepseek_v4_flash_dspark/decode_hca.py
+++ b/models/deepseek_v4_flash_dspark/decode_hca.py
@@ -67,6 +67,7 @@ from decode_o_proj import (
     LOCAL_T_PAD,
     O_WINDOW_ROWS,
     decode_o_proj,
+    decode_o_proj_tp1,
     o_group_a2a,
     o_proj_reduce_scatter,
 )
@@ -78,7 +79,6 @@ from decode_sparse_attn_hca import (
     T_PAD,
     VALID_TOKEN_TILE,
     sparse_attn_hca,
-    sparse_attn_hca_heads,
 )
 
 # Dynamic shape variables.
@@ -167,8 +167,117 @@ if O_LORA < 3 * HEADS_PER_GROUP:
     raise ValueError("HCA fixture output projection needs three observable rows per local head")
 
 
+@pl.jit
+def decode_hca(
+    q: pl.Tensor[[T_DYN, H, HEAD_DIM], pl.BF16],
+    ori_kv: pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    window_swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
+    cmp_kv: pl.Tensor[[CMP_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    cmp_block_table: pl.Tensor[[B_DYN, CMP_MAX_BLOCKS], pl.INT32],
+    cmp_sparse_indices: pl.Tensor[[T_DYN, CMP_TOPK], pl.INT32],
+    attn_sink: pl.Tensor[[H], pl.FP32],
+    freqs_cos: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
+    wo_a: pl.Tensor[[LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
+    wo_b: pl.Tensor[[D, LOCAL_O_WIDTH], pl.INT8],
+    wo_b_scale: pl.Tensor[[D], pl.FP32],
+    o_local: pl.InOut[pl.Tensor[[LOCAL_T_PAD, D], pl.BF16]],
+    attention_window: pld.DistributedTensor[[ATTENTION_WINDOW_ROWS, O_GROUP_IN], pl.BF16],
+    attention_signal: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
+    o_window: pld.DistributedTensor[[O_WINDOW_ROWS, D], pl.FP32],
+    o_signal: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
+    group_base: pl.Scalar[pl.INT32],
+    tp_rank: pl.Scalar[pl.INT32],
+    local_t: pl.Scalar[pl.INT32],
+):
+    """Run rank-local HCA heads, output A2A, sharded O projection, and RS."""
+    q.bind_dynamic(0, T_DYN)
+    ori_kv.bind_dynamic(0, ORI_BLOCK_NUM_DYN)
+    window_swa_indices.bind_dynamic(0, T_DYN)
+    cmp_kv.bind_dynamic(0, CMP_BLOCK_NUM_DYN)
+    cmp_block_table.bind_dynamic(0, B_DYN)
+    cmp_sparse_indices.bind_dynamic(0, T_DYN)
+    freqs_cos.bind_dynamic(0, T_DYN)
+    freqs_sin.bind_dynamic(0, T_DYN)
+
+    attention_grouped = pl.create_tensor([O_GROUPS * LOCAL_T_PAD, O_GROUP_IN], dtype=pl.BF16)
+    attention_grouped, _ = sparse_attn_hca(
+        q, ori_kv, window_swa_indices,
+        cmp_kv, cmp_block_table, cmp_sparse_indices,
+        attn_sink, freqs_cos, freqs_sin,
+        attention_grouped,
+    )
+
+    attention_local_flat = pl.create_tensor([ATTENTION_WINDOW_ROWS, O_GROUP_IN], dtype=pl.BF16)
+    attention_local_flat, attention_signal = o_group_a2a(
+        attention_grouped, attention_local_flat,
+        attention_window, attention_signal,
+        group_base, tp_rank, local_t,
+    )
+
+    attention_local_groups = pl.reshape(attention_local_flat, [LOCAL_O_GROUPS, GROUP_T_PAD, O_GROUP_IN])
+    o_partial = pl.create_tensor([GROUP_T_PAD, D], dtype=pl.FP32)
+    o_partial, projection_tid = decode_o_proj(
+        attention_local_groups,
+        wo_a, wo_b, wo_b_scale,
+        local_t, o_partial,
+    )
+
+    o_local, o_signal = o_proj_reduce_scatter(
+        o_partial, o_local,
+        o_window, o_signal,
+        group_base, tp_rank, local_t, projection_tid,
+    )
+    return o_local, attention_signal, o_signal
+
+
+@pl.jit.host
+def l3_decode_hca(
+    q: pl.Tensor[[TP_SIZE, T_DYN, H, HEAD_DIM], pl.BF16],
+    ori_kv: pl.Tensor[[TP_SIZE, ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    window_swa_indices: pl.Tensor[[TP_SIZE, T_DYN, WIN], pl.INT32],
+    cmp_kv: pl.Tensor[[TP_SIZE, CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    cmp_block_table: pl.Tensor[[TP_SIZE, B_DYN, CMP_MAX_BLOCKS], pl.INT32],
+    cmp_sparse_indices: pl.Tensor[[TP_SIZE, T_DYN, CMP_TOPK], pl.INT32],
+    attn_sink: pl.Tensor[[TP_SIZE, H], pl.FP32],
+    freqs_cos: pl.Tensor[[TP_SIZE, T_DYN, ROPE_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[TP_SIZE, T_DYN, ROPE_DIM], pl.BF16],
+    wo_a: pl.Tensor[[TP_SIZE, LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
+    wo_b: pl.Tensor[[TP_SIZE, D, LOCAL_O_WIDTH], pl.INT8],
+    wo_b_scale: pl.Tensor[[TP_SIZE, D], pl.FP32],
+    o_local: pl.InOut[pl.Tensor[[TP_SIZE, LOCAL_T_PAD, D], pl.BF16]],
+    local_t: pl.Scalar[pl.INT32],
+):
+    """Launch the HCA output path on one TP group."""
+    q.bind_dynamic(1, T_DYN)
+    window_swa_indices.bind_dynamic(1, T_DYN)
+    cmp_block_table.bind_dynamic(1, B_DYN)
+    cmp_sparse_indices.bind_dynamic(1, T_DYN)
+    freqs_cos.bind_dynamic(1, T_DYN)
+    freqs_sin.bind_dynamic(1, T_DYN)
+
+    attention_window_buf = pld.alloc_window_buffer([ATTENTION_WINDOW_ROWS, O_GROUP_IN], dtype=pl.BF16)
+    attention_signal_buf = pld.alloc_window_buffer([TP_SIZE, 1], dtype=pl.INT32)
+    o_window_buf = pld.alloc_window_buffer([O_WINDOW_ROWS, D], dtype=pl.FP32)
+    o_signal_buf = pld.alloc_window_buffer([TP_SIZE, 1], dtype=pl.INT32)
+
+    for rank in pl.range(pld.world_size()):
+        attention_window = pld.window(attention_window_buf, [ATTENTION_WINDOW_ROWS, O_GROUP_IN], dtype=pl.BF16)
+        attention_signal = pld.window(attention_signal_buf, [TP_SIZE, 1], dtype=pl.INT32)
+        o_window = pld.window(o_window_buf, [O_WINDOW_ROWS, D], dtype=pl.FP32)
+        o_signal = pld.window(o_signal_buf, [TP_SIZE, 1], dtype=pl.INT32)
+        decode_hca(
+            q[rank], ori_kv[rank], window_swa_indices[rank],
+            cmp_kv[rank], cmp_block_table[rank], cmp_sparse_indices[rank],
+            attn_sink[rank], freqs_cos[rank], freqs_sin[rank],
+            wo_a[rank], wo_b[rank], wo_b_scale[rank], o_local[rank],
+            attention_window, attention_signal, o_window, o_signal,
+            0, rank, local_t, device=rank,
+        )
+
+
 @pl.jit.inline
-def attention_hca(
+def decode_hca_tp1(
     x_hc: pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32],
     # hc_pre weights
     hc_attn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
@@ -311,11 +420,17 @@ def attention_hca(
                     else:
                         pl.write(topk_all, [topk_t, topk_ck], pl.cast(-1, pl.INT32))
 
-    sparse_attn_hca(
+    o_packed_heads = pl.create_tensor([O_GROUPS * T_PAD, O_GROUP_IN], dtype=pl.BF16)
+    o_packed_heads, heads_dep = sparse_attn_hca(
         q, kv_cache, window_swa_indices,
         cmp_kv, cmp_block_table, topk_all,
         attn_sink, rope_cos_t, rope_sin_t,
-        wo_a, wo_b, wo_b_scale, attn_out,
+        o_packed_heads,
+    )
+    attn_out = decode_o_proj_tp1(
+        o_packed_heads,
+        wo_a, wo_b, wo_b_scale,
+        attn_out, heads_dep,
     )
 
     hc_post(attn_out, x_hc, post_t, comb_t, x_out)
@@ -323,7 +438,7 @@ def attention_hca(
 
 
 @pl.jit
-def attention_hca_test(
+def decode_hca_tp1_test(
     x_hc: pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32],
     hc_attn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
     hc_attn_scale: pl.Tensor[[3], pl.FP32],
@@ -371,7 +486,7 @@ def attention_hca_test(
     cmp_block_table.bind_dynamic(0, B_DYN)
     x_out.bind_dynamic(0, T_DYN)
 
-    attention_hca(
+    decode_hca_tp1(
         x_hc,
         hc_attn_fn, hc_attn_scale, hc_attn_base,
         attn_norm_w, wq_a, wq_b, wq_b_scale, wkv, gamma_cq, gamma_ckv,
@@ -389,116 +504,270 @@ def attention_hca_test(
     return x_out
 
 
-@pl.jit
-def decode_hca_output(
-    q: pl.Tensor[[T_DYN, H, HEAD_DIM], pl.BF16],
-    ori_kv: pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
-    window_swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
-    cmp_kv: pl.Tensor[[CMP_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
-    cmp_block_table: pl.Tensor[[B_DYN, CMP_MAX_BLOCKS], pl.INT32],
-    cmp_sparse_indices: pl.Tensor[[T_DYN, CMP_TOPK], pl.INT32],
-    attn_sink: pl.Tensor[[H], pl.FP32],
-    freqs_cos: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
-    freqs_sin: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
-    wo_a: pl.Tensor[[LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
-    wo_b: pl.Tensor[[D, LOCAL_O_WIDTH], pl.INT8],
-    wo_b_scale: pl.Tensor[[D], pl.FP32],
-    o_local: pl.InOut[pl.Tensor[[LOCAL_T_PAD, D], pl.BF16]],
-    attention_window: pld.DistributedTensor[[ATTENTION_WINDOW_ROWS, O_GROUP_IN], pl.BF16],
-    attention_signal: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
-    o_window: pld.DistributedTensor[[O_WINDOW_ROWS, D], pl.FP32],
-    o_signal: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
-    group_base: pl.Scalar[pl.INT32],
-    tp_rank: pl.Scalar[pl.INT32],
-    local_t: pl.Scalar[pl.INT32],
-):
-    """Run rank-local HCA heads, output A2A, sharded O projection, and RS."""
-    q.bind_dynamic(0, T_DYN)
-    ori_kv.bind_dynamic(0, ORI_BLOCK_NUM_DYN)
-    window_swa_indices.bind_dynamic(0, T_DYN)
-    cmp_kv.bind_dynamic(0, CMP_BLOCK_NUM_DYN)
-    cmp_block_table.bind_dynamic(0, B_DYN)
-    cmp_sparse_indices.bind_dynamic(0, T_DYN)
-    freqs_cos.bind_dynamic(0, T_DYN)
-    freqs_sin.bind_dynamic(0, T_DYN)
+def build_tp_tensor_specs(local_t):
+    """Build deterministic tensor-parallel HCA output inputs."""
+    import torch
 
-    attention_grouped = pl.create_tensor([O_GROUPS * LOCAL_T_PAD, O_GROUP_IN], dtype=pl.BF16)
-    attention_grouped, _ = sparse_attn_hca_heads(
-        q, ori_kv, window_swa_indices,
-        cmp_kv, cmp_block_table, cmp_sparse_indices,
-        attn_sink, freqs_cos, freqs_sin,
-        attention_grouped,
-    )
+    from golden import ScalarSpec, TensorSpec
 
-    attention_local_flat = pl.create_tensor([ATTENTION_WINDOW_ROWS, O_GROUP_IN], dtype=pl.BF16)
-    attention_local_flat, attention_signal = o_group_a2a(
-        attention_grouped, attention_local_flat,
-        attention_window, attention_signal,
-        group_base, tp_rank, local_t,
-    )
-
-    attention_local_groups = pl.reshape(attention_local_flat, [LOCAL_O_GROUPS, GROUP_T_PAD, O_GROUP_IN])
-    o_partial = pl.create_tensor([GROUP_T_PAD, D], dtype=pl.FP32)
-    o_partial, projection_tid = decode_o_proj(
-        attention_local_groups,
-        wo_a, wo_b, wo_b_scale,
-        local_t, o_partial,
-    )
-
-    o_local, o_signal = o_proj_reduce_scatter(
-        o_partial, o_local,
-        o_window, o_signal,
-        group_base, tp_rank, local_t, projection_tid,
-    )
-    return o_local, attention_signal, o_signal
-
-
-@pl.jit.host
-def l3_decode_hca_output(
-    q: pl.Tensor[[TP_SIZE, T_DYN, H, HEAD_DIM], pl.BF16],
-    ori_kv: pl.Tensor[[TP_SIZE, ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
-    window_swa_indices: pl.Tensor[[TP_SIZE, T_DYN, WIN], pl.INT32],
-    cmp_kv: pl.Tensor[[TP_SIZE, CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
-    cmp_block_table: pl.Tensor[[TP_SIZE, B_DYN, CMP_MAX_BLOCKS], pl.INT32],
-    cmp_sparse_indices: pl.Tensor[[TP_SIZE, T_DYN, CMP_TOPK], pl.INT32],
-    attn_sink: pl.Tensor[[TP_SIZE, H], pl.FP32],
-    freqs_cos: pl.Tensor[[TP_SIZE, T_DYN, ROPE_DIM], pl.BF16],
-    freqs_sin: pl.Tensor[[TP_SIZE, T_DYN, ROPE_DIM], pl.BF16],
-    wo_a: pl.Tensor[[TP_SIZE, LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
-    wo_b: pl.Tensor[[TP_SIZE, D, LOCAL_O_WIDTH], pl.INT8],
-    wo_b_scale: pl.Tensor[[TP_SIZE, D], pl.FP32],
-    o_local: pl.InOut[pl.Tensor[[TP_SIZE, LOCAL_T_PAD, D], pl.BF16]],
-    local_t: pl.Scalar[pl.INT32],
-):
-    """Launch the HCA output path on one TP group."""
-    q.bind_dynamic(1, T_DYN)
-    window_swa_indices.bind_dynamic(1, T_DYN)
-    cmp_block_table.bind_dynamic(1, B_DYN)
-    cmp_sparse_indices.bind_dynamic(1, T_DYN)
-    freqs_cos.bind_dynamic(1, T_DYN)
-    freqs_sin.bind_dynamic(1, T_DYN)
-
-    attention_window_buf = pld.alloc_window_buffer([ATTENTION_WINDOW_ROWS, O_GROUP_IN], dtype=pl.BF16)
-    attention_signal_buf = pld.alloc_window_buffer([TP_SIZE, 1], dtype=pl.INT32)
-    o_window_buf = pld.alloc_window_buffer([O_WINDOW_ROWS, D], dtype=pl.FP32)
-    o_signal_buf = pld.alloc_window_buffer([TP_SIZE, 1], dtype=pl.INT32)
-
-    for rank in pl.range(pld.world_size()):
-        attention_window = pld.window(attention_window_buf, [ATTENTION_WINDOW_ROWS, O_GROUP_IN], dtype=pl.BF16)
-        attention_signal = pld.window(attention_signal_buf, [TP_SIZE, 1], dtype=pl.INT32)
-        o_window = pld.window(o_window_buf, [O_WINDOW_ROWS, D], dtype=pl.FP32)
-        o_signal = pld.window(o_signal_buf, [TP_SIZE, 1], dtype=pl.INT32)
-        decode_hca_output(
-            q[rank], ori_kv[rank], window_swa_indices[rank],
-            cmp_kv[rank], cmp_block_table[rank], cmp_sparse_indices[rank],
-            attn_sink[rank], freqs_cos[rank], freqs_sin[rank],
-            wo_a[rank], wo_b[rank], wo_b_scale[rank], o_local[rank],
-            attention_window, attention_signal, o_window, o_signal,
-            0, rank, local_t, device=rank,
+    if (local_t < VALID_TOKEN_TILE or local_t > LOCAL_T
+            or local_t % VALID_TOKEN_TILE != 0 or local_t % S != 0):
+        raise ValueError(
+            f"local_t must be a multiple of {VALID_TOKEN_TILE} "
+            f"in [{VALID_TOKEN_TILE}, {LOCAL_T}], got {local_t}"
         )
+    local_batch = local_t // S
+    cmp_block_table_shape = [TP_SIZE, local_batch, CMP_MAX_BLOCKS]
+
+    def init_q():
+        q = torch.zeros(TP_SIZE, local_t, H, HEAD_DIM, dtype=torch.bfloat16)
+        rank = torch.arange(TP_SIZE, dtype=torch.float32).reshape(TP_SIZE, 1, 1)
+        token = torch.arange(local_t, dtype=torch.float32).reshape(1, local_t, 1)
+        head = torch.arange(H, dtype=torch.float32).reshape(1, 1, H)
+        q[..., 0] = (rank + token * 0.25 + head * 0.0625).to(torch.bfloat16)
+        return q
+
+    def init_ori_kv():
+        shape = (TP_SIZE, ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM)
+        ori_kv = torch.full(shape, float("nan"), dtype=torch.bfloat16)
+        ori_kv[:, :FIXTURE_WINDOW_BLOCKS, :, 0, :] = 0.0
+        ori_kv[:, :FIXTURE_WINDOW_BLOCKS, :, 0, 0] = 0.25
+        return ori_kv
+
+    def init_window_swa_indices():
+        window_row = torch.arange(WIN, dtype=torch.int32)
+        return window_row.reshape(1, 1, WIN).expand(TP_SIZE, local_t, WIN).clone()
+
+    def init_cmp_kv():
+        shape = (TP_SIZE, CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM)
+        cmp_kv = torch.full(shape, float("nan"), dtype=torch.bfloat16)
+        for rank in range(TP_SIZE):
+            rank_block_base = rank * FIXTURE_CMP_BLOCKS_PER_RANK
+            for request in range(local_batch):
+                request_block_base = rank_block_base + request * FIXTURE_CMP_LOGICAL_BLOCKS
+                for slot_index, cmp_slot in enumerate(FIXTURE_CMP_SLOTS):
+                    logical_block = cmp_slot // BLOCK_SIZE
+                    physical_block = request_block_base + FIXTURE_CMP_LOGICAL_BLOCKS - 1 - logical_block
+                    row = cmp_slot % BLOCK_SIZE
+                    cmp_kv[rank, physical_block, row, 0, :] = 0.0
+                    cmp_kv[rank, physical_block, row, 0, 0] = 0.25
+                    cmp_kv[rank, physical_block, row, 0, NOPE_DIM] = (
+                        (rank + 1) * 0.0625
+                        + (request + 1) * 0.015625
+                        + (slot_index + 1) * 0.00390625
+                    )
+                    cmp_kv[rank, physical_block, row, 0, NOPE_DIM + 1] = (
+                        -(logical_block + 1) * 0.0625
+                        + (rank + 1) * 0.0078125
+                        + (request + 1) * 0.001953125
+                    )
+        return cmp_kv
+
+    def init_cmp_block_table():
+        table = torch.full(cmp_block_table_shape, -1, dtype=torch.int32)
+        for rank in range(TP_SIZE):
+            rank_block_base = rank * FIXTURE_CMP_BLOCKS_PER_RANK
+            for request in range(local_batch):
+                request_block_base = rank_block_base + request * FIXTURE_CMP_LOGICAL_BLOCKS
+                for logical_block in range(FIXTURE_CMP_LOGICAL_BLOCKS):
+                    table[rank, request, logical_block] = (
+                        request_block_base + FIXTURE_CMP_LOGICAL_BLOCKS - 1 - logical_block
+                    )
+        return table
+
+    def init_cmp_sparse_indices():
+        indices = torch.full((TP_SIZE, local_t, CMP_TOPK), -1, dtype=torch.int32)
+        for cmp_slot in FIXTURE_CMP_SLOTS:
+            indices[:, :, cmp_slot] = cmp_slot
+        return indices
+
+    def init_attn_sink():
+        head = torch.arange(H, dtype=torch.int32).remainder(HEADS_PER_GROUP).to(torch.float32)
+        sink = 4.0 + head * 0.125
+        return sink.reshape(1, H).expand(TP_SIZE, H).clone()
+
+    def init_freqs_cos():
+        rank = torch.arange(TP_SIZE, dtype=torch.int32).reshape(TP_SIZE, 1)
+        token = torch.arange(local_t, dtype=torch.int32).reshape(1, local_t)
+        phase = (rank + token).remainder(4)
+        values = torch.tensor((1.0, 0.0, -1.0, 0.0), dtype=torch.bfloat16)
+        return values[phase].unsqueeze(-1).expand(TP_SIZE, local_t, ROPE_DIM).clone()
+
+    def init_freqs_sin():
+        rank = torch.arange(TP_SIZE, dtype=torch.int32).reshape(TP_SIZE, 1)
+        token = torch.arange(local_t, dtype=torch.int32).reshape(1, local_t)
+        phase = (rank + token).remainder(4)
+        values = torch.tensor((0.0, 1.0, 0.0, -1.0), dtype=torch.bfloat16)
+        return values[phase].unsqueeze(-1).expand(TP_SIZE, local_t, ROPE_DIM).clone()
+
+    def init_wo_a():
+        wo_a = torch.zeros(TP_SIZE, LOCAL_O_GROUPS, O_LORA, O_GROUP_IN, dtype=torch.bfloat16)
+        for rank in range(TP_SIZE):
+            for local_group in range(LOCAL_O_GROUPS):
+                shard_scale = (rank + 1) * (local_group + 1) * 0.125
+                for head in range(HEADS_PER_GROUP):
+                    wo_a[rank, local_group, head, head * HEAD_DIM] = shard_scale * (head + 1)
+                    wo_a[
+                        rank, local_group, HEADS_PER_GROUP + head,
+                        head * HEAD_DIM + NOPE_DIM,
+                    ] = shard_scale * (head + 1) * 0.75
+                    wo_a[
+                        rank, local_group, 2 * HEADS_PER_GROUP + head,
+                        head * HEAD_DIM + NOPE_DIM + 1,
+                    ] = -shard_scale * (head + 1) * 0.5
+        return wo_a
+
+    def init_wo_b():
+        base = torch.arange(D * LOCAL_O_WIDTH, dtype=torch.int32).reshape(D, LOCAL_O_WIDTH)
+        rank = torch.arange(TP_SIZE, dtype=torch.int32).reshape(TP_SIZE, 1, 1)
+        return (base.unsqueeze(0) + rank).remainder(7).sub(3).to(torch.int8)
+
+    def init_wo_b_scale():
+        channel_scale = torch.arange(D, dtype=torch.int32).remainder(4).to(torch.float32) * 0.25 + 0.5
+        return channel_scale.reshape(1, D).expand(TP_SIZE, D).clone()
+
+    return [
+        TensorSpec("q", [TP_SIZE, local_t, H, HEAD_DIM], torch.bfloat16, init_value=init_q),
+        TensorSpec("ori_kv", [TP_SIZE, ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_ori_kv),
+        TensorSpec("window_swa_indices", [TP_SIZE, local_t, WIN], torch.int32, init_value=init_window_swa_indices),
+        TensorSpec("cmp_kv", [TP_SIZE, CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_cmp_kv),
+        TensorSpec("cmp_block_table", cmp_block_table_shape, torch.int32, init_value=init_cmp_block_table),
+        TensorSpec("cmp_sparse_indices", [TP_SIZE, local_t, CMP_TOPK], torch.int32, init_value=init_cmp_sparse_indices),
+        TensorSpec("attn_sink", [TP_SIZE, H], torch.float32, init_value=init_attn_sink),
+        TensorSpec("freqs_cos", [TP_SIZE, local_t, ROPE_DIM], torch.bfloat16, init_value=init_freqs_cos),
+        TensorSpec("freqs_sin", [TP_SIZE, local_t, ROPE_DIM], torch.bfloat16, init_value=init_freqs_sin),
+        TensorSpec("wo_a", [TP_SIZE, LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], torch.bfloat16, init_value=init_wo_a),
+        TensorSpec("wo_b", [TP_SIZE, D, LOCAL_O_WIDTH], torch.int8, init_value=init_wo_b),
+        TensorSpec("wo_b_scale", [TP_SIZE, D], torch.float32, init_value=init_wo_b_scale),
+        TensorSpec(
+            "o_local", [TP_SIZE, LOCAL_T_PAD, D], torch.bfloat16,
+            init_value=FIXTURE_OUTPUT_SENTINEL, is_output=True,
+        ),
+        ScalarSpec("local_t", torch.int32, local_t),
+    ]
 
 
-def golden_attention_hca(tensors):
+def golden_decode_hca(tensors):
+    """Compute the controlled HCA heads, sharded O projection, and reduced rows."""
+    import torch
+
+    local_t = int(tensors["local_t"])
+    local_batch = local_t // S
+    group_t = TP_SIZE * local_t
+    q = tensors["q"].float()
+    window_kv = tensors["ori_kv"][:, 0, 0, 0].float()
+
+    cmp_rows_by_request = torch.empty(
+        TP_SIZE, local_batch, len(FIXTURE_CMP_SLOTS), HEAD_DIM,
+        dtype=torch.float32,
+    )
+    for rank in range(TP_SIZE):
+        for request in range(local_batch):
+            token = request * S
+            for row, sparse_position in enumerate(FIXTURE_CMP_SLOTS):
+                cmp_slot = int(tensors["cmp_sparse_indices"][rank, token, sparse_position].item())
+                logical_block = cmp_slot // BLOCK_SIZE
+                physical_block = int(tensors["cmp_block_table"][rank, request, logical_block].item())
+                cmp_rows_by_request[rank, request, row] = tensors[
+                    "cmp_kv"
+                ][rank, physical_block, cmp_slot % BLOCK_SIZE, 0].float()
+    cmp_rows = cmp_rows_by_request.repeat_interleave(S, dim=1)
+
+    window_mi = torch.einsum("rthd,rd->rth", q, window_kv)
+    window_mi = (window_mi * M.softmax_scale).unsqueeze(-1)
+    window_li = torch.full_like(window_mi, float(WIN))
+    window_oi = window_kv.reshape(TP_SIZE, 1, 1, HEAD_DIM) * WIN
+
+    cmp_scores = torch.einsum("rthd,rtkd->rthk", q, cmp_rows)
+    cmp_scores = cmp_scores * M.softmax_scale
+    cmp_mi = cmp_scores.max(dim=-1, keepdim=True).values
+    cmp_exp = torch.exp(cmp_scores - cmp_mi)
+    cmp_li = cmp_exp.sum(dim=-1, keepdim=True)
+    cmp_oi = torch.einsum(
+        "rthk,rtkd->rthd",
+        cmp_exp.to(torch.bfloat16).float(), cmp_rows,
+    )
+
+    score_max = torch.maximum(window_mi, cmp_mi)
+    window_alpha = torch.exp(window_mi - score_max)
+    cmp_beta = torch.exp(cmp_mi - score_max)
+    li = window_alpha * window_li + cmp_beta * cmp_li
+    oi = window_alpha * window_oi + cmp_beta * cmp_oi
+    sink = tensors["attn_sink"].float().reshape(TP_SIZE, 1, H, 1)
+    head_value = oi / (li + torch.exp(sink - score_max))
+
+    rope_pair = head_value[..., NOPE_DIM:].unflatten(-1, (-1, 2))
+    rope_even = rope_pair[..., 0]
+    rope_odd = rope_pair[..., 1]
+    cos_half = tensors["freqs_cos"][..., :HALF_ROPE].float().unsqueeze(2)
+    sin_half = tensors["freqs_sin"][..., :HALF_ROPE].float().unsqueeze(2)
+    inverse_even = (rope_even * cos_half + rope_odd * sin_half).to(torch.bfloat16).float()
+    inverse_odd = (rope_odd * cos_half - rope_even * sin_half).to(torch.bfloat16).float()
+    inverse_rope = torch.stack((inverse_even, inverse_odd), dim=-1).flatten(-2)
+    head_value = torch.cat((head_value[..., :NOPE_DIM], inverse_rope), dim=-1).to(torch.bfloat16)
+
+    attention_grouped = head_value.reshape(
+        TP_SIZE, local_t, O_GROUPS, HEADS_PER_GROUP, HEAD_DIM,
+    )
+    attention_grouped = attention_grouped.permute(0, 2, 1, 3, 4)
+    attention_grouped = attention_grouped.reshape(
+        TP_SIZE, O_GROUPS, local_t, O_GROUP_IN,
+    )
+
+    attention_local = torch.zeros(TP_SIZE, LOCAL_O_GROUPS, group_t, O_GROUP_IN, dtype=torch.bfloat16)
+    for destination_rank in range(TP_SIZE):
+        for local_group in range(LOCAL_O_GROUPS):
+            global_group = destination_rank * LOCAL_O_GROUPS + local_group
+            group_rows = attention_grouped[:, global_group].reshape(group_t, O_GROUP_IN)
+            attention_local[destination_rank, local_group] = group_rows
+
+    partials = torch.zeros(TP_SIZE, group_t, D, dtype=torch.float32)
+    for rank in range(TP_SIZE):
+        attention = attention_local[rank].float()
+        o_a = torch.einsum("gti,gri->gtr", attention, tensors["wo_a"][rank].float())
+        row_amax = o_a.abs().amax(dim=-1, keepdim=True).clamp_min(INT8_AMAX_EPS)
+        scale_q = INT8_SCALE_MAX / row_amax
+        o_a_i8 = torch.round(o_a * scale_q).to(torch.int32).to(torch.float16).to(torch.int8)
+        scale_dq = 1.0 / scale_q
+        wo_b = tensors["wo_b"][rank].reshape(D, LOCAL_O_GROUPS, O_LORA)
+        for local_group in range(LOCAL_O_GROUPS):
+            group_i32 = o_a_i8[local_group].to(torch.int32)
+            weight_i32 = wo_b[:, local_group].to(torch.int32)
+            group_partial = group_i32 @ weight_i32.T
+            partials[rank] += group_partial.float() * scale_dq[local_group]
+        partials[rank] *= tensors["wo_b_scale"][rank].float().reshape(1, D)
+
+    reduced = partials.sum(dim=0)
+    tensors["o_local"].fill_(FIXTURE_OUTPUT_SENTINEL)
+    for rank in range(TP_SIZE):
+        row_start = rank * local_t
+        tensors["o_local"][rank, :local_t] = reduced[row_start : row_start + local_t].to(torch.bfloat16)
+
+
+def build_o_local_compare(local_t):
+    """Compare valid token rows and require the poisoned capacity tail to survive."""
+    import torch
+
+    from golden import ratio_allclose
+
+    prefix_compare = ratio_allclose(
+        atol=1e-4, rtol=1.0 / 128, max_error_ratio=0.005,
+        valid_rows=local_t, valid_axis=1,
+    )
+
+    def compare(actual, expected, **kwargs):
+        actual_tail = actual[:, local_t:]
+        expected_tail = expected[:, local_t:]
+        if not torch.equal(actual_tail, expected_tail):
+            mismatch_count = int((actual_tail != expected_tail).sum().item())
+            return False, f"    inactive token tail mismatch count={mismatch_count}"
+        return prefix_compare(actual, expected, **kwargs)
+
+    compare.__name__ = f"hca_output_prefix_and_tail(local_t={local_t})"
+    return compare
+
+
+def golden_decode_hca_tp1(tensors):
     """End-to-end orchestration for the ratio=128 (HCA) layers.
     Mirrors Block.hc_pre + Attention.forward (decode branch, ratio==128 path: main compressor only,
     no indexer, compress_topk_idxs computed deterministically) + Block.hc_post."""
@@ -854,269 +1123,6 @@ def build_tensor_specs(start_pos=None, batch=B):
     ]
 
 
-def build_tp_tensor_specs(local_t):
-    """Build deterministic tensor-parallel HCA output inputs."""
-    import torch
-
-    from golden import ScalarSpec, TensorSpec
-
-    if (local_t < VALID_TOKEN_TILE or local_t > LOCAL_T
-            or local_t % VALID_TOKEN_TILE != 0 or local_t % S != 0):
-        raise ValueError(
-            f"local_t must be a multiple of {VALID_TOKEN_TILE} "
-            f"in [{VALID_TOKEN_TILE}, {LOCAL_T}], got {local_t}"
-        )
-    local_batch = local_t // S
-    cmp_block_table_shape = [TP_SIZE, local_batch, CMP_MAX_BLOCKS]
-
-    def init_q():
-        q = torch.zeros(TP_SIZE, local_t, H, HEAD_DIM, dtype=torch.bfloat16)
-        rank = torch.arange(TP_SIZE, dtype=torch.float32).reshape(TP_SIZE, 1, 1)
-        token = torch.arange(local_t, dtype=torch.float32).reshape(1, local_t, 1)
-        head = torch.arange(H, dtype=torch.float32).reshape(1, 1, H)
-        q[..., 0] = (rank + token * 0.25 + head * 0.0625).to(torch.bfloat16)
-        return q
-
-    def init_ori_kv():
-        shape = (TP_SIZE, ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM)
-        ori_kv = torch.full(shape, float("nan"), dtype=torch.bfloat16)
-        ori_kv[:, :FIXTURE_WINDOW_BLOCKS, :, 0, :] = 0.0
-        ori_kv[:, :FIXTURE_WINDOW_BLOCKS, :, 0, 0] = 0.25
-        return ori_kv
-
-    def init_window_swa_indices():
-        window_row = torch.arange(WIN, dtype=torch.int32)
-        return window_row.reshape(1, 1, WIN).expand(TP_SIZE, local_t, WIN).clone()
-
-    def init_cmp_kv():
-        shape = (TP_SIZE, CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM)
-        cmp_kv = torch.full(shape, float("nan"), dtype=torch.bfloat16)
-        for rank in range(TP_SIZE):
-            rank_block_base = rank * FIXTURE_CMP_BLOCKS_PER_RANK
-            for request in range(local_batch):
-                request_block_base = rank_block_base + request * FIXTURE_CMP_LOGICAL_BLOCKS
-                for slot_index, cmp_slot in enumerate(FIXTURE_CMP_SLOTS):
-                    logical_block = cmp_slot // BLOCK_SIZE
-                    physical_block = request_block_base + FIXTURE_CMP_LOGICAL_BLOCKS - 1 - logical_block
-                    row = cmp_slot % BLOCK_SIZE
-                    cmp_kv[rank, physical_block, row, 0, :] = 0.0
-                    cmp_kv[rank, physical_block, row, 0, 0] = 0.25
-                    cmp_kv[rank, physical_block, row, 0, NOPE_DIM] = (
-                        (rank + 1) * 0.0625
-                        + (request + 1) * 0.015625
-                        + (slot_index + 1) * 0.00390625
-                    )
-                    cmp_kv[rank, physical_block, row, 0, NOPE_DIM + 1] = (
-                        -(logical_block + 1) * 0.0625
-                        + (rank + 1) * 0.0078125
-                        + (request + 1) * 0.001953125
-                    )
-        return cmp_kv
-
-    def init_cmp_block_table():
-        table = torch.full(cmp_block_table_shape, -1, dtype=torch.int32)
-        for rank in range(TP_SIZE):
-            rank_block_base = rank * FIXTURE_CMP_BLOCKS_PER_RANK
-            for request in range(local_batch):
-                request_block_base = rank_block_base + request * FIXTURE_CMP_LOGICAL_BLOCKS
-                for logical_block in range(FIXTURE_CMP_LOGICAL_BLOCKS):
-                    table[rank, request, logical_block] = (
-                        request_block_base + FIXTURE_CMP_LOGICAL_BLOCKS - 1 - logical_block
-                    )
-        return table
-
-    def init_cmp_sparse_indices():
-        indices = torch.full((TP_SIZE, local_t, CMP_TOPK), -1, dtype=torch.int32)
-        for cmp_slot in FIXTURE_CMP_SLOTS:
-            indices[:, :, cmp_slot] = cmp_slot
-        return indices
-
-    def init_attn_sink():
-        head = torch.arange(H, dtype=torch.int32).remainder(HEADS_PER_GROUP).to(torch.float32)
-        sink = 4.0 + head * 0.125
-        return sink.reshape(1, H).expand(TP_SIZE, H).clone()
-
-    def init_freqs_cos():
-        rank = torch.arange(TP_SIZE, dtype=torch.int32).reshape(TP_SIZE, 1)
-        token = torch.arange(local_t, dtype=torch.int32).reshape(1, local_t)
-        phase = (rank + token).remainder(4)
-        values = torch.tensor((1.0, 0.0, -1.0, 0.0), dtype=torch.bfloat16)
-        return values[phase].unsqueeze(-1).expand(TP_SIZE, local_t, ROPE_DIM).clone()
-
-    def init_freqs_sin():
-        rank = torch.arange(TP_SIZE, dtype=torch.int32).reshape(TP_SIZE, 1)
-        token = torch.arange(local_t, dtype=torch.int32).reshape(1, local_t)
-        phase = (rank + token).remainder(4)
-        values = torch.tensor((0.0, 1.0, 0.0, -1.0), dtype=torch.bfloat16)
-        return values[phase].unsqueeze(-1).expand(TP_SIZE, local_t, ROPE_DIM).clone()
-
-    def init_wo_a():
-        wo_a = torch.zeros(TP_SIZE, LOCAL_O_GROUPS, O_LORA, O_GROUP_IN, dtype=torch.bfloat16)
-        for rank in range(TP_SIZE):
-            for local_group in range(LOCAL_O_GROUPS):
-                shard_scale = (rank + 1) * (local_group + 1) * 0.125
-                for head in range(HEADS_PER_GROUP):
-                    wo_a[rank, local_group, head, head * HEAD_DIM] = shard_scale * (head + 1)
-                    wo_a[
-                        rank, local_group, HEADS_PER_GROUP + head,
-                        head * HEAD_DIM + NOPE_DIM,
-                    ] = shard_scale * (head + 1) * 0.75
-                    wo_a[
-                        rank, local_group, 2 * HEADS_PER_GROUP + head,
-                        head * HEAD_DIM + NOPE_DIM + 1,
-                    ] = -shard_scale * (head + 1) * 0.5
-        return wo_a
-
-    def init_wo_b():
-        base = torch.arange(D * LOCAL_O_WIDTH, dtype=torch.int32).reshape(D, LOCAL_O_WIDTH)
-        rank = torch.arange(TP_SIZE, dtype=torch.int32).reshape(TP_SIZE, 1, 1)
-        return (base.unsqueeze(0) + rank).remainder(7).sub(3).to(torch.int8)
-
-    def init_wo_b_scale():
-        channel_scale = torch.arange(D, dtype=torch.int32).remainder(4).to(torch.float32) * 0.25 + 0.5
-        return channel_scale.reshape(1, D).expand(TP_SIZE, D).clone()
-
-    return [
-        TensorSpec("q", [TP_SIZE, local_t, H, HEAD_DIM], torch.bfloat16, init_value=init_q),
-        TensorSpec("ori_kv", [TP_SIZE, ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_ori_kv),
-        TensorSpec("window_swa_indices", [TP_SIZE, local_t, WIN], torch.int32, init_value=init_window_swa_indices),
-        TensorSpec("cmp_kv", [TP_SIZE, CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_cmp_kv),
-        TensorSpec("cmp_block_table", cmp_block_table_shape, torch.int32, init_value=init_cmp_block_table),
-        TensorSpec("cmp_sparse_indices", [TP_SIZE, local_t, CMP_TOPK], torch.int32, init_value=init_cmp_sparse_indices),
-        TensorSpec("attn_sink", [TP_SIZE, H], torch.float32, init_value=init_attn_sink),
-        TensorSpec("freqs_cos", [TP_SIZE, local_t, ROPE_DIM], torch.bfloat16, init_value=init_freqs_cos),
-        TensorSpec("freqs_sin", [TP_SIZE, local_t, ROPE_DIM], torch.bfloat16, init_value=init_freqs_sin),
-        TensorSpec("wo_a", [TP_SIZE, LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], torch.bfloat16, init_value=init_wo_a),
-        TensorSpec("wo_b", [TP_SIZE, D, LOCAL_O_WIDTH], torch.int8, init_value=init_wo_b),
-        TensorSpec("wo_b_scale", [TP_SIZE, D], torch.float32, init_value=init_wo_b_scale),
-        TensorSpec(
-            "o_local", [TP_SIZE, LOCAL_T_PAD, D], torch.bfloat16,
-            init_value=FIXTURE_OUTPUT_SENTINEL, is_output=True,
-        ),
-        ScalarSpec("local_t", torch.int32, local_t),
-    ]
-
-
-def golden_decode_hca_output(tensors):
-    """Compute the controlled HCA heads, sharded O projection, and reduced rows."""
-    import torch
-
-    local_t = int(tensors["local_t"])
-    local_batch = local_t // S
-    group_t = TP_SIZE * local_t
-    q = tensors["q"].float()
-    window_kv = tensors["ori_kv"][:, 0, 0, 0].float()
-
-    cmp_rows_by_request = torch.empty(
-        TP_SIZE, local_batch, len(FIXTURE_CMP_SLOTS), HEAD_DIM,
-        dtype=torch.float32,
-    )
-    for rank in range(TP_SIZE):
-        for request in range(local_batch):
-            token = request * S
-            for row, sparse_position in enumerate(FIXTURE_CMP_SLOTS):
-                cmp_slot = int(tensors["cmp_sparse_indices"][rank, token, sparse_position].item())
-                logical_block = cmp_slot // BLOCK_SIZE
-                physical_block = int(tensors["cmp_block_table"][rank, request, logical_block].item())
-                cmp_rows_by_request[rank, request, row] = tensors[
-                    "cmp_kv"
-                ][rank, physical_block, cmp_slot % BLOCK_SIZE, 0].float()
-    cmp_rows = cmp_rows_by_request.repeat_interleave(S, dim=1)
-
-    window_mi = torch.einsum("rthd,rd->rth", q, window_kv)
-    window_mi = (window_mi * M.softmax_scale).unsqueeze(-1)
-    window_li = torch.full_like(window_mi, float(WIN))
-    window_oi = window_kv.reshape(TP_SIZE, 1, 1, HEAD_DIM) * WIN
-
-    cmp_scores = torch.einsum("rthd,rtkd->rthk", q, cmp_rows)
-    cmp_scores = cmp_scores * M.softmax_scale
-    cmp_mi = cmp_scores.max(dim=-1, keepdim=True).values
-    cmp_exp = torch.exp(cmp_scores - cmp_mi)
-    cmp_li = cmp_exp.sum(dim=-1, keepdim=True)
-    cmp_oi = torch.einsum(
-        "rthk,rtkd->rthd",
-        cmp_exp.to(torch.bfloat16).float(), cmp_rows,
-    )
-
-    score_max = torch.maximum(window_mi, cmp_mi)
-    window_alpha = torch.exp(window_mi - score_max)
-    cmp_beta = torch.exp(cmp_mi - score_max)
-    li = window_alpha * window_li + cmp_beta * cmp_li
-    oi = window_alpha * window_oi + cmp_beta * cmp_oi
-    sink = tensors["attn_sink"].float().reshape(TP_SIZE, 1, H, 1)
-    head_value = oi / (li + torch.exp(sink - score_max))
-
-    rope_pair = head_value[..., NOPE_DIM:].unflatten(-1, (-1, 2))
-    rope_even = rope_pair[..., 0]
-    rope_odd = rope_pair[..., 1]
-    cos_half = tensors["freqs_cos"][..., :HALF_ROPE].float().unsqueeze(2)
-    sin_half = tensors["freqs_sin"][..., :HALF_ROPE].float().unsqueeze(2)
-    inverse_even = (rope_even * cos_half + rope_odd * sin_half).to(torch.bfloat16).float()
-    inverse_odd = (rope_odd * cos_half - rope_even * sin_half).to(torch.bfloat16).float()
-    inverse_rope = torch.stack((inverse_even, inverse_odd), dim=-1).flatten(-2)
-    head_value = torch.cat((head_value[..., :NOPE_DIM], inverse_rope), dim=-1).to(torch.bfloat16)
-
-    attention_grouped = head_value.reshape(
-        TP_SIZE, local_t, O_GROUPS, HEADS_PER_GROUP, HEAD_DIM,
-    )
-    attention_grouped = attention_grouped.permute(0, 2, 1, 3, 4)
-    attention_grouped = attention_grouped.reshape(
-        TP_SIZE, O_GROUPS, local_t, O_GROUP_IN,
-    )
-
-    attention_local = torch.zeros(TP_SIZE, LOCAL_O_GROUPS, group_t, O_GROUP_IN, dtype=torch.bfloat16)
-    for destination_rank in range(TP_SIZE):
-        for local_group in range(LOCAL_O_GROUPS):
-            global_group = destination_rank * LOCAL_O_GROUPS + local_group
-            group_rows = attention_grouped[:, global_group].reshape(group_t, O_GROUP_IN)
-            attention_local[destination_rank, local_group] = group_rows
-
-    partials = torch.zeros(TP_SIZE, group_t, D, dtype=torch.float32)
-    for rank in range(TP_SIZE):
-        attention = attention_local[rank].float()
-        o_a = torch.einsum("gti,gri->gtr", attention, tensors["wo_a"][rank].float())
-        row_amax = o_a.abs().amax(dim=-1, keepdim=True).clamp_min(INT8_AMAX_EPS)
-        scale_q = INT8_SCALE_MAX / row_amax
-        o_a_i8 = torch.round(o_a * scale_q).to(torch.int32).to(torch.float16).to(torch.int8)
-        scale_dq = 1.0 / scale_q
-        wo_b = tensors["wo_b"][rank].reshape(D, LOCAL_O_GROUPS, O_LORA)
-        for local_group in range(LOCAL_O_GROUPS):
-            group_i32 = o_a_i8[local_group].to(torch.int32)
-            weight_i32 = wo_b[:, local_group].to(torch.int32)
-            group_partial = group_i32 @ weight_i32.T
-            partials[rank] += group_partial.float() * scale_dq[local_group]
-        partials[rank] *= tensors["wo_b_scale"][rank].float().reshape(1, D)
-
-    reduced = partials.sum(dim=0)
-    tensors["o_local"].fill_(FIXTURE_OUTPUT_SENTINEL)
-    for rank in range(TP_SIZE):
-        row_start = rank * local_t
-        tensors["o_local"][rank, :local_t] = reduced[row_start : row_start + local_t].to(torch.bfloat16)
-
-
-def build_o_local_compare(local_t):
-    """Compare valid token rows and require the poisoned capacity tail to survive."""
-    import torch
-
-    from golden import ratio_allclose
-
-    prefix_compare = ratio_allclose(
-        atol=1e-4, rtol=1.0 / 128, max_error_ratio=0.005,
-        valid_rows=local_t, valid_axis=1,
-    )
-
-    def compare(actual, expected, **kwargs):
-        actual_tail = actual[:, local_t:]
-        expected_tail = expected[:, local_t:]
-        if not torch.equal(actual_tail, expected_tail):
-            mismatch_count = int((actual_tail != expected_tail).sum().item())
-            return False, f"    inactive token tail mismatch count={mismatch_count}"
-        return prefix_compare(actual, expected, **kwargs)
-
-    compare.__name__ = f"hca_output_prefix_and_tail(local_t={local_t})"
-    return compare
-
-
 if __name__ == "__main__":
     import argparse
 
@@ -1153,9 +1159,9 @@ if __name__ == "__main__":
     for case in selected_cases:
         local_t = case_local_t[case]
         result = run_jit(
-            fn=l3_decode_hca_output,
+            fn=l3_decode_hca,
             specs=build_tp_tensor_specs(local_t),
-            golden_fn=golden_decode_hca_output,
+            golden_fn=golden_decode_hca,
             compile_only=args.compile_only,
             compile_cfg=dict(
                 dump_passes=args.dump_passes,

--- a/models/deepseek_v4_flash_dspark/decode_hca.py
+++ b/models/deepseek_v4_flash_dspark/decode_hca.py
@@ -84,6 +84,9 @@ from decode_sparse_attn_hca import (
 # Dynamic shape variables.
 B_DYN = pl.dynamic("B_DYN")  # per-request axis
 T_DYN = pl.dynamic("T_DYN")  # T = B * S
+ORI_BLOCK_NUM_DYN = pl.dynamic("ORI_BLOCK_NUM_DYN")
+CMP_BLOCK_NUM_DYN = pl.dynamic("CMP_BLOCK_NUM_DYN")
+COMPRESS_STATE_BLOCK_NUM_DYN = pl.dynamic("HCA_STATE_BLOCK_NUM_DYN")
 
 
 # model config
@@ -117,20 +120,16 @@ COFF = 1 + int(OVERLAP)         # always 1 for HCA
 MAIN_OUT_DIM = COFF * HEAD_DIM
 ORI_MAX_BLOCKS = KV_ORI_MAX_BLOCKS
 ORI_BLOCK_NUM = KV_ORI_BLOCK_NUM
-ORI_BLOCK_NUM_DYN = pl.dynamic("ORI_BLOCK_NUM_DYN")
 CMP_MAX_BLOCKS = KV_CMP_MAX_BLOCKS
 CMP_BLOCK_NUM = KV_CMP_BLOCK_NUM
-CMP_BLOCK_NUM_DYN = pl.dynamic("CMP_BLOCK_NUM_DYN")
 # Main compressor state pool (kv + score channels merged into one paged FP32 buffer).
 COMPRESS_STATE_BLOCK_SIZE = C128_COMPRESSOR_BLOCK_SIZE
 COMPRESS_STATE_PHYSICAL_BLOCKS = HCA_STATE_PHYSICAL_BLOCKS
 COMPRESS_STATE_MAX_BLOCKS = (MAX_SEQ_LEN + COMPRESS_STATE_BLOCK_SIZE - 1) // COMPRESS_STATE_BLOCK_SIZE
 COMPRESS_STATE_BLOCK_NUM = COMPRESS_STATE_PHYSICAL_BLOCKS
-COMPRESS_STATE_BLOCK_NUM_DYN = pl.dynamic("HCA_STATE_BLOCK_NUM_DYN")
 COMPRESS_STATE_DIM = 2 * MAIN_OUT_DIM
 COMPRESS_TOPK = MAX_SEQ_LEN // COMPRESS_RATIO   # demo 32; flash 128 (= 16384/128); max compressed positions
-# HCA has no indexer: the compressed tail is every slot the cache holds, so the
-# only bound is the cache capacity (`index_topk` belongs to the ratio-4 indexer).
+# HCA has no indexer; the compressed tail is bounded by cache capacity.
 # Longest context served = COMPRESS_TOPK * COMPRESS_RATIO = MAX_SEQ_LEN.
 HCA_TOPK_LIMIT = COMPRESS_TOPK
 
@@ -142,29 +141,10 @@ SPARSE_ROPE_INTERLEAVE_TILE = 2 * SPARSE_ROPE_TILE
 HCA_TOPK_TOKEN_TILE = 8   # tokens per cache-window topk SPMD block
 HCA_WB_TOKEN_TILE = 8  # tokens per cache-writeback SPMD block
 
-# fixture
-FIXTURE_WINDOW_BLOCKS = (WIN + BLOCK_SIZE - 1) // BLOCK_SIZE
-FIXTURE_CMP_SLOTS = (0, 31, 32, 63, 64, 95, 96, 127)
-FIXTURE_CMP_LOGICAL_BLOCKS = (max(FIXTURE_CMP_SLOTS) + 1 + BLOCK_SIZE - 1) // BLOCK_SIZE
-FIXTURE_CMP_BLOCKS_PER_RANK = CMP_BLOCK_NUM // TP_SIZE
-FIXTURE_OUTPUT_SENTINEL = -7.0
-
 if T != LOCAL_T:
     raise ValueError(f"HCA token capacity {T} must equal TP local token capacity {LOCAL_T}")
 if T_PAD != LOCAL_T_PAD:
     raise ValueError(f"HCA token capacity {T_PAD} must equal TP local token capacity {LOCAL_T_PAD}")
-if max(FIXTURE_CMP_SLOTS) >= CMP_TOPK:
-    raise ValueError("HCA fixture compressed slots exceed the configured top-k capacity")
-if FIXTURE_WINDOW_BLOCKS > ORI_BLOCK_NUM:
-    raise ValueError("HCA fixture window exceeds the original KV cache capacity")
-if FIXTURE_CMP_LOGICAL_BLOCKS > CMP_MAX_BLOCKS:
-    raise ValueError("HCA fixture compressed slots exceed the compressed block table")
-if CMP_BLOCK_NUM % TP_SIZE != 0:
-    raise ValueError("HCA fixture requires equal compressed-cache partitions across TP ranks")
-if (LOCAL_T // S) * FIXTURE_CMP_LOGICAL_BLOCKS > FIXTURE_CMP_BLOCKS_PER_RANK:
-    raise ValueError("HCA fixture compressed-cache partition is too small for the local requests")
-if O_LORA < 3 * HEADS_PER_GROUP:
-    raise ValueError("HCA fixture output projection needs three observable rows per local head")
 
 
 @pl.jit
@@ -334,10 +314,7 @@ def decode_hca_tp1(
     rope_sin_t = pl.create_tensor([t_dim, ROPE_HEAD_DIM], dtype=pl.BF16)
     cmp_cos = pl.create_tensor([B, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
     cmp_sin = pl.create_tensor([B, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
-    # Interleave-duplicated / sign-folded compressed-position rope rows. The ratio-128
-    # compressor's rmsnorm_rope_cache_write rebuilt this j>>1 dup-gather itself; pl.gather
-    # lowers to a per-row TGATHER loop, so it is hoisted here (once, B rows) and read as a
-    # plain load downstream.
+    # Interleave-duplicated / sign-folded compressed-position rope rows, built once over B rows.
     cmp_cos_il = pl.create_tensor([B, ROPE_HEAD_DIM], dtype=pl.FP32)
     cmp_sin_signed = pl.create_tensor([B, ROPE_HEAD_DIM], dtype=pl.FP32)
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="hca_rope"):
@@ -362,7 +339,7 @@ def decode_hca_tp1(
 
     x_normed = pl.create_tensor([t_dim, D], dtype=pl.BF16)
     rms_tid = rms_norm(x_mixed, attn_norm_w, x_normed)
-    # Defers kv_proj_matmul one hop behind rms_norm so qr_proj_matmul dispatches first.
+    # Dispatch barrier: kv_proj_matmul resolves one hop after rms_norm.
     late_dep = pl.system.task_dummy(deps=[rms_tid])
     q = pl.create_tensor([t_dim, H, HEAD_DIM], dtype=pl.BF16)
     kv = pl.create_tensor([t_dim, HEAD_DIM], dtype=pl.BF16)
@@ -395,11 +372,8 @@ def decode_hca_tp1(
         late_dep,
     )
 
-    # Sparse-index build fanned out over an SPMD (8 tokens/block) instead of one
-    # serial CORE_GROUP loop. The two window-slot abs_pos branches collapse into
-    # one: column k -> ring slot k, live iff k <= abs_pos. sparse_attn pairs each
-    # K/V by its stored raw value (order-agnostic), so the full-ring rotation is
-    # dead. The compressed-slot ramp is fused into the same block.
+    # Sparse-index build over an SPMD of 8 tokens per block: window column k -> ring
+    # slot k, live iff k <= abs_pos, with the compressed-slot ramp fused into the same block.
     attn_out = pl.create_tensor([t_dim, D], dtype=pl.BF16)
     topk_all = pl.create_tensor([t_dim, HCA_CMP_TOPK], dtype=pl.INT32)
     for topk_block in pl.spmd(topk_blocks, name_hint="hca_cache_topk"):
@@ -504,6 +478,27 @@ def decode_hca_tp1_test(
     return x_out
 
 
+# fixture
+FIXTURE_WINDOW_BLOCKS = (WIN + BLOCK_SIZE - 1) // BLOCK_SIZE
+FIXTURE_CMP_SLOTS = (0, 31, 32, 63, 64, 95, 96, 127)
+FIXTURE_CMP_LOGICAL_BLOCKS = (max(FIXTURE_CMP_SLOTS) + 1 + BLOCK_SIZE - 1) // BLOCK_SIZE
+FIXTURE_CMP_BLOCKS_PER_RANK = CMP_BLOCK_NUM // TP_SIZE
+FIXTURE_OUTPUT_SENTINEL = -7.0
+
+if max(FIXTURE_CMP_SLOTS) >= CMP_TOPK:
+    raise ValueError("HCA fixture compressed slots exceed the configured top-k capacity")
+if FIXTURE_WINDOW_BLOCKS > ORI_BLOCK_NUM:
+    raise ValueError("HCA fixture window exceeds the original KV cache capacity")
+if FIXTURE_CMP_LOGICAL_BLOCKS > CMP_MAX_BLOCKS:
+    raise ValueError("HCA fixture compressed slots exceed the compressed block table")
+if CMP_BLOCK_NUM % TP_SIZE != 0:
+    raise ValueError("HCA fixture requires equal compressed-cache partitions across TP ranks")
+if (LOCAL_T // S) * FIXTURE_CMP_LOGICAL_BLOCKS > FIXTURE_CMP_BLOCKS_PER_RANK:
+    raise ValueError("HCA fixture compressed-cache partition is too small for the local requests")
+if O_LORA < 3 * HEADS_PER_GROUP:
+    raise ValueError("HCA fixture output projection needs three observable rows per local head")
+
+
 def build_tp_tensor_specs(local_t):
     """Build deterministic tensor-parallel HCA output inputs."""
     import torch
@@ -551,16 +546,10 @@ def build_tp_tensor_specs(local_t):
                     row = cmp_slot % BLOCK_SIZE
                     cmp_kv[rank, physical_block, row, 0, :] = 0.0
                     cmp_kv[rank, physical_block, row, 0, 0] = 0.25
-                    cmp_kv[rank, physical_block, row, 0, NOPE_DIM] = (
-                        (rank + 1) * 0.0625
-                        + (request + 1) * 0.015625
-                        + (slot_index + 1) * 0.00390625
-                    )
-                    cmp_kv[rank, physical_block, row, 0, NOPE_DIM + 1] = (
-                        -(logical_block + 1) * 0.0625
-                        + (rank + 1) * 0.0078125
-                        + (request + 1) * 0.001953125
-                    )
+                    nope_value = (rank + 1) * 0.0625 + (request + 1) * 0.015625 + (slot_index + 1) * 0.00390625
+                    block_value = -(logical_block + 1) * 0.0625 + (rank + 1) * 0.0078125 + (request + 1) * 0.001953125
+                    cmp_kv[rank, physical_block, row, 0, NOPE_DIM] = nope_value
+                    cmp_kv[rank, physical_block, row, 0, NOPE_DIM + 1] = block_value
         return cmp_kv
 
     def init_cmp_block_table():
@@ -570,9 +559,8 @@ def build_tp_tensor_specs(local_t):
             for request in range(local_batch):
                 request_block_base = rank_block_base + request * FIXTURE_CMP_LOGICAL_BLOCKS
                 for logical_block in range(FIXTURE_CMP_LOGICAL_BLOCKS):
-                    table[rank, request, logical_block] = (
-                        request_block_base + FIXTURE_CMP_LOGICAL_BLOCKS - 1 - logical_block
-                    )
+                    physical_block = request_block_base + FIXTURE_CMP_LOGICAL_BLOCKS - 1 - logical_block
+                    table[rank, request, logical_block] = physical_block
         return table
 
     def init_cmp_sparse_indices():
@@ -606,15 +594,11 @@ def build_tp_tensor_specs(local_t):
             for local_group in range(LOCAL_O_GROUPS):
                 shard_scale = (rank + 1) * (local_group + 1) * 0.125
                 for head in range(HEADS_PER_GROUP):
-                    wo_a[rank, local_group, head, head * HEAD_DIM] = shard_scale * (head + 1)
-                    wo_a[
-                        rank, local_group, HEADS_PER_GROUP + head,
-                        head * HEAD_DIM + NOPE_DIM,
-                    ] = shard_scale * (head + 1) * 0.75
-                    wo_a[
-                        rank, local_group, 2 * HEADS_PER_GROUP + head,
-                        head * HEAD_DIM + NOPE_DIM + 1,
-                    ] = -shard_scale * (head + 1) * 0.5
+                    head_col = head * HEAD_DIM
+                    head_scale = shard_scale * (head + 1)
+                    wo_a[rank, local_group, head, head_col] = head_scale
+                    wo_a[rank, local_group, HEADS_PER_GROUP + head, head_col + NOPE_DIM] = head_scale * 0.75
+                    wo_a[rank, local_group, 2 * HEADS_PER_GROUP + head, head_col + NOPE_DIM + 1] = -head_scale * 0.5
         return wo_a
 
     def init_wo_b():
@@ -797,7 +781,7 @@ def golden_decode_hca_tp1(tensors):
         "comb": comb_t,
     })
 
-    # ===== Attention.forward, ratio==128 branch =====
+    # Attention.forward, ratio==128 branch
     position_ids = tensors["position_ids"].to(torch.int64)
     kv_seq_lens = tensors["kv_seq_lens"].to(torch.int64)
     ratio = COMPRESS_RATIO
@@ -919,7 +903,7 @@ def golden_decode_hca_tp1(tensors):
 
 def build_tensor_specs(start_pos=None, batch=B):
     tokens = batch * S
-    import torch  # type: ignore[import]
+    import torch
     from utils import (
         block_table,
         compressed_slot_mapping,
@@ -956,9 +940,7 @@ def build_tensor_specs(start_pos=None, batch=B):
 
     def init_x_hc():
         return torch.empty(tokens, HC_MULT, D).uniform_(-1, 1)
-    # Real layer-9 (HCA, ratio-128) hc_attn scale/base (fn synthetic at real magnitude). A
-    # synthetic scale=0.5/base=0 leaves hc_pre post~=1 + near-uniform comb, cancelling attn_out
-    # and the hc residual to near-zero in x_out where W8A8 noise blows up the relative tail.
+    # Real layer-9 (HCA, ratio-128) hc_attn scale/base; fn is synthetic at the real magnitude.
     def init_hc_attn_fn():
         return torch.randn(MIX_HC, HC_DIM) * 0.0495
     def init_hc_attn_scale():
@@ -1130,12 +1112,13 @@ if __name__ == "__main__":
     from pypto.ir.distributed_compiled_program import DistributedConfig
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("-p", "--platform", type=str, default="a2a3",
-                        choices=["a2a3", "a2a3sim", "a5", "a5sim"])
-    parser.add_argument("--tp", type=int, default=TP_SIZE, choices=list(_TP_CHOICES),
-                        help="tensor-parallel world size")
-    parser.add_argument("-d", "--device", type=str, default=",".join(str(rank) for rank in range(TP_SIZE)),
-                        help=f"comma-separated device ids; need exactly {TP_SIZE}")
+    default_devices = ",".join(str(rank) for rank in range(TP_SIZE))
+    parser.add_argument("-p", "--platform", type=str, default="a2a3", choices=["a2a3", "a2a3sim", "a5", "a5sim"])
+    parser.add_argument("--tp", type=int, default=TP_SIZE, choices=list(_TP_CHOICES), help="tensor-parallel world size")
+    parser.add_argument(
+        "-d", "--device", type=str, default=default_devices,
+        help=f"comma-separated device ids; need exactly {TP_SIZE}",
+    )
     parser.add_argument("--case", choices=("all", "max", "subcapacity"), default="all")
     parser.add_argument("--compile-only", action="store_true", default=False)
     parser.add_argument("--dump-passes", action="store_true", default=False)

--- a/models/deepseek_v4_flash_dspark/decode_hca.py
+++ b/models/deepseek_v4_flash_dspark/decode_hca.py
@@ -66,9 +66,9 @@ from decode_o_proj import (
     LOCAL_T,
     LOCAL_T_PAD,
     O_WINDOW_ROWS,
-    attention_token_head_all_to_all_step,
-    decode_sharded_o_projection,
-    o_projection_reduce_scatter_step,
+    decode_o_proj,
+    o_group_a2a,
+    o_proj_reduce_scatter,
 )
 from decode_sparse_attn_hca import (
     CMP_TOPK,
@@ -431,7 +431,7 @@ def decode_hca_output(
     )
 
     attention_local_flat = pl.create_tensor([ATTENTION_WINDOW_ROWS, O_GROUP_IN], dtype=pl.BF16)
-    attention_local_flat, attention_signal = attention_token_head_all_to_all_step(
+    attention_local_flat, attention_signal = o_group_a2a(
         attention_grouped, attention_local_flat,
         attention_window, attention_signal,
         group_base, tp_rank, local_t,
@@ -439,18 +439,17 @@ def decode_hca_output(
 
     attention_local_groups = pl.reshape(attention_local_flat, [LOCAL_O_GROUPS, GROUP_T_PAD, O_GROUP_IN])
     o_partial = pl.create_tensor([GROUP_T_PAD, D], dtype=pl.FP32)
-    o_partial, projection_tid = decode_sharded_o_projection(
+    o_partial, projection_tid = decode_o_proj(
         attention_local_groups,
         wo_a, wo_b, wo_b_scale,
         local_t, o_partial,
     )
 
-    with pl.spmd(1, name_hint="tp_o_reduce_scatter", deps=[projection_tid]) as _reduce_scatter_tid:
-        o_local, o_signal = o_projection_reduce_scatter_step(
-            o_partial, o_local,
-            o_window, o_signal,
-            group_base, tp_rank, local_t,
-        )
+    o_local, o_signal = o_proj_reduce_scatter(
+        o_partial, o_local,
+        o_window, o_signal,
+        group_base, tp_rank, local_t, projection_tid,
+    )
     return o_local, attention_signal, o_signal
 
 

--- a/models/deepseek_v4_flash_dspark/decode_o_proj.py
+++ b/models/deepseek_v4_flash_dspark/decode_o_proj.py
@@ -292,7 +292,7 @@ def kv_token_allgather_step(
 
 
 @pl.jit.incore
-def attention_token_head_all_to_all_step(
+def o_group_a2a(
     attention_grouped: pl.Tensor[[O_GROUPS * LOCAL_T_PAD, O_GROUP_IN], pl.BF16],
     local_groups_out: pl.InOut[pl.Tensor[[ATTENTION_WINDOW_ROWS, O_GROUP_IN], pl.BF16]],
     exchange_window: pld.DistributedTensor[[ATTENTION_WINDOW_ROWS, O_GROUP_IN], pl.BF16],
@@ -328,8 +328,8 @@ def attention_token_head_all_to_all_step(
     return local_groups_out, exchange_signal
 
 
-@pl.jit.incore
-def o_projection_reduce_scatter_step(
+@pl.jit.inline
+def o_proj_reduce_scatter(
     o_partial: pl.Tensor[[GROUP_T_PAD, D], pl.FP32],
     local_out: pl.InOut[pl.Tensor[[LOCAL_T_PAD, D], pl.BF16]],
     reduce_window: pld.DistributedTensor[[O_WINDOW_ROWS, D], pl.FP32],
@@ -337,30 +337,33 @@ def o_projection_reduce_scatter_step(
     group_base: pl.Scalar[pl.INT32],
     tp_rank: pl.Scalar[pl.INT32],
     local_t: pl.Scalar[pl.INT32],
+    proj_dep: pl.Scalar[pl.TASK_ID],
 ):
     """Sum O-B rank partials and scatter valid contiguous local token rows."""
-    for owner_rank in pl.range(TP_SIZE):
-        owner_source_row = owner_rank * local_t
-        target_row = tp_rank * local_t
-        pld.tensor.put(
-            dst=reduce_window, peer=group_base + owner_rank, src=o_partial,
-            dst_offsets=[target_row, 0], src_offsets=[owner_source_row, 0], shape=[local_t, D],
-            chunk_rows=COMM_ROW_TILE, chunk_cols=D,
-        )
+    # Own core-group scope, ordered after the O-B partial through proj_dep.
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="tp_o_reduce_scatter", deps=[proj_dep]):
+        for owner_rank in pl.range(TP_SIZE):
+            owner_source_row = owner_rank * local_t
+            target_row = tp_rank * local_t
+            pld.tensor.put(
+                dst=reduce_window, peer=group_base + owner_rank, src=o_partial,
+                dst_offsets=[target_row, 0], src_offsets=[owner_source_row, 0], shape=[local_t, D],
+                chunk_rows=COMM_ROW_TILE, chunk_cols=D,
+            )
 
-    expected_one = pl.cast(1, pl.INT32)
-    reduce_signal = tp_group_barrier(reduce_signal, group_base, tp_rank, expected_one)
-    for local_row in pl.range(local_t):
-        acc = pl.load(reduce_window, [local_row, 0], [1, D])
-        for source_tp in pl.range(1, TP_SIZE):
-            source_partial_row = source_tp * local_t + local_row
-            source_partial = pl.load(reduce_window, [source_partial_row, 0], [1, D])
-            acc = pl.add(acc, source_partial)
-        reduced_bf16 = pl.cast(acc, target_type=pl.BF16, mode="rint")
-        pl.store(reduced_bf16, [local_row, 0], local_out)
-    expected_two = pl.cast(2, pl.INT32)
-    reduce_signal = tp_group_barrier(reduce_signal, group_base, tp_rank, expected_two)
-    reduce_signal = reset_tp_group_signal(reduce_signal, group_base, tp_rank)
+        expected_one = pl.cast(1, pl.INT32)
+        reduce_signal = tp_group_barrier(reduce_signal, group_base, tp_rank, expected_one)
+        for local_row in pl.range(local_t):
+            acc = pl.load(reduce_window, [local_row, 0], [1, D])
+            for source_tp in pl.range(1, TP_SIZE):
+                source_partial_row = source_tp * local_t + local_row
+                source_partial = pl.load(reduce_window, [source_partial_row, 0], [1, D])
+                acc = pl.add(acc, source_partial)
+            reduced_bf16 = pl.cast(acc, target_type=pl.BF16, mode="rint")
+            pl.store(reduced_bf16, [local_row, 0], local_out)
+        expected_two = pl.cast(2, pl.INT32)
+        reduce_signal = tp_group_barrier(reduce_signal, group_base, tp_rank, expected_two)
+        reduce_signal = reset_tp_group_signal(reduce_signal, group_base, tp_rank)
     return local_out, reduce_signal
 
 
@@ -386,11 +389,13 @@ def decode_attention_collectives_fixture(
     kv_group, kv_signal = kv_token_allgather_step(
         kv_local, kv_group, kv_window, kv_signal, group_base, tp_rank, local_t,
     )
-    attention_local_groups, attention_signal = attention_token_head_all_to_all_step(
+    attention_local_groups, attention_signal = o_group_a2a(
         attention_grouped, attention_local_groups, attention_window, attention_signal, group_base, tp_rank, local_t,
     )
-    o_local, o_signal = o_projection_reduce_scatter_step(
-        o_partial, o_local, o_window, o_signal, group_base, tp_rank, local_t,
+    # o_partial arrives as a program input, so anchor an empty dep.
+    o_partial_dep = pl.system.task_dummy(deps=[])
+    o_local, o_signal = o_proj_reduce_scatter(
+        o_partial, o_local, o_window, o_signal, group_base, tp_rank, local_t, o_partial_dep,
     )
     return kv_group, attention_local_groups, o_local, kv_signal, attention_signal, o_signal
 
@@ -509,7 +514,7 @@ def golden_decode_attention_collectives_fixture(tensors):
 
 
 @pl.jit.inline
-def decode_sharded_o_projection(
+def decode_o_proj(
     attention_local_groups: pl.Tensor[[LOCAL_O_GROUPS, GROUP_T_PAD, O_GROUP_IN], pl.BF16],
     wo_a: pl.Tensor[[LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
     wo_b: pl.Tensor[[D, LOCAL_O_WIDTH], pl.INT8],
@@ -629,7 +634,7 @@ def decode_sharded_o_projection(
 
 
 @pl.jit
-def decode_sharded_o_projection_test(
+def decode_o_proj_test(
     attention_local_groups: pl.Tensor[[LOCAL_O_GROUPS, GROUP_T_PAD, O_GROUP_IN], pl.BF16],
     wo_a: pl.Tensor[[LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
     wo_b: pl.Tensor[[D, LOCAL_O_WIDTH], pl.INT8],
@@ -638,7 +643,7 @@ def decode_sharded_o_projection_test(
     o_partial: pl.InOut[pl.Tensor[[GROUP_T_PAD, D], pl.FP32]],
 ):
     """Run one receive-side output projection at a runtime token count."""
-    o_partial, completion_tid = decode_sharded_o_projection(
+    o_partial, completion_tid = decode_o_proj(
         attention_local_groups, wo_a, wo_b, wo_b_scale,
         local_t, o_partial,
     )
@@ -648,7 +653,7 @@ def decode_sharded_o_projection_test(
     return o_partial
 
 
-def build_sharded_o_proj_tensor_specs(local_t):
+def build_o_proj_tensor_specs(local_t):
     """Build deterministic capacity-static inputs with a poisoned receive tail."""
     import torch
 
@@ -698,7 +703,7 @@ def build_sharded_o_proj_tensor_specs(local_t):
     ]
 
 
-def golden_decode_sharded_o_projection(tensors):
+def golden_decode_o_proj(tensors):
     """Compute the per-group A8 projection over the compact receive prefix."""
     import torch
 
@@ -799,9 +804,9 @@ if __name__ == "__main__":
                 zero_tail=True,
             )
             result = run_jit(
-                fn=decode_sharded_o_projection_test,
-                specs=build_sharded_o_proj_tensor_specs(local_t),
-                golden_fn=golden_decode_sharded_o_projection,
+                fn=decode_o_proj_test,
+                specs=build_o_proj_tensor_specs(local_t),
+                golden_fn=golden_decode_o_proj,
                 compile_only=args.compile_only,
                 compile_cfg=dict(dump_passes=args.dump_passes),
                 runtime_cfg=dict(platform=args.platform, device_id=device_ids[0]),

--- a/models/deepseek_v4_flash_dspark/decode_o_proj.py
+++ b/models/deepseek_v4_flash_dspark/decode_o_proj.py
@@ -6,8 +6,33 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-# ci: devices=4
+# ci: devices=2  # CI: 2-card run; borrows 2 cards via task-submit --device-num
 """DeepSeek-V4 decode output projections and their TP communication."""
+
+import sys
+
+import config
+
+
+# TP-derived shapes freeze at import time, so select the TP world before the
+# config read below.
+_TP_CHOICES = (1, 2, 4)
+_TP_DEFAULT = 2
+
+
+def _parse_tp_argv():
+    for index, arg in enumerate(sys.argv):
+        if arg == "--tp" and index + 1 < len(sys.argv):
+            return int(sys.argv[index + 1])
+        if arg.startswith("--tp="):
+            return int(arg.split("=", 1)[1])
+    return _TP_DEFAULT
+
+
+TP_SIZE = _parse_tp_argv()
+if TP_SIZE not in _TP_CHOICES:
+    raise ValueError(f"--tp must be one of {_TP_CHOICES} (got {TP_SIZE})")
+config.TP = TP_SIZE
 
 import pypto.language as pl
 import pypto.language.distributed as pld
@@ -17,12 +42,8 @@ from config import (
     FLASH as M,
     INT8_AMAX_EPS,
     INT8_SCALE_MAX,
-    TP,
 )
 
-
-# parallel layout
-TP_SIZE = TP
 
 # model config
 D = M.hidden_size
@@ -734,6 +755,7 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3", choices=("a2a3", "a2a3sim", "a5", "a5sim"))
+    parser.add_argument("--tp", type=int, default=TP_SIZE, choices=list(_TP_CHOICES), help="tensor-parallel world size")
     parser.add_argument("-d", "--device", type=str, default=",".join(str(i) for i in range(TP_SIZE)))
     parser.add_argument("--mode", choices=("all", "collectives", "sharded"), default="all")
     parser.add_argument(
@@ -751,6 +773,9 @@ if __name__ == "__main__":
     )
     parser.add_argument("--dump-passes", action="store_true", default=False)
     args = parser.parse_args()
+
+    if args.tp != TP_SIZE:
+        parser.error(f"--tp must remain {TP_SIZE} after import-time specialization")
 
     device_ids = [int(device) for device in args.device.split(",")]
     if args.mode in ("all", "collectives") and len(device_ids) != TP_SIZE:

--- a/models/deepseek_v4_flash_dspark/decode_sparse_attn_csa.py
+++ b/models/deepseek_v4_flash_dspark/decode_sparse_attn_csa.py
@@ -25,10 +25,7 @@ from config import (
     KV_ORI_BLOCK_NUM,
     KV_CMP_MAX_BLOCKS,
     KV_ORI_MAX_BLOCKS,
-    INT8_SCALE_MAX,
-    INT8_AMAX_EPS,
 )
-from decode_o_proj import decode_o_proj_tp1
 
 
 # Dynamic shape variables.
@@ -415,10 +412,7 @@ def sparse_attn_csa_test(
     attn_sink: pl.Tensor[[H], pl.FP32],
     freqs_cos: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
     freqs_sin: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
-    wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
-    wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
-    wo_b_scale: pl.Tensor[[D], pl.FP32],
-    attn_out: pl.Out[pl.Tensor[[T_DYN, D], pl.BF16]],
+    o_packed_heads: pl.Out[pl.Tensor[[O_GROUPS, T_PAD, O_GROUP_IN], pl.BF16]],
 ):
     q.bind_dynamic(0, T_DYN)
     window_swa_indices.bind_dynamic(0, T_DYN)
@@ -427,27 +421,21 @@ def sparse_attn_csa_test(
     position_ids.bind_dynamic(0, T_DYN)
     freqs_cos.bind_dynamic(0, T_DYN)
     freqs_sin.bind_dynamic(0, T_DYN)
-    attn_out.bind_dynamic(0, T_DYN)
 
-    o_packed_heads = pl.create_tensor([O_GROUPS * T_PAD, O_GROUP_IN], dtype=pl.BF16)
-    o_packed_heads, heads_dep = sparse_attn_csa(
+    o_packed_flat = pl.reshape(o_packed_heads, [O_GROUPS * T_PAD, O_GROUP_IN])
+    o_packed_flat, _ = sparse_attn_csa(
         q,
         ori_kv, window_swa_indices,
         cmp_kv, cmp_block_table, idx_topk,
         position_ids, attn_sink,
         freqs_cos, freqs_sin,
-        o_packed_heads,
+        o_packed_flat,
     )
-    attn_out = decode_o_proj_tp1(
-        o_packed_heads,
-        wo_a, wo_b, wo_b_scale,
-        attn_out, heads_dep,
-    )
-    return attn_out
+    return o_packed_heads
 
 
 def golden_sparse_attn(tensors):
-    """Torch reference: sparse_attn decode path followed by grouped o_proj."""
+    """Torch reference for the CSA sparse-attention heads."""
     import torch
 
     q = tensors["q"].float()
@@ -465,9 +453,6 @@ def golden_sparse_attn(tensors):
     attn_sink = tensors["attn_sink"].float()
     cos = tensors["freqs_cos"].float()
     sin = tensors["freqs_sin"].float()
-    wo_a = tensors["wo_a"].float()
-    wo_b_i8 = tensors["wo_b"]
-    wo_b_scale = tensors["wo_b_scale"].float()
 
     o = torch.zeros(tokens, H, HEAD_DIM)
 
@@ -552,25 +537,10 @@ def golden_sparse_attn(tensors):
     o_rope = torch.stack([inv_even, inv_odd], dim=-1).flatten(-2)
     o = torch.cat([o[..., :NOPE_DIM], o_rope], dim=-1).to(torch.bfloat16)
 
-    seq_per_batch = tokens // batch
-    o_model = o.float().view(batch, seq_per_batch, O_GROUPS, O_GROUP_IN)
-    o_r = torch.einsum("bsgd,grd->bsgr", o_model, wo_a)
-    # PER-GROUP INT8 activation quant: one amax per O_LORA group. Each group's INT32
-    # partial is dequantized by its OWN per-row act scale before the groups are summed
-    # (the per-group scale cannot factor out of the K-sum), then the channel scale.
-    o_r_g = o_r.reshape(tokens, O_GROUPS, O_LORA)
-    amax_g = o_r_g.abs().amax(dim=-1, keepdim=True).clamp_min(INT8_AMAX_EPS)   # [tokens, G, 1]
-    scale_q_g = INT8_SCALE_MAX / amax_g
-    o_r_i8_g = torch.round(o_r_g * scale_q_g).to(torch.int32).to(torch.float16).to(torch.int8)
-    scale_dq_g = 1.0 / scale_q_g                                              # [tokens, G, 1]
-    wo_b_g = wo_b_i8.reshape(D, O_GROUPS, O_LORA)
-    out = torch.zeros(tokens, D, dtype=torch.float32)
-    for g in range(O_GROUPS):
-        p_g = o_r_i8_g[:, g].to(torch.int32) @ wo_b_g[:, g].to(torch.int32).T   # [tokens, D]
-        out = out + p_g.float() * scale_dq_g[:, g]                             # per-row group scale
-    out = out * wo_b_scale.unsqueeze(0)                                        # per-channel weight scale
-
-    tensors["attn_out"][:] = out.to(torch.bfloat16)
+    # Pack as [group, T_PAD, group-input]; rows past the runtime token count are
+    # capacity padding the kernel never writes.
+    packed = tensors["o_packed_heads"]
+    packed[:, :tokens] = o.float().view(tokens, O_GROUPS, O_GROUP_IN).permute(1, 0, 2).to(torch.bfloat16)
 
 def build_tensor_specs(
     causal_regression_fixture: bool = False,
@@ -582,7 +552,7 @@ def build_tensor_specs(
     """Build deterministic demo tensors for the CSA standalone harness."""
     import torch
     from golden import TensorSpec
-    from utils import block_table, quant_w_per_channel, swa_indices_and_lens
+    from utils import block_table, swa_indices_and_lens
     from utils import build_rope_tables, materialize_token_rope_tables
 
     tokens = batch * S
@@ -680,21 +650,6 @@ def build_tensor_specs(
         """Build the split-half sine table used by the inverse-RoPE reference."""
         return shared_rope_sin.clone()
 
-    def init_wo_a():
-        """Initialize the grouped first-stage output-projection weights."""
-        return (torch.rand(O_GROUPS, O_LORA, O_GROUP_IN) - 0.5) / (O_GROUP_IN ** 0.5)
-
-    wo_b_bf16 = ((torch.rand(D, O_GROUPS * O_LORA) - 0.5) / ((O_GROUPS * O_LORA) ** 0.5)).to(torch.bfloat16)
-    wo_b_i8, wo_b_scale = quant_w_per_channel(wo_b_bf16)
-
-    def init_wo_b():
-        """Initialize the second-stage output-projection weights in per-channel INT8 form."""
-        return wo_b_i8
-
-    def init_wo_b_scale():
-        """Initialize the dequant scales paired with the INT8 second-stage weights."""
-        return wo_b_scale
-
     return [
         TensorSpec("q", [tokens, H, HEAD_DIM], torch.bfloat16, init_value=init_q),
         TensorSpec("ori_kv", [ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_ori_kv),
@@ -706,10 +661,7 @@ def build_tensor_specs(
         TensorSpec("attn_sink", [H], torch.float32, init_value=init_attn_sink),
         TensorSpec("freqs_cos", [tokens, ROPE_DIM], torch.bfloat16, init_value=init_cos),
         TensorSpec("freqs_sin", [tokens, ROPE_DIM], torch.bfloat16, init_value=init_sin),
-        TensorSpec("wo_a", [O_GROUPS, O_LORA, O_GROUP_IN], torch.bfloat16, init_value=init_wo_a),
-        TensorSpec("wo_b", [D, O_GROUPS * O_LORA], torch.int8, init_value=init_wo_b),
-        TensorSpec("wo_b_scale", [D], torch.float32, init_value=init_wo_b_scale),
-        TensorSpec("attn_out", [tokens, D], torch.bfloat16, is_output=True),
+        TensorSpec("o_packed_heads", [O_GROUPS, T_PAD, O_GROUP_IN], torch.bfloat16, is_output=True),
     ]
 
 
@@ -766,7 +718,10 @@ if __name__ == "__main__":
         rtol=1e-3,
         atol=1e-3,
         compare_fn={
-            "attn_out": ratio_allclose(atol=1e-4, rtol=1.0 / 128),
+            "o_packed_heads": ratio_allclose(
+                atol=1e-4, rtol=1.0 / 128,
+                valid_rows=args.batch * S, valid_axis=1,
+            ),
         },
     )
     if not result.passed:

--- a/models/deepseek_v4_flash_dspark/decode_sparse_attn_csa.py
+++ b/models/deepseek_v4_flash_dspark/decode_sparse_attn_csa.py
@@ -95,7 +95,7 @@ assert T % BIAS_T_TILE == 0
 
 
 @pl.jit.inline
-def sparse_attn_csa_heads(
+def sparse_attn_csa(
     q: pl.Tensor[[T_DYN, H, HEAD_DIM], pl.BF16],
     ori_kv: pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     window_swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
@@ -403,43 +403,8 @@ def sparse_attn_csa_heads(
     return o_packed_heads, merge_tid
 
 
-@pl.jit.inline
-def sparse_attn_csa(
-    q: pl.Tensor[[T_DYN, H, HEAD_DIM], pl.BF16],
-    ori_kv: pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
-    window_swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
-    cmp_kv: pl.Tensor[[CMP_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
-    cmp_block_table: pl.Tensor[[B_DYN, CMP_MAX_BLOCKS], pl.INT32],
-    idx_topk: pl.Tensor[[T_DYN, INDEXER_SCORE_LEN], pl.INT32],
-    position_ids: pl.Tensor[[T_DYN, 1], pl.INT32],
-    attn_sink: pl.Tensor[[H], pl.FP32],
-    freqs_cos: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
-    freqs_sin: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
-    wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
-    wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
-    wo_b_scale: pl.Tensor[[D], pl.FP32],
-    attn_out: pl.Tensor[[T_DYN, D], pl.BF16],
-):
-    """Compute CSA sparse attention and the grouped output projection."""
-    o_packed_heads = pl.create_tensor([O_GROUPS * T_PAD, O_GROUP_IN], dtype=pl.BF16)
-    o_packed_heads, heads_dep = sparse_attn_csa_heads(
-        q,
-        ori_kv, window_swa_indices,
-        cmp_kv, cmp_block_table, idx_topk,
-        position_ids, attn_sink,
-        freqs_cos, freqs_sin,
-        o_packed_heads,
-    )
-    attn_out = decode_o_proj_tp1(
-        o_packed_heads,
-        wo_a, wo_b, wo_b_scale,
-        attn_out, heads_dep,
-    )
-    return attn_out
-
-
 @pl.jit
-def sparse_attn_test(
+def sparse_attn_csa_test(
     q: pl.Tensor[[T_DYN, H, HEAD_DIM], pl.BF16],
     ori_kv: pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     window_swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
@@ -464,14 +429,19 @@ def sparse_attn_test(
     freqs_sin.bind_dynamic(0, T_DYN)
     attn_out.bind_dynamic(0, T_DYN)
 
-    sparse_attn_csa(
+    o_packed_heads = pl.create_tensor([O_GROUPS * T_PAD, O_GROUP_IN], dtype=pl.BF16)
+    o_packed_heads, heads_dep = sparse_attn_csa(
         q,
         ori_kv, window_swa_indices,
         cmp_kv, cmp_block_table, idx_topk,
         position_ids, attn_sink,
         freqs_cos, freqs_sin,
+        o_packed_heads,
+    )
+    attn_out = decode_o_proj_tp1(
+        o_packed_heads,
         wo_a, wo_b, wo_b_scale,
-        attn_out,
+        attn_out, heads_dep,
     )
     return attn_out
 
@@ -775,7 +745,7 @@ if __name__ == "__main__":
     print(f"compress_ratio={COMPRESS_RATIO} -> TOPK={TOPK} SPARSE_BLOCKS={SPARSE_BLOCKS} PADDED_TOPK={PADDED_TOPK}", flush=True)
 
     result = run_jit(
-        fn=sparse_attn_test,
+        fn=sparse_attn_csa_test,
         specs=build_tensor_specs(
             args.causal_regression_fixture,
             args.short_window_fixture,

--- a/models/deepseek_v4_flash_dspark/decode_sparse_attn_hca.py
+++ b/models/deepseek_v4_flash_dspark/decode_sparse_attn_hca.py
@@ -107,7 +107,7 @@ assert BLOCK_SIZE % GATHER_RUN == 0, "a contiguous run must not straddle two pag
 
 
 @pl.jit.inline
-def sparse_attn_hca_heads(
+def sparse_attn_hca(
     q: pl.Tensor[[T_DYN, H, HEAD_DIM], pl.BF16],
     ori_kv: pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     window_swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
@@ -375,40 +375,8 @@ def sparse_attn_hca_heads(
     return o_packed_heads, merge_tid
 
 
-@pl.jit.inline
-def sparse_attn_hca(
-    q: pl.Tensor[[T_DYN, H, HEAD_DIM], pl.BF16],
-    ori_kv: pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
-    window_swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
-    cmp_kv: pl.Tensor[[CMP_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
-    cmp_block_table: pl.Tensor[[B_DYN, CMP_MAX_BLOCKS], pl.INT32],
-    cmp_sparse_indices: pl.Tensor[[T_DYN, CMP_TOPK], pl.INT32],
-    attn_sink: pl.Tensor[[H], pl.FP32],
-    freqs_cos: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
-    freqs_sin: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
-    wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
-    wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
-    wo_b_scale: pl.Tensor[[D], pl.FP32],
-    attn_out: pl.Tensor[[T_DYN, D], pl.BF16],
-):
-    """Compute HCA sparse attention and the grouped output projection."""
-    o_packed_heads = pl.create_tensor([O_GROUPS * T_PAD, O_GROUP_IN], dtype=pl.BF16)
-    o_packed_heads, heads_dep = sparse_attn_hca_heads(
-        q, ori_kv, window_swa_indices,
-        cmp_kv, cmp_block_table, cmp_sparse_indices,
-        attn_sink, freqs_cos, freqs_sin,
-        o_packed_heads,
-    )
-    attn_out = decode_o_proj_tp1(
-        o_packed_heads,
-        wo_a, wo_b, wo_b_scale,
-        attn_out, heads_dep,
-    )
-    return attn_out
-
-
 @pl.jit
-def sparse_attn_test(
+def sparse_attn_hca_test(
     q: pl.Tensor[[T_DYN, H, HEAD_DIM], pl.BF16],
     ori_kv: pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     window_swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
@@ -431,20 +399,17 @@ def sparse_attn_test(
     freqs_sin.bind_dynamic(0, T_DYN)
     attn_out.bind_dynamic(0, T_DYN)
 
-    sparse_attn_hca(
-        q,
-        ori_kv,
-        window_swa_indices,
-        cmp_kv,
-        cmp_block_table,
-        cmp_sparse_indices,
-        attn_sink,
-        freqs_cos,
-        freqs_sin,
-        wo_a,
-        wo_b,
-        wo_b_scale,
-        attn_out,
+    o_packed_heads = pl.create_tensor([O_GROUPS * T_PAD, O_GROUP_IN], dtype=pl.BF16)
+    o_packed_heads, heads_dep = sparse_attn_hca(
+        q, ori_kv, window_swa_indices,
+        cmp_kv, cmp_block_table, cmp_sparse_indices,
+        attn_sink, freqs_cos, freqs_sin,
+        o_packed_heads,
+    )
+    attn_out = decode_o_proj_tp1(
+        o_packed_heads,
+        wo_a, wo_b, wo_b_scale,
+        attn_out, heads_dep,
     )
     return attn_out
 
@@ -734,7 +699,7 @@ if __name__ == "__main__":
     print(f"compress_ratio={COMPRESS_RATIO} -> TOPK={TOPK} SPARSE_BLOCKS={SPARSE_BLOCKS} PADDED_TOPK={PADDED_TOPK}", flush=True)
 
     result = run_jit(
-        fn=sparse_attn_test,
+        fn=sparse_attn_hca_test,
         specs=build_tensor_specs(
             args.causal_regression_fixture,
             args.short_window_fixture,

--- a/models/deepseek_v4_flash_dspark/decode_sparse_attn_hca.py
+++ b/models/deepseek_v4_flash_dspark/decode_sparse_attn_hca.py
@@ -25,10 +25,7 @@ from config import (
     KV_ORI_BLOCK_NUM,
     KV_CMP_MAX_BLOCKS,
     KV_ORI_MAX_BLOCKS,
-    INT8_SCALE_MAX,
-    INT8_AMAX_EPS,
 )
-from decode_o_proj import decode_o_proj_tp1
 
 
 # Dynamic shape variables.
@@ -386,10 +383,7 @@ def sparse_attn_hca_test(
     attn_sink: pl.Tensor[[H], pl.FP32],
     freqs_cos: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
     freqs_sin: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
-    wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
-    wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
-    wo_b_scale: pl.Tensor[[D], pl.FP32],
-    attn_out: pl.Out[pl.Tensor[[T_DYN, D], pl.BF16]],
+    o_packed_heads: pl.Out[pl.Tensor[[O_GROUPS, T_PAD, O_GROUP_IN], pl.BF16]],
 ):
     q.bind_dynamic(0, T_DYN)
     cmp_block_table.bind_dynamic(0, B_DYN)
@@ -397,25 +391,19 @@ def sparse_attn_hca_test(
     cmp_sparse_indices.bind_dynamic(0, T_DYN)
     freqs_cos.bind_dynamic(0, T_DYN)
     freqs_sin.bind_dynamic(0, T_DYN)
-    attn_out.bind_dynamic(0, T_DYN)
 
-    o_packed_heads = pl.create_tensor([O_GROUPS * T_PAD, O_GROUP_IN], dtype=pl.BF16)
-    o_packed_heads, heads_dep = sparse_attn_hca(
+    o_packed_flat = pl.reshape(o_packed_heads, [O_GROUPS * T_PAD, O_GROUP_IN])
+    o_packed_flat, _ = sparse_attn_hca(
         q, ori_kv, window_swa_indices,
         cmp_kv, cmp_block_table, cmp_sparse_indices,
         attn_sink, freqs_cos, freqs_sin,
-        o_packed_heads,
+        o_packed_flat,
     )
-    attn_out = decode_o_proj_tp1(
-        o_packed_heads,
-        wo_a, wo_b, wo_b_scale,
-        attn_out, heads_dep,
-    )
-    return attn_out
+    return o_packed_heads
 
 
 def golden_sparse_attn(tensors):
-    """Torch reference: sparse_attn decode path followed by grouped o_proj."""
+    """Torch reference for the HCA sparse-attention heads."""
     import torch
 
     q = tensors["q"].float()
@@ -429,9 +417,6 @@ def golden_sparse_attn(tensors):
     attn_sink = tensors["attn_sink"].float()
     cos = tensors["freqs_cos"].float()
     sin = tensors["freqs_sin"].float()
-    wo_a = tensors["wo_a"].float()
-    wo_b_i8 = tensors["wo_b"]
-    wo_b_scale = tensors["wo_b_scale"].float()
 
     o = torch.zeros(tokens, H, HEAD_DIM)
 
@@ -516,27 +501,10 @@ def golden_sparse_attn(tensors):
     o_rope = torch.stack([inv_even, inv_odd], dim=-1).flatten(-2)
     o = torch.cat([o[..., :NOPE_DIM], o_rope], dim=-1).to(torch.bfloat16)
 
-    seq_per_batch = tokens // batch
-    o_model = o.float().view(batch, seq_per_batch, O_GROUPS, O_GROUP_IN)
-    o_r = torch.einsum("bsgd,grd->bsgr", o_model, wo_a)
-    # PER-GROUP INT8 activation quant (one amax per O_LORA group, not per full row):
-    # this localizes the reduction so proj_a[g]->quant[g]->proj_b[g] can pipeline
-    # back-to-back. Each group's INT32 partial is dequantized by its OWN per-row
-    # activation scale before the groups are summed (the per-group scale cannot
-    # factor out of the K-sum), then the per-channel weight scale is applied.
-    o_r_g = o_r.reshape(tokens, O_GROUPS, O_LORA)
-    amax_g = o_r_g.abs().amax(dim=-1, keepdim=True).clamp_min(INT8_AMAX_EPS)   # [tokens, G, 1]
-    scale_q_g = INT8_SCALE_MAX / amax_g
-    o_r_i8_g = torch.round(o_r_g * scale_q_g).to(torch.int32).to(torch.float16).to(torch.int8)
-    scale_dq_g = 1.0 / scale_q_g                                              # [tokens, G, 1]
-    wo_b_g = wo_b_i8.reshape(D, O_GROUPS, O_LORA)
-    out = torch.zeros(tokens, D, dtype=torch.float32)
-    for g in range(O_GROUPS):
-        p_g = o_r_i8_g[:, g].to(torch.int32) @ wo_b_g[:, g].to(torch.int32).T   # [tokens, D]
-        out = out + p_g.float() * scale_dq_g[:, g]                             # per-row group scale
-    out = out * wo_b_scale.unsqueeze(0)                                        # per-channel weight scale
-
-    tensors["attn_out"][:] = out.to(torch.bfloat16)
+    # Pack as [group, T_PAD, group-input]; rows past the runtime token count are
+    # capacity padding the kernel never writes.
+    packed = tensors["o_packed_heads"]
+    packed[:, :tokens] = o.float().view(tokens, O_GROUPS, O_GROUP_IN).permute(1, 0, 2).to(torch.bfloat16)
 
 def build_tensor_specs(
     causal_regression_fixture: bool = False,
@@ -548,7 +516,7 @@ def build_tensor_specs(
     """Build deterministic demo tensors for the HCA standalone harness."""
     import torch
     from golden import TensorSpec
-    from utils import block_table, quant_w_per_channel
+    from utils import block_table
 
     tokens = batch * S
 
@@ -634,21 +602,6 @@ def build_tensor_specs(
         sin_half = torch.sin(angles)
         return torch.cat([sin_half, sin_half], dim=-1)
 
-    def init_wo_a():
-        """Initialize the grouped first-stage output-projection weights."""
-        return (torch.rand(O_GROUPS, O_LORA, O_GROUP_IN) - 0.5) / (O_GROUP_IN ** 0.5)
-
-    wo_b_bf16 = ((torch.rand(D, O_GROUPS * O_LORA) - 0.5) / ((O_GROUPS * O_LORA) ** 0.5)).to(torch.bfloat16)
-    wo_b_i8, wo_b_scale = quant_w_per_channel(wo_b_bf16)
-
-    def init_wo_b():
-        """Initialize the second-stage output-projection weights in per-channel INT8 form."""
-        return wo_b_i8
-
-    def init_wo_b_scale():
-        """Initialize the dequant scales paired with the INT8 second-stage weights."""
-        return wo_b_scale
-
     return [
         TensorSpec("q", [tokens, H, HEAD_DIM], torch.bfloat16, init_value=init_q),
         TensorSpec("ori_kv", [ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_ori_kv),
@@ -659,10 +612,7 @@ def build_tensor_specs(
         TensorSpec("attn_sink", [H], torch.float32, init_value=init_attn_sink),
         TensorSpec("freqs_cos", [tokens, ROPE_DIM], torch.bfloat16, init_value=init_cos),
         TensorSpec("freqs_sin", [tokens, ROPE_DIM], torch.bfloat16, init_value=init_sin),
-        TensorSpec("wo_a", [O_GROUPS, O_LORA, O_GROUP_IN], torch.bfloat16, init_value=init_wo_a),
-        TensorSpec("wo_b", [D, O_GROUPS * O_LORA], torch.int8, init_value=init_wo_b),
-        TensorSpec("wo_b_scale", [D], torch.float32, init_value=init_wo_b_scale),
-        TensorSpec("attn_out", [tokens, D], torch.bfloat16, is_output=True),
+        TensorSpec("o_packed_heads", [O_GROUPS, T_PAD, O_GROUP_IN], torch.bfloat16, is_output=True),
     ]
 
 
@@ -720,7 +670,10 @@ if __name__ == "__main__":
         rtol=1e-3,
         atol=1e-3,
         compare_fn={
-            "attn_out": ratio_allclose(atol=1e-4, rtol=1.0 / 128),
+            "o_packed_heads": ratio_allclose(
+                atol=1e-4, rtol=1.0 / 128,
+                valid_rows=args.batch * S, valid_axis=1,
+            ),
         },
     )
     if not result.passed:

--- a/models/deepseek_v4_flash_dspark/decode_sparse_attn_swa.py
+++ b/models/deepseek_v4_flash_dspark/decode_sparse_attn_swa.py
@@ -77,7 +77,7 @@ assert WIN == ATTN_K_TILE, f"SWA decode expects WIN ({WIN}) == ATTN_K_TILE ({ATT
 
 
 @pl.jit.inline
-def sparse_attn_swa_heads(
+def sparse_attn_swa(
     q: pl.Tensor[[T_DYN, H, HEAD_DIM], pl.BF16],
     ori_kv: pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
@@ -274,38 +274,8 @@ def sparse_attn_swa_heads(
     return o_packed_heads, merge_tid
 
 
-@pl.jit.inline
-def sparse_attn_swa(
-    q: pl.Tensor[[T_DYN, H, HEAD_DIM], pl.BF16],
-    ori_kv: pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
-    swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
-    sparse_bias: pl.Tensor[[T_DYN, PADDED_TOPK], pl.FP32],
-    attn_sink: pl.Tensor[[H], pl.FP32],
-    freqs_cos: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
-    freqs_sin: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
-    wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
-    wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
-    wo_b_scale: pl.Tensor[[D], pl.FP32],
-    attn_out: pl.Tensor[[T_DYN, D], pl.BF16],
-):
-    """Compute SWA sparse attention and the grouped output projection."""
-    o_packed_heads = pl.create_tensor([O_GROUPS * T_PAD * HEADS_PER_GROUP, HEAD_DIM], dtype=pl.BF16)
-    o_packed_heads, heads_dep = sparse_attn_swa_heads(
-        q, ori_kv, swa_indices, sparse_bias,
-        attn_sink, freqs_cos, freqs_sin,
-        o_packed_heads,
-    )
-    o_packed = pl.reshape(o_packed_heads, [O_GROUPS * T_PAD, O_GROUP_IN])
-    attn_out = decode_o_proj_tp1(
-        o_packed,
-        wo_a, wo_b, wo_b_scale,
-        attn_out, heads_dep,
-    )
-    return attn_out
-
-
 @pl.jit
-def sparse_attn_test(
+def sparse_attn_swa_test(
     q: pl.Tensor[[T_DYN, H, HEAD_DIM], pl.BF16],
     ori_kv: pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
@@ -338,18 +308,17 @@ def sparse_attn_test(
                 1.0,
             )
             sparse_bias[v_t0 : v_t0 + BIAS_T_TILE, 0:ATTN_K_TILE] = pl.mul(pl.sub(v_valid, 1.0), -NEG_INF)
-    sparse_attn_swa(
-        q,
-        ori_kv,
-        swa_indices,
-        sparse_bias,
-        attn_sink,
-        freqs_cos,
-        freqs_sin,
-        wo_a,
-        wo_b,
-        wo_b_scale,
-        attn_out,
+    o_packed_heads = pl.create_tensor([O_GROUPS * T_PAD * HEADS_PER_GROUP, HEAD_DIM], dtype=pl.BF16)
+    o_packed_heads, heads_dep = sparse_attn_swa(
+        q, ori_kv, swa_indices, sparse_bias,
+        attn_sink, freqs_cos, freqs_sin,
+        o_packed_heads,
+    )
+    o_packed = pl.reshape(o_packed_heads, [O_GROUPS * T_PAD, O_GROUP_IN])
+    attn_out = decode_o_proj_tp1(
+        o_packed,
+        wo_a, wo_b, wo_b_scale,
+        attn_out, heads_dep,
     )
     return attn_out
 
@@ -591,7 +560,7 @@ if __name__ == "__main__":
     print(f"TOPK={TOPK} SPARSE_BLOCKS={SPARSE_BLOCKS} PADDED_TOPK={PADDED_TOPK}", flush=True)
 
     result = run_jit(
-        fn=sparse_attn_test,
+        fn=sparse_attn_swa_test,
         specs=build_tensor_specs(
             args.causal_regression_fixture,
             args.short_window_fixture,

--- a/models/deepseek_v4_flash_dspark/decode_sparse_attn_swa.py
+++ b/models/deepseek_v4_flash_dspark/decode_sparse_attn_swa.py
@@ -23,10 +23,7 @@ from config import (
     BLOCK_SIZE,
     KV_ORI_BLOCK_NUM,
     KV_ORI_MAX_BLOCKS,
-    INT8_SCALE_MAX,
-    INT8_AMAX_EPS,
 )
-from decode_o_proj import decode_o_proj_tp1
 
 
 # Dynamic shape variables.
@@ -283,17 +280,13 @@ def sparse_attn_swa_test(
     attn_sink: pl.Tensor[[H], pl.FP32],
     freqs_cos: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
     freqs_sin: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
-    wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
-    wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
-    wo_b_scale: pl.Tensor[[D], pl.FP32],
-    attn_out: pl.Out[pl.Tensor[[T_DYN, D], pl.BF16]],
+    o_packed_heads: pl.Out[pl.Tensor[[O_GROUPS, T_PAD * HEADS_PER_GROUP, HEAD_DIM], pl.BF16]],
 ):
     q.bind_dynamic(0, T_DYN)
     swa_indices.bind_dynamic(0, T_DYN)
     swa_lens.bind_dynamic(0, T_DYN)
     freqs_cos.bind_dynamic(0, T_DYN)
     freqs_sin.bind_dynamic(0, T_DYN)
-    attn_out.bind_dynamic(0, T_DYN)
     t_dim = pl.tensor.dim(q, 0)
     bias_blocks = t_dim // BIAS_T_TILE
     sparse_bias = pl.create_tensor([t_dim, PADDED_TOPK], dtype=pl.FP32)
@@ -308,23 +301,17 @@ def sparse_attn_swa_test(
                 1.0,
             )
             sparse_bias[v_t0 : v_t0 + BIAS_T_TILE, 0:ATTN_K_TILE] = pl.mul(pl.sub(v_valid, 1.0), -NEG_INF)
-    o_packed_heads = pl.create_tensor([O_GROUPS * T_PAD * HEADS_PER_GROUP, HEAD_DIM], dtype=pl.BF16)
-    o_packed_heads, heads_dep = sparse_attn_swa(
+    o_packed_flat = pl.reshape(o_packed_heads, [O_GROUPS * T_PAD * HEADS_PER_GROUP, HEAD_DIM])
+    o_packed_flat, _ = sparse_attn_swa(
         q, ori_kv, swa_indices, sparse_bias,
         attn_sink, freqs_cos, freqs_sin,
-        o_packed_heads,
+        o_packed_flat,
     )
-    o_packed = pl.reshape(o_packed_heads, [O_GROUPS * T_PAD, O_GROUP_IN])
-    attn_out = decode_o_proj_tp1(
-        o_packed,
-        wo_a, wo_b, wo_b_scale,
-        attn_out, heads_dep,
-    )
-    return attn_out
+    return o_packed_heads
 
 
 def golden_sparse_attn(tensors):
-    """Torch reference: sparse_attn decode path followed by grouped o_proj."""
+    """Torch reference for the SWA sparse-attention heads."""
     import torch
 
     q = tensors["q"].float()
@@ -335,12 +322,8 @@ def golden_sparse_attn(tensors):
     attn_sink = tensors["attn_sink"].float()
     cos = tensors["freqs_cos"].float()
     sin = tensors["freqs_sin"].float()
-    wo_a = tensors["wo_a"].float()
-    wo_b_i8 = tensors["wo_b"]
-    wo_b_scale = tensors["wo_b_scale"].float()
 
     tokens = q.shape[0]
-    batch = tokens // S
     o = torch.zeros(tokens, H, HEAD_DIM)
 
     # Per-query-token attention. swa_indices is the authoritative physical
@@ -412,27 +395,11 @@ def golden_sparse_attn(tensors):
     o_rope = torch.stack([inv_even, inv_odd], dim=-1).flatten(-2)
     o = torch.cat([o[..., :NOPE_DIM], o_rope], dim=-1).to(torch.bfloat16)
 
-    seq_per_batch = tokens // batch
-    o_model = o.float().view(batch, seq_per_batch, O_GROUPS, O_GROUP_IN)
-    o_r = torch.einsum("bsgd,grd->bsgr", o_model, wo_a)
-    # PER-GROUP INT8 activation quant (one amax per O_LORA group, not per full row):
-    # this localizes the reduction so proj_a[g]->quant[g]->proj_b[g] can pipeline
-    # back-to-back. Each group's INT32 partial is dequantized by its OWN per-row
-    # activation scale before the groups are summed (the per-group scale cannot
-    # factor out of the K-sum), then the per-channel weight scale is applied.
-    o_r_g = o_r.reshape(tokens, O_GROUPS, O_LORA)
-    amax_g = o_r_g.abs().amax(dim=-1, keepdim=True).clamp_min(INT8_AMAX_EPS)   # [tokens, G, 1]
-    scale_q_g = INT8_SCALE_MAX / amax_g
-    o_r_i8_g = torch.round(o_r_g * scale_q_g).to(torch.int32).to(torch.float16).to(torch.int8)
-    scale_dq_g = 1.0 / scale_q_g                                              # [tokens, G, 1]
-    wo_b_g = wo_b_i8.reshape(D, O_GROUPS, O_LORA)
-    out = torch.zeros(tokens, D, dtype=torch.float32)
-    for g in range(O_GROUPS):
-        p_g = o_r_i8_g[:, g].to(torch.int32) @ wo_b_g[:, g].to(torch.int32).T   # [tokens, D]
-        out = out + p_g.float() * scale_dq_g[:, g]                             # per-row group scale
-    out = out * wo_b_scale.unsqueeze(0)                                        # per-channel weight scale
-
-    tensors["attn_out"][:] = out.to(torch.bfloat16)
+    # Pack as [group, T_PAD, head-in-group, dim]; rows past the runtime token
+    # count are capacity padding the kernel never writes.
+    packed = tensors["o_packed_heads"].view(O_GROUPS, T_PAD, HEADS_PER_GROUP, HEAD_DIM)
+    o_grouped = o.view(tokens, O_GROUPS, HEADS_PER_GROUP, HEAD_DIM)
+    packed[:, :tokens] = o_grouped.permute(1, 0, 2, 3).to(torch.bfloat16)
 
 def build_tensor_specs(
     causal_regression_fixture: bool = False,
@@ -443,7 +410,7 @@ def build_tensor_specs(
     tokens = batch * S
     import torch
     from golden import TensorSpec
-    from utils import block_table, quant_w_per_channel
+    from utils import block_table
 
     def init_q():
         """Initialize the query tensor used by the decode attention stage."""
@@ -501,21 +468,6 @@ def build_tensor_specs(
         sin_half = torch.sin(angles)
         return torch.cat([sin_half, sin_half], dim=-1)
 
-    def init_wo_a():
-        """Initialize the grouped first-stage output-projection weights."""
-        return (torch.rand(O_GROUPS, O_LORA, O_GROUP_IN) - 0.5) / (O_GROUP_IN ** 0.5)
-
-    wo_b_bf16 = ((torch.rand(D, O_GROUPS * O_LORA) - 0.5) / ((O_GROUPS * O_LORA) ** 0.5)).to(torch.bfloat16)
-    wo_b_i8, wo_b_scale = quant_w_per_channel(wo_b_bf16)
-
-    def init_wo_b():
-        """Initialize the second-stage output-projection weights in per-channel INT8 form."""
-        return wo_b_i8
-
-    def init_wo_b_scale():
-        """Initialize the dequant scales paired with the INT8 second-stage weights."""
-        return wo_b_scale
-
     return [
         TensorSpec("q", [tokens, H, HEAD_DIM], torch.bfloat16, init_value=init_q),
         TensorSpec("ori_kv", [ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_ori_kv),
@@ -524,10 +476,7 @@ def build_tensor_specs(
         TensorSpec("attn_sink", [H], torch.float32, init_value=init_attn_sink),
         TensorSpec("freqs_cos", [tokens, ROPE_DIM], torch.bfloat16, init_value=init_cos),
         TensorSpec("freqs_sin", [tokens, ROPE_DIM], torch.bfloat16, init_value=init_sin),
-        TensorSpec("wo_a", [O_GROUPS, O_LORA, O_GROUP_IN], torch.bfloat16, init_value=init_wo_a),
-        TensorSpec("wo_b", [D, O_GROUPS * O_LORA], torch.int8, init_value=init_wo_b),
-        TensorSpec("wo_b_scale", [D], torch.float32, init_value=init_wo_b_scale),
-        TensorSpec("attn_out", [tokens, D], torch.bfloat16, is_output=True),
+        TensorSpec("o_packed_heads", [O_GROUPS, T_PAD * HEADS_PER_GROUP, HEAD_DIM], torch.bfloat16, is_output=True),
     ]
 
 
@@ -579,7 +528,10 @@ if __name__ == "__main__":
         rtol=1e-3,
         atol=1e-3,
         compare_fn={
-            "attn_out": ratio_allclose(atol=1e-4, rtol=1.0 / 128),
+            "o_packed_heads": ratio_allclose(
+                atol=1e-4, rtol=1.0 / 128,
+                valid_rows=args.batch * S * HEADS_PER_GROUP, valid_axis=1,
+            ),
         },
     )
     if not result.passed:

--- a/models/deepseek_v4_flash_dspark/decode_swa.py
+++ b/models/deepseek_v4_flash_dspark/decode_swa.py
@@ -70,13 +70,13 @@ from decode_sparse_attn_swa import ATTN_K_TILE, PADDED_TOPK, T_PAD, sparse_attn_
 
 # Dynamic shape variables.
 T_DYN = pl.dynamic("T_DYN")  # T = B * S
+ORI_BLOCK_NUM_DYN = pl.dynamic("ORI_BLOCK_NUM_DYN")
 
 
 # model config
 B = DECODE_BATCH // TP_SIZE
 S = DECODE_SEQ
 T = B * S
-BIAS_T_TILE = 8  # sparse_bias row block; T is a multiple of 8 by the batch contract
 EPS = M.rms_norm_eps
 D = M.hidden_size
 H = M.num_attention_heads
@@ -100,27 +100,22 @@ O_GROUP_IN = H * HEAD_DIM // O_GROUPS
 # kernel-local (SWA: ratio-0, no compressor/indexer)
 ORI_MAX_BLOCKS = KV_ORI_MAX_BLOCKS
 ORI_BLOCK_NUM = KV_ORI_BLOCK_NUM
-ORI_BLOCK_NUM_DYN = pl.dynamic("ORI_BLOCK_NUM_DYN")
 TOPK = WIN                          # SWA: sparse_attn topk = window only
 SPARSE_IDX_TOPK = M.index_topk      # sparse_attn module's IDX_TOPK (static shape contract)
 SPARSE_TOPK = WIN + SPARSE_IDX_TOPK
 SPARSE_CMP_MAX_BLOCKS = KV_CMP_MAX_BLOCKS
 
 # tiling
+BIAS_T_TILE = 8  # sparse_bias row block; T is a multiple of 8 by the batch contract
 SPARSE_ROPE_TILE = 16
 SPARSE_ROPE_INTERLEAVE_TILE = 2 * SPARSE_ROPE_TILE
 NEG_INF = -1.0e20
-
-# fixture
-TP_FIXTURE_WINDOW_BLOCKS = (WIN + BLOCK_SIZE - 1) // BLOCK_SIZE
-TP_FIXTURE_OUTPUT_SENTINEL = -7.0
 
 if T != LOCAL_T:
     raise ValueError(f"SWA token capacity {T} must equal TP-local token capacity {LOCAL_T}")
 if T_PAD != LOCAL_T_PAD:
     raise ValueError(f"SWA padded token capacity {T_PAD} must equal TP capacity {LOCAL_T_PAD}")
-if TP_FIXTURE_WINDOW_BLOCKS > ORI_BLOCK_NUM:
-    raise ValueError("SWA fixture window exceeds the original KV cache capacity")
+
 
 @pl.jit
 def decode_swa(
@@ -292,7 +287,7 @@ def decode_swa_tp1(
 
     x_normed_t = pl.create_tensor([t_dim, D], dtype=pl.BF16)
     rms_tid = rms_norm(x_mixed, attn_norm_w, x_normed_t)
-    # Defers kv_proj_matmul one hop behind rms_norm so qr_proj_matmul dispatches first.
+    # Dispatch barrier: kv_proj_matmul resolves one hop after rms_norm.
     late_dep = pl.system.task_dummy(deps=[rms_tid])
     q = pl.create_tensor([t_dim, H, HEAD_DIM], dtype=pl.BF16)
     kv = pl.create_tensor([t_dim, HEAD_DIM], dtype=pl.BF16)
@@ -394,6 +389,14 @@ def decode_swa_tp1_test(
         x_out,
     )
     return x_out
+
+
+# fixture
+TP_FIXTURE_WINDOW_BLOCKS = (WIN + BLOCK_SIZE - 1) // BLOCK_SIZE
+TP_FIXTURE_OUTPUT_SENTINEL = -7.0
+
+if TP_FIXTURE_WINDOW_BLOCKS > ORI_BLOCK_NUM:
+    raise ValueError("SWA fixture window exceeds the original KV cache capacity")
 
 
 def build_tp_tensor_specs(local_t):
@@ -565,7 +568,7 @@ def golden_decode_swa_tp1(tensors):
     tokens = tensors["x_hc"].shape[0]
     from hc_post import golden_hc_post
 
-    # ---- Block.hc_pre (model.py:691) ----
+    # Block.hc_pre
     x_mixed = torch.zeros(tokens, D, dtype=torch.bfloat16)
     post_t = torch.zeros(tokens, HC_MULT)
     comb_t = torch.zeros(tokens, HC_MULT * HC_MULT)
@@ -579,7 +582,7 @@ def golden_decode_swa_tp1(tensors):
         "comb": comb_t,
     })
 
-    # ===== Attention.forward (model.py:484-543), ratio==0 branch =====
+    # Attention.forward, ratio==0 branch
     position_ids = tensors["position_ids"].to(torch.int64)
     rd = ROPE_HEAD_DIM
 
@@ -592,7 +595,7 @@ def golden_decode_swa_tp1(tensors):
         rope_cos_T[t] = freqs_cos[pos]
         rope_sin_T[t] = freqs_sin[pos]
 
-    # q + win kv (model.py:495-504)
+    # q + win kv
     q = torch.zeros(tokens, H, HEAD_DIM, dtype=torch.bfloat16)
     kv = torch.zeros(tokens, HEAD_DIM, dtype=torch.bfloat16)
     qr = torch.zeros(tokens, Q_LORA, dtype=torch.int8)
@@ -641,7 +644,7 @@ def golden_decode_swa_tp1(tensors):
         "attn_out": attn_out,
     })
 
-    # ===== Block.hc_post (model.py:694) =====
+    # Block.hc_post
     y = torch.zeros(tokens, HC_MULT, D, dtype=torch.float32)
     golden_hc_post({
         "x": attn_out,
@@ -656,7 +659,7 @@ def golden_decode_swa_tp1(tensors):
 
 def build_tensor_specs(start_pos=None, batch=B):
     tokens = batch * S
-    import torch  # type: ignore[import]
+    import torch
     from utils import (
         block_table,
         paged_slot_mapping,
@@ -690,9 +693,7 @@ def build_tensor_specs(start_pos=None, batch=B):
 
     def init_x_hc():
         return torch.empty(tokens, HC_MULT, D).uniform_(-1, 1)
-    # Real layer-0 (SWA) hc_attn scale/base (fn synthetic at real magnitude). A synthetic
-    # scale=0.5/base=0 leaves hc_pre post~=1 + near-uniform comb, cancelling attn_out and the
-    # hc residual to near-zero in x_out where quant noise blows up the relative tail.
+    # Real layer-0 (SWA) hc_attn scale/base; fn is synthetic at the real magnitude.
     def init_hc_attn_fn():
         return torch.randn(MIX_HC, HC_DIM) * 0.039
     def init_hc_attn_scale():
@@ -809,12 +810,13 @@ if __name__ == "__main__":
     from pypto.ir.distributed_compiled_program import DistributedConfig
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("-p", "--platform", type=str, default="a2a3",
-                        choices=["a2a3", "a2a3sim", "a5", "a5sim"])
-    parser.add_argument("--tp", type=int, default=TP_SIZE, choices=list(_TP_CHOICES),
-                        help="tensor-parallel world size")
-    parser.add_argument("-d", "--device", type=str, default=",".join(str(rank) for rank in range(TP_SIZE)),
-                        help=f"comma-separated device ids; need exactly {TP_SIZE}")
+    default_devices = ",".join(str(rank) for rank in range(TP_SIZE))
+    parser.add_argument("-p", "--platform", type=str, default="a2a3", choices=["a2a3", "a2a3sim", "a5", "a5sim"])
+    parser.add_argument("--tp", type=int, default=TP_SIZE, choices=list(_TP_CHOICES), help="tensor-parallel world size")
+    parser.add_argument(
+        "-d", "--device", type=str, default=default_devices,
+        help=f"comma-separated device ids; need exactly {TP_SIZE}",
+    )
     parser.add_argument("--case", choices=("all", "max", "subcapacity"), default="all")
     parser.add_argument("--compile-only", action="store_true", default=False)
     parser.add_argument("--dump-passes", action="store_true", default=False)

--- a/models/deepseek_v4_flash_dspark/decode_swa.py
+++ b/models/deepseek_v4_flash_dspark/decode_swa.py
@@ -61,11 +61,12 @@ from decode_o_proj import (
     LOCAL_T,
     LOCAL_T_PAD,
     O_WINDOW_ROWS,
-    attention_token_head_all_to_all_step,
-    decode_sharded_o_projection,
-    o_projection_reduce_scatter_step,
+    decode_o_proj,
+    decode_o_proj_tp1,
+    o_group_a2a,
+    o_proj_reduce_scatter,
 )
-from decode_sparse_attn_swa import ATTN_K_TILE, PADDED_TOPK, T_PAD, sparse_attn_swa, sparse_attn_swa_heads
+from decode_sparse_attn_swa import ATTN_K_TILE, PADDED_TOPK, T_PAD, sparse_attn_swa
 
 # Dynamic shape variables.
 T_DYN = pl.dynamic("T_DYN")  # T = B * S
@@ -121,8 +122,125 @@ if T_PAD != LOCAL_T_PAD:
 if TP_FIXTURE_WINDOW_BLOCKS > ORI_BLOCK_NUM:
     raise ValueError("SWA fixture window exceeds the original KV cache capacity")
 
+@pl.jit
+def decode_swa(
+    q: pl.Tensor[[T_DYN, H, HEAD_DIM], pl.BF16],
+    ori_kv: pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
+    swa_lens: pl.Tensor[[T_DYN], pl.INT32],
+    attn_sink: pl.Tensor[[H], pl.FP32],
+    freqs_cos: pl.Tensor[[T_DYN, ROPE_HEAD_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[T_DYN, ROPE_HEAD_DIM], pl.BF16],
+    wo_a: pl.Tensor[[LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
+    wo_b: pl.Tensor[[D, LOCAL_O_WIDTH], pl.INT8],
+    wo_b_scale: pl.Tensor[[D], pl.FP32],
+    o_local: pl.InOut[pl.Tensor[[LOCAL_T_PAD, D], pl.BF16]],
+    attention_window: pld.DistributedTensor[[ATTENTION_WINDOW_ROWS, O_GROUP_IN], pl.BF16],
+    attention_signal: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
+    o_window: pld.DistributedTensor[[O_WINDOW_ROWS, D], pl.FP32],
+    o_signal: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
+    group_base: pl.Scalar[pl.INT32],
+    tp_rank: pl.Scalar[pl.INT32],
+    local_t: pl.Scalar[pl.INT32],
+):
+    """Run rank-local SWA heads, output A2A, sharded O projection, and RS."""
+    q.bind_dynamic(0, T_DYN)
+    swa_indices.bind_dynamic(0, T_DYN)
+    swa_lens.bind_dynamic(0, T_DYN)
+    freqs_cos.bind_dynamic(0, T_DYN)
+    freqs_sin.bind_dynamic(0, T_DYN)
+
+    t_dim = pl.tensor.dim(q, 0)
+    sparse_bias = pl.create_tensor([t_dim, PADDED_TOPK], dtype=pl.FP32)
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="swa_valid_bias"):
+        valid_col = pl.cast(pl.arange(0, [1, ATTN_K_TILE], dtype=pl.INT32), target_type=pl.FP32)
+        for bias_block in pl.range(t_dim // BIAS_T_TILE):
+            token_start = bias_block * BIAS_T_TILE
+            zero_rows = pl.full([BIAS_T_TILE, ATTN_K_TILE], dtype=pl.FP32, value=0.0)
+            valid_cols = pl.col_expand(zero_rows, valid_col)
+            lens_slice = swa_lens[token_start : token_start + BIAS_T_TILE]
+            lens_col = pl.reshape(lens_slice, [BIAS_T_TILE, 1])
+            lens_fp32 = pl.cast(lens_col, target_type=pl.FP32)
+            valid = pl.neg(pl.row_expand_sub(valid_cols, lens_fp32))
+            valid = pl.maximum(valid, 0.0)
+            valid = pl.minimum(valid, 1.0)
+            invalid = pl.sub(valid, 1.0)
+            sparse_bias[token_start : token_start + BIAS_T_TILE, 0:ATTN_K_TILE] = pl.mul(invalid, -NEG_INF)
+
+    o_packed_heads = pl.create_tensor([O_GROUPS * T_PAD * HEADS_PER_GROUP, HEAD_DIM], dtype=pl.BF16)
+    o_packed_heads, _ = sparse_attn_swa(
+        q, ori_kv, swa_indices, sparse_bias,
+        attn_sink, freqs_cos, freqs_sin,
+        o_packed_heads,
+    )
+
+    attention_grouped = pl.reshape(o_packed_heads, [O_GROUPS * LOCAL_T_PAD, O_GROUP_IN])
+    attention_local_flat = pl.create_tensor([ATTENTION_WINDOW_ROWS, O_GROUP_IN], dtype=pl.BF16)
+    attention_local_flat, attention_signal = o_group_a2a(
+        attention_grouped, attention_local_flat,
+        attention_window, attention_signal,
+        group_base, tp_rank, local_t,
+    )
+
+    attention_local_groups = pl.reshape(attention_local_flat, [LOCAL_O_GROUPS, GROUP_T_PAD, O_GROUP_IN])
+    o_partial = pl.create_tensor([GROUP_T_PAD, D], dtype=pl.FP32)
+    o_partial, projection_tid = decode_o_proj(
+        attention_local_groups,
+        wo_a, wo_b, wo_b_scale,
+        local_t, o_partial,
+    )
+
+    o_local, o_signal = o_proj_reduce_scatter(
+        o_partial, o_local,
+        o_window, o_signal,
+        group_base, tp_rank, local_t, projection_tid,
+    )
+    return o_local, attention_signal, o_signal
+
+
+@pl.jit.host
+def l3_decode_swa(
+    q: pl.Tensor[[TP_SIZE, T_DYN, H, HEAD_DIM], pl.BF16],
+    ori_kv: pl.Tensor[[TP_SIZE, ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    swa_indices: pl.Tensor[[TP_SIZE, T_DYN, WIN], pl.INT32],
+    swa_lens: pl.Tensor[[TP_SIZE, T_DYN], pl.INT32],
+    attn_sink: pl.Tensor[[TP_SIZE, H], pl.FP32],
+    freqs_cos: pl.Tensor[[TP_SIZE, T_DYN, ROPE_HEAD_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[TP_SIZE, T_DYN, ROPE_HEAD_DIM], pl.BF16],
+    wo_a: pl.Tensor[[TP_SIZE, LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
+    wo_b: pl.Tensor[[TP_SIZE, D, LOCAL_O_WIDTH], pl.INT8],
+    wo_b_scale: pl.Tensor[[TP_SIZE, D], pl.FP32],
+    o_local: pl.InOut[pl.Tensor[[TP_SIZE, LOCAL_T_PAD, D], pl.BF16]],
+    local_t: pl.Scalar[pl.INT32],
+):
+    """Launch the SWA output half on one physical TP group."""
+    q.bind_dynamic(1, T_DYN)
+    swa_indices.bind_dynamic(1, T_DYN)
+    swa_lens.bind_dynamic(1, T_DYN)
+    freqs_cos.bind_dynamic(1, T_DYN)
+    freqs_sin.bind_dynamic(1, T_DYN)
+
+    attention_window_buf = pld.alloc_window_buffer([ATTENTION_WINDOW_ROWS, O_GROUP_IN], dtype=pl.BF16)
+    attention_signal_buf = pld.alloc_window_buffer([TP_SIZE, 1], dtype=pl.INT32)
+    o_window_buf = pld.alloc_window_buffer([O_WINDOW_ROWS, D], dtype=pl.FP32)
+    o_signal_buf = pld.alloc_window_buffer([TP_SIZE, 1], dtype=pl.INT32)
+
+    for rank in pl.range(pld.world_size()):
+        attention_window = pld.window(attention_window_buf, [ATTENTION_WINDOW_ROWS, O_GROUP_IN], dtype=pl.BF16)
+        attention_signal = pld.window(attention_signal_buf, [TP_SIZE, 1], dtype=pl.INT32)
+        o_window = pld.window(o_window_buf, [O_WINDOW_ROWS, D], dtype=pl.FP32)
+        o_signal = pld.window(o_signal_buf, [TP_SIZE, 1], dtype=pl.INT32)
+        decode_swa(
+            q[rank], ori_kv[rank], swa_indices[rank], swa_lens[rank],
+            attn_sink[rank], freqs_cos[rank], freqs_sin[rank],
+            wo_a[rank], wo_b[rank], wo_b_scale[rank], o_local[rank],
+            attention_window, attention_signal, o_window, o_signal,
+            0, rank, local_t, device=rank,
+        )
+
+
 @pl.jit.inline
-def attention_swa(
+def decode_swa_tp1(
     x_hc: pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32],
     # hc_pre weights
     hc_attn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
@@ -209,10 +327,17 @@ def attention_swa(
             )
             sparse_bias[v_t0 : v_t0 + BIAS_T_TILE, 0:WIN] = pl.mul(pl.sub(v_valid, 1.0), -NEG_INF)
     attn_out = pl.create_tensor([t_dim, D], dtype=pl.BF16)
-    sparse_attn_swa(
+    o_packed_heads = pl.create_tensor([O_GROUPS * T_PAD * HEADS_PER_GROUP, HEAD_DIM], dtype=pl.BF16)
+    o_packed_heads, heads_dep = sparse_attn_swa(
         q, kv_cache, swa_indices, sparse_bias,
         attn_sink, rope_cos_t, rope_sin_t,
-        wo_a, wo_b, wo_b_scale, attn_out,
+        o_packed_heads,
+    )
+    o_packed = pl.reshape(o_packed_heads, [O_GROUPS * T_PAD, O_GROUP_IN])
+    attn_out = decode_o_proj_tp1(
+        o_packed,
+        wo_a, wo_b, wo_b_scale,
+        attn_out, heads_dep,
     )
 
     hc_post(attn_out, x_hc, post_t, comb_t, x_out)
@@ -220,7 +345,7 @@ def attention_swa(
 
 
 @pl.jit
-def attention_swa_test(
+def decode_swa_tp1_test(
     x_hc: pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32],
     # hc_pre weights
     hc_attn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
@@ -257,7 +382,7 @@ def attention_swa_test(
     position_ids.bind_dynamic(0, T_DYN)
     x_out.bind_dynamic(0, T_DYN)
 
-    attention_swa(
+    decode_swa_tp1(
         x_hc,
         hc_attn_fn, hc_attn_scale, hc_attn_base,
         attn_norm_w, wq_a, wq_b, wq_b_scale, wkv,
@@ -271,125 +396,162 @@ def attention_swa_test(
     return x_out
 
 
-@pl.jit
-def decode_swa_output(
-    q: pl.Tensor[[T_DYN, H, HEAD_DIM], pl.BF16],
-    ori_kv: pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
-    swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
-    swa_lens: pl.Tensor[[T_DYN], pl.INT32],
-    attn_sink: pl.Tensor[[H], pl.FP32],
-    freqs_cos: pl.Tensor[[T_DYN, ROPE_HEAD_DIM], pl.BF16],
-    freqs_sin: pl.Tensor[[T_DYN, ROPE_HEAD_DIM], pl.BF16],
-    wo_a: pl.Tensor[[LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
-    wo_b: pl.Tensor[[D, LOCAL_O_WIDTH], pl.INT8],
-    wo_b_scale: pl.Tensor[[D], pl.FP32],
-    o_local: pl.InOut[pl.Tensor[[LOCAL_T_PAD, D], pl.BF16]],
-    attention_window: pld.DistributedTensor[[ATTENTION_WINDOW_ROWS, O_GROUP_IN], pl.BF16],
-    attention_signal: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
-    o_window: pld.DistributedTensor[[O_WINDOW_ROWS, D], pl.FP32],
-    o_signal: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
-    group_base: pl.Scalar[pl.INT32],
-    tp_rank: pl.Scalar[pl.INT32],
-    local_t: pl.Scalar[pl.INT32],
-):
-    """Run rank-local SWA heads, output A2A, sharded O projection, and RS."""
-    q.bind_dynamic(0, T_DYN)
-    swa_indices.bind_dynamic(0, T_DYN)
-    swa_lens.bind_dynamic(0, T_DYN)
-    freqs_cos.bind_dynamic(0, T_DYN)
-    freqs_sin.bind_dynamic(0, T_DYN)
+def build_tp_tensor_specs(local_t):
+    """Build deterministic tensor-parallel SWA output-half inputs."""
+    import torch
 
-    t_dim = pl.tensor.dim(q, 0)
-    sparse_bias = pl.create_tensor([t_dim, PADDED_TOPK], dtype=pl.FP32)
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="swa_valid_bias"):
-        valid_col = pl.cast(pl.arange(0, [1, ATTN_K_TILE], dtype=pl.INT32), target_type=pl.FP32)
-        for bias_block in pl.range(t_dim // BIAS_T_TILE):
-            token_start = bias_block * BIAS_T_TILE
-            zero_rows = pl.full([BIAS_T_TILE, ATTN_K_TILE], dtype=pl.FP32, value=0.0)
-            valid_cols = pl.col_expand(zero_rows, valid_col)
-            lens_slice = swa_lens[token_start : token_start + BIAS_T_TILE]
-            lens_col = pl.reshape(lens_slice, [BIAS_T_TILE, 1])
-            lens_fp32 = pl.cast(lens_col, target_type=pl.FP32)
-            valid = pl.neg(pl.row_expand_sub(valid_cols, lens_fp32))
-            valid = pl.maximum(valid, 0.0)
-            valid = pl.minimum(valid, 1.0)
-            invalid = pl.sub(valid, 1.0)
-            sparse_bias[token_start : token_start + BIAS_T_TILE, 0:ATTN_K_TILE] = pl.mul(invalid, -NEG_INF)
+    from golden import ScalarSpec, TensorSpec
 
-    o_packed_heads = pl.create_tensor([O_GROUPS * T_PAD * HEADS_PER_GROUP, HEAD_DIM], dtype=pl.BF16)
-    o_packed_heads, _ = sparse_attn_swa_heads(
-        q, ori_kv, swa_indices, sparse_bias,
-        attn_sink, freqs_cos, freqs_sin,
-        o_packed_heads,
+    if local_t < BIAS_T_TILE or local_t > LOCAL_T or local_t % BIAS_T_TILE != 0 or local_t % S != 0:
+        raise ValueError(f"local_t must be a multiple of {BIAS_T_TILE} in [{BIAS_T_TILE}, {LOCAL_T}], got {local_t}")
+
+    def init_q():
+        q = torch.zeros(TP_SIZE, local_t, H, HEAD_DIM, dtype=torch.bfloat16)
+        rank = torch.arange(TP_SIZE, dtype=torch.float32).reshape(TP_SIZE, 1, 1)
+        token = torch.arange(local_t, dtype=torch.float32).reshape(1, local_t, 1)
+        head = torch.arange(H, dtype=torch.float32).reshape(1, 1, H)
+        q[..., 0] = (rank + token * 0.25 + head * 0.0625).to(torch.bfloat16)
+        return q
+
+    def init_ori_kv():
+        shape = (ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM)
+        cache = torch.full(shape, float("nan"), dtype=torch.bfloat16)
+        cache[:TP_FIXTURE_WINDOW_BLOCKS, :, 0, :] = 0.0
+        cache[:TP_FIXTURE_WINDOW_BLOCKS, :, 0, 0] = 0.25
+        return cache.unsqueeze(0).expand(TP_SIZE, *shape).clone()
+
+    def init_swa_indices():
+        window_row = torch.arange(WIN, dtype=torch.int32)
+        return window_row.reshape(1, 1, WIN).expand(TP_SIZE, local_t, WIN).clone()
+
+    def init_swa_lens():
+        return torch.full((TP_SIZE, local_t), WIN, dtype=torch.int32)
+
+    def init_attn_sink():
+        head = torch.arange(H, dtype=torch.int32).remainder(HEADS_PER_GROUP).to(torch.float32)
+        sink = 4.0 + head * 0.125
+        return sink.reshape(1, H).expand(TP_SIZE, H).clone()
+
+    def init_freqs_cos():
+        cos = torch.ones(local_t, ROPE_HEAD_DIM, dtype=torch.bfloat16)
+        return cos.unsqueeze(0).expand(TP_SIZE, local_t, ROPE_HEAD_DIM).clone()
+
+    def init_freqs_sin():
+        sin = torch.zeros(local_t, ROPE_HEAD_DIM, dtype=torch.bfloat16)
+        return sin.unsqueeze(0).expand(TP_SIZE, local_t, ROPE_HEAD_DIM).clone()
+
+    def init_wo_a():
+        wo_a = torch.zeros(TP_SIZE, LOCAL_O_GROUPS, O_LORA, O_GROUP_IN, dtype=torch.bfloat16)
+        for rank in range(TP_SIZE):
+            for local_group in range(LOCAL_O_GROUPS):
+                shard_scale = (rank + 1) * (local_group + 1) * 0.125
+                for head in range(HEADS_PER_GROUP):
+                    wo_a[rank, local_group, head, head * HEAD_DIM] = shard_scale * (head + 1)
+        return wo_a
+
+    def init_wo_b():
+        base = torch.arange(D * LOCAL_O_WIDTH, dtype=torch.int32).reshape(D, LOCAL_O_WIDTH)
+        rank = torch.arange(TP_SIZE, dtype=torch.int32).reshape(TP_SIZE, 1, 1)
+        return (base.unsqueeze(0) + rank).remainder(7).sub(3).to(torch.int8)
+
+    def init_wo_b_scale():
+        channel_scale = torch.arange(D, dtype=torch.int32).remainder(4).to(torch.float32) * 0.25 + 0.5
+        return channel_scale.reshape(1, D).expand(TP_SIZE, D).clone()
+
+    return [
+        TensorSpec("q", [TP_SIZE, local_t, H, HEAD_DIM], torch.bfloat16, init_value=init_q),
+        TensorSpec("ori_kv", [TP_SIZE, ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_ori_kv),
+        TensorSpec("swa_indices", [TP_SIZE, local_t, WIN], torch.int32, init_value=init_swa_indices),
+        TensorSpec("swa_lens", [TP_SIZE, local_t], torch.int32, init_value=init_swa_lens),
+        TensorSpec("attn_sink", [TP_SIZE, H], torch.float32, init_value=init_attn_sink),
+        TensorSpec("freqs_cos", [TP_SIZE, local_t, ROPE_HEAD_DIM], torch.bfloat16, init_value=init_freqs_cos),
+        TensorSpec("freqs_sin", [TP_SIZE, local_t, ROPE_HEAD_DIM], torch.bfloat16, init_value=init_freqs_sin),
+        TensorSpec("wo_a", [TP_SIZE, LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], torch.bfloat16, init_value=init_wo_a),
+        TensorSpec("wo_b", [TP_SIZE, D, LOCAL_O_WIDTH], torch.int8, init_value=init_wo_b),
+        TensorSpec("wo_b_scale", [TP_SIZE, D], torch.float32, init_value=init_wo_b_scale),
+        TensorSpec(
+            "o_local", [TP_SIZE, LOCAL_T_PAD, D], torch.bfloat16,
+            init_value=TP_FIXTURE_OUTPUT_SENTINEL, is_output=True,
+        ),
+        ScalarSpec("local_t", torch.int32, local_t),
+    ]
+
+
+def golden_decode_swa(tensors):
+    """Compute the controlled SWA heads, sharded O projection, and reduced rows."""
+    import torch
+
+    local_t = tensors["q"].shape[1]
+    group_t = TP_SIZE * local_t
+    q0 = tensors["q"][..., 0].float()
+    kv0 = tensors["ori_kv"][:, 0, 0, 0, 0].float()
+    sink = tensors["attn_sink"].float()
+    score = q0 * kv0.reshape(TP_SIZE, 1, 1) * M.softmax_scale
+    numerator = WIN * kv0.reshape(TP_SIZE, 1, 1)
+    head_value = numerator / (WIN + torch.exp(sink.reshape(TP_SIZE, 1, H) - score))
+    head_value = head_value.to(torch.bfloat16)
+
+    attention_grouped = torch.zeros(TP_SIZE, O_GROUPS, local_t, O_GROUP_IN, dtype=torch.bfloat16)
+    for group in range(O_GROUPS):
+        for head in range(HEADS_PER_GROUP):
+            global_head = group * HEADS_PER_GROUP + head
+            group_col = head * HEAD_DIM
+            attention_grouped[:, group, :, group_col] = head_value[:, :, global_head]
+
+    attention_local = torch.zeros(TP_SIZE, LOCAL_O_GROUPS, group_t, O_GROUP_IN, dtype=torch.bfloat16)
+    for destination_rank in range(TP_SIZE):
+        for local_group in range(LOCAL_O_GROUPS):
+            global_group = destination_rank * LOCAL_O_GROUPS + local_group
+            group_rows = attention_grouped[:, global_group].reshape(group_t, O_GROUP_IN)
+            attention_local[destination_rank, local_group] = group_rows
+
+    partials = torch.zeros(TP_SIZE, group_t, D, dtype=torch.float32)
+    for rank in range(TP_SIZE):
+        attention = attention_local[rank].float()
+        o_a = torch.einsum("gti,gri->gtr", attention, tensors["wo_a"][rank].float())
+        row_amax = o_a.abs().amax(dim=-1, keepdim=True).clamp_min(INT8_AMAX_EPS)
+        scale_q = INT8_SCALE_MAX / row_amax
+        o_a_i8 = torch.round(o_a * scale_q).to(torch.int32).to(torch.float16).to(torch.int8)
+        scale_dq = 1.0 / scale_q
+        wo_b = tensors["wo_b"][rank].reshape(D, LOCAL_O_GROUPS, O_LORA)
+        for local_group in range(LOCAL_O_GROUPS):
+            group_i32 = o_a_i8[local_group].to(torch.int32)
+            weight_i32 = wo_b[:, local_group].to(torch.int32)
+            group_partial = group_i32 @ weight_i32.T
+            partials[rank] += group_partial.float() * scale_dq[local_group]
+        partials[rank] *= tensors["wo_b_scale"][rank].float().reshape(1, D)
+
+    reduced = partials.sum(dim=0)
+    tensors["o_local"].fill_(TP_FIXTURE_OUTPUT_SENTINEL)
+    for rank in range(TP_SIZE):
+        row_start = rank * local_t
+        tensors["o_local"][rank, :local_t] = reduced[row_start : row_start + local_t].to(torch.bfloat16)
+
+
+def build_o_local_compare(local_t):
+    """Compare valid token rows and require the poisoned capacity tail to survive."""
+    import torch
+
+    from golden import ratio_allclose
+
+    prefix_compare = ratio_allclose(
+        atol=1e-4, rtol=1.0 / 128, max_error_ratio=0.0,
+        valid_rows=local_t, valid_axis=1,
     )
 
-    attention_grouped = pl.reshape(o_packed_heads, [O_GROUPS * LOCAL_T_PAD, O_GROUP_IN])
-    attention_local_flat = pl.create_tensor([ATTENTION_WINDOW_ROWS, O_GROUP_IN], dtype=pl.BF16)
-    attention_local_flat, attention_signal = attention_token_head_all_to_all_step(
-        attention_grouped, attention_local_flat,
-        attention_window, attention_signal,
-        group_base, tp_rank, local_t,
-    )
+    def compare(actual, expected, **kwargs):
+        actual_tail = actual[:, local_t:]
+        expected_tail = expected[:, local_t:]
+        if not torch.equal(actual_tail, expected_tail):
+            mismatch_count = int((actual_tail != expected_tail).sum().item())
+            return False, f"    inactive token tail mismatch count={mismatch_count}"
+        return prefix_compare(actual, expected, **kwargs)
 
-    attention_local_groups = pl.reshape(attention_local_flat, [LOCAL_O_GROUPS, GROUP_T_PAD, O_GROUP_IN])
-    o_partial = pl.create_tensor([GROUP_T_PAD, D], dtype=pl.FP32)
-    o_partial, projection_tid = decode_sharded_o_projection(
-        attention_local_groups,
-        wo_a, wo_b, wo_b_scale,
-        local_t, o_partial,
-    )
-
-    with pl.spmd(1, name_hint="tp_o_reduce_scatter", deps=[projection_tid]) as _reduce_scatter_tid:
-        o_local, o_signal = o_projection_reduce_scatter_step(
-            o_partial, o_local,
-            o_window, o_signal,
-            group_base, tp_rank, local_t,
-        )
-    return o_local, attention_signal, o_signal
+    compare.__name__ = f"swa_output_prefix_and_tail(local_t={local_t})"
+    return compare
 
 
-@pl.jit.host
-def l3_decode_swa_output(
-    q: pl.Tensor[[TP_SIZE, T_DYN, H, HEAD_DIM], pl.BF16],
-    ori_kv: pl.Tensor[[TP_SIZE, ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
-    swa_indices: pl.Tensor[[TP_SIZE, T_DYN, WIN], pl.INT32],
-    swa_lens: pl.Tensor[[TP_SIZE, T_DYN], pl.INT32],
-    attn_sink: pl.Tensor[[TP_SIZE, H], pl.FP32],
-    freqs_cos: pl.Tensor[[TP_SIZE, T_DYN, ROPE_HEAD_DIM], pl.BF16],
-    freqs_sin: pl.Tensor[[TP_SIZE, T_DYN, ROPE_HEAD_DIM], pl.BF16],
-    wo_a: pl.Tensor[[TP_SIZE, LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
-    wo_b: pl.Tensor[[TP_SIZE, D, LOCAL_O_WIDTH], pl.INT8],
-    wo_b_scale: pl.Tensor[[TP_SIZE, D], pl.FP32],
-    o_local: pl.InOut[pl.Tensor[[TP_SIZE, LOCAL_T_PAD, D], pl.BF16]],
-    local_t: pl.Scalar[pl.INT32],
-):
-    """Launch the SWA output half on one physical TP group."""
-    q.bind_dynamic(1, T_DYN)
-    swa_indices.bind_dynamic(1, T_DYN)
-    swa_lens.bind_dynamic(1, T_DYN)
-    freqs_cos.bind_dynamic(1, T_DYN)
-    freqs_sin.bind_dynamic(1, T_DYN)
-
-    attention_window_buf = pld.alloc_window_buffer([ATTENTION_WINDOW_ROWS, O_GROUP_IN], dtype=pl.BF16)
-    attention_signal_buf = pld.alloc_window_buffer([TP_SIZE, 1], dtype=pl.INT32)
-    o_window_buf = pld.alloc_window_buffer([O_WINDOW_ROWS, D], dtype=pl.FP32)
-    o_signal_buf = pld.alloc_window_buffer([TP_SIZE, 1], dtype=pl.INT32)
-
-    for rank in pl.range(pld.world_size()):
-        attention_window = pld.window(attention_window_buf, [ATTENTION_WINDOW_ROWS, O_GROUP_IN], dtype=pl.BF16)
-        attention_signal = pld.window(attention_signal_buf, [TP_SIZE, 1], dtype=pl.INT32)
-        o_window = pld.window(o_window_buf, [O_WINDOW_ROWS, D], dtype=pl.FP32)
-        o_signal = pld.window(o_signal_buf, [TP_SIZE, 1], dtype=pl.INT32)
-        decode_swa_output(
-            q[rank], ori_kv[rank], swa_indices[rank], swa_lens[rank],
-            attn_sink[rank], freqs_cos[rank], freqs_sin[rank],
-            wo_a[rank], wo_b[rank], wo_b_scale[rank], o_local[rank],
-            attention_window, attention_signal, o_window, o_signal,
-            0, rank, local_t, device=rank,
-        )
-
-
-def golden_attention_swa(tensors):
+def golden_decode_swa_tp1(tensors):
     """End-to-end orchestration for the ratio=0 (SWA) layers.
     Mirrors Block.hc_pre + Attention.forward (decode branch, ratio==0 path: no compressor,
     no indexer, no cmp_kv) + Block.hc_post."""
@@ -640,161 +802,6 @@ def build_tensor_specs(start_pos=None, batch=B):
     ]
 
 
-def build_tp_tensor_specs(local_t):
-    """Build deterministic tensor-parallel SWA output-half inputs."""
-    import torch
-
-    from golden import ScalarSpec, TensorSpec
-
-    if local_t < BIAS_T_TILE or local_t > LOCAL_T or local_t % BIAS_T_TILE != 0 or local_t % S != 0:
-        raise ValueError(f"local_t must be a multiple of {BIAS_T_TILE} in [{BIAS_T_TILE}, {LOCAL_T}], got {local_t}")
-
-    def init_q():
-        q = torch.zeros(TP_SIZE, local_t, H, HEAD_DIM, dtype=torch.bfloat16)
-        rank = torch.arange(TP_SIZE, dtype=torch.float32).reshape(TP_SIZE, 1, 1)
-        token = torch.arange(local_t, dtype=torch.float32).reshape(1, local_t, 1)
-        head = torch.arange(H, dtype=torch.float32).reshape(1, 1, H)
-        q[..., 0] = (rank + token * 0.25 + head * 0.0625).to(torch.bfloat16)
-        return q
-
-    def init_ori_kv():
-        shape = (ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM)
-        cache = torch.full(shape, float("nan"), dtype=torch.bfloat16)
-        cache[:TP_FIXTURE_WINDOW_BLOCKS, :, 0, :] = 0.0
-        cache[:TP_FIXTURE_WINDOW_BLOCKS, :, 0, 0] = 0.25
-        return cache.unsqueeze(0).expand(TP_SIZE, *shape).clone()
-
-    def init_swa_indices():
-        window_row = torch.arange(WIN, dtype=torch.int32)
-        return window_row.reshape(1, 1, WIN).expand(TP_SIZE, local_t, WIN).clone()
-
-    def init_swa_lens():
-        return torch.full((TP_SIZE, local_t), WIN, dtype=torch.int32)
-
-    def init_attn_sink():
-        head = torch.arange(H, dtype=torch.int32).remainder(HEADS_PER_GROUP).to(torch.float32)
-        sink = 4.0 + head * 0.125
-        return sink.reshape(1, H).expand(TP_SIZE, H).clone()
-
-    def init_freqs_cos():
-        cos = torch.ones(local_t, ROPE_HEAD_DIM, dtype=torch.bfloat16)
-        return cos.unsqueeze(0).expand(TP_SIZE, local_t, ROPE_HEAD_DIM).clone()
-
-    def init_freqs_sin():
-        sin = torch.zeros(local_t, ROPE_HEAD_DIM, dtype=torch.bfloat16)
-        return sin.unsqueeze(0).expand(TP_SIZE, local_t, ROPE_HEAD_DIM).clone()
-
-    def init_wo_a():
-        wo_a = torch.zeros(TP_SIZE, LOCAL_O_GROUPS, O_LORA, O_GROUP_IN, dtype=torch.bfloat16)
-        for rank in range(TP_SIZE):
-            for local_group in range(LOCAL_O_GROUPS):
-                shard_scale = (rank + 1) * (local_group + 1) * 0.125
-                for head in range(HEADS_PER_GROUP):
-                    wo_a[rank, local_group, head, head * HEAD_DIM] = shard_scale * (head + 1)
-        return wo_a
-
-    def init_wo_b():
-        base = torch.arange(D * LOCAL_O_WIDTH, dtype=torch.int32).reshape(D, LOCAL_O_WIDTH)
-        rank = torch.arange(TP_SIZE, dtype=torch.int32).reshape(TP_SIZE, 1, 1)
-        return (base.unsqueeze(0) + rank).remainder(7).sub(3).to(torch.int8)
-
-    def init_wo_b_scale():
-        channel_scale = torch.arange(D, dtype=torch.int32).remainder(4).to(torch.float32) * 0.25 + 0.5
-        return channel_scale.reshape(1, D).expand(TP_SIZE, D).clone()
-
-    return [
-        TensorSpec("q", [TP_SIZE, local_t, H, HEAD_DIM], torch.bfloat16, init_value=init_q),
-        TensorSpec("ori_kv", [TP_SIZE, ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_ori_kv),
-        TensorSpec("swa_indices", [TP_SIZE, local_t, WIN], torch.int32, init_value=init_swa_indices),
-        TensorSpec("swa_lens", [TP_SIZE, local_t], torch.int32, init_value=init_swa_lens),
-        TensorSpec("attn_sink", [TP_SIZE, H], torch.float32, init_value=init_attn_sink),
-        TensorSpec("freqs_cos", [TP_SIZE, local_t, ROPE_HEAD_DIM], torch.bfloat16, init_value=init_freqs_cos),
-        TensorSpec("freqs_sin", [TP_SIZE, local_t, ROPE_HEAD_DIM], torch.bfloat16, init_value=init_freqs_sin),
-        TensorSpec("wo_a", [TP_SIZE, LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], torch.bfloat16, init_value=init_wo_a),
-        TensorSpec("wo_b", [TP_SIZE, D, LOCAL_O_WIDTH], torch.int8, init_value=init_wo_b),
-        TensorSpec("wo_b_scale", [TP_SIZE, D], torch.float32, init_value=init_wo_b_scale),
-        TensorSpec(
-            "o_local", [TP_SIZE, LOCAL_T_PAD, D], torch.bfloat16,
-            init_value=TP_FIXTURE_OUTPUT_SENTINEL, is_output=True,
-        ),
-        ScalarSpec("local_t", torch.int32, local_t),
-    ]
-
-
-def golden_decode_swa_output(tensors):
-    """Compute the controlled SWA heads, sharded O projection, and reduced rows."""
-    import torch
-
-    local_t = tensors["q"].shape[1]
-    group_t = TP_SIZE * local_t
-    q0 = tensors["q"][..., 0].float()
-    kv0 = tensors["ori_kv"][:, 0, 0, 0, 0].float()
-    sink = tensors["attn_sink"].float()
-    score = q0 * kv0.reshape(TP_SIZE, 1, 1) * M.softmax_scale
-    numerator = WIN * kv0.reshape(TP_SIZE, 1, 1)
-    head_value = numerator / (WIN + torch.exp(sink.reshape(TP_SIZE, 1, H) - score))
-    head_value = head_value.to(torch.bfloat16)
-
-    attention_grouped = torch.zeros(TP_SIZE, O_GROUPS, local_t, O_GROUP_IN, dtype=torch.bfloat16)
-    for group in range(O_GROUPS):
-        for head in range(HEADS_PER_GROUP):
-            global_head = group * HEADS_PER_GROUP + head
-            group_col = head * HEAD_DIM
-            attention_grouped[:, group, :, group_col] = head_value[:, :, global_head]
-
-    attention_local = torch.zeros(TP_SIZE, LOCAL_O_GROUPS, group_t, O_GROUP_IN, dtype=torch.bfloat16)
-    for destination_rank in range(TP_SIZE):
-        for local_group in range(LOCAL_O_GROUPS):
-            global_group = destination_rank * LOCAL_O_GROUPS + local_group
-            group_rows = attention_grouped[:, global_group].reshape(group_t, O_GROUP_IN)
-            attention_local[destination_rank, local_group] = group_rows
-
-    partials = torch.zeros(TP_SIZE, group_t, D, dtype=torch.float32)
-    for rank in range(TP_SIZE):
-        attention = attention_local[rank].float()
-        o_a = torch.einsum("gti,gri->gtr", attention, tensors["wo_a"][rank].float())
-        row_amax = o_a.abs().amax(dim=-1, keepdim=True).clamp_min(INT8_AMAX_EPS)
-        scale_q = INT8_SCALE_MAX / row_amax
-        o_a_i8 = torch.round(o_a * scale_q).to(torch.int32).to(torch.float16).to(torch.int8)
-        scale_dq = 1.0 / scale_q
-        wo_b = tensors["wo_b"][rank].reshape(D, LOCAL_O_GROUPS, O_LORA)
-        for local_group in range(LOCAL_O_GROUPS):
-            group_i32 = o_a_i8[local_group].to(torch.int32)
-            weight_i32 = wo_b[:, local_group].to(torch.int32)
-            group_partial = group_i32 @ weight_i32.T
-            partials[rank] += group_partial.float() * scale_dq[local_group]
-        partials[rank] *= tensors["wo_b_scale"][rank].float().reshape(1, D)
-
-    reduced = partials.sum(dim=0)
-    tensors["o_local"].fill_(TP_FIXTURE_OUTPUT_SENTINEL)
-    for rank in range(TP_SIZE):
-        row_start = rank * local_t
-        tensors["o_local"][rank, :local_t] = reduced[row_start : row_start + local_t].to(torch.bfloat16)
-
-
-def build_o_local_compare(local_t):
-    """Compare valid token rows and require the poisoned capacity tail to survive."""
-    import torch
-
-    from golden import ratio_allclose
-
-    prefix_compare = ratio_allclose(
-        atol=1e-4, rtol=1.0 / 128, max_error_ratio=0.0,
-        valid_rows=local_t, valid_axis=1,
-    )
-
-    def compare(actual, expected, **kwargs):
-        actual_tail = actual[:, local_t:]
-        expected_tail = expected[:, local_t:]
-        if not torch.equal(actual_tail, expected_tail):
-            mismatch_count = int((actual_tail != expected_tail).sum().item())
-            return False, f"    inactive token tail mismatch count={mismatch_count}"
-        return prefix_compare(actual, expected, **kwargs)
-
-    compare.__name__ = f"swa_output_prefix_and_tail(local_t={local_t})"
-    return compare
-
-
 if __name__ == "__main__":
     import argparse
 
@@ -831,9 +838,9 @@ if __name__ == "__main__":
     for case in selected_cases:
         local_t = case_local_t[case]
         result = run_jit(
-            fn=l3_decode_swa_output,
+            fn=l3_decode_swa,
             specs=build_tp_tensor_specs(local_t),
-            golden_fn=golden_decode_swa_output,
+            golden_fn=golden_decode_swa,
             compile_only=args.compile_only,
             compile_cfg=dict(
                 dump_passes=args.dump_passes,


### PR DESCRIPTION
The dspark decode SWA, HCA and CSA entries each compile one TP program
for every --tp value, but their names implied a separate single-card
path, and each sparse-attention test also covered the output projection.

- Rename each TP output half to decode_swa / decode_hca / decode_csa
  with l3_ host wrappers, and the no-collective full-attention variant
  to decode_<xxa>_tp1, matching decode_o_proj_tp1
- Drop the sparse_attn_<xxa> wrapper that bundled decode_o_proj_tp1;
  sparse_attn_<xxa> is now the heads-only kernel both callers already
  wanted, and decode_<xxa>_tp1 pairs it with decode_o_proj_tp1 itself
- Scope sparse_attn_<xxa>_test to the heads: it returns them as
  [group, token, group-input] so the capacity padding is a trailing
  prefix the harness compares with ratio_allclose(valid_rows=...,
  valid_axis=1), and its fixture drops the o-proj weights
- Give decode_o_proj the same import-time --tp hook as the decode
  entries, defaulting to 2, so its CI job borrows two cards not four
- Rename the TP collectives and projection to o_group_a2a,
  decode_o_proj and o_proj_reduce_scatter; the old all_to_all name said
  token_head, but the exchanged unit is the O group
- Give o_proj_reduce_scatter its own pl.at core-group scope and a
  proj_dep argument, so the three decode entries chain it directly
  instead of restating a pl.spmd(1) wrapper
- Order each decode_<xxa>.py as kernels first (TP, then tp1), then the
  tensor specs and goldens, and sink the fixture constants with their
  capacity guards down to build_tp_tensor_specs; only the TP-local
  token-capacity contract with decode_o_proj stays in the header
- Restyle the three decode entries to one statement per line, comments
  that state what the code does, and header constants grouped with the
  pl.dynamic declarations together