### PR TITLE
CI: pin the pypto revision instead of tracking its HEAD

### DIFF
--- a/.github/actions/pypto-serving-tests/action.yml
+++ b/.github/actions/pypto-serving-tests/action.yml
@@ -83,6 +83,25 @@ runs:
         echo "pypto-lib under test: $(git -C "$PYPTO_SERVING_CHECKOUT/pypto-lib" rev-parse HEAD)"
         echo "pypto-serving base:  $(git -C "$PYPTO_SERVING_CHECKOUT" rev-parse HEAD)"
 
+    - name: Verify the pinned pypto is what serving will run
+      # The serving jobs get their pypto from setup-ci-job like every other job,
+      # so they inherit PYPTO_PIN — but they are the only ones that then run
+      # someone else's test suite against it, and they are the most expensive
+      # thing to discover a wrong toolchain in (8 cards, ~30 min). Assert the
+      # build tree is still at the pin before spending that.
+      shell: bash
+      run: |
+        if [ -z "${PYPTO_PIN:-}" ] || [ -z "${PYPTO_SRC:-}" ]; then
+          echo "::error::PYPTO_PIN/PYPTO_SRC are unset — run setup-ci-job first"
+          exit 1
+        fi
+        actual=$(git -C "$PYPTO_SRC" rev-parse HEAD)
+        if [ "$actual" != "$PYPTO_PIN" ]; then
+          echo "::error::serving would run pypto $actual, not the pinned $PYPTO_PIN"
+          exit 1
+        fi
+        echo "serving runs pypto $actual (pinned)"
+
     - name: Install pypto-serving test dependencies
       shell: bash
       working-directory: ${{ inputs.pypto-lib-checkout-path }}

--- a/.github/actions/setup-ci-job/action.yml
+++ b/.github/actions/setup-ci-job/action.yml
@@ -350,6 +350,9 @@ runs:
           echo "PTOAS_ARCH=$PTOAS_ARCH"
           echo "PTOAS_SHA256=$PTOAS_SHA256"
           echo "PTO_ISA_COMMIT=$(tr -d '[:space:]' < "$PYPTO_SRC/runtime/pto_isa.pin")"
+          # Exported so later steps in the same job can assert what they build
+          # on — the pypto-serving action checks it before spending a device.
+          echo "PYPTO_PIN=$PYPTO_PIN"
         } >> "$GITHUB_ENV"
 
     - name: Check NPU

--- a/.github/actions/setup-ci-job/action.yml
+++ b/.github/actions/setup-ci-job/action.yml
@@ -269,6 +269,10 @@ runs:
       # so the toolchain pins and the installed pypto are always the same
       # revision. pypto owns ptoas (toolchain/versions.env) and pins pto-isa via
       # its runtime submodule (runtime/pto_isa.pin); read both.
+      #
+      # The revision is PINNED (PYPTO_PIN below), not pypto's HEAD: CI must fail
+      # on pypto-lib changes only, and an upstream regression otherwise turns
+      # every open PR red at once with no way to tell the two apart.
       shell: bash
       run: |
         # $PYPTO_SRC is the per-job build tree exported by the loader step:
@@ -294,19 +298,35 @@ runs:
             sleep $((attempt * 10))
           done
         }
+        # The pypto revision CI builds against. Bump this deliberately, in its
+        # own PR, so the toolchain move is reviewable and revertable on its own.
+        #
+        # 33ff8b49 is the commit before pypto #2273 ("adapt soft SYNCALL and
+        # Simpler Buffer ABIs"), which bumps the simpler submodule 3165cc89 ->
+        # 1f27a157. From that bump on, any two-rank program whose first
+        # cross-rank step is a push/notify + spin-wait pair hangs: the waiting
+        # AIV task never completes and the peer times out on the release
+        # barrier. That is every multi-card model entry in ci.yml and
+        # daily_ci.yml, so unrelated pypto-lib PRs inherit a red CI they cannot
+        # fix. Raise the pin again once the hang is fixed upstream.
+        PYPTO_PIN=33ff8b4974b98b3a529fea3c8443292f97b8ae4d
         if [ -d "$PYPTO_SRC/.git" ]; then
-          echo "Cache hit — updating pypto"
-          retry git -C "$PYPTO_SRC" fetch --depth=1 origin HEAD || exit 1
-          git -C "$PYPTO_SRC" reset --hard FETCH_HEAD
-          git -C "$PYPTO_SRC" clean -ffdx
-          git -C "$PYPTO_SRC" submodule foreach --recursive 'git reset --hard && git clean -ffdx' || true
+          echo "Cache hit — updating pypto to $PYPTO_PIN"
         else
-          echo "Cache miss — cloning pypto"
+          echo "Cache miss — seeding pypto repo"
           mkdir -p "$(dirname "$PYPTO_SRC")"
-          # rm before each attempt so a retried clone never hits a partial dir.
-          clone_pypto() { rm -rf "$PYPTO_SRC"; git clone --depth=1 https://github.com/hw-native-sys/pypto.git "$PYPTO_SRC"; }
-          retry clone_pypto || exit 1
+          rm -rf "$PYPTO_SRC"
+          git init -q "$PYPTO_SRC"
+          git -C "$PYPTO_SRC" remote add origin https://github.com/hw-native-sys/pypto.git
         fi
+        # Fetch the pinned commit itself rather than a branch tip, so the cached
+        # tree is the same revision on a cache hit and a cache miss alike. Still
+        # --depth=1: a pin needs one commit, not the history behind it.
+        retry git -C "$PYPTO_SRC" fetch --depth=1 origin "$PYPTO_PIN" || exit 1
+        git -C "$PYPTO_SRC" reset --hard FETCH_HEAD
+        git -C "$PYPTO_SRC" clean -ffdx
+        git -C "$PYPTO_SRC" submodule foreach --recursive 'git reset --hard && git clean -ffdx' || true
+        echo "pypto at $(git -C "$PYPTO_SRC" rev-parse HEAD)"
         retry git -C "$PYPTO_SRC" submodule update --init --recursive --depth=1 || exit 1
         rm -rf "$PYPTO_SRC/build" "$PYPTO_SRC/_skbuild" "$PYPTO_SRC/runtime/build"
         # PTOAS ships one wheel per arch, with a matching PTOAS_SHA256_<ARCH> in


### PR DESCRIPTION
Every self-hosted job resolves its toolchain from the pypto clone that
`setup-ci-job` keeps in `ci-cache/`, and that clone tracked pypto's default
branch: a `--depth=1` clone on a cache miss, `fetch origin HEAD` on a cache
hit. CI therefore ran against whatever pypto had merged that morning, so an
upstream regression turns every open pypto-lib PR red at once and the failure
is indistinguishable from one the PR itself caused.

- Add `PYPTO_PIN` to the "Resolve toolchain + sync pypto source" step and
  fetch that commit directly
- Collapse the cache-hit and cache-miss paths onto that one fetch: a miss now
  seeds an empty repo with the remote and falls through, instead of running a
  separate `git clone`

The two paths previously differed in what they produced and in what the
transient-TLS `retry` wrapped; one pinned fetch keeps the retry around the
single network step and drops the duplicated reset/clean block.

The pin is
[`33ff8b49`](https://github.com/hw-native-sys/pypto/commit/33ff8b4974b98b3a529fea3c8443292f97b8ae4d),
the commit before pypto #2273 ("adapt soft SYNCALL and Simpler Buffer ABIs"),
which moves the simpler submodule `3165cc89` → `1f27a157`. From that bump on,
a two-rank program whose first cross-rank step is a push/notify + spin-wait
pair hangs: the waiting AIV task never completes, the scheduler reports no
runnable work, and the peer rank times out on the release barrier
(`S1:running-stalled`, then `Emergency shutdown: 1 cores did not acknowledge
exit`). That is every multi-card model entry in `ci.yml` and `daily_ci.yml`.
A clean `main` worktree passes those entries on the pinned revision and hangs
on the current one.

Toolchain resolution is unchanged in kind: ptoas (v0.57 at this pin) and the
pto-isa commit are still read out of the pinned checkout, so the installed
pypto and the pins still match by construction. Bumping is a one-line edit of
`PYPTO_PIN` in its own PR — which is the point: the toolchain move becomes
reviewable and revertable on its own. Raise it once the cross-rank hang is
fixed upstream.

The serving jobs inherit the pin the same way — `setup-ci-job` is where their
pypto comes from too — but nothing said so, and they are the one place that
runs an external test suite against our toolchain, on up to 8 cards for up to
30 minutes. The second commit exports `PYPTO_PIN` into the job environment
next to `PTOAS_VERSION` / `PTO_ISA_COMMIT` and has the pypto-serving action
compare the build tree's HEAD against it before installing anything, so a
serving run on some other pypto fails in seconds with both revisions named
instead of burning a device lease.
