### PR TITLE
CI: unpin pypto and resolve the toolchain from HEAD again

### DIFF
--- a/.github/actions/pypto-serving-tests/action.yml
+++ b/.github/actions/pypto-serving-tests/action.yml
@@ -91,25 +91,6 @@ runs:
         echo "pypto-lib under test: $(git -C "$PYPTO_SERVING_CHECKOUT/pypto-lib" rev-parse HEAD)"
         echo "pypto-serving base:  $(git -C "$PYPTO_SERVING_CHECKOUT" rev-parse HEAD)"
 
-    - name: Verify the pinned pypto is what serving will run
-      # The serving jobs get their pypto from setup-ci-job like every other job,
-      # so they inherit PYPTO_PIN — but they are the only ones that then run
-      # someone else's test suite against it, and they are the most expensive
-      # thing to discover a wrong toolchain in (8 cards, ~30 min). Assert the
-      # build tree is still at the pin before spending that.
-      shell: bash
-      run: |
-        if [ -z "${PYPTO_PIN:-}" ] || [ -z "${PYPTO_SRC:-}" ]; then
-          echo "::error::PYPTO_PIN/PYPTO_SRC are unset — run setup-ci-job first"
-          exit 1
-        fi
-        actual=$(git -C "$PYPTO_SRC" rev-parse HEAD)
-        if [ "$actual" != "$PYPTO_PIN" ]; then
-          echo "::error::serving would run pypto $actual, not the pinned $PYPTO_PIN"
-          exit 1
-        fi
-        echo "serving runs pypto $actual (pinned)"
-
     - name: Install pypto-serving test dependencies
       shell: bash
       working-directory: ${{ inputs.pypto-lib-checkout-path }}

--- a/.github/actions/setup-ci-job/action.yml
+++ b/.github/actions/setup-ci-job/action.yml
@@ -269,10 +269,6 @@ runs:
       # so the toolchain pins and the installed pypto are always the same
       # revision. pypto owns ptoas (toolchain/versions.env) and pins pto-isa via
       # its runtime submodule (runtime/pto_isa.pin); read both.
-      #
-      # The revision is PINNED (PYPTO_PIN below), not pypto's HEAD: CI must fail
-      # on pypto-lib changes only, and an upstream regression otherwise turns
-      # every open PR red at once with no way to tell the two apart.
       shell: bash
       run: |
         # $PYPTO_SRC is the per-job build tree exported by the loader step:
@@ -298,35 +294,19 @@ runs:
             sleep $((attempt * 10))
           done
         }
-        # The pypto revision CI builds against. Bump this deliberately, in its
-        # own PR, so the toolchain move is reviewable and revertable on its own.
-        #
-        # 33ff8b49 is the commit before pypto #2273 ("adapt soft SYNCALL and
-        # Simpler Buffer ABIs"), which bumps the simpler submodule 3165cc89 ->
-        # 1f27a157. From that bump on, any two-rank program whose first
-        # cross-rank step is a push/notify + spin-wait pair hangs: the waiting
-        # AIV task never completes and the peer times out on the release
-        # barrier. That is every multi-card model entry in ci.yml and
-        # daily_ci.yml, so unrelated pypto-lib PRs inherit a red CI they cannot
-        # fix. Raise the pin again once the hang is fixed upstream.
-        PYPTO_PIN=33ff8b4974b98b3a529fea3c8443292f97b8ae4d
         if [ -d "$PYPTO_SRC/.git" ]; then
-          echo "Cache hit — updating pypto to $PYPTO_PIN"
+          echo "Cache hit — updating pypto"
+          retry git -C "$PYPTO_SRC" fetch --depth=1 origin HEAD || exit 1
+          git -C "$PYPTO_SRC" reset --hard FETCH_HEAD
+          git -C "$PYPTO_SRC" clean -ffdx
+          git -C "$PYPTO_SRC" submodule foreach --recursive 'git reset --hard && git clean -ffdx' || true
         else
-          echo "Cache miss — seeding pypto repo"
+          echo "Cache miss — cloning pypto"
           mkdir -p "$(dirname "$PYPTO_SRC")"
-          rm -rf "$PYPTO_SRC"
-          git init -q "$PYPTO_SRC"
-          git -C "$PYPTO_SRC" remote add origin https://github.com/hw-native-sys/pypto.git
+          # rm before each attempt so a retried clone never hits a partial dir.
+          clone_pypto() { rm -rf "$PYPTO_SRC"; git clone --depth=1 https://github.com/hw-native-sys/pypto.git "$PYPTO_SRC"; }
+          retry clone_pypto || exit 1
         fi
-        # Fetch the pinned commit itself rather than a branch tip, so the cached
-        # tree is the same revision on a cache hit and a cache miss alike. Still
-        # --depth=1: a pin needs one commit, not the history behind it.
-        retry git -C "$PYPTO_SRC" fetch --depth=1 origin "$PYPTO_PIN" || exit 1
-        git -C "$PYPTO_SRC" reset --hard FETCH_HEAD
-        git -C "$PYPTO_SRC" clean -ffdx
-        git -C "$PYPTO_SRC" submodule foreach --recursive 'git reset --hard && git clean -ffdx' || true
-        echo "pypto at $(git -C "$PYPTO_SRC" rev-parse HEAD)"
         retry git -C "$PYPTO_SRC" submodule update --init --recursive --depth=1 || exit 1
         rm -rf "$PYPTO_SRC/build" "$PYPTO_SRC/_skbuild" "$PYPTO_SRC/runtime/build"
         # PTOAS ships one wheel per arch, with a matching PTOAS_SHA256_<ARCH> in
@@ -350,9 +330,6 @@ runs:
           echo "PTOAS_ARCH=$PTOAS_ARCH"
           echo "PTOAS_SHA256=$PTOAS_SHA256"
           echo "PTO_ISA_COMMIT=$(tr -d '[:space:]' < "$PYPTO_SRC/runtime/pto_isa.pin")"
-          # Exported so later steps in the same job can assert what they build
-          # on — the pypto-serving action checks it before spending a device.
-          echo "PYPTO_PIN=$PYPTO_PIN"
         } >> "$GITHUB_ENV"
 
     - name: Check NPU

--- a/models/deepseek_v4_flash_mtp/decode_fwd_mtp.py
+++ b/models/deepseek_v4_flash_mtp/decode_fwd_mtp.py
@@ -1205,3 +1205,4 @@ def main():
 
 if __name__ == "__main__":
     main()
+


### PR DESCRIPTION
- Revert #990: setup-ci-job drops PYPTO_PIN and returns to the cache-hit
  `fetch origin HEAD` / cache-miss `git clone --depth=1` pair, so every
  self-hosted job builds pypto's default-branch HEAD again.
- Drop the pypto-serving-tests pre-flight assertion that the build tree
  sits at the pin, and the PYPTO_PIN export it read.
- Touch models/deepseek_v4_flash_mtp/decode_fwd_mtp.py so detect-changes
  selects the a2a3 device job and the 8-card DeepSeek serving job, the
  two entries the pin was protecting.

The pin was added because hw-native-sys/pypto#2273 ("adapt soft SYNCALL
and Simpler Buffer ABIs") hung any two-rank program whose first
cross-rank step is a push/notify plus spin-wait pair: the waiting AIV
task never completed and the peer timed out on the release barrier. Both
protected entries are green against pypto HEAD on this PR, so the hang no
longer reproduces and the pin is no longer needed.