### PR TITLE
Fix: port the DeepSeek-V4 MoE, hc_pre and prefill fixes to DSpark

### DIFF
--- a/models/deepseek_v4_flash_dspark/hc_pre.py
+++ b/models/deepseek_v4_flash_dspark/hc_pre.py
@@ -33,17 +33,18 @@ FUSION (unified decode + prefill): the whole op is ONE ``pl.spmd(NUM_CORES=24)``
 hard ``pl.system.syncall(core_type="mix")`` requires). The body is 3 phases separated by 2
 barriers; each barrier publishes the prior phase's cross-core HBM writes:
 
-    Phase A  cast (x BF16 -> x_fp32 FP32)  +  seed (zero mixes_raw)          AIV
-    ── syncall ──  (x_fp32 + zeroed mixes_raw visible)
-    Phase B  linear (split-K matmul -> mixes_raw, AIC)  +  rms (split-K SoS -> sq_sum_acc, AIV)
-    ── syncall ──  (sq_sum_acc + all LINEAR_OK atomic-add partials visible)
+    Phase A  linear (split-K matmul -> mixes_partials, AIC)  +  rms (split-K SoS
+             -> sq_partials, AIV)
+    ── syncall ──  (every LINEAR_OK / RMS_OK partial visible)
+    Phase B  reduce the partials in ascending K order -> mixes_raw + sq_sum_acc   AIV
+    ── syncall ──  (mixes_raw + sq_sum_acc visible)
     Phase D  per task: rsqrt(sq_sum) + scale/sigmoid GATE, then                    AIV
              comb_sinkhorn (-> comb) | mix_x (-> x_mixed) | write_post (-> post)
 
 The old Phase C (a separate rsqrt+scale+sigmoid gate pass, published by a 3rd barrier) is
 FOLDED into Phase D: since the C->D handoff was cross-core (different grid-stride striping),
 it needed a barrier -- but each D task can just recompute the ONE gate it consumes from the
-barrier-2-published mixes_raw + sq_sum_acc on its OWN core (rsqrt+sigmoid is nearly free on
+published mixes_raw + sq_sum_acc on its OWN core (rsqrt+sigmoid is nearly free on
 this latency-bound kernel). That deletes a whole hard FFTS barrier (-8% decode / -11% prefill
 on the device L2 swimlane, latency-bound so barrier removal > byte removal). comb_logits /
 post_pad_store survive only as SAME-CORE scratch (assemble then load-back, no barrier) because
@@ -115,19 +116,12 @@ LINEAR_K_CHUNK = 256  # cube K-fragment per matmul_acc (32x256x4 FP32 weight fit
 D_CHUNK = 256  # mix_x inner D-fragment (BF16 load = 1KB, 512B-aligned)
 D_SPMD = 1024  # mix_x D per spmd block: decode fans 4096 reduce over D/D_SPMD cores
 CAST_K_SPMD = 2048  # cast K per spmd block: decode fans the BF16->FP32 cast over HC_DIM/CAST_K_SPMD cores
-# Split the K=HC_DIM reduction into LINEAR_OK slices that atomic-add their FP32
-# partials, filling idle cubes at small T (decode: 1 token-tile -> LINEAR_OK
-# cube tasks) and shortening each task's matmul_acc chain. Higher OK fills more
-# decode cubes; prefill (8 token-tiles) packs OK*8 tasks into waves of ~24.
+# Split the K=HC_DIM reduction into LINEAR_OK disjoint partials.
 LINEAR_OK = 4
 LINEAR_K_PER_SPLIT = HC_DIM // LINEAR_OK
 LINEAR_CHUNKS_PER_SPLIT = LINEAR_K_PER_SPLIT // LINEAR_K_CHUNK
 
-# Split the RMS sum-of-squares K reduction over RMS_OK cores, mirroring LINEAR_OK: at decode
-# (1 token-tile) the full 16384-wide reduce is otherwise a single-lane straggler. Each
-# (token-tile, K-slice) task atomic-adds its FP32 partial sum-of-squares into sq_sum_acc
-# (zero-seeded in Phase A); Phase C reads the barrier-published total and applies rsqrt inline
-# per group (no separate inv_rms buffer / no within-phase RAW).
+# Split the RMS sum-of-squares K reduction into RMS_OK disjoint partials.
 RMS_OK = 16
 RMS_K_PER_SPLIT = HC_DIM // RMS_OK
 RMS_CHUNKS_PER_SPLIT = RMS_K_PER_SPLIT // RMS_K_CHUNK
@@ -172,6 +166,8 @@ def _hc_pre_syncall(
     # x arrives as FP32 (hc residual stream is FP32 end-to-end), so there is no x_fp32
     # staging buffer: linear / rms read x_flat directly.
     mixes_raw = pl.create_tensor([t_linear, MIX_PAD], dtype=pl.FP32)
+    linear_partial_rows = LINEAR_OK * t_linear
+    mixes_partials = pl.create_tensor([linear_partial_rows, MIX_PAD], dtype=pl.FP32)
     # post_pad_store is SAME-CORE scratch: write_post writes its token-tile's post gate then
     # reads it back on the SAME core (no barrier). It is kept (not deleted) because its
     # downstream pl.load->pl.store needs an HC_PAD-wide (32B-aligned) tile -- a narrow
@@ -185,36 +181,25 @@ def _hc_pre_syncall(
     # vs the 128-float [.,16] comb_logits round-trip this replaces).
     inv_gm = pl.create_tensor([t_linear, 1], dtype=pl.FP32)
     sq_sum_acc = pl.create_tensor([1, t_linear], dtype=pl.FP32)  # RMS split-K sum-of-squares (row layout: [1,T_TILE] tiles stay 32B-aligned)
+    sq_partials = pl.create_tensor([RMS_OK, t_linear], dtype=pl.FP32)
 
     # Per-phase grid-stride bounds (dynamic in t_dim; grid-stride round-robins any T over cores).
     tt_n = t_dim // T_TILE            # token-tiles (pre / post / comb / rsqrt / sinkhorn / write_post base)
-    cast_n = tt_n * CAST_KS           # cast fans over token-tile x K-slice
-    seed_n = t_linear // T_TILE       # seed zeros t_linear rows (includes the 8->16 pad rows)
     lin_n = (t_linear // LINEAR_T_TILE) * LINEAR_OK  # linear fans over row-block x OK K-slice
     rms_n = tt_n * RMS_OK             # rms fans over token-tile x K-slice (split-K sum-of-squares)
+    linear_reduce_n = t_linear // LINEAR_T_TILE  # linear partials reduced per row-block
+    reduce_n = linear_reduce_n + tt_n  # flattened reduce pool: linear row-blocks | rms token-tiles
     mixx_n = tt_n * MIXX_DS           # mix_x fans over token-tile x D-slice
     pool_d = 2 * tt_n + mixx_n        # phase-D flattened pool: sinkhorn(tt_n)|mix_x(mixx_n)|write_post(tt_n)
 
     with pl.spmd(NUM_CORES, name_hint="hc_pre_fused", sync_start=True, allow_early_resolve=True) as _hc_tid:  # inline form requires the TaskId capture
         core = pl.tile.get_block_idx()  # 0 .. NUM_CORES-1
 
-        # ===================== PHASE A: seed (AIV) ================================
-        # x is already FP32 (no cast); Phase A only zero-seeds mixes_raw + sq_sum_acc.
-        # Barrier 1 publishes the zeroed mixes_raw / sq_sum_acc for the Phase-B atomic-adds.
-        for aiv_id in pl.split_aiv(2, mode=pl.SplitMode.NONE):
-            lane = core * 2 + aiv_id  # 0..47
-            for tc in pl.range(lane, seed_n, NUM_CORES * 2):
-                ts0 = tc * T_TILE
-                mixes_raw = pl.assemble(mixes_raw, pl.full([T_TILE, MIX_PAD], dtype=pl.FP32, value=0.0), [ts0, 0])
-                sq_sum_acc = pl.assemble(sq_sum_acc, pl.full([1, T_TILE], dtype=pl.FP32, value=0.0), [0, ts0])
-        pl.system.syncall(core_type="mix")
-
-        # ===================== PHASE B: linear (AIC) + rms (AIV) ====================
-        # Cube split-K matmul strides over the 24 AIC; vector RMS over the 48 AIV lanes,
-        # concurrently. Barrier 2 publishes inv_rms + every LINEAR_OK atomic-add partial.
+        # Cube linear partials and vector RMS partials run concurrently.
         for task in pl.range(core, lin_n, NUM_CORES):
             t0 = (task // LINEAR_OK) * LINEAR_T_TILE
-            k_base = (task % LINEAR_OK) * LINEAR_K_PER_SPLIT
+            linear_split = task % LINEAR_OK
+            k_base = linear_split * LINEAR_K_PER_SPLIT
             t_rows = pl.min(LINEAR_T_TILE, t_dim - t0)  # last row-block spills past t_dim; valid_shape zero-fills the tail
             acc = pl.create_tensor([LINEAR_T_TILE, MIX_PAD], dtype=pl.FP32)
             for kb in pl.pipeline(0, LINEAR_CHUNKS_PER_SPLIT, stage=2):
@@ -225,23 +210,59 @@ def _hc_pre_syncall(
                     acc = pl.matmul(x_linear_chunk, w_chunk, b_trans=True, out_dtype=pl.FP32)
                 else:
                     acc = pl.matmul_acc(acc, x_linear_chunk, w_chunk, b_trans=True)
-            mixes_raw = pl.assemble(mixes_raw, acc, [t0, 0], atomic=pl.AtomicType.Add)
+            mixes_partials = pl.assemble(
+                mixes_partials,
+                acc,
+                [linear_split * t_linear + t0, 0],
+            )
         for aiv_id in pl.split_aiv(2, mode=pl.SplitMode.NONE):
             lane = core * 2 + aiv_id
             for task in pl.range(lane, rms_n, NUM_CORES * 2):
                 t0 = (task // RMS_OK) * T_TILE
-                k_base = (task % RMS_OK) * RMS_K_PER_SPLIT
+                rms_split = task % RMS_OK
+                k_base = rms_split * RMS_K_PER_SPLIT
                 sq_part = pl.full([1, T_TILE], dtype=pl.FP32, value=0.0)
                 for kb in pl.pipeline(RMS_CHUNKS_PER_SPLIT, stage=4):
                     k0 = k_base + kb * RMS_K_CHUNK
                     x_chunk = x_flat[t0:t0 + T_TILE, k0:k0 + RMS_K_CHUNK]
                     sq_part = pl.add(sq_part, pl.reshape(pl.row_sum(pl.mul(x_chunk, x_chunk)), [1, T_TILE]))
-                sq_sum_acc = pl.assemble(sq_sum_acc, sq_part, [0, t0], atomic=pl.AtomicType.Add)
+                sq_partials = pl.assemble(sq_partials, sq_part, [rms_split, t0])
+        pl.system.syncall(core_type="mix")
+
+        # Split-K partials are reduced in ascending K order.
+        for aiv_id in pl.split_aiv(2, mode=pl.SplitMode.NONE):
+            lane = core * 2 + aiv_id
+            for reduce_task in pl.range(lane, reduce_n, NUM_CORES * 2):
+                if reduce_task < linear_reduce_n:
+                    linear_t0 = reduce_task * LINEAR_T_TILE
+                    mixes_total = mixes_partials[
+                        linear_t0 : linear_t0 + LINEAR_T_TILE,
+                        0:MIX_PAD,
+                    ]
+                    for linear_split in pl.range(1, LINEAR_OK):
+                        partial_t0 = linear_split * t_linear + linear_t0
+                        mixes_total = pl.add(
+                            mixes_total,
+                            mixes_partials[
+                                partial_t0 : partial_t0 + LINEAR_T_TILE,
+                                0:MIX_PAD,
+                            ],
+                        )
+                    mixes_raw = pl.assemble(mixes_raw, mixes_total, [linear_t0, 0])
+                else:
+                    rms_t0 = (reduce_task - linear_reduce_n) * T_TILE
+                    sq_total = sq_partials[0:1, rms_t0 : rms_t0 + T_TILE]
+                    for rms_split in pl.range(1, RMS_OK):
+                        sq_total = pl.add(
+                            sq_total,
+                            sq_partials[rms_split : rms_split + 1, rms_t0 : rms_t0 + T_TILE],
+                        )
+                    sq_sum_acc = pl.assemble(sq_sum_acc, sq_total, [0, rms_t0])
         pl.system.syncall(core_type="mix")
 
         # ===================== PHASE C+D FUSED: gate + sinkhorn/mix_x/write_post (AIV) =====
         # Phase C (rsqrt + scale + sigmoid gates) is FOLDED into each Phase-D task: every
-        # task recomputes the gate it needs from the barrier-2-published mixes_raw + sq_sum_acc
+        # task recomputes the gate it needs from the published mixes_raw + sq_sum_acc
         # on its OWN core, just before using it. Recompute is nearly free here (latency-bound
         # kernel), and it deletes an entire cross-core barrier plus the pre/post/comb gate
         # round-trips -- the C->D handoff was the reason the old Barrier 3 existed. comb_logits
@@ -446,6 +467,8 @@ def _hc_pre_separate(
     # linear matmul masks them with valid_shape (zero-fill past t_dim), and rms only reads
     # the t_dim real rows.
     mixes_raw = pl.create_tensor([t_linear, MIX_PAD], dtype=pl.FP32)
+    linear_partial_rows = LINEAR_OK * t_linear
+    mixes_partials = pl.create_tensor([linear_partial_rows, MIX_PAD], dtype=pl.FP32)
 
     # rms: full-K sum-of-squares per token-tile -> inv_rms (one scope, no split-K).
     for t in pl.spmd(t_dim // T_TILE, name_hint="hc_pre_rms", allow_early_resolve=True):
@@ -458,18 +481,11 @@ def _hc_pre_separate(
         inv = pl.reshape(pl.rsqrt(pl.add(pl.mul(sq_sum, HC_DIM_INV), NORM_EPS), high_precision=True), [T_TILE, 1])
         inv_rms = pl.assemble(inv_rms, inv, [t0, 0])
 
-    # seed: zero mixes_raw for the split-K atomic-add accumulation. ONE task (single InCore
-    # region) loops the t_linear // T_TILE row-blocks internally, instead of fanning them out.
-    # On-core (not create_tensor init_value=0): AICPU init serializes on the scheduler and
-    # roughly doubles the decode orch window, whereas the on-core memset overlaps.
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="hc_pre_seed", allow_early_resolve=True):
-        for ts0 in pl.range(0, t_linear, T_TILE):
-            mixes_raw[ts0:ts0 + T_TILE, 0:MIX_PAD] = pl.full([T_TILE, MIX_PAD], dtype=pl.FP32, value=0.0)
-
-    # linear: split-K matmul; each (row-block, K-slice) atomic-adds its FP32 partial.
+    # Linear split-K partials are reduced in ascending K order.
     for task in pl.spmd((t_linear // LINEAR_T_TILE) * LINEAR_OK, name_hint="hc_pre_linear", allow_early_resolve=True):
         t0 = (task // LINEAR_OK) * LINEAR_T_TILE
-        k_base = (task % LINEAR_OK) * LINEAR_K_PER_SPLIT
+        linear_split = task % LINEAR_OK
+        k_base = linear_split * LINEAR_K_PER_SPLIT
         t_rows = pl.min(LINEAR_T_TILE, t_dim - t0)  # last row-block spills past t_dim; valid_shape zero-fills the tail
         acc = pl.create_tensor([LINEAR_T_TILE, MIX_PAD], dtype=pl.FP32)
         for kb in pl.pipeline(0, LINEAR_CHUNKS_PER_SPLIT, stage=2):
@@ -480,7 +496,22 @@ def _hc_pre_separate(
                 acc = pl.matmul(x_linear_chunk, w_chunk, b_trans=True, out_dtype=pl.FP32)
             else:
                 acc = pl.matmul_acc(acc, x_linear_chunk, w_chunk, b_trans=True)
-        mixes_raw = pl.assemble(mixes_raw, acc, [t0, 0], atomic=pl.AtomicType.Add)
+        mixes_partials = pl.assemble(mixes_partials, acc, [linear_split * t_linear + t0, 0])
+
+    for linear_block in pl.spmd(
+        t_linear // LINEAR_T_TILE,
+        name_hint="hc_pre_linear_reduce",
+        allow_early_resolve=True,
+    ):
+        linear_t0 = linear_block * LINEAR_T_TILE
+        mixes_total = mixes_partials[linear_t0 : linear_t0 + LINEAR_T_TILE, 0:MIX_PAD]
+        for linear_split in pl.range(1, LINEAR_OK):
+            partial_t0 = linear_split * t_linear + linear_t0
+            mixes_total = pl.add(
+                mixes_total,
+                mixes_partials[partial_t0 : partial_t0 + LINEAR_T_TILE, 0:MIX_PAD],
+            )
+        mixes_raw = pl.assemble(mixes_raw, mixes_total, [linear_t0, 0])
 
     # split_pre_post: inv_rms-scaled pre gate -> pre_val_store (for mix_x), post gate -> post.
     # Both compute at HC_PAD width; post narrows to HC_MULT via a valid-shape slice (an 8-wide
@@ -701,10 +732,7 @@ def _golden_a2a3_cube_linear(x_flat_2d, hc_fn):
         for group in range(group_dots.shape[-1]):
             split_mixes = (split_mixes.double() + group_dots[..., group]).float()
 
-    # Atomic completion order is not a semantic guarantee.  Canonical split
-    # order is the deterministic golden representative.  Other legal orders
-    # differ by only a few FP32 ULPs; the output tolerances cover the rare case
-    # where that difference crosses a BF16 boundary.
+    # Match the kernel's ascending split order.
     mixes = torch.zeros(t_dim, MIX_HC, dtype=torch.float32)
     for split in range(LINEAR_OK):
         mixes += split_mixes[..., split]

--- a/models/deepseek_v4_flash_dspark/moe.py
+++ b/models/deepseek_v4_flash_dspark/moe.py
@@ -200,7 +200,7 @@ def dispatch(
     # loc_e on EVERY destination rank, so the blocking cross-rank puts fan out
     # across N_LOCAL cores. One slot counter per destination rank; token-major
     # order matches the meta pass's per-(dst, loc_e) cumulative count.
-    with pl.spmd(N_LOCAL, name_hint="dispatch_push", allow_early_resolve=True):
+    with pl.spmd(N_LOCAL, name_hint="dispatch_push", allow_early_resolve=True) as _push_tid:
         loc_e = pl.tile.get_block_idx()
         active_tokens = pl.cast(num_tokens, pl.INDEX)
         if active_tokens < 0:
@@ -262,7 +262,12 @@ def dispatch(
     # with dispatch_push instead of trailing dispatch_meta's spin. Anchor it to
     # something -- an unanchored wait is dispatched immediately and spins holding a
     # core group, so pipelined layers stack up spinners.
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="dispatch_wait", allow_early_resolve=True) as _wait_tid:
+    with pl.at(
+        level=pl.Level.CORE_GROUP,
+        name_hint="dispatch_wait",
+        deps=[_push_tid],
+        allow_early_resolve=True,
+    ) as _wait_tid:
         _idx_anchor = pl.read(indices, [0, 0])
         for src in pl.range(N_RANKS):
             if src != my_rank:
@@ -282,7 +287,8 @@ def dispatch(
         N_LOCAL,
         name_hint="dispatch_gather",
         deps=[_wait_tid, _meta_tid],
-        allow_early_resolve=True,
+        # Keep the routed expert tasks off the cores until this gather retires.
+        allow_early_resolve=False,
     ) as _gather_tid:
         e = pl.tile.get_block_idx()
         e_base_row = e * RECV_MAX
@@ -300,6 +306,8 @@ def dispatch(
                 pl.write(recv_r_route_out, [e, out_col], pl.read(recv_route, [in_row, 0]))
             b = b + n
 
+    return _push_tid
+
 
 # === Combine =================================================================
 # Push recv_y rows back to their origin rank keyed by r_route, barrier, then a
@@ -316,6 +324,7 @@ def combine(
     num_tokens: pl.Scalar[pl.INT32],
     my_rank: pl.Scalar[pl.INT32],
     moe_epoch: pl.Scalar[pl.INT32],
+    dispatch_push_tid: pl.Scalar[pl.TASK_ID],
 ):
     recv_y_flat = pl.reshape(recv_y, [N_LOCAL * RECV_MAX, D])
     # One SPMD block per LOCAL EXPERT: block e pushes expert e's compact rows back to
@@ -323,9 +332,9 @@ def combine(
     # Rows are src-major, so the per-(e, src) base is a loop-carried prefix sum over
     # src inside the block (same shape as dispatch_gather). Each route maps to a
     # unique (dst, loc_e) and r_route, so the blocks' puts are write-disjoint.
-    # allow_early_resolve: shared_routed pre-stages only when every producer of its
-    # fanin is flagged, and combine_wait already is.
-    with pl.spmd(N_LOCAL, name_hint="combine", allow_early_resolve=True):
+    # Keep the scatter TaskId so the arrival handshake cannot occupy AIV cores
+    # until every routed_y_buf put from this rank has completed.
+    with pl.spmd(N_LOCAL, name_hint="combine") as _combine_tid:
         e = pl.tile.get_block_idx()
         e_base_row = e * RECV_MAX
         b = pl.cast(0, pl.INDEX)
@@ -344,11 +353,14 @@ def combine(
                 )
             b = b + n
 
-        # Payload-arrival notify folded into the scatter (mirrors dispatch_push):
-        # each block signals every peer after its own puts, so the wait below expects
-        # N_LOCAL * moe_epoch. Saves a task launch on the cross-rank critical path.
-        # The [1, D] puts above are single-shot TPUTs, which drain themselves before
-        # this notify issues.
+    # Publish only after the complete scatter grid. Keeping this cross-rank wait
+    # out of the speculative early-dispatch chain prevents it and shared_routed
+    # from reserving the AIV cores needed by the scatter itself.
+    with pl.at(
+        level=pl.Level.CORE_GROUP,
+        name_hint="combine_wait",
+        deps=[_combine_tid, dispatch_push_tid],
+    ) as _cwait_tid:
         for peer in pl.range(N_RANKS):
             if peer != my_rank:
                 pld.system.notify(
@@ -359,20 +371,12 @@ def combine(
                     op=pld.NotifyOp.AtomicAdd,
                 )
 
-    # Wait only (the notify rides inside the scatter), so it spins on the peers'
-    # counters while our own scatter runs. The recv_y_flat read is an anchor, not
-    # data: it auto-deps this task on exp_w2_act, starting the wait when the scatter
-    # starts. Anchor it to something -- a wait with no dep at all is dispatched the
-    # moment the scheduler reaches it and spins holding a core group, so pipelined
-    # layers stack up spinners that starve the scatters they wait on.
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="combine_wait", allow_early_resolve=True) as _cwait_tid:
-        _recv_y_anchor = pl.read(recv_y_flat, [0, 0])
         for src in pl.range(N_RANKS):
             if src != my_rank:
                 pld.system.wait(
                     signal=combine_arrived,
                     offsets=[src, 0],
-                    expected=pl.cast(moe_epoch * N_LOCAL, pl.INT32),
+                    expected=moe_epoch,
                     cmp=pld.WaitCmp.Ge,
                 )
 
@@ -388,7 +392,6 @@ def combine(
         T,
         name_hint="shared_routed",
         deps=[_cwait_tid],
-        allow_early_resolve=True,
     ) as _reduce_tid:
         t = pl.tile.get_block_idx()
         if t < active_tokens:
@@ -476,7 +479,7 @@ def moe(
     recv_r_route_out = pl.create_tensor([N_LOCAL, RECV_MAX], dtype=pl.INT32, manual_dep=True)
     recv_count_out = pl.create_tensor([N_LOCAL, 1], dtype=pl.INT32)
     recv_meta_local = pl.create_tensor([N_RANKS, N_LOCAL], dtype=pl.INT32, manual_dep=True)
-    dispatch(
+    dispatch_push_tid = dispatch(
         indices, x_norm_i8, x_norm_scale, weights,
         recv_x_out, recv_scale_out, recv_w_out, recv_r_route_out, recv_count_out, recv_meta_local,
         recv_meta, recv_x, recv_aux, recv_route, arrived, data_arrived,
@@ -497,7 +500,7 @@ def moe(
             recv_y, recv_r_route_out, sh,
             ffn_out, recv_meta_local,
             routed_y_buf, combine_arrived,
-            num_tokens, my_rank, moe_epoch,
+            num_tokens, my_rank, moe_epoch, dispatch_push_tid,
         )
 
         hc_post(ffn_out, x_hc, post_ffn, comb_ffn, x_next)

--- a/models/deepseek_v4_flash_dspark/prefill_csa.py
+++ b/models/deepseek_v4_flash_dspark/prefill_csa.py
@@ -585,7 +585,9 @@ def build_tensor_specs(
             f"needs {max_visible_cmp} scored compressed positions; the indexer score "
             f"cap is {INDEXER_SCORE_CAP} and the tail past it is silently dropped"
         )
-    max_sparse_rows = WIN + max_visible_cmp
+    # The sparse rows are the window plus what the indexer actually emits, which
+    # is its top-k, not every visible compressed position.
+    max_sparse_rows = WIN + min(max_visible_cmp, IDX_TOPK)
     if max_sparse_rows > SPARSE_PREFILL_SPARSE_PAD:
         raise ValueError(
             f"needs {max_sparse_rows} sparse rows; current packed sparse CSA cap is {SPARSE_PREFILL_SPARSE_PAD}"

--- a/models/deepseek_v4_flash_dspark/prefill_indexer.py
+++ b/models/deepseek_v4_flash_dspark/prefill_indexer.py
@@ -94,8 +94,8 @@ QH_MM_TILE = 64
 # columns; the rest stays -inf.
 SORT_LEN = 2048
 # topk_pairs (= 2*PREFILL_TOPK_CAP) must be a power of two aligned to the final mrgsort run: a
-# misaligned prefix (e.g. 2*192) faults like a narrow sort. The real score cap is 256, so two
-# merge stages are sufficient: the only finite values are sorted within the first 512-value run.
+# misaligned prefix (e.g. 2*192) faults like a narrow sort. Two merge stages order the first
+# 512-value run, which covers a 256-wide score; past that the 1024 stage below is required.
 PREFILL_TOPK_CAP = INDEXER_TOPK_CAP
 TOPK_PAIR_WIDTH = 2 * PREFILL_TOPK_CAP
 SCORE_INIT_TILE = 16                   # rows per -inf init write; keeps [tile, SORT_LEN] under the Vec limit
@@ -339,13 +339,16 @@ def prefill_indexer(
                 pos = pl.read(position_ids, [t])
                 visible_t = pl.min((pos + 1) // COMPRESS_RATIO, INDEXER_SCORE_CAP)
                 if visible_t > 0:
-                    # Sort the wide score row and gather the top-k indices. Only the first 256
-                    # values can be finite, so the 64/256 merge stages fully order the useful run.
+                    # Sort the wide score row and gather the top-k indices. The finite values
+                    # occupy the first INDEXER_SCORE_CAP columns; the merge stages must order
+                    # that whole prefix, so a cap past 256 takes the 1024 stage as well.
                     score_row = score_wide[t : t + 1, :]
                     idx_init = pl.arange(0, [1, SORT_LEN], dtype=pl.UINT32)
                     sorted_tile = pl.sort32(score_row, idx_init)
                     sorted_tile = pl.mrgsort(sorted_tile, block_len=64)
                     sorted_tile = pl.mrgsort(sorted_tile, block_len=256)
+                    if INDEXER_SCORE_CAP > 256:
+                        sorted_tile = pl.mrgsort(sorted_tile, block_len=1024)
                     topk_pairs = sorted_tile[:, 0:TOPK_PAIR_WIDTH]
                     topk_idxs_tile = pl.gather(topk_pairs, mask_pattern=pl.tile.MaskPattern.P1010, output_dtype=pl.INT32)
                     valid_topk = pl.min(PREFILL_TOPK_CAP, visible_t)


### PR DESCRIPTION
The dspark directory forked from deepseek_v4_flash_mtp before #893 and
#953 landed, so it still carries the MoE handshake, split-K and indexer
sort behaviour those two fixed. This ports their dspark-applicable
parts; the stacked YaRN RoPE tables from #953 are not included, since
they live in the decode_fwd / prefill_fwd routing dspark does not have
yet.

- Declare dispatch_push -> dispatch_wait and drop the pre-resolve on
  dispatch_gather, so a blocking waiter cannot hold a core group while
  the local notifier still has blocks parked in that core's pending
  slot. Without those edges EP8 prefill deadlocks once a request runs
  enough all-to-all rounds, and dspark runs EP16.
- Publish the MoE combine arrivals from a combine_wait scope gated on
  the whole scatter grid and on dispatch_push, instead of folding one
  notify into each scatter block, so the wait expects moe_epoch rather
  than moe_epoch * N_LOCAL. The combine scatter, its wait and
  shared_routed lose allow_early_resolve, so the cross-rank handshake
  cannot reserve the AIV cores the scatter itself needs. moe.py is now
  identical to the mtp file apart from the EP naming and the
  16-experts-per-rank split.
- Replace the FP32 AtomicAdd accumulation in hc_pre's linear and RMS
  split-K paths with disjoint per-split partial buffers reduced in
  ascending K order, in both the fused and the separate implementation,
  and retire the zero-seed phase the atomics required. AtomicAdd sums
  the partials in task-completion order, which is neither fixed nor
  associative, so the same greedy request can diverge and then compound
  autoregressively over a long decode. The golden follows the same
  ascending order.
- Add the block_len=1024 merge stage to the prefill indexer top-k when
  INDEXER_SCORE_CAP exceeds 256. dspark sizes the cap as
  2 * T / COMPRESS_RATIO, so it is exactly 256 at the checked-in
  PREFILL_SEQ=512 and larger for any longer chunk; past 256 the 64/256
  stages leave the score prefix partially ordered and the top-k
  silently picks the wrong keys. The CP score path already carries this
  stage for its 1024-wide cap.
- Bound the packed sparse CSA rows by what the indexer actually emits,
  WIN + min(max_visible_cmp, IDX_TOPK), so build_tensor_specs stops
  refusing prompts that fit.

The hc_pre reduction costs the determinism it buys: on a2a3, 100 rounds
after 5 warmup, the 512-row prefill case goes from 167.0 to 199.5 us
minimum over two runs, while the 128-row decode case is unchanged.