### PR TITLE
Docs: add scheduling and ring-heap guides, rework installation

### DIFF
--- a/.claude/skills/create-issue/SKILL.md
+++ b/.claude/skills/create-issue/SKILL.md
@@ -104,12 +104,17 @@ git -C "$PYPTO_ROOT/runtime" branch --show-current   # often empty (detached)
 git -C "$PTO_ISA_ROOT" rev-parse --short HEAD
 git -C "$PTO_ISA_ROOT" branch --show-current         # often empty (detached)
 
-# ptoas version
-ptoas_bin="$PTOAS_ROOT/ptoas"
-if [ ! -f "$ptoas_bin" ] || [ ! -x "$ptoas_bin" ]; then
-  ptoas_bin="$PTOAS_ROOT/bin/ptoas"
-fi
-if [ -f "$ptoas_bin" ] && [ -x "$ptoas_bin" ]; then
+# ptoas version. Probe in pypto's own order (backend/_ptoas_locate.py): the
+# three entries are not interchangeable, and from v0.55 only ptoas.sh selects
+# the CPython the release bundles — bin/ptoas dies on the caller's interpreter.
+ptoas_bin=""
+for rel in ptoas ptoas.sh bin/ptoas; do
+  if [ -f "$PTOAS_ROOT/$rel" ] && [ -x "$PTOAS_ROOT/$rel" ]; then
+    ptoas_bin="$PTOAS_ROOT/$rel"
+    break
+  fi
+done
+if [ -n "$ptoas_bin" ]; then
   "$ptoas_bin" --version
 else
   echo "not found"

--- a/.claude/skills/setup-env/SKILL.md
+++ b/.claude/skills/setup-env/SKILL.md
@@ -31,11 +31,11 @@ this skill.
 4. Follow the installation guide and derive every dependency from the selected
    PyPTO revision:
    - initialize PyPTO submodules;
-   - derive the PTOAS version/checksum and PTO ISA commit from that exact PyPTO
-     revision;
-   - check out PTO ISA at the pin;
-   - install PyPTO;
-   - verify the PTOAS checksum before extraction.
+   - take `PTOAS_VERSION` from that revision's `toolchain/versions.env`, never
+     from a log or a previous session;
+   - install PyPTO, then unpack that PTOAS release under `PTOAS_ROOT`;
+   - leave PTO ISA alone unless the user maintains their own checkout — PyPTO
+     and simpler each clone and pin one on first use.
 5. For a device environment, source the selected CANN `set_env.sh` and run
    `npu-smi info` before installing simpler. Simpler detects `ccec` and the
    cross-compiler during installation and only prebuilds the platforms whose
@@ -49,12 +49,14 @@ this skill.
 8. For a device environment, use only a device allocated to the user.
 9. Verify:
    - `import pypto`, `import torch`, and imports from `golden`;
-   - one supported PTOAS executable (`ptoas` or `bin/ptoas`) is a regular
-     executable file;
+   - `<root>/ptoas`, `<root>/ptoas.sh`, or `<root>/bin/ptoas` under `PTOAS_ROOT`
+     answers `--version` — probe in that order, as pypto's
+     `backend/_ptoas_locate.py` does, because a v0.55+ release runs only
+     through its own `ptoas.sh`;
    - the simpler submodule revision belongs to the selected PyPTO checkout;
-   - PTO ISA `HEAD` matches `runtime/pto_isa.pin`;
-   - `PTOAS_ROOT`, `PTO_ISA_ROOT`, and the repository `PYTHONPATH` are usable in
-     the shell that will run the case.
+   - any PTO ISA checkout in use is at `runtime/pto_isa.pin`;
+   - `PTOAS_ROOT` and the repository `PYTHONPATH` are usable in the shell that
+     will run the case.
 10. When the requested platform is available, run
    `examples/beginner/hello_world.py` as the final smoke test. A device smoke
    requires an allocation; do not substitute an arbitrary visible device.

--- a/docs/debug-and-tune/dependency-and-scheduling.md
+++ b/docs/debug-and-tune/dependency-and-scheduling.md
@@ -1,0 +1,583 @@
+# Dependencies and Scheduling
+
+Two independent layers decide when a kernel runs on an Ascend NPU.
+
+1. **The dependency graph** says what must happen before what. It is built while
+   the orchestration program runs, from tensor arguments and from edges you
+   declare. Get it wrong and results are wrong — usually intermittently.
+2. **The runtime scheduler** picks, among all orders the graph permits, when
+   each task is actually issued to a core. Get it wrong and results are right
+   but late.
+
+Most "why is this kernel wrong" answers live in the first layer, and most "why
+is there a 4 µs hole in my swimlane" answers live in the second. This guide
+builds both from the ground up, shows which artifact proves which claim, and
+ends with the loop that turns those artifacts into a shorter schedule.
+
+The authoritative references are upstream:
+[Tasks and Ordering](https://www.pypto.ai/pypto/user/tasks/00-model/) for the
+dependency model and the keywords, and the
+[simpler](https://www.pypto.ai/simpler/) runtime docs for what the scheduler
+does with them. This page is the pypto-lib view — the mechanism as it appears
+in our models and our capture artifacts, plus the failures this repository has
+actually hit.
+
+## The unit of scheduling is a task
+
+A **task** is one dispatch. The runtime never executes an orchestration
+function statement by statement; it builds a graph of tasks and runs whatever
+is ready.
+
+Four spellings produce a task, and they produce only two shapes:
+
+| Spelling | Available in | Shape |
+|----------|--------------|-------|
+| `with pl.at(level=..., name_hint=...) as tid:` | `@pl.jit`, `@pl.function` | One task |
+| `result, tid = pl.submit(self.kernel, ...)` | `@pl.program` classes | One task |
+| `with pl.spmd(n, ...) as tid:` | `@pl.jit`, `@pl.function` | One task, `n` logical blocks |
+| `result, tid = pl.spmd_submit(self.kernel, ..., core_num=n)` | `@pl.program` classes | One task, `n` logical blocks |
+
+Two properties follow, and both matter downstream:
+
+- **A mixed cube+vector region is still one task.** `pl.at` carrying both a
+  `pl.matmul` and the vector op consuming it dispatches as a single task with
+  up to three active subslots — `[AIC, AIV0, AIV1]` — that complete
+  independently and retire together. It is one node in the graph, one row in
+  `deps.json`, and several physical rows in a swimlane.
+- **An SPMD launch is still one task.** `pl.spmd(n)` is one scheduling unit
+  fanned out over `n` logical blocks. It carries one TaskId, so a consumer
+  waits on the whole fan-out, not on a block. Blocks are dispatched
+  individually — with more blocks than cores the launch proceeds in waves —
+  unless `sync_start=True` forces an atomic all-or-nothing launch.
+
+Each task also carries a **resource shape** — `MIX` (a cluster of 1 AIC + 2
+AIV), `AIC`, or `AIV` — derived from its active subslots. The shape decides
+which ready queue it enters and which cores can take it. A task never waits on
+a core it could not have used.
+
+> **Statement order expresses nothing.** Two dispatches written one after the
+> other are ordered only if something says so: a buffer overlap the runtime can
+> see, or an edge you declared. Source adjacency is not that something.
+
+## How an edge comes to exist
+
+There are exactly two mechanisms, and they compose:
+
+```text
+final wait set  =  TensorMap-inferred edges  ∪  declared deps=
+```
+
+### TensorMap inference
+
+The orchestrator keeps a map from tensor memory regions to the task that last
+wrote them. On every submit it does three things with the task's arguments:
+
+| Step | Applies to | Effect |
+|------|-----------|--------|
+| Creator retention | Every tensor argument, any direction | Edge on the task that created that tensor |
+| Producer lookup | `In` / `InOut` | Edge on the registered producer of any **overlapping** region |
+| Producer registration | `Out` / `InOut` | This task becomes the registered producer |
+
+So parameter directions are not documentation — they are the input to
+dependency inference. Declaring an `InOut` buffer as `Out` tells the runtime
+that nothing needs to finish before this task writes it.
+
+Which hazards that covers:
+
+| Hazard | Tracked | Why |
+|--------|---------|-----|
+| RAW — read after write | Yes | The reader looks up the current writer and takes an edge |
+| WAW — write after write | Yes | The new writer takes an edge on the prior writer, then replaces it |
+| WAR — write after read | **No** | A writer would have to find every in-flight reader; that is a per-write walk over a reader set on the orchestration hot path |
+
+WAR being untracked is a deliberate runtime trade-off
+([WAR anti-dependencies](https://www.pypto.ai/simpler/war-anti-dependency/)),
+not a defect. When a pure reader must finish before a later overwrite, that
+edge is yours to declare — and declare it with `deps=` on the writer rather
+than by promoting the reader to `InOut`, which makes the reader a writer and
+serializes it against every other reader of that buffer.
+
+The overlap test works on buffer regions and is conservative: a region it
+cannot prove disjoint is treated as overlapping. That is where false
+serialization comes from — most often a loop whose iterations write disjoint
+slices of one output but look to the map like one buffer.
+
+### Declared edges
+
+Bind a task's TaskId and name it later:
+
+```python
+with pl.at(level=pl.Level.CORE_GROUP, name_hint="producer") as first:
+    ...
+with pl.at(level=pl.Level.CORE_GROUP, name_hint="consumer", deps=[first]) as second:
+    ...
+```
+
+Three shapes worth knowing:
+
+- **Fan-in through an array.** One TaskId names one task. To wait on a loop's
+  worth of producers, collect them into a `pl.array` of `pl.TASK_ID` and pass
+  the array — or the per-index list, which is what `models/qwen3_14b/decode_fwd.py`
+  relies on when the array is hoisted across a scope boundary.
+- **A join with no work.** `pl.system.task_dummy(deps=[...])` returns a TaskId
+  that collapses several producers into one handle.
+- **`deps=` needs the `as` form.** `with pl.spmd(n):` and `for i in pl.spmd(n):`
+  run the same work without naming it and reject `deps=` outright.
+
+Declared edges are not tied to manual scope. They compose with inference, so
+one `deps=` inside an ordinary auto scope is the precision tool for the one
+edge the inference could not reach.
+
+### Turning inference off
+
+Four opt-outs, from narrowest to widest. Each is an assertion the compiler
+**cannot check**:
+
+| Construct | Scope of the claim | Used in this repo |
+|-----------|--------------------|-------------------|
+| `pl.at(..., no_dep_args=[t])` | One tensor, one task | `models/qwen3_14b/decode_layer_a8w8.py:669` |
+| `pl.no_dep(t)` at a call argument | One tensor, one task (`@pl.program` form) | — |
+| `pl.create_tensor(..., manual_dep=True)` | One tensor, its whole lifetime | `models/deepseek_v4_pro/moe.py:493` |
+| `with pl.manual_scope():` | Every task in the region | `models/qwen3_14b/decode_fwd.py:314` |
+
+Prefer the narrowest one that expresses the claim. `manual_scope` says "I own
+the entire graph here" — inside it the runtime skips creator retention,
+producer lookup and producer registration alike, so every edge in the region is
+one you wrote, including the ones that used to be correct for free.
+
+### What this looks like in `deps.json`
+
+Every edge records where it came from, which makes the mechanism directly
+observable:
+
+| `source` | Meaning |
+|----------|---------|
+| `creator` | Creator retention — the task that allocated the tensor |
+| `tensormap` | An overlap lookup hit; carries `overlap: covered \| other` and both slice geometries |
+| `explicit` | A declared `deps=` edge; `arg` is `-1` because it belongs to no argument slot |
+
+An edge you expected but cannot find in `deps.json` does not exist at run time.
+
+## What happens at run time
+
+Two AICPU roles run concurrently. On a2a3 the AICPU has four threads: one
+orchestrator and three schedulers.
+
+**The orchestrator thread** executes the orchestration program and submits
+tasks. Per submit it allocates a task-ring slot and heap space for outputs,
+copies parameters, performs the TensorMap lookup and insert, records the
+producer set, wires fanout edges, and publishes the task to a ready queue if
+nothing is outstanding.
+
+**The scheduler threads** each own a share of the cores and run a two-phase
+loop: drain completions, then dispatch. Completion polls each core's `COND`
+register for FIN, aggregates the task's subslots, and walks the finished task's
+fanout list incrementing each consumer's released-producer count — the consumer
+whose producers are all released moves to a ready queue. Dispatch pops a ready
+task whose resource shape matches an available core, writes a dispatch payload,
+and signals the core.
+
+That gives one task the following timeline, and every timestamp in a level-4
+capture is a point on it:
+
+```text
+ submit ──► ready ──► dispatch ──► start ──► end ──► finish ──► consumed
+    │         │          │           │        │        │           │
+ orch      every      payload      core     kernel   AICPU     fanout
+ thread   producer    written    picks it   returns  sees FIN  released,
+          FIN'd      to a core      up                         slot freed
+```
+
+An early-dispatched task takes the same path with `dispatch` moved ahead of
+`ready`: the payload is staged on a gated core and released by a doorbell when
+the last producer finishes.
+
+The four timestamps a swimlane record carries:
+
+| Field | Stamped by | Means |
+|-------|-----------|-------|
+| `dispatch_time_us` | AICPU | The scheduler handed this block to a core |
+| `start_time_us` | AICore | The core began executing the kernel |
+| `end_time_us` | AICore | The kernel returned |
+| `finish_time_us` | AICPU | The scheduler observed FIN and can release consumers |
+
+`end → finish` is FIN detection latency, not compute. A consumer becomes ready
+at its last producer's **finish**, not its `end`.
+
+### Queues and their order
+
+Ready work is partitioned by resource shape, and each shape has a normal lane
+and a speculative lane:
+
+| Source | Regular lanes | `sync_start` lane |
+|--------|---------------|-------------------|
+| Normal (all producers done) | `ready_queues[MIX\|AIC\|AIV]` | `ready_sync_queues[MIX\|AIC\|AIV]` |
+| Early (speculative pre-stage) | `early_dispatch_queues[MIX\|AIC\|AIV]` | `early_sync_start_queue` |
+
+Within a source the order is `sync_start` ▸ MIX ▸ AIC/AIV, and per shape idle
+cores before busy ones (a busy core can take a gated pending slot, promoted on
+completion). Across sources, **normal strictly precedes early** — speculative
+work runs only once both normal lanes are empty. A ready task therefore never
+loses a core to a speculative one.
+
+### Back-pressure
+
+The orchestrator can outrun the scheduler, so submission blocks when the ring
+holding task slots, output heap bytes, or dependency-list entries is full. It
+resumes when the scheduler retires tasks and advances that ring's watermark.
+
+This is ordinary flow control until it becomes a deadlock: a task's fanout
+count includes a reference from its owning runtime scope, released only when
+`scope_end()` runs — and `scope_end()` is called by the orchestrator, the very
+thread blocked waiting for space. A scope that submits more tasks than its
+ring's window can hold therefore cannot drain itself. The runtime detects the
+condition and exits with an `orch_error_code` naming which resource wedged.
+
+Sizing the rings, placing scopes to shorten intermediate-tensor lifetime, and
+reading the per-scope peaks are their own topic — see
+[Ring Heap and Scope Stats](ring-heap-and-scope-stats.md).
+
+## Observing it
+
+None of the above is inferable from a kernel's source. Every claim in the rest
+of this page — which edge exists, when a task was dispatched, what a gap was
+waiting for — is settled by two artifacts and their join.
+
+### The artifacts
+
+| File | Produced by | Carries |
+|------|------------|---------|
+| `deps.json` | `--enable-dep-gen` | The task graph: tasks, `kernel_ids`, `block_num`, `early_dispatch`, annotated edges |
+| `l2_swimlane_records.json` | `--enable-l2-swimlane` | Per-task timing and scheduler/orchestrator phases; **no** edges |
+| `name_map*.json` | Compile | Callable id → source name |
+| `dispatch_program.json` | Compile | Which program a dispatch directory belongs to |
+| `merged_swimlane*.json` | `swimlane_converter` | The two joined, for Perfetto |
+
+Timing and topology are deliberately separate: per-task fanout on the device
+hot path would cost a ~1 KB GM store and a linked-list walk per task. The
+converter joins them offline, which also means one `deps.json` can serve many
+timing runs of the same topology.
+
+### Capture levels
+
+| Level | Adds |
+|-------|------|
+| 1 | AICore `start` / `end` per task |
+| 2 | + AICPU `dispatch` / `finish` |
+| 3 | + scheduler phase records |
+| 4 | + orchestrator phase records |
+
+Anything that reasons about dispatch — gap attribution, early-dispatch proof —
+needs level 4. Note this is the L2 swimlane's *perf level*; it is unrelated to
+the runtime hierarchy's L4 worker level.
+
+**Check the entry's `argparse` before assuming a flag shape.** Across
+`models/` and `examples/` the flag is declared six different ways in 128
+places: 68 use `action="store_true"` (a bare flag means level 4), 28 use
+`nargs="?", const=1, choices=(0, 1, 2)` (a bare flag means level **1**, and
+level 4 is rejected outright), 17 allow 4 explicitly, 5 make a bare flag mean
+4, and 7 require an explicit value. There is no safe default form; read the
+target's `--help`.
+
+### Identity chain
+
+Runtime task IDs are capture-local — they are execution instances, not source
+identifiers, and they do not survive a rebuild. To get from a swimlane row back
+to a line of Python:
+
+```text
+dispatch_program.json
+  → next_levels/<program>/kernel_config.py
+  → name_map*.json :: callable_id_to_name
+  → deps.json :: tasks[task_id].kernel_ids
+  → source name_hint or submitted callee
+```
+
+A MIX task maps to more than one callable name — check every active
+`kernel_ids` slot. Compiler suffixes such as `_0` can be inlined copies of one
+shared `name_hint`, so one source site may own several runtime occurrences.
+
+### Validating a capture before trusting it
+
+Join the streams with `swimlane_converter.read_perf_data()`; the raw file holds
+separate cycle-domain streams that must not be joined by hand. Then require:
+
+- `l2_swimlane_level == 4` in the records file;
+- raw AICore rows, raw AICPU rows and joined rows have **equal counts**;
+- for every timed task, `joined physical rows == deps.block_num × active kernel_ids slots`.
+
+The last check is the one that matters most: a single dropped SPMD or MIX row
+turns a `partial` early-dispatch result into a false `full N/N`.
+
+Distributed captures live under `<work_dir>/dfx_outputs/rank{r}/d{k}/`, where
+`d{k}` is that card's k-th L2 dispatch. Match the program by
+`dispatch_program.json` — two programs can reuse a `func_id`.
+
+### Reconstructing the critical path
+
+```bash
+python -m simpler_setup.tools.critical_path <work_dir> --stdout
+```
+
+It computes two paths, and the difference is the point:
+
+- **Static CPM** — the duration-weighted longest dependency path assuming
+  unlimited cores. This is what the *graph* costs.
+- **Observed** — the as-executed backward blame path through data and same-core
+  predecessors. This is what the *run* cost, and its task compute plus stalls
+  tile the measured AICore makespan.
+
+Use Observed to decide where time went; use Static CPM as a cross-check. A
+large gap between them is a scheduling problem, not a graph problem.
+
+The makespan covers first AICore start through last AICore end — it excludes
+host and orchestrator front time and the AICPU tail. Level-4 collection has
+observer cost, so use it for causal evidence and take production numbers from
+an unprofiled benchmark; see [Performance Tuning](performance-tuning.md).
+
+## Tuning the schedule
+
+Everything above describes the machine. This section is the method: a loop that
+turns a level-4 capture into a shorter schedule, one question at a time.
+
+```text
+1. find the Observed critical path        ── only its tasks can shorten the makespan
+2. split every gap on that path           ── FIN detect | undispatched | pickup
+3. flag the producers of a gapped task    ── allow_early_resolve=True on each one
+4. prove the task was actually staged     ── dispatch < producer FIN, per block
+5. if a sibling took the window, evict it ── unflagged dummy on the SIBLING
+6. re-measure, and re-derive the path     ── it moves once the head shortens
+```
+
+**1. Find the path.** Reconstruct the Observed critical path from the capture
+(see [Reconstructing the critical path](#reconstructing-the-critical-path)).
+Only tasks on that path can shorten the makespan; time spent on anything else
+is slack until the path itself moves.
+
+**2. Split every gap on the path.** A gap is not one thing — it is producer-FIN
+detection, ready-but-undispatched scheduler delay, or post-dispatch pickup, and
+each has a different remedy. The taxonomy below does the splitting.
+
+**3. Flag the producers.** The undispatched and pickup parts of a gap in front
+of a *short* task are what speculative early dispatch removes. Flag every
+direct producer of that task — all of them, because one unflagged producer
+disables the whole opportunity.
+
+**4. Prove the window was actually won.** A flag in the source is not a result.
+Check the dispatch timestamp against the producers' FIN, per physical block,
+and accept `full`, `partial` or `none` as the answer.
+
+**5. If a sibling took the window, evict it.** When the path task is
+structurally eligible yet still not staged, look at what else shares its
+producer. Normal work outranks early work and the early lane is serviced only
+once both normal lanes are empty, so a non-critical sibling resolving off the
+same producer can consume the opportunity first:
+
+```text
+c ──► a     on the critical path — wants the early window
+└──► b      not on the path — currently taking it
+```
+
+Adding an **unflagged** dummy predecessor to `b` makes `b` structurally
+ineligible and leaves the window to `a`. Add it to `b` only — never to `a`, and
+never to the shared producer `c`, which would delay both.
+
+**6. Re-measure, then re-derive the path.** Shortening the head of a path
+usually moves the path. Judge the change on wall time from an unprofiled
+benchmark, not on the level-4 capture that has observer cost built in, and not
+on core busy time.
+
+The rest of this section is the reference for steps 2 through 5.
+
+### Reading the gaps
+
+Split the interval before a task into three causes, because each has a
+different fix:
+
+| Interval | Name | Meaning |
+|----------|------|---------|
+| producer `end` → producer `finish` | FIN detection | The scheduler had not yet noticed the producer finished |
+| last producer `finish` → `dispatch` | Ready-but-undispatched | The task was legal to run and no core took it |
+| `dispatch` → `start` | Pickup / gate | The core had not yet picked it up, or the task is early-staged and still gated |
+
+With these four values folded across every physical block of a task:
+
+```text
+data_ready(C)     = max(pred.end_time_us)
+observed_ready(C) = max(pred.finish_time_us)
+dispatch(C)       = min(C block dispatch_time_us)
+start(C)          = min(C block start_time_us)
+```
+
+Attribution rules that keep a gap analysis honest:
+
+- A **ready-but-undispatched** gap is a scheduler or occupancy claim, and
+  naming a blocking task requires proving that every compatible core lacked a
+  free slot throughout the interval — not merely that some other task
+  overlapped it. Level-4 scheduler phase records carry counts, not causal task
+  IDs; temporal proximity is not causality.
+- A **pickup** gap can be same-core contention, but only if the occupying task
+  ran until `start(C)`. A task that freed the core before `data_ready(C)` did
+  not gate anything.
+- `dispatch(C) < observed_ready(C)` means the task was dispatched before its
+  producers finished. That is not a paradox — it is speculative early dispatch,
+  and the remaining wait is a gate, not a queue.
+
+### Speculative early dispatch
+
+The one lever that removes the ready-but-undispatched and pickup gaps together.
+The scheduler may pre-stage a not-yet-released task onto an idle core, gated,
+and release it with a doorbell the instant its producers finish. The core is
+already holding the payload, so pickup latency is off the critical path.
+
+It is enabled by a **producer-side** hint:
+
+```python
+with pl.spmd(token_tiles, name_hint="rms_norm", allow_early_resolve=True) as rms_tid:
+    ...
+```
+
+`allow_early_resolve=True` is accepted by `pl.at`, `pl.spmd`, `pl.submit` and
+`pl.spmd_submit`. It is pure scheduling — results are unaffected.
+
+Four conditions decide whether it does anything:
+
+1. **Every** direct producer of the consumer must be flagged or already
+   complete. Flagging one producer of a three-producer consumer buys nothing.
+   This is why the hint tends to be applied along a whole chain, as in
+   `models/qwen3_14b/decode_fwd.py`.
+2. A producer propagates eligibility only once **fully published** —
+   `published_block_count == logical_block_num`. A 50-block SPMD producer on 24
+   cores dispatches in waves, and a consumer that gated every slot after the
+   first wave would strand the remaining producer blocks. Full publication is
+   the deadlock guard.
+3. Normal work outranks early work. Under a saturated engine there is no early
+   window to win.
+4. A predicated task never early-dispatches, and a `sync_start` cohort needs
+   all-or-nothing capacity.
+
+#### Proving a task was actually early-dispatched
+
+`deps.json::tasks[].early_dispatch` is **not** proof. It records that the task
+carries the producer-side flag — a statement about that task's consumers, not
+about the task itself. Two things must hold together:
+
+```text
+structural:  every direct producer is an allocation source or has early_dispatch=true,
+             and at least one is a non-allocation task
+temporal:    block.dispatch_time_us + tol < max(producer finish_time_us)
+             where tol = 2 * 1e6 / metadata.clock_freq_hz   (two clock ticks)
+```
+
+An SPMD task can satisfy this on some physical rows and not others, so the
+honest answer is `full N/N`, `partial N/M`, or `none` — never a bare yes. If
+the timestamps look early but the graph is not structurally eligible, the
+capture and the source disagree; suspect a stale artifact before believing the
+timestamps.
+
+### Deliberately delaying a task
+
+`pl.system.task_dummy` has uses beyond joining producers, because a task with
+no work still costs one dispatch hop. Three idioms appear in this tree, and
+they are easy to confuse:
+
+```python
+# 1. Join: collapse several producers into one handle.
+gate = pl.system.task_dummy(deps=[tid_a, tid_b])
+
+# 2. Delay by one hop: a real producer, plus a hop, before a non-critical
+#    consumer — so it stops resolving at the same instant as the critical one.
+#    models/deepseek_v4_flash_dspark/decode_swa.py:320
+late_dep = pl.system.task_dummy(deps=[rms_tid])
+qkv_proj_rope(..., late_dep)
+
+# 3. Placeholder: a standalone entry has no fused-path producer to fence
+#    against, so an empty dummy satisfies the shared signature and is ready on
+#    submit.  models/deepseek_v4_flash_dspark/decode_indexer.py:428
+late_dep = pl.system.task_dummy(deps=[])
+```
+
+Form 2 is the deliberate one. Its comment in `decode_swa.py` states the intent
+plainly — *"Dispatch barrier: kv_proj_matmul resolves one hop after
+rms_norm"* — and it costs a dispatch to buy the ordering.
+
+The fourth form is step 5 of the loop: an **unflagged** dummy predecessor makes
+its consumer structurally ineligible for early dispatch — it breaks condition 1
+above — which is how a non-critical sibling is pushed out of a speculative
+window a critical-path task needs. No model in this tree currently ships one,
+because it is a scheduling experiment rather than a structural requirement: it
+is defensible only with before/after level-4 evidence that the sibling stopped
+being staged *and* the protected task started, plus a wall-time result. Keep
+`deps=` empty — `task_dummy(deps=[c_tid])` adds a real hop after `c` and tests
+something else entirely.
+
+`task_dummy` accepts only `deps=`; it cannot itself carry
+`allow_early_resolve`. All of these trade throughput for ordering, none changes
+results, and none is justified without a before/after measurement.
+
+## Traps this repository has hit
+
+Each of these produced wrong results, not a diagnostic.
+
+**WAR through two views of one tensor.** Tracking keys on the tensor value, so
+two distinct `pl.reshape` views of the same external `inout` tensor look
+independent. A task reading through one view and a later task writing in place
+through the other get no edge, and the write races the read. Seen on the decode
+KV-cache writeback: `kv_cache` validated clean while `x_out` failed around 7%
+with non-deterministic indices — the signature of a race, not of a numerics
+bug. The live fix is a no-op self-copy that marks the parameter `inout` before
+the gather, so the writeback takes a WAW edge on it; `add_inout` is a
+param-level property, so one tile touch is enough. See the `kv_touch` scope in
+`models/deepseek_v4_pro/decode_sparse_attn.py:239` and its siblings in the
+`_csa` variants.
+
+**A GM round-trip registered as `add_output`.** A GM tensor written by one task
+and read by a later one must be registered on the producing task as
+`add_inout`, not `add_output`. `add_output` records only the write, so the
+consumer's read-after-write edge never exists. A clean A/B on
+`decode_compressor_ratio4.py` gave 20/20 passes with `add_inout` and 16/20 with
+`add_output`, the failures splitting between wrong values and a 507046 AICPU
+sync timeout. Worth knowing when reading generated orchestration under
+`build_output/<case>/orchestration/`.
+
+**A `manual_dep=True` tensor rides only on the explicit chain.** Its ordering
+comes from `deps=` and nothing else, for the tensor's whole lifetime. Removing
+one `deps=[tid]` to re-anchor a wait silently dropped the only edge ordering a
+cumsum before its consumer — no compile error, stale reads. The restored form
+is visible as the two-element dependency in
+`models/deepseek_v4_flash_dspark/moe.py:289`. Before cutting an explicit edge,
+check whether any task it transitively orders reads a `manual_dep` tensor.
+
+**A conservative overlap that was not a dependency.** A `pl.range` loop whose
+iterations write disjoint slices of one output serializes on a WAW chain. The
+opt-outs fix it by assertion; slicing the output in orchestration so each task
+receives a distinct region fixes it by construction, at the cost of more
+orchestration tensors to register and walk. On a dispatch-bound graph that cost
+can exceed the serialization it removed — measure both ends.
+
+## See also
+
+- [Performance Tuning](performance-tuning.md) — where the swimlane fits in the
+  L2 → L1/L0 tuning flow.
+- [Ring Heap and Scope Stats](ring-heap-and-scope-stats.md) — the ring model
+  behind the back-pressure above, and how to size it.
+- [Debugging](debugging.md) — device logs for a hang, and 507xxx triage.
+- [PyPTO coding style](../pypto-coding/pypto-coding-style.md) — the kernel forms
+  and loop constructs these tasks are written with.
+
+Upstream references:
+
+- [The dependency model](https://www.pypto.ai/pypto/user/tasks/00-model/),
+  [Runtime scopes](https://www.pypto.ai/pypto/user/tasks/01-scopes/),
+  [Declaring an edge](https://www.pypto.ai/pypto/user/tasks/02-submit/), and
+  [Refining the graph](https://www.pypto.ai/pypto/user/tasks/03-tuning/) — the
+  authoritative treatment of inference, `deps=`, the opt-outs, `predicate=`
+  and `allow_early_resolve=`.
+- [Managing dependencies](https://www.pypto.ai/pypto/user/performance/03-dependencies/)
+  and [Runtime overhead](https://www.pypto.ai/pypto/user/performance/02-runtime-overhead/)
+  — false serialization and per-task cost, upstream.
+- [L2 swimlane profiling](https://www.pypto.ai/simpler/dfx/l2-swimlane-profiling/)
+  and [dep_gen](https://www.pypto.ai/simpler/dfx/dep-gen/) — artifact schemas.
+- [Orchestrator](https://www.pypto.ai/simpler/orchestrator/) and
+  [WAR anti-dependencies](https://www.pypto.ai/simpler/war-anti-dependency/) —
+  submission semantics and why WAR is not tracked.

--- a/docs/debug-and-tune/index.md
+++ b/docs/debug-and-tune/index.md
@@ -16,6 +16,7 @@ then move from the broadest evidence to the narrowest:
 | Diagnose compile errors, runtime failures, hangs, or missing dependencies | [Debugging](debugging.md) |
 | Diagnose numerical drift and choose comparison thresholds | [Precision Tuning](precision-tuning.md) |
 | Measure end-to-end time and inspect the task schedule | [Performance Tuning](performance-tuning.md) |
+| Understand how task edges are formed and when the scheduler issues them | [Dependencies and Scheduling](dependency-and-scheduling.md) |
 | Fit intermediate tensors in the runtime's ring heaps and measure per-scope peaks | [Ring Heap and Scope Stats](ring-heap-and-scope-stats.md) |
 | Choose matmul row, N, and K tiles | [Cube Tile Tuning](cube-tile-tuning.md) |
 | Inspect one generated kernel in the operator simulator | [In-Core Simulator Profiling](incore-simulator-profiling.md) |

--- a/docs/debug-and-tune/index.md
+++ b/docs/debug-and-tune/index.md
@@ -16,6 +16,7 @@ then move from the broadest evidence to the narrowest:
 | Diagnose compile errors, runtime failures, hangs, or missing dependencies | [Debugging](debugging.md) |
 | Diagnose numerical drift and choose comparison thresholds | [Precision Tuning](precision-tuning.md) |
 | Measure end-to-end time and inspect the task schedule | [Performance Tuning](performance-tuning.md) |
+| Fit intermediate tensors in the runtime's ring heaps and measure per-scope peaks | [Ring Heap and Scope Stats](ring-heap-and-scope-stats.md) |
 | Choose matmul row, N, and K tiles | [Cube Tile Tuning](cube-tile-tuning.md) |
 | Inspect one generated kernel in the operator simulator | [In-Core Simulator Profiling](incore-simulator-profiling.md) |
 | Partition phases inside a multi-core CCE extern kernel on real hardware | [CCE In-Core Profiling](cce-incore-profiling.md) |

--- a/docs/debug-and-tune/performance-tuning.md
+++ b/docs/debug-and-tune/performance-tuning.md
@@ -6,7 +6,7 @@ AICPU side (L2 swimlane), then optimize each kernel's internal pipeline
 (L1/L0 swimlane + PMU).
 
 For the underlying levels see simpler's
-[hierarchical_level_runtime.md](https://github.com/hw-native-sys/simpler/blob/main/docs/hierarchical_level_runtime.md):
+[Hierarchical Level Runtime](https://www.pypto.ai/simpler/hierarchical-level-runtime/):
 L2 = one chip (AICPU + AIC/AIV cores), L1 = die / L2 cache, L0 = single
 compute core.
 

--- a/docs/debug-and-tune/performance-tuning.md
+++ b/docs/debug-and-tune/performance-tuning.md
@@ -156,6 +156,13 @@ Look for these shapes on the swimlane that indicate a problem:
 | Cube lane busy while vector lane idle (or vice versa) | Vec/cube epilogue is split into separate kernels | Merge into a mixed kernel (item 2c) |
 | Sequential AICPU dispatch trail per region | Region issues one kernel per iteration | Use `pl.spmd` to dispatch a block fan-out once (item 5) |
 
+A gap on this trace is not automatically a scheduling problem: the interval
+before a task splits into producer-FIN detection, ready-but-undispatched
+scheduler delay, and post-dispatch pickup, and each has a different fix. See
+[Dependencies and Scheduling](dependency-and-scheduling.md) for how edges are
+formed, what the four per-task timestamps mean, and how to attribute a gap
+without guessing.
+
 ### Tuning rules
 
 #### 1. Use `pl.range` vs. `pl.parallel` correctly

--- a/docs/debug-and-tune/ring-heap-and-scope-stats.md
+++ b/docs/debug-and-tune/ring-heap-and-scope-stats.md
@@ -1,0 +1,321 @@
+# Ring Heap and Scope Stats
+
+Intermediate GM tensors — everything `pl.create_tensor` produces in
+orchestration — are not malloc'd. They live in the simpler runtime's
+**four ring heaps**, and the only levers over them are *where you place a
+runtime scope* and *how big you size each ring*. This page covers the ring
+model, how `pl.scope` shapes intermediate-tensor lifetime, and how
+`scope_stats` measures the result.
+
+Read it when a run dies with `HEAP_RING_DEADLOCK`, when a longer sequence
+length or a bigger EP degree stops fitting, or before changing
+`PTO2_RING_HEAP` on a kernel whose peaks nobody has measured.
+
+---
+
+## 1. The four rings
+
+The T&R runtime (`tensormap_and_ringbuffer`, the default for every platform
+this repo targets) does not keep one global pool. It keeps
+`PTO2_MAX_RING_DEPTH = 4` independent **ring sets**, and the scope nesting
+depth at submit time selects which one a task uses:
+
+```text
+scope depth 0  ->  ring 0 = { task window, heap, dep pool, fanin pool }
+scope depth 1  ->  ring 1 = { ... }
+scope depth 2  ->  ring 2 = { ... }
+scope depth >=3 ->  ring 3 = { ... }        # clamped: everything deeper folds in here
+```
+
+Depth 0 is the root scope the executor wraps around
+`aicpu_orchestration_entry`; the first `PTO2_SCOPE` in generated
+orchestration code is depth 1. Each ring reclaims on its own watermark
+(`last_task_alive`), which is the whole point of the split: an inner
+scope's tasks can be reclaimed without waiting for the outer scope's tasks
+to finish.
+
+| Per-ring resource | Compile default (a2a3, **per ring**) | Env override |
+|---|---|---|
+| Task window (task slots) | 16384 | `PTO2_RING_TASK_WINDOW` |
+| Heap (bytes for task outputs / intermediates) | 256 MiB | `PTO2_RING_HEAP` |
+| Dep-list pool (fanin spill entries) | 16384 | `PTO2_RING_DEP_POOL` |
+
+The tensormap is **not** per ring — it is one global table (65536 entries by
+default) and appears as a single row in every report.
+
+> A run rarely uses the compile defaults: CI pins its own `PTO2_RING_*`
+> values, several model entries set them at import time, and shared dev hosts
+> often export them globally. Never assume — read the effective capacities off
+> the `scope_stats` metadata line (§5).
+
+Upstream reference: simpler's
+[`MULTI_RING.md`](https://github.com/hw-native-sys/simpler/blob/main/src/a2a3/runtime/tensormap_and_ringbuffer/docs/MULTI_RING.md)
+— a runtime-internal design note, so it is only on GitHub, not on the
+published [simpler docs](https://www.pypto.ai/simpler/).
+
+---
+
+## 2. What happens to an intermediate tensor
+
+A `pl.create_tensor` in an orchestration function compiles to an
+`alloc_tensors(...)` call — a **kernel-less task** that owns a heap block on
+the ring of the scope it sits in:
+
+```cpp
+// build_output/<prog>/orchestration/<prog>.cpp
+uint32_t tmp_ci_shapes[2] = {8192, 1024};
+TensorCreateInfo tmp_ci(tmp_ci_shapes, 2, DataType::FLOAT32);
+TaskOutputTensors alloc_0 = alloc_tensors(tmp_ci);   // 32 MiB off the current ring
+const Tensor& tmp = alloc_0.get_ref(0);
+```
+
+That block is released when the owning task reaches `CONSUMED`, which needs
+**both** conditions:
+
+1. every consumer task has completed (fanout refcount drained), **and**
+2. the scope that submitted it has **closed** (the scope holds its own
+   reference, `PTO2_FANOUT_SCOPE_BIT`, released at scope exit).
+
+Reclaim is then strictly **FIFO per ring**: `heap_tail` follows
+`last_task_alive`, so the oldest live allocation pins everything allocated
+behind it on that ring.
+
+Three consequences drive every tuning decision on this page:
+
+- **Memory is not freed at last use — it is freed at scope exit.** A buffer
+  whose consumers finished long ago still occupies the ring until its scope
+  closes.
+- **A loop without an inner scope accumulates.** Every iteration's
+  intermediate stays live until the *enclosing* scope ends. In the extreme —
+  everything at depth 0 — nothing can ever be reclaimed before the program
+  ends, and the ring can only fail, never drain.
+- **One long-lived allocation blocks the whole ring behind it** (head-of-line
+  blocking), because the reclaim pointer is a single FIFO watermark.
+
+---
+
+## 3. Placing scopes with `pl.scope`
+
+By default (`auto_scope=True`) the compiler inserts an AUTO scope around the
+function body **and around each `for` / `if` body**, including inside every
+`@pl.jit.inline` callee it inlines. That is convenient but blind: a model
+with 6–7 nesting levels collapses everything past depth 3 into ring 3, which
+then carries the entire program while rings 0–2 sit empty.
+
+To place scopes yourself, turn the automatic ones off and write them:
+
+```python
+@pl.jit(auto_scope=False)                       # or @pl.jit.inline(auto_scope=False)
+def prefill_fwd(...):
+    for layer_idx in pl.range(num_layers):
+        with pl.scope():                        # ring 1 — one layer
+            for p0 in pl.range(tok_blocks):
+                with pl.scope():                # ring 2 — one token block
+                    tmp = pl.create_tensor(...)  # freed when this scope closes
+                    ...
+```
+
+Rules and gotchas:
+
+- `pl.scope()` is legal only in orchestration code, and AUTO mode
+  (`pl.scope()`) requires `auto_scope=False` on the enclosing function.
+  `pl.scope(mode=pl.ScopeMode.MANUAL)` / `pl.manual_scope()` is a
+  *dependency-tracking* choice, not a ring choice, and an AUTO scope may not
+  nest inside a MANUAL one.
+- `pl.create_tensor` inside a `pl.at` block yields a **tile**, not a GM
+  tensor. Allocate GM scratch just outside the `pl.at` that first writes it,
+  inside the scope that should own its lifetime.
+- Keep loop-carried values (`hidden_states = layer(...)`, output params) out
+  of the inner scope's ownership — they must outlive it, and a value still
+  read after its scope closed keeps its block live anyway.
+- Nesting past depth 3 buys nothing: ring 3 is a clamp, so a 5-deep chain
+  just concentrates pressure there.
+- A scope is also a scheduling boundary — the runtime drains scope
+  bookkeeping at `scope_end`. Very fine scopes around a handful of tasks cost
+  more than they reclaim.
+
+### Example in this repo
+
+[`models/deepseek_v4_flash_mtp/decode_fwd.py`](../../models/deepseek_v4_flash_mtp/decode_fwd.py)
+is the reference shape: `auto_scope=False` on both the entry and the inlined
+body, the ping-pong carriers (`x_attn0` / `x_attn1` / `hidden`) created outside
+every scope, and one `with pl.scope()` per attention / MoE stage — with the
+callees (`moe`, `attention_swa`) adding the deeper levels themselves.
+
+---
+
+## 4. Sizing the rings
+
+When the peaks are genuinely needed — a big cross-phase payload, a long
+prefill — size the rings explicitly. Both knobs take either a scalar
+(broadcast to all four rings) or four per-ring values, and `0` means "fall
+through to the next tier".
+
+Precedence: `RunConfig` field > per-ring env > scalar env > compile default.
+
+```python
+# L3 (distributed) entries: RunConfig fields, forwarded by golden's run_jit.
+PREFILL_RING_HEAP = (0, 0, 2 * 1024 * 1024 * 1024, 0)   # ring 2 only
+runtime_cfg=dict(platform=args.platform, ring_heap=PREFILL_RING_HEAP)
+```
+
+```python
+# L2 (single-chip) entries: execute_compiled has no ring_* kwarg, so a
+# runtime_cfg["ring_heap"] raises TypeError. Use the env fallback instead.
+os.environ.setdefault("PTO2_RING_HEAP", ",".join(str(v) for v in RING_HEAP))
+```
+
+```bash
+# Or from the command line, per ring 0..3:
+PTO2_RING_HEAP=134217728,268435456,402653184,536870912 python <kernel>.py -p a2a3 -d 0
+```
+
+Live examples: [`models/deepseek_v4_pro/prefill_fwd.py`](../../models/deepseek_v4_pro/prefill_fwd.py)
+(`ring_heap=` on the L3 path), [`models/deepseek_v4_pro/prefill_attention_csa.py`](../../models/deepseek_v4_pro/prefill_attention_csa.py)
+(env fallback, all four rings), [`models/deepseek_v4_flash_dspark/lm_head.py`](../../models/deepseek_v4_flash_dspark/lm_head.py)
+(scalar `setdefault`).
+
+`os.environ.setdefault` at import time is the repo idiom: it documents the
+kernel's requirement without overriding an explicit shell pin.
+
+---
+
+## 5. Measuring with `scope_stats`
+
+`scope_stats` records one sample at every scope boundary — task-window,
+heap, dep-pool head/tail plus tensormap usage — so a peak can be attributed
+to a **scope site**, not just a resource.
+
+### Enable it
+
+`enable_scope_stats` is one of the five DFX flags the golden harness
+forwards (`enable_l2_swimlane`, `enable_dump_args`, `enable_pmu`,
+`enable_dep_gen`, `enable_scope_stats`). Add the flag to the entry's argparse
+and pass it through:
+
+```python
+parser.add_argument("--enable-scope-stats", action="store_true", default=False)
+...
+runtime_cfg=dict(
+    platform=args.platform,
+    device_id=args.device,
+    enable_scope_stats=args.enable_scope_stats,
+)
+```
+
+Any DFX flag forces `save_kernels=True`, so the work dir survives the run.
+It works on both the L2 and L3 paths, and it needs an actual execution —
+`--compile-only` never reaches the runtime, so it records nothing.
+
+### Read the output
+
+```text
+<work_dir>/dfx_outputs/scope_stats/scope_stats.jsonl        # L2
+<work_dir>/dfx_outputs/rank<N>/d<K>/scope_stats/...jsonl    # L3: per rank, per dispatch
+```
+
+Line 1 is run metadata — schema `version`, `fatal`, `dropped`, and the
+**effective capacities** `task_window_max` / `heap_max` / `dep_pool_max`
+(arrays indexed by ring) and `tensormap_max`. This line is the fastest way
+to confirm a `PTO2_RING_*` pin actually took effect. Every later line is one
+`begin` or `end` sample carrying `site` (`<orchestration>.cpp:<line>`),
+`depth`, `ring`, and the head/tail pairs. Heap counters are monotonic
+cumulative bytes in `version` 6 (they wrapped in version 5).
+
+Pair a `begin` with its `end` to get the metrics:
+
+| Metric | Formula | Read it for |
+|---|---|---|
+| `scope_high_water` | `end.head − begin.tail` | Upper bound on the pressure this scope reached (entry backlog + everything it allocated). Not capped — a streaming scope can report more than the ring. |
+| `real_occupancy` | `end.head − end.tail` | What is still held when the scope exits. Always within `[0, cap]`. |
+| `scope_alloc` | `end.head − begin.head` | Allocation throughput of the scope, independent of reclaim. |
+
+### Render or summarize
+
+```bash
+python -m simpler_setup.tools.scope_stats_plot \
+    build_output/<prog>_<ts>/dfx_outputs/scope_stats/scope_stats.jsonl
+# writes scope_stats.html next to the input
+```
+
+The runner prints a hint naming `runtime/tools/scope_stats_plot.py`; that
+path does not exist in a pypto-lib checkout — use the module form above.
+
+For a quick per-ring number, pair the records yourself:
+
+```python
+import json, sys
+from collections import defaultdict
+
+lines = [json.loads(line) for line in open(sys.argv[1])]
+meta, records, open_scopes = lines[0], lines[1:], {}
+peak = defaultdict(lambda: (0, 0, ""))          # ring -> (high_water, live_at_exit, site)
+for r in records:
+    if r["phase"] == "begin":
+        open_scopes[r["depth"]] = r
+        continue
+    b = open_scopes.pop(r["depth"], None)
+    if b is None:
+        continue
+    hw = r["heap_end"] - b["heap_start"]        # scope_high_water
+    live = r["heap_end"] - r["heap_start"]      # real_occupancy
+    prev = peak[r["ring"]]
+    peak[r["ring"]] = (max(hw, prev[0]), max(live, prev[1]), r["site"] if hw > prev[0] else prev[2])
+
+print(f"fatal={meta['fatal']} dropped={meta['dropped']}")
+for ring, (hw, live, site) in sorted(peak.items()):
+    cap = meta["heap_max"][ring]
+    print(f"ring {ring}: high_water {hw/2**20:7.1f} MiB ({100*hw/cap:5.1f}% of {cap/2**20:.0f} MiB)"
+          f"  live_at_exit {live/2**20:7.1f} MiB  peak site {site}")
+```
+
+### Interpret it
+
+| Observation | Meaning | Action |
+|---|---|---|
+| One ring near or over capacity, others near zero | auto-scope collapse, or all work at one depth | place scopes so the load spreads over rings 0–3 (§3) |
+| High `scope_high_water`, low `real_occupancy` | the scope streams: it allocates a lot but reclaim keeps up | fine — the ring is doing its job |
+| `real_occupancy` high at scope exit | something long-lived is pinned in that ring | shrink the cross-phase payload, or move it to an outer scope that closes later |
+| Only `begin` records at the tail of the file | the run wedged inside that scope | the last open `site` is where the ring filled |
+| `dropped > 0` | collector back-pressure — records are missing | peaks are lower bounds; re-run with less concurrency before trusting them |
+| `fatal: true` | a fatal was latched mid-run | records after it are diagnostic only |
+
+Measure under the capacity the run will actually have. Reclaim only happens
+once the allocator has to wait, so on an oversized ring nothing is ever
+reclaimed and a scoped program reports the same frontier as an unscoped one —
+the scoping only shows its worth when the ring is tight enough to fill.
+
+---
+
+## 6. Failure modes this explains
+
+Every one of these surfaces host-side as the generic
+`507018 ACL_ERROR_RT_AICPU_EXCEPTION`. The real cause is the
+`orch_error_code=` line in the host log, and the runtime's own hint points
+at `scope_stats`:
+
+| `orch_error_code` | Name | What it means | First move |
+|---|---|---|---|
+| 1 | `SCOPE_DEADLOCK` | one scope submitted more tasks than the ring's task window; slots only free at `scope_end` | split the scope, or raise `PTO2_RING_TASK_WINDOW` |
+| 2 | `HEAP_RING_DEADLOCK` | the ring ran out of heap bytes (and slots) — no further task can be admitted | scope the intermediates, shrink them, or raise `PTO2_RING_HEAP` |
+| 3 | `FLOW_CONTROL_DEADLOCK` | task window blocked while heap is free — usually nesting on the *same* ring | move the nested submission to another ring |
+| 4 | `DEP_POOL_OVERFLOW` | a task's fanin edges overflowed the ring's dep pool | cut the fanin, or raise `PTO2_RING_DEP_POOL` |
+| 11 | `TENSORMAP_OVERFLOW` | the global tensormap wedged | extreme scale — check the tensormap row in the report |
+
+Oversizing has its own failure: the static arena scales with every ring's
+window / dep-pool / heap, and a run that pins all three large enough dies
+with an `rtMalloc 207001` OOM before it ever reaches the kernel.
+
+---
+
+## Related
+
+- [Debugging](debugging.md) — device logs for a hang, `runtime_dir` reuse,
+  the other four DFX flags.
+- [Performance tuning](performance-tuning.md) — L2 swimlane and PMU; scope
+  placement changes the schedule too, so re-measure wall time after it.
+- [PyPTO coding style](../pypto-coding/pypto-coding-style.md) — `pl.at`
+  scopes (InCore), which are a different thing from the runtime scopes here.
+- simpler's [Scope stats](https://www.pypto.ai/simpler/dfx/scope-stats/)
+  — the collector's own reference: report layout, JSONL schema history, and
+  the AICPU / host internals.

--- a/docs/debug-and-tune/ring-heap-and-scope-stats.md
+++ b/docs/debug-and-tune/ring-heap-and-scope-stats.md
@@ -312,6 +312,9 @@ with an `rtMalloc 207001` OOM before it ever reaches the kernel.
 
 - [Debugging](debugging.md) — device logs for a hang, `runtime_dir` reuse,
   the other four DFX flags.
+- [Dependencies and scheduling](dependency-and-scheduling.md) — the task
+  graph and scheduler behind the rings: what a task is, how edges are formed,
+  and what fills a window.
 - [Performance tuning](performance-tuning.md) — L2 swimlane and PMU; scope
   placement changes the schedule too, so re-measure wall time after it.
 - [PyPTO coding style](../pypto-coding/pypto-coding-style.md) — `pl.at`

--- a/docs/get-started/installation.md
+++ b/docs/get-started/installation.md
@@ -3,201 +3,161 @@
 PyPTO-Lib is a source repository rather than an installable Python package.
 Run its scripts from the repository root with that root on `PYTHONPATH`.
 
-The environment has four external components:
+Four external components sit under it, and the PyPTO checkout you select pins
+every one of them:
 
-| Component | Purpose | Version source |
+| Component | How it is installed | Version source |
 |---|---|---|
-| PyPTO | Language, IR, compiler, and Python runtime API | The selected PyPTO checkout |
-| simpler | Runtime implementation | PyPTO's `runtime/` submodule |
-| PTOAS | PTO bytecode assembler and optimizer | PyPTO's `toolchain/versions.env` |
-| PTO ISA | Tile-ISA implementation and headers | PyPTO's `runtime/pto_isa.pin` |
+| PyPTO | `pip install` the checkout | the checkout you clone |
+| simpler | `pip install` PyPTO's `runtime/` | PyPTO's `runtime/` submodule |
+| PTOAS | binary release under `PTOAS_ROOT` | PyPTO's `toolchain/versions.env` |
+| PTO ISA | cloned automatically on first use | PyPTO's `runtime/pto_isa.pin` |
 
-The selected PyPTO revision is the single source of truth. Do not copy a PTOAS
-version or PTO ISA commit from an old CI log or hard-code one in a local setup
-script.
+Install what the selected PyPTO revision points at. Do not copy a PTOAS version
+or a PTO ISA commit from an old CI log or hard-code one in a setup script.
 
 ## Prerequisites
 
-The repository CI uses Python 3.10. A source build also needs Git, `curl`,
-`tar`, `sha256sum`, CMake, Ninja, and a C/C++ compiler.
+- Python 3.10 or newer, Git, CMake, Ninja, and a C++17 compiler — `pip install`
+  builds PyPTO's C++ core.
+- Simulator platforms compile C++23: `gcc-15` and `g++-15` must resolve to GCC
+  15 or newer (`gcc-15 -dumpversion`).
+- Real-device runs additionally need CANN and an Ascend device matching the
+  platform passed to `-p`. Simulator runs need neither.
 
-Simulator builds invoke `gcc-15` and `g++-15` and compile C++23 code. Ensure
-those commands resolve to GCC 15 or newer:
-
-```bash
-gcc-15 -dumpversion
-g++-15 -dumpversion
-```
-
-For a real NPU run, also provide:
-
-- an installed CANN toolkit with a usable `set_env.sh`;
-- `npu-smi` on `PATH`;
-- an Ascend device matching the selected runtime platform.
-
-CANN is not required by the simulator jobs in this repository's CI.
-
-## Create a Python environment
+## Python environment
 
 From the PyPTO-Lib repository root:
 
 ```bash
-python3.10 -m venv .venv
+python3 -m venv .venv
 source .venv/bin/activate
 python -m pip install --upgrade pip
-python -m pip install scikit-build-core nanobind cmake ninja torch
+python -m pip install scikit-build-core nanobind cmake ninja
+python -m pip install torch --index-url https://download.pytorch.org/whl/cpu
 
-export PYPTO_LIB_ROOT="$PWD"
-export PYTHONPATH="$PYPTO_LIB_ROOT${PYTHONPATH:+:$PYTHONPATH}"
-export PYPTO_WORKSPACE="$(dirname "$PYPTO_LIB_ROOT")"
+export PYTHONPATH="$PWD${PYTHONPATH:+:$PYTHONPATH}"
 ```
 
-The remaining commands assume that `pypto`, `pto-isa`, and `ptoas-bin` do not
-already exist in `PYPTO_WORKSPACE`. If they do, inspect and update those
-checkouts deliberately instead of overwriting them.
+Install torch **before** PyPTO, and from the CPU index: PyPTO resolves
+`torch>=2.0.0` to the default wheel otherwise, which drags in the whole CUDA
+stack that nothing here uses. `PYTHONPATH` is the only variable the repository
+itself needs — entry scripts import the `golden/` harness from the repository
+root while running from their own directory.
 
-## Clone PyPTO and its runtime
-
-```bash
-git clone --recurse-submodules \
-  https://github.com/hw-native-sys/pypto.git \
-  "$PYPTO_WORKSPACE/pypto"
-
-export PYPTO_ROOT="$PYPTO_WORKSPACE/pypto"
-git -C "$PYPTO_ROOT" submodule update --init --recursive
-```
-
-The `runtime/` directory is the simpler submodule pinned by this PyPTO
-revision.
-
-## Resolve the toolchain pins
-
-Read both pins from the same PyPTO checkout:
-
-```bash
-export PTOAS_ARCH="$(uname -m)"
-export PTOAS_VERSION="$(
-  sed -n 's/^PTOAS_VERSION=//p' "$PYPTO_ROOT/toolchain/versions.env" |
-    tr -d '[:space:]'
-)"
-export PTOAS_SHA256="$(
-  sed -n \
-    "s/^PTOAS_SHA256_$(printf '%s' "$PTOAS_ARCH" | tr '[:lower:]' '[:upper:]')=//p" \
-    "$PYPTO_ROOT/toolchain/versions.env" |
-    tr -d '[:space:]'
-)"
-export PTO_ISA_COMMIT="$(
-  tr -d '[:space:]' < "$PYPTO_ROOT/runtime/pto_isa.pin"
-)"
-
-test -n "$PTOAS_VERSION"
-test -n "$PTOAS_SHA256"
-test -n "$PTO_ISA_COMMIT"
-```
-
-`uname -m` selects the matching PTOAS release asset and checksum. It does
-**not** choose between a simulator and a real device; the script's `-p`
-argument makes that choice.
-
-## Install PTO ISA and PyPTO
-
-```bash
-git clone https://github.com/hw-native-sys/pto-isa.git \
-  "$PYPTO_WORKSPACE/pto-isa"
-git -C "$PYPTO_WORKSPACE/pto-isa" checkout "$PTO_ISA_COMMIT"
-export PTO_ISA_ROOT="$PYPTO_WORKSPACE/pto-isa"
-
-python -m pip install --no-build-isolation "$PYPTO_ROOT"
-```
-
-## Prepare a real-device build
+## CANN (real devices only)
 
 Skip this section for a simulator-only environment.
 
-For real-device support, source CANN **before installing simpler**:
+Driver and firmware belong to the machine, need root, and are normally already
+there — they are what provides `npu-smi`. Check before installing anything; if
+this fails, the host is missing the Ascend HDK packages and that is an
+administrator task:
 
 ```bash
-export CANN_ROOT=/path/to/Ascend/cann
-source "$CANN_ROOT/set_env.sh"
 npu-smi info
 ```
 
-The simpler installer detects CANN's `ccec` and cross compiler and builds the
-onboard runtime binaries at installation time. Sourcing CANN only after simpler
-has been installed does not add those binaries.
-
-## Install simpler
+The toolkit is what PyPTO-Lib builds against, and a plain user can install it.
+Download `Ascend-cann-toolkit_<version>_linux-<arch>.run` from the
+[community release page](https://www.hiascend.com/developer/download/community/result?module=cann),
+matching the driver above (`cat /usr/local/Ascend/driver/version.info`); device
+runs in this repository currently use CANN 9.0.0.
 
 ```bash
+# Packages the .run installer checks for
+python -m pip install attrs numpy decorator sympy cffi pyyaml pathlib2 psutil protobuf scipy requests absl-py
+
+chmod +x Ascend-cann-toolkit_<version>_linux-<arch>.run
+./Ascend-cann-toolkit_<version>_linux-<arch>.run --install
+
+# A root install lands in /usr/local/Ascend/ascend-toolkit/latest
+export CANN_ROOT="$HOME/Ascend/ascend-toolkit/latest"
+source "$CANN_ROOT/set_env.sh"
+```
+
+`set_env.sh` exports `ASCEND_HOME_PATH`, where simpler looks for the two
+compilers it builds the onboard runtime with. Both must be present, or simpler
+builds the simulator platforms only and every device platform is rejected
+later:
+
+```bash
+test -x "$ASCEND_HOME_PATH/bin/ccec"                                  # AICore
+test -f "$ASCEND_HOME_PATH/tools/hcc/bin/aarch64-target-linux-gnu-g++"  # AICPU
+```
+
+The toolkit is the only CANN package needed: PyPTO-Lib generates and assembles
+its own kernels, and the runtime links only ACL and HCCL, so
+`Ascend-cann-kernels-*` and NNAL are not required.
+
+## PyPTO and the runtime
+
+```bash
+git clone --recurse-submodules https://github.com/hw-native-sys/pypto.git ../pypto
+export PYPTO_ROOT="$(cd ../pypto && pwd)"
+
+python -m pip install --no-build-isolation "$PYPTO_ROOT"
 python -m pip install --no-build-isolation "$PYPTO_ROOT/runtime"
 ```
 
-Installing simpler from `runtime/` keeps the build and runtime at the revision
-selected by PyPTO. If simpler was installed before CANN was sourced, source
-CANN and reinstall this same path.
+`runtime/` is the simpler submodule this PyPTO revision pins; installing from
+that path keeps build and runtime at the same revision.
 
-## Install the pinned PTOAS release
+**Source CANN before this step.** The simpler installer builds the onboard
+binaries with the compilers it finds at install time; sourcing `set_env.sh`
+afterwards does not add them, and the fix is to source it and reinstall
+`runtime/`.
 
-```bash
-export PTOAS_ROOT="$PYPTO_WORKSPACE/ptoas-bin"
-export PTOAS_ARCHIVE="/tmp/ptoas-bin-${PTOAS_ARCH}-${PTOAS_VERSION}.tar.gz"
+## PTOAS
 
-curl --fail --location --retry 3 --retry-all-errors \
-  "https://github.com/hw-native-sys/PTOAS/releases/download/${PTOAS_VERSION}/ptoas-bin-${PTOAS_ARCH}.tar.gz" \
-  -o "$PTOAS_ARCHIVE"
-printf '%s  %s\n' "$PTOAS_SHA256" "$PTOAS_ARCHIVE" | sha256sum -c -
-
-mkdir -p "$PTOAS_ROOT"
-tar -xzf "$PTOAS_ARCHIVE" -C "$PTOAS_ROOT"
-
-if [ -f "$PTOAS_ROOT/ptoas" ]; then
-  chmod +x "$PTOAS_ROOT/ptoas"
-elif [ -f "$PTOAS_ROOT/bin/ptoas" ]; then
-  chmod +x "$PTOAS_ROOT/bin/ptoas"
-else
-  printf 'PTOAS executable not found under %s\n' "$PTOAS_ROOT" >&2
-  exit 1
-fi
-```
-
-Do not skip the checksum. A missing checksum for the current architecture
-means the selected PyPTO revision does not declare a compatible PTOAS asset.
-
-## Re-enter a real-device shell
-
-Before each NPU run, source the same CANN environment used to build simpler:
+Take the pinned version from the same PyPTO checkout and unpack that release:
 
 ```bash
-export CANN_ROOT=/path/to/Ascend/cann
-source "$CANN_ROOT/set_env.sh"
-npu-smi info
+version=$(grep '^PTOAS_VERSION=' "$PYPTO_ROOT/toolchain/versions.env" | cut -d= -f2)
+echo "$version"   # e.g. v0.57
+
+curl -fL -O "https://github.com/hw-native-sys/PTOAS/releases/download/$version/ptoas-bin-$(uname -m).tar.gz"
+mkdir -p ../ptoas-bin
+tar -xzf "ptoas-bin-$(uname -m).tar.gz" -C ../ptoas-bin
+export PTOAS_ROOT="$(cd ../ptoas-bin && pwd)"
 ```
 
-Keep the environment variables from the earlier steps in the same shell:
+The bundle carries its own CPython, so it need not match the venv's Python; the
+release also ships `cp310`–`cp312` wheels, which work when installed into a
+dedicated venv that `PTOAS_ROOT` then points at. While `PTOAS_ROOT` is set only
+that directory is searched, so a `ptoas` earlier on `PATH` cannot shadow the
+pinned one.
 
-```bash
-export PYTHONPATH="$PYPTO_LIB_ROOT${PYTHONPATH:+:$PYTHONPATH}"
-export PTOAS_ROOT="$PYPTO_WORKSPACE/ptoas-bin"
-export PTO_ISA_ROOT="$PYPTO_WORKSPACE/pto-isa"
-```
+## PTO ISA
 
-## Verify the installation
+Nothing to clone by hand — PyPTO and simpler each manage their own checkout at
+the commit in `$PYPTO_ROOT/runtime/pto_isa.pin`:
+
+| Consumer | Managed checkout | Honours `PTO_ISA_ROOT` |
+|---|---|---|
+| PyPTO | `build_output/_deps/pto-isa` under the working directory | yes — set it and no clone happens |
+| simpler | `build/pto-isa` under the installed `simpler_setup` package | no — it always uses its own copy |
+
+Both clone on first use, so the first device build in a fresh environment
+pauses on a `git clone` — on a slow or blocked network that looks like a hang.
+Seeding either path with a symlink to an existing pto-isa at the pinned commit
+avoids the wait.
+
+## Verify
 
 ```bash
 python -c "import pypto, torch; from golden import run, run_jit; print(torch.__version__)"
+python examples/beginner/hello_world.py -p a2a3sim
+```
 
-if [ -f "$PTOAS_ROOT/ptoas" ] && [ -x "$PTOAS_ROOT/ptoas" ]; then
-  ptoas_bin="$PTOAS_ROOT/ptoas"
-elif [ -f "$PTOAS_ROOT/bin/ptoas" ] && [ -x "$PTOAS_ROOT/bin/ptoas" ]; then
-  ptoas_bin="$PTOAS_ROOT/bin/ptoas"
-else
-  printf 'PTOAS executable not found under %s\n' "$PTOAS_ROOT" >&2
-  exit 1
-fi
-"$ptoas_bin" --version
+The example ends in a `[RUN] PASS` line, having exercised the whole chain —
+front end, PTOAS, runtime, simulator — so it fails loudly if any piece above is
+missing. On a device, in a shell carrying `PYTHONPATH`, `PTOAS_ROOT`, and the
+same CANN environment simpler was built against:
 
-git -C "$PYPTO_ROOT" submodule status runtime
-git -C "$PTO_ISA_ROOT" rev-parse HEAD
+```bash
+source "$CANN_ROOT/set_env.sh"
+python examples/beginner/hello_world.py -p a2a3 -d 0
 ```
 
 Then proceed to [Run your first kernel](first-kernel.md).
@@ -207,13 +167,8 @@ Then proceed to [Run your first kernel](first-kernel.md).
 | Symptom | Check |
 |---|---|
 | `ModuleNotFoundError: golden` | Run from the repository root and export that root in `PYTHONPATH`. |
-| `ModuleNotFoundError: pypto` | Activate the intended Python environment and reinstall the selected PyPTO checkout. |
-| PTOAS cannot be found | Verify that either `$PTOAS_ROOT/ptoas` or `$PTOAS_ROOT/bin/ptoas` is a regular executable file, and keep `PTOAS_ROOT` exported. |
-| PTO ISA headers cannot be found | Verify `PTO_ISA_ROOT` and that its `HEAD` equals `runtime/pto_isa.pin`. |
-| Simulator compilation cannot find `g++-15` | Install GCC 15 or provide `gcc-15` and `g++-15` wrappers for the active compiler environment. |
-| A device run cannot find or initialize the onboard runtime | Confirm CANN was sourced when simpler was installed, reinstall simpler if necessary, source the same `set_env.sh`, then check `npu-smi info`. |
-
-The CI-equivalent setup is implemented in
-[`.github/actions/setup-ci-job/action.yml`](../../.github/actions/setup-ci-job/action.yml).
-Use it as the executable source of truth when this page and automation appear
-to disagree.
+| `ModuleNotFoundError: pypto` | Activate the intended environment and reinstall the selected PyPTO checkout. |
+| PTOAS cannot be found | `PTOAS_ROOT` must be exported and hold `ptoas.sh` (bundle) or `bin/ptoas` (wheel venv). |
+| The first device build stalls on a `git clone` | It is fetching pto-isa. On a blocked network, seed the checkout the error names, or symlink an existing clone. |
+| Simulator compilation cannot find `g++-15` | Install GCC 15, or provide `gcc-15` / `g++-15` wrappers for the active compiler. |
+| A device platform is rejected, or the onboard runtime will not initialize, while `a2a3sim` works | simpler was installed without CANN. Source `set_env.sh`, confirm the two compilers above, then reinstall `$PYPTO_ROOT/runtime`. |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -96,6 +96,7 @@ nav:
       - Debugging: debug-and-tune/debugging.md
       - Precision tuning: debug-and-tune/precision-tuning.md
       - Performance tuning: debug-and-tune/performance-tuning.md
+      - Ring heap and scope stats: debug-and-tune/ring-heap-and-scope-stats.md
       - Cube tile tuning: debug-and-tune/cube-tile-tuning.md
       - In-core simulator profiling: debug-and-tune/incore-simulator-profiling.md
       - CCE in-core profiling: debug-and-tune/cce-incore-profiling.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -96,6 +96,7 @@ nav:
       - Debugging: debug-and-tune/debugging.md
       - Precision tuning: debug-and-tune/precision-tuning.md
       - Performance tuning: debug-and-tune/performance-tuning.md
+      - Dependencies and scheduling: debug-and-tune/dependency-and-scheduling.md
       - Ring heap and scope stats: debug-and-tune/ring-heap-and-scope-stats.md
       - Cube tile tuning: debug-and-tune/cube-tile-tuning.md
       - In-core simulator profiling: debug-and-tune/incore-simulator-profiling.md


### PR DESCRIPTION
- Add a dependency and scheduling guide: what a task is (pl.at is one
  task, pl.spmd one task fanned out over n blocks), the two ways an edge
  exists (TensorMap inference over parameter directions, with WAR
  untracked, and declared deps=), the runtime timeline behind the four
  swimlane timestamps, the artifacts that settle each claim, and a
  tuning loop from the Observed critical path through a gap taxonomy to
  allow_early_resolve and an unflagged dummy that frees a contended
  early-dispatch window
- Add a ring heap and scope stats guide: the runtime's four per-depth
  rings, how a pl.create_tensor intermediate is allocated and when it
  becomes reclaimable, pl.scope placement plus PTO2_RING_* / RunConfig
  sizing, enable_scope_stats and its JSONL metrics, and the
  orch_error_code failures those peaks explain
- Cut the installation guide to what a setup needs: drop PYPTO_LIB_ROOT,
  PYPTO_WORKSPACE and the PTOAS_ARCH / PTOAS_VERSION / PTOAS_SHA256 /
  PTO_ISA_COMMIT shell derivations that belong to CI, stop cloning
  pto-isa by hand now that pypto and simpler each manage their own
  checkout at runtime/pto_isa.pin, and verify with a hello_world run on
  a2a3sim instead of a ptoas-locating shell ladder
- Add a CANN section covering driver/firmware versus toolkit, the .run
  install, and the ccec / AICPU cross-compiler checks that decide
  whether simpler builds the device platforms at all
- Probe ptoas.sh alongside ptoas and bin/ptoas, as pypto's
  _ptoas_locate.py does: a v0.55+ release bundles its own CPython and
  runs only through that launcher, so the old two-path probe reported a
  CPython mismatch instead of a version. Same fix in create-issue's
  environment collection, and setup-env's steps follow the rewritten
  guide
- Point performance-tuning's simpler runtime reference at the published
  docs page, and link both new guides from the debug-and-tune index and
  the mkdocs nav