### PR TITLE
CI: exclude only *_draft.py, not every path containing "draft"

### DIFF
--- a/.github/scripts/detect_changes.py
+++ b/.github/scripts/detect_changes.py
@@ -75,7 +75,7 @@ def _iter_source_files():
     for root in SOURCE_ROOTS:
         for dirpath, _, files in os.walk(root):
             for name in files:
-                if name.endswith(".py") and "draft" not in name:
+                if name.endswith(".py") and not name.endswith("_draft.py"):
                     yield os.path.join(dirpath, name)
 
 
@@ -164,7 +164,7 @@ def select_runnable(changed):
         c
         for c in changed
         if c.endswith(".py")
-        and "draft" not in os.path.basename(c)
+        and not c.endswith("_draft.py")
         and c.startswith("models/")
         and not c.startswith("models/deepseek_v4_pro/")
         and os.path.isfile(c)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,7 +199,7 @@ jobs:
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             FILES="${{ needs.detect-changes.outputs.files }}"
           else
-            FILES=$(find examples -name '*.py' ! -name '*draft*' | sort)
+            FILES=$(find examples -name '*.py' ! -name '*_draft.py' | sort)
           fi
           if [ -z "$FILES" ]; then
             echo "No runnable changed files; nothing to test."
@@ -300,7 +300,7 @@ jobs:
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             FILES="${{ needs.detect-changes.outputs.files }}"
           else
-            FILES=$(find examples -name '*.py' ! -name '*draft*' | sort)
+            FILES=$(find examples -name '*.py' ! -name '*_draft.py' | sort)
           fi
           if [ -z "$FILES" ]; then
             echo "No runnable changed files; nothing to test."

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -93,7 +93,7 @@ jobs:
           # Run every model file once with no extra args. Files marked
           # `# ci: no-sim` (full multi-layer / multi-card forwards) are
           # device-only and would just argparse-reject *sim, so skip them here.
-          for f in $(find models -name '*.py' ! -name '*draft*' \
+          for f in $(find models -name '*.py' ! -name '*_draft.py' \
               ! -path 'models/deepseek_v4_pro/*' | sort); do
             # Shared modules (config.py, helper libs) have no __main__ guard —
             # they are imported by kernels, not run. Running them import-exits 0
@@ -251,7 +251,7 @@ jobs:
             echo "::endgroup::"
           }
           # Run every model file once at its default world size (ep2 / 2-card).
-          for f in $(find models -name '*.py' ! -name '*draft*' \
+          for f in $(find models -name '*.py' ! -name '*_draft.py' \
               ! -path 'models/deepseek_v4_pro/*' | sort); do
             # Skip shared modules with no __main__ guard (config.py, helper libs):
             # they are imported, not run, so they don't belong in the report.
@@ -439,7 +439,7 @@ jobs:
             echo "::endgroup::"
           }
           # Sweep ONLY the V4-Pro variant — its dedicated A5 daily set.
-          for f in $(find models/deepseek_v4_pro -name '*.py' ! -name '*draft*' \
+          for f in $(find models/deepseek_v4_pro -name '*.py' ! -name '*_draft.py' \
               ! -name 'synthetic_token_loop.py' | sort); do
             # Skip shared modules with no __main__ guard (config.py, helper
             # libs): they are imported, not run.


### PR DESCRIPTION
## Problem

The draft-file filter is written as `*draft*` (`find`) and `"draft" not in name`
(`detect_changes.py`), but the documented convention — README, `docs/get-started/index.md`,
`docs/models/index.md` — is that **files ending in `_draft.py`** are works in progress
excluded from CI.

The broader pattern also swallows `models/deepseek_v4_flash_dspark/dspark_drafter.py`,
a shipping kernel. It was silently absent from both nightly model sweeps and never
selected by PR change detection, so nothing has ever exercised it in CI.

## Change

Match on the `_draft.py` suffix in all seven places:

- `.github/workflows/ci.yml` — 2 example sweeps
- `.github/workflows/daily_ci.yml` — sim, a2a3 and V4-Pro model sweeps
- `.github/scripts/detect_changes.py` — import-graph walk and PR model selection

## Selection delta

Newly covered:

```
models/deepseek_v4_flash_dspark/dspark_drafter.py
```

Still excluded (all five genuine drafts):

```
models/deepseek_v4_flash_mtp/prefill_cp_fwd_draft.py
models/qwen3_14b/decode_ssn_draft.py
models/qwen3_14b/decode_tq_draft.py
models/qwen3_14b/prefill_tq_draft.py
models/qwen3_32b/prefill_draft.py
```

## Testing

- Both workflow files parse as YAML; `detect_changes.py` walks 160 source files with
  zero `_draft.py` entries and `dspark_drafter.py` present in the graph.
- `dspark_drafter.py` run at the daily-CI a2a3 settings via task-submit (2 cards,
  `-p a2a3`): **PASS** in 39.95 s, all four outputs (`initial_hidden`,
  `intermediate_hidden`, `kv_caches`, `head_hidden`) validated.
- `python models/deepseek_v4_flash_dspark/dspark_drafter.py -p a2a3sim`: **PASS**
  in 48.90 s, well inside the sim sweep's 300 s per-case timeout.

Note for follow-up (not changed here): the drafter's argparse offers only
`a2a3`/`a2a3sim`, so the `a5sim` leg of the nightly sim matrix will argparse-reject it.
`models/deepseek_v4_flash_dspark/dspark_markov.py` already has that same gap today.
