### PR TITLE
Fix: keep the DeepSeek-V4 fused MTP decode rank-major InOut metadata resident

### DIFF
--- a/models/deepseek_v4_flash_mtp/decode_fwd_mtp.py
+++ b/models/deepseek_v4_flash_mtp/decode_fwd_mtp.py
@@ -896,6 +896,13 @@ def build_tensor_specs(
             continue
         specs[f"mtp_{name}"] = replace(spec, name=f"mtp_{name}")
 
+    # Rank-major InOut metadata stays device-resident. A host-resident arg is keyed
+    # by buffer identity alone, so both ranks collide on one tensormap key and their
+    # dispatches serialize, deadlocking the cross-rank rendezvous. Revert once
+    # hw-native-sys/pypto#2448 makes the host key rank-aware.
+    for name in ("input_ids", "position_ids", "kv_seq_lens", "mtp_tail_token_ids", "mtp_tail_positions"):
+        specs[name] = replace(specs[name], resident="stacked")
+
     param_names = l3_decode_fwd_mtp._param_names()
     missing = set(param_names) - specs.keys()
     extra = specs.keys() - set(param_names)


### PR DESCRIPTION
## Summary

`models/deepseek_v4_flash_mtp/decode_fwd_mtp.py` hangs on 2 cards with
`orch_error_code=8 TENSOR_WAIT_TIMEOUT` (`sub_class=S1:running-stalled`,
`completed=73/0 running=3 ready=0 waiting=0`). It is currently the only red case in the
`a2a3` job for changes touching this model — the other eight `deepseek_v4_flash_mtp`
entries pass — so PRs that never touch the cross-rank path inherit it.

The hang is **not** ours: a clean `main` checkout reproduces it, and the same commit
passes on the pre-Buffer-ABI toolchain. Root cause and both confirming probes are in
hw-native-sys/pypto#2448.

## What is wrong

The generated `orchestration/host_orch.py` binds 16 rank-major shared tensors `INOUT`,
one dispatch per rank. The runtime keys a dispatch arg by address space:

- DEVICE → `local_child(hash(identity), worker_id)` — carries the rank
- HOST → `local_host(hash(identity))` — `worker_id = -1`, does not

`INOUT` both looks up the key's producer (taking an edge) and inserts itself as the new
one. So for a **host** arg shared by both ranks, rank 0 registers as producer and rank 1
takes a `rank0 -> rank1` edge — while rank 0's kernel spins on rank 1's cross-rank notify
that the held-back dispatch can never send.

Of this program's 16 `INOUT` args, 11 are device-resident and unaffected; 5 stay host-side
and collide: `input_ids`, `position_ids`, `kv_seq_lens`, `mtp_tail_token_ids`,
`mtp_tail_positions`.

The two groups differ in **no** DSL-visible respect — same `pl.InOut[[N_RANKS, ...]]`
declaration, same disjoint `x[r]` slicing, same read-modify-write semantics. What separates
them is only this file's `TensorSpec(resident=...)` flag, which decides whether
`make_tensor_arg` takes the `DeviceTensor` branch or the host `torch_interop` branch.

## The change

Mark those five `resident="stacked"`, moving them onto the rank-aware key. Seven lines in
`build_tensor_specs`, no kernel or DSL change.

## Verification

Probed against the **unmodified** generated `host_orch.py`, all 16 `INOUT` bindings intact —
the only variable is which address space the five tensors live in:

| | a2a3, 2 cards |
|---|---|
| before | hang, `TENSOR_WAIT_TIMEOUT` |
| after | `[RUN] PASS (146.75s)` |

An independent probe in the opposite direction (drop the `lookup` by tagging those same five
`OUTPUT_EXISTING` in the generated orchestration, address space unchanged) also clears the
hang — `PASS (170.36s)`. Details in hw-native-sys/pypto#2448.

## Revert condition

This is a workaround, not a fix: the residency of a fixture tensor should not decide whether
a program deadlocks. Revert it once pypto#2448 makes the host key rank-aware.
