### PR TITLE
Refactor: inline the dspark decode output entries and route by --tp

### DIFF
--- a/docs/debug-and-tune/dependency-and-scheduling.md
+++ b/docs/debug-and-tune/dependency-and-scheduling.md
@@ -487,7 +487,7 @@ gate = pl.system.task_dummy(deps=[tid_a, tid_b])
 
 # 2. Delay by one hop: a real producer, plus a hop, before a non-critical
 #    consumer — so it stops resolving at the same instant as the critical one.
-#    models/deepseek_v4_flash_dspark/decode_swa.py:320
+#    models/deepseek_v4_flash_dspark/decode_swa.py:171
 late_dep = pl.system.task_dummy(deps=[rms_tid])
 qkv_proj_rope(..., late_dep)
 

--- a/models/deepseek_v4_flash_dspark/decode_csa.py
+++ b/models/deepseek_v4_flash_dspark/decode_csa.py
@@ -76,12 +76,7 @@ from decode_o_proj import (
     o_proj_reduce_scatter,
 )
 from decode_sparse_attn_csa import (
-    ATTN_K_TILE,
-    CMP_TOPK,
-    NOPE_DIM,
-    ROPE_DIM,
     ROPE_CS_T_TILE,
-    SOFTMAX_SCALE,
     T_PAD,
     sparse_attn_csa,
 )
@@ -148,162 +143,6 @@ if T != LOCAL_T:
     raise ValueError(f"CSA token capacity {T} must equal TP local token capacity {LOCAL_T}")
 if T_PAD != LOCAL_T_PAD:
     raise ValueError(f"CSA token capacity {T_PAD} must equal TP local token capacity {LOCAL_T_PAD}")
-
-
-@pl.jit.inline
-def decode_csa_output(
-    q: pl.Tensor[[T_DYN, H, HEAD_DIM], pl.BF16],
-    ori_kv: pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
-    window_swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
-    cmp_kv: pl.Tensor[[CMP_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
-    cmp_block_table: pl.Tensor[[B_DYN, CMP_MAX_BLOCKS], pl.INT32],
-    idx_topk: pl.Tensor[[T_DYN, INDEXER_SCORE_LEN], pl.INT32],
-    position_ids: pl.Tensor[[T_DYN, 1], pl.INT32],
-    attn_sink: pl.Tensor[[H], pl.FP32],
-    freqs_cos: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
-    freqs_sin: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
-    wo_a: pl.Tensor[[LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
-    wo_b: pl.Tensor[[D, LOCAL_O_WIDTH], pl.INT8],
-    wo_b_scale: pl.Tensor[[D], pl.FP32],
-    o_local: pl.Tensor[[LOCAL_T_PAD, D], pl.BF16],
-    attention_window: pld.DistributedTensor[[ATTENTION_WINDOW_ROWS, O_GROUP_IN], pl.BF16],
-    attention_signal: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
-    o_window: pld.DistributedTensor[[O_WINDOW_ROWS, D], pl.FP32],
-    o_signal: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
-    group_base: pl.Scalar[pl.INT32],
-    tp_rank: pl.Scalar[pl.INT32],
-    local_t: pl.Scalar[pl.INT32],
-):
-    """Run sparse attention and the distributed sharded O projection."""
-    attention_grouped = pl.create_tensor([O_GROUPS * LOCAL_T_PAD, O_GROUP_IN], dtype=pl.BF16)
-    attention_grouped, heads_tid = sparse_attn_csa(
-        q, ori_kv, window_swa_indices,
-        cmp_kv, cmp_block_table, idx_topk,
-        position_ids, attn_sink, freqs_cos, freqs_sin,
-        attention_grouped,
-    )
-
-    attention_local_flat = pl.create_tensor([ATTENTION_WINDOW_ROWS, O_GROUP_IN], dtype=pl.BF16)
-    attention_local_flat, attention_signal = o_group_a2a(
-        attention_grouped, attention_local_flat,
-        attention_window, attention_signal,
-        group_base, tp_rank, local_t,
-    )
-
-    attention_local_groups = pl.reshape(attention_local_flat, [LOCAL_O_GROUPS, GROUP_T_PAD, O_GROUP_IN])
-    o_partial = pl.create_tensor([GROUP_T_PAD, D], dtype=pl.FP32)
-    o_partial, projection_tid = decode_o_proj(
-        attention_local_groups,
-        wo_a, wo_b, wo_b_scale,
-        local_t, o_partial,
-    )
-
-    o_local, o_signal = o_proj_reduce_scatter(
-        o_partial, o_local,
-        o_window, o_signal,
-        group_base, tp_rank, local_t, projection_tid,
-    )
-    return o_local, attention_signal, o_signal
-
-
-@pl.jit
-def decode_csa_output_test(
-    q: pl.Tensor[[T_DYN, H, HEAD_DIM], pl.BF16],
-    ori_kv: pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
-    window_swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
-    cmp_kv: pl.Tensor[[CMP_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
-    cmp_block_table: pl.Tensor[[B_DYN, CMP_MAX_BLOCKS], pl.INT32],
-    idx_topk: pl.Tensor[[T_DYN, INDEXER_SCORE_LEN], pl.INT32],
-    position_ids: pl.Tensor[[T_DYN, 1], pl.INT32],
-    attn_sink: pl.Tensor[[H], pl.FP32],
-    freqs_cos: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
-    freqs_sin: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
-    wo_a: pl.Tensor[[LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
-    wo_b: pl.Tensor[[D, LOCAL_O_WIDTH], pl.INT8],
-    wo_b_scale: pl.Tensor[[D], pl.FP32],
-    o_local: pl.InOut[pl.Tensor[[LOCAL_T_PAD, D], pl.BF16]],
-    attention_window: pld.DistributedTensor[[ATTENTION_WINDOW_ROWS, O_GROUP_IN], pl.BF16],
-    attention_signal: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
-    o_window: pld.DistributedTensor[[O_WINDOW_ROWS, D], pl.FP32],
-    o_signal: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
-    group_base: pl.Scalar[pl.INT32],
-    tp_rank: pl.Scalar[pl.INT32],
-    local_t: pl.Scalar[pl.INT32],
-):
-    """Bind dynamic inputs for standalone CSA output-half validation."""
-    q.bind_dynamic(0, T_DYN)
-    ori_kv.bind_dynamic(0, ORI_BLOCK_NUM_DYN)
-    window_swa_indices.bind_dynamic(0, T_DYN)
-    cmp_kv.bind_dynamic(0, CMP_BLOCK_NUM_DYN)
-    cmp_block_table.bind_dynamic(0, B_DYN)
-    idx_topk.bind_dynamic(0, T_DYN)
-    position_ids.bind_dynamic(0, T_DYN)
-    freqs_cos.bind_dynamic(0, T_DYN)
-    freqs_sin.bind_dynamic(0, T_DYN)
-
-    return decode_csa_output(
-        q, ori_kv, window_swa_indices,
-        cmp_kv, cmp_block_table, idx_topk,
-        position_ids, attn_sink, freqs_cos, freqs_sin,
-        wo_a, wo_b, wo_b_scale, o_local,
-        attention_window, attention_signal, o_window, o_signal,
-        group_base, tp_rank, local_t,
-    )
-
-
-@pl.jit.host
-def l3_decode_csa_output_test(
-    q: pl.Tensor[[TP_SIZE, T_DYN, H, HEAD_DIM], pl.BF16],
-    ori_kv: pl.Tensor[[TP_SIZE, ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
-    window_swa_indices: pl.Tensor[[TP_SIZE, T_DYN, WIN], pl.INT32],
-    cmp_kv: pl.Tensor[[TP_SIZE, CMP_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
-    cmp_block_table: pl.Tensor[[TP_SIZE, B_DYN, CMP_MAX_BLOCKS], pl.INT32],
-    idx_topk: pl.Tensor[[TP_SIZE, T_DYN, INDEXER_SCORE_LEN], pl.INT32],
-    position_ids: pl.Tensor[[TP_SIZE, T_DYN, 1], pl.INT32],
-    attn_sink: pl.Tensor[[TP_SIZE, H], pl.FP32],
-    freqs_cos: pl.Tensor[[TP_SIZE, T_DYN, ROPE_DIM], pl.BF16],
-    freqs_sin: pl.Tensor[[TP_SIZE, T_DYN, ROPE_DIM], pl.BF16],
-    wo_a: pl.Tensor[[TP_SIZE, LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
-    wo_b: pl.Tensor[[TP_SIZE, D, LOCAL_O_WIDTH], pl.INT8],
-    wo_b_scale: pl.Tensor[[TP_SIZE, D], pl.FP32],
-    o_local: pl.InOut[pl.Tensor[[TP_SIZE, LOCAL_T_PAD, D], pl.BF16]],
-    local_t: pl.Scalar[pl.INT32],
-):
-    """Launch the CSA output half on one physical TP group."""
-    q.bind_dynamic(1, T_DYN)
-    ori_kv.bind_dynamic(1, ORI_BLOCK_NUM_DYN)
-    window_swa_indices.bind_dynamic(1, T_DYN)
-    cmp_kv.bind_dynamic(1, CMP_BLOCK_NUM_DYN)
-    cmp_block_table.bind_dynamic(1, B_DYN)
-    idx_topk.bind_dynamic(1, T_DYN)
-    position_ids.bind_dynamic(1, T_DYN)
-    freqs_cos.bind_dynamic(1, T_DYN)
-    freqs_sin.bind_dynamic(1, T_DYN)
-
-    attention_window_buf = pld.alloc_window_buffer([ATTENTION_WINDOW_ROWS, O_GROUP_IN], dtype=pl.BF16)
-    attention_signal_buf = pld.alloc_window_buffer([TP_SIZE, 1], dtype=pl.INT32)
-    o_window_buf = pld.alloc_window_buffer([O_WINDOW_ROWS, D], dtype=pl.FP32)
-    o_signal_buf = pld.alloc_window_buffer([TP_SIZE, 1], dtype=pl.INT32)
-
-    for rank in pl.range(pld.world_size()):
-        attention_window = pld.window(attention_window_buf, [ATTENTION_WINDOW_ROWS, O_GROUP_IN], dtype=pl.BF16)
-        attention_signal = pld.window(attention_signal_buf, [TP_SIZE, 1], dtype=pl.INT32)
-        o_window = pld.window(o_window_buf, [O_WINDOW_ROWS, D], dtype=pl.FP32)
-        o_signal = pld.window(o_signal_buf, [TP_SIZE, 1], dtype=pl.INT32)
-        decode_csa_output_test(
-            q[rank],
-            ori_kv[rank], window_swa_indices[rank],
-            cmp_kv[rank], cmp_block_table[rank], idx_topk[rank],
-            position_ids[rank], attn_sink[rank],
-            freqs_cos[rank], freqs_sin[rank],
-            wo_a[rank], wo_b[rank], wo_b_scale[rank],
-            o_local[rank],
-            attention_window, attention_signal,
-            o_window, o_signal,
-            0, rank, local_t,
-            device=rank,
-        )
-
 
 
 @pl.jit.inline
@@ -476,14 +315,33 @@ def decode_csa(
     )
 
     position_ids_t1 = pl.reshape(position_ids, [t_dim, 1])
-    o_local = pl.create_tensor([LOCAL_T_PAD, D], dtype=pl.BF16)
-    o_local, attention_signal, o_signal = decode_csa_output(
+    attention_grouped = pl.create_tensor([O_GROUPS * LOCAL_T_PAD, O_GROUP_IN], dtype=pl.BF16)
+    attention_grouped, heads_tid = sparse_attn_csa(
         q, kv_cache, window_swa_indices,
         cmp_kv, cmp_block_table, idx_topk_full,
         position_ids_t1, attn_sink, rope_cos_t, rope_sin_t,
-        wo_a, wo_b, wo_b_scale, o_local,
-        attention_window, attention_signal, o_window, o_signal,
+        attention_grouped,
+    )
+
+    attention_local_flat = pl.create_tensor([ATTENTION_WINDOW_ROWS, O_GROUP_IN], dtype=pl.BF16)
+    attention_local_flat, attention_signal = o_group_a2a(
+        attention_grouped, attention_local_flat,
+        attention_window, attention_signal,
         group_base, tp_rank, local_t,
+    )
+
+    attention_local_groups = pl.reshape(attention_local_flat, [LOCAL_O_GROUPS, GROUP_T_PAD, O_GROUP_IN])
+    o_partial = pl.create_tensor([GROUP_T_PAD, D], dtype=pl.FP32)
+    o_partial, projection_tid = decode_o_proj(
+        attention_local_groups,
+        wo_a, wo_b, wo_b_scale,
+        local_t, o_partial,
+    )
+    o_local = pl.create_tensor([LOCAL_T_PAD, D], dtype=pl.BF16)
+    o_local, o_signal = o_proj_reduce_scatter(
+        o_partial, o_local,
+        o_window, o_signal,
+        group_base, tp_rank, local_t, projection_tid,
     )
     attn_out = pl.create_tensor([t_dim, D], dtype=pl.BF16)
     for block in pl.spmd(t_dim // CSA_WB_TOKEN_TILE, name_hint="csa_o_local_bridge"):
@@ -1016,326 +874,12 @@ def decode_csa_tp1_test(
 
 
 # fixture
-FIXTURE_CMP_ENTRIES = (
-    (ATTN_K_TILE - 1, BLOCK_SIZE // 4 - 1),
-    (2 * ATTN_K_TILE - 1, BLOCK_SIZE),
-    (3 * ATTN_K_TILE - 1, 2 * BLOCK_SIZE),
-    (4 * ATTN_K_TILE - 1, 4 * BLOCK_SIZE - 3),
-)
-FIXTURE_FILTERED_POSITIONS = (1, ATTN_K_TILE + 1, 2 * ATTN_K_TILE + 1, 3 * ATTN_K_TILE + 1)
-FIXTURE_CMP_SLOTS = tuple(slot for _, slot in FIXTURE_CMP_ENTRIES)
-FIXTURE_CMP_LOGICAL_BLOCKS = (max(FIXTURE_CMP_SLOTS) + 1 + BLOCK_SIZE - 1) // BLOCK_SIZE
-FIXTURE_CMP_BOUND = 4 * BLOCK_SIZE - 2
-FIXTURE_FILTERED_SLOT = FIXTURE_CMP_BOUND
-FIXTURE_POSITION_ID = COMPRESS_RATIO * FIXTURE_CMP_BOUND - 1
-FIXTURE_WINDOW_HEAD = (FIXTURE_POSITION_ID - WIN + 1) % BLOCK_SIZE
-FIXTURE_WINDOW_BLOCKS = (FIXTURE_WINDOW_HEAD + WIN + BLOCK_SIZE - 1) // BLOCK_SIZE
-FIXTURE_CMP_BLOCKS = (LOCAL_T // S) * FIXTURE_CMP_LOGICAL_BLOCKS
-FIXTURE_OUTPUT_SENTINEL = -7.0
-
 if LOCAL_T < 2 * ROPE_CS_T_TILE:
     raise ValueError("CSA fixture token capacity must leave one RoPE row tile for subcapacity")
 if LOCAL_T % ROPE_CS_T_TILE != 0:
     raise ValueError("CSA fixture token capacity must align to the RoPE row tile")
 if (LOCAL_T - ROPE_CS_T_TILE) % S != 0:
     raise ValueError("CSA fixture subcapacity must preserve whole decode requests")
-if max(position for position, _ in FIXTURE_CMP_ENTRIES) >= INDEXER_SCORE_LEN:
-    raise ValueError("CSA fixture compressed positions exceed the indexer score row")
-if max(position for position, _ in FIXTURE_CMP_ENTRIES) >= 4 * ATTN_K_TILE:
-    raise ValueError("CSA fixture compressed positions exceed the four sparse tiles")
-if max(FIXTURE_FILTERED_POSITIONS) >= CMP_TOPK:
-    raise ValueError("CSA fixture filtered positions exceed the compressed top-k row")
-if FIXTURE_FILTERED_SLOT >= FIXTURE_CMP_LOGICAL_BLOCKS * BLOCK_SIZE:
-    raise ValueError("CSA filtered slot must remain inside the fixture block table")
-if FIXTURE_WINDOW_BLOCKS > ORI_BLOCK_NUM:
-    raise ValueError("CSA fixture window exceeds the original KV cache capacity")
-if FIXTURE_CMP_LOGICAL_BLOCKS > CMP_MAX_BLOCKS:
-    raise ValueError("CSA fixture compressed slots exceed the compressed block table")
-if FIXTURE_CMP_BLOCKS > CMP_BLOCK_NUM:
-    raise ValueError("CSA fixture compressed-cache pool exceeds its physical capacity")
-if O_LORA < 4 * HEADS_PER_GROUP:
-    raise ValueError("CSA fixture output projection needs four observable rows per local head")
-
-
-def build_output_tensor_specs(local_t):
-    """Build deterministic tensor-parallel CSA output inputs."""
-    import torch
-
-    from golden import ScalarSpec, TensorSpec
-
-    if (local_t < ROPE_CS_T_TILE or local_t > LOCAL_T
-            or local_t % ROPE_CS_T_TILE != 0 or local_t % S != 0):
-        raise ValueError(
-            f"local_t must be a multiple of {ROPE_CS_T_TILE} "
-            f"in [{ROPE_CS_T_TILE}, {LOCAL_T}], got {local_t}"
-        )
-    local_batch = local_t // S
-    cmp_block_table_shape = [TP_SIZE, local_batch, CMP_MAX_BLOCKS]
-
-    def init_q():
-        q = torch.zeros(TP_SIZE, local_t, H, HEAD_DIM, dtype=torch.bfloat16)
-        rank = torch.arange(TP_SIZE, dtype=torch.float32).reshape(TP_SIZE, 1, 1)
-        token = torch.arange(local_t, dtype=torch.float32).reshape(1, local_t, 1)
-        head = torch.arange(H, dtype=torch.float32).reshape(1, 1, H)
-        q[..., 0] = (rank + token * 0.25 + head * 0.0625).to(torch.bfloat16)
-        return q
-
-    def init_ori_kv():
-        shape = (TP_SIZE, FIXTURE_WINDOW_BLOCKS, BLOCK_SIZE, 1, HEAD_DIM)
-        ori_kv = torch.zeros(shape, dtype=torch.bfloat16)
-        rank = torch.arange(TP_SIZE, dtype=torch.float32).reshape(TP_SIZE, 1, 1)
-        block = torch.arange(FIXTURE_WINDOW_BLOCKS, dtype=torch.float32).reshape(1, FIXTURE_WINDOW_BLOCKS, 1)
-        row = torch.arange(BLOCK_SIZE, dtype=torch.float32).reshape(1, 1, BLOCK_SIZE)
-        ori_kv[:, :, :, 0, 0] = 0.25
-        ori_kv[:, :, :, 0, 1] = (
-            (rank + 1.0) * 0.0625
-            + (block + 1.0) * 0.015625
-            + (row + 1.0) * 0.0001220703125
-        ).to(torch.bfloat16)
-        return ori_kv
-
-    def init_window_swa_indices():
-        logical_row = FIXTURE_WINDOW_HEAD + torch.arange(WIN, dtype=torch.int32)
-        logical_block = logical_row // BLOCK_SIZE
-        physical_block = FIXTURE_WINDOW_BLOCKS - 1 - logical_block
-        physical_row = logical_row % BLOCK_SIZE
-        window_row = physical_block * BLOCK_SIZE + physical_row
-        return window_row.reshape(1, 1, WIN).expand(TP_SIZE, local_t, WIN).clone()
-
-    def init_cmp_kv():
-        shape = (TP_SIZE, FIXTURE_CMP_BLOCKS, BLOCK_SIZE, 1, HEAD_DIM)
-        cmp_kv = torch.full(shape, float("nan"), dtype=torch.bfloat16)
-        for rank in range(TP_SIZE):
-            for request in range(local_batch):
-                request_block_base = request * FIXTURE_CMP_LOGICAL_BLOCKS
-                for entry_index, cmp_slot in enumerate(FIXTURE_CMP_SLOTS):
-                    logical_block = cmp_slot // BLOCK_SIZE
-                    physical_block = request_block_base + FIXTURE_CMP_LOGICAL_BLOCKS - 1 - logical_block
-                    row = cmp_slot % BLOCK_SIZE
-                    cmp_kv[rank, physical_block, row, 0, :] = 0.0
-                    cmp_kv[rank, physical_block, row, 0, 0] = 0.25
-                    col1_value = (rank + 1) * 0.03125 + (request + 1) * 0.0078125 + (entry_index + 1) * 0.001953125
-                    nope_value = (rank + 1) * 0.0625 + (request + 1) * 0.015625 + (entry_index + 1) * 0.00390625
-                    block_value = -(logical_block + 1) * 0.0625 + (rank + 1) * 0.0078125 + (request + 1) * 0.001953125
-                    cmp_kv[rank, physical_block, row, 0, 1] = col1_value
-                    cmp_kv[rank, physical_block, row, 0, NOPE_DIM] = nope_value
-                    cmp_kv[rank, physical_block, row, 0, NOPE_DIM + 1] = block_value
-        return cmp_kv
-
-    def init_cmp_block_table():
-        table = torch.full(cmp_block_table_shape, -1, dtype=torch.int32)
-        for rank in range(TP_SIZE):
-            for request in range(local_batch):
-                request_block_base = request * FIXTURE_CMP_LOGICAL_BLOCKS
-                for logical_block in range(FIXTURE_CMP_LOGICAL_BLOCKS):
-                    physical_block = request_block_base + FIXTURE_CMP_LOGICAL_BLOCKS - 1 - logical_block
-                    table[rank, request, logical_block] = physical_block
-        return table
-
-    def init_idx_topk():
-        topk = torch.full((TP_SIZE, local_t, INDEXER_SCORE_LEN), -1, dtype=torch.int32)
-        for position, cmp_slot in FIXTURE_CMP_ENTRIES:
-            topk[:, :, position] = cmp_slot
-        for position in FIXTURE_FILTERED_POSITIONS:
-            topk[:, :, position] = FIXTURE_FILTERED_SLOT
-        return topk
-
-    def init_position_ids():
-        return torch.full((TP_SIZE, local_t, 1), FIXTURE_POSITION_ID, dtype=torch.int32)
-
-    def init_attn_sink():
-        head = torch.arange(H, dtype=torch.int32).remainder(HEADS_PER_GROUP).to(torch.float32)
-        sink = 4.0 + head * 0.125
-        return sink.reshape(1, H).expand(TP_SIZE, H).clone()
-
-    def init_freqs_cos():
-        rank = torch.arange(TP_SIZE, dtype=torch.int32).reshape(TP_SIZE, 1, 1)
-        token = torch.arange(local_t, dtype=torch.int32).reshape(1, local_t, 1)
-        column = torch.arange(ROPE_DIM, dtype=torch.int32).reshape(1, 1, ROPE_DIM)
-        phase = (rank + token + column).remainder(4)
-        phase[:, :, HALF_ROPE:] = (phase[:, :, HALF_ROPE:] + 1).remainder(4)
-        values = torch.tensor((1.0, 0.0, -1.0, 0.0), dtype=torch.bfloat16)
-        return values[phase]
-
-    def init_freqs_sin():
-        rank = torch.arange(TP_SIZE, dtype=torch.int32).reshape(TP_SIZE, 1, 1)
-        token = torch.arange(local_t, dtype=torch.int32).reshape(1, local_t, 1)
-        column = torch.arange(ROPE_DIM, dtype=torch.int32).reshape(1, 1, ROPE_DIM)
-        phase = (rank + token + column).remainder(4)
-        phase[:, :, HALF_ROPE:] = (phase[:, :, HALF_ROPE:] + 1).remainder(4)
-        values = torch.tensor((0.0, 1.0, 0.0, -1.0), dtype=torch.bfloat16)
-        return values[phase]
-
-    def init_wo_a():
-        wo_a = torch.zeros(TP_SIZE, LOCAL_O_GROUPS, O_LORA, O_GROUP_IN, dtype=torch.bfloat16)
-        for rank in range(TP_SIZE):
-            for local_group in range(LOCAL_O_GROUPS):
-                shard_scale = (rank + 1) * (local_group + 1) * 0.125
-                for head in range(HEADS_PER_GROUP):
-                    head_col = head * HEAD_DIM
-                    head_scale = shard_scale * (head + 1)
-                    wo_a[rank, local_group, head, head_col] = head_scale
-                    wo_a[rank, local_group, HEADS_PER_GROUP + head, head_col + 1] = head_scale * 0.75
-                    wo_a[rank, local_group, 2 * HEADS_PER_GROUP + head, head_col + NOPE_DIM] = -head_scale * 0.5
-                    wo_a[rank, local_group, 3 * HEADS_PER_GROUP + head, head_col + NOPE_DIM + 1] = head_scale * 0.25
-        return wo_a
-
-    def init_wo_b():
-        base = torch.arange(D * LOCAL_O_WIDTH, dtype=torch.int32).reshape(D, LOCAL_O_WIDTH)
-        rank = torch.arange(TP_SIZE, dtype=torch.int32).reshape(TP_SIZE, 1, 1)
-        return (base.unsqueeze(0) + rank).remainder(7).sub(3).to(torch.int8)
-
-    def init_wo_b_scale():
-        channel_scale = torch.arange(D, dtype=torch.int32).remainder(4).to(torch.float32) * 0.25 + 0.5
-        return channel_scale.reshape(1, D).expand(TP_SIZE, D).clone()
-
-    return [
-        TensorSpec("q", [TP_SIZE, local_t, H, HEAD_DIM], torch.bfloat16, init_value=init_q),
-        TensorSpec(
-            "ori_kv", [TP_SIZE, FIXTURE_WINDOW_BLOCKS, BLOCK_SIZE, 1, HEAD_DIM],
-            torch.bfloat16, init_value=init_ori_kv,
-        ),
-        TensorSpec("window_swa_indices", [TP_SIZE, local_t, WIN], torch.int32, init_value=init_window_swa_indices),
-        TensorSpec(
-            "cmp_kv", [TP_SIZE, FIXTURE_CMP_BLOCKS, BLOCK_SIZE, 1, HEAD_DIM],
-            torch.bfloat16, init_value=init_cmp_kv,
-        ),
-        TensorSpec("cmp_block_table", cmp_block_table_shape, torch.int32, init_value=init_cmp_block_table),
-        TensorSpec("idx_topk", [TP_SIZE, local_t, INDEXER_SCORE_LEN], torch.int32, init_value=init_idx_topk),
-        TensorSpec("position_ids", [TP_SIZE, local_t, 1], torch.int32, init_value=init_position_ids),
-        TensorSpec("attn_sink", [TP_SIZE, H], torch.float32, init_value=init_attn_sink),
-        TensorSpec("freqs_cos", [TP_SIZE, local_t, ROPE_DIM], torch.bfloat16, init_value=init_freqs_cos),
-        TensorSpec("freqs_sin", [TP_SIZE, local_t, ROPE_DIM], torch.bfloat16, init_value=init_freqs_sin),
-        TensorSpec("wo_a", [TP_SIZE, LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], torch.bfloat16, init_value=init_wo_a),
-        TensorSpec("wo_b", [TP_SIZE, D, LOCAL_O_WIDTH], torch.int8, init_value=init_wo_b),
-        TensorSpec("wo_b_scale", [TP_SIZE, D], torch.float32, init_value=init_wo_b_scale),
-        TensorSpec(
-            "o_local", [TP_SIZE, LOCAL_T_PAD, D], torch.bfloat16,
-            init_value=FIXTURE_OUTPUT_SENTINEL, is_output=True,
-        ),
-        ScalarSpec("local_t", torch.int32, local_t),
-    ]
-
-
-def golden_decode_csa_output(tensors):
-    """Compute the controlled CSA heads, sharded O projection, and reduced rows."""
-    import torch
-
-    local_t = int(tensors["local_t"])
-    group_t = TP_SIZE * local_t
-    observed_dims = torch.tensor((0, 1, NOPE_DIM, NOPE_DIM + 1), dtype=torch.int64)
-    q = tensors["q"].float()
-
-    window_indices = tensors["window_swa_indices"].long()
-    window_valid = window_indices >= 0
-    safe_window_indices = window_indices.clamp_min(0)
-    ori_rows = tensors["ori_kv"][:, :, :, 0].reshape(TP_SIZE, -1, HEAD_DIM)
-    ori_values = ori_rows[..., observed_dims].float()
-    window_sum = torch.zeros(TP_SIZE, local_t, len(observed_dims), dtype=torch.float32)
-    for rank in range(TP_SIZE):
-        gathered = ori_values[rank][safe_window_indices[rank]]
-        window_sum[rank] = (
-            gathered * window_valid[rank].unsqueeze(-1)
-        ).sum(dim=1)
-    window_count = window_valid.sum(dim=-1).to(torch.float32)
-
-    raw = tensors["idx_topk"][:, :, :CMP_TOPK].to(torch.int64)
-    bound = ((tensors["position_ids"][:, :, 0].to(torch.int64) + 1) // COMPRESS_RATIO).unsqueeze(-1)
-    keep = (raw >= 0) & (raw < bound)
-    cmp_rows = tensors["cmp_kv"][:, :, :, 0]
-    cmp_sum = torch.zeros_like(window_sum)
-    cmp_count = torch.zeros(TP_SIZE, local_t, dtype=torch.float32)
-    for rank in range(TP_SIZE):
-        for token in range(local_t):
-            request = token // S
-            valid_slots = raw[rank, token][keep[rank, token]]
-            cmp_count[rank, token] = valid_slots.numel()
-            for cmp_slot_tensor in valid_slots:
-                cmp_slot = int(cmp_slot_tensor.item())
-                logical_block = cmp_slot // BLOCK_SIZE
-                physical_block = int(tensors["cmp_block_table"][rank, request, logical_block].item())
-                cmp_sum[rank, token] += cmp_rows[
-                    rank, physical_block, cmp_slot % BLOCK_SIZE, observed_dims
-                ].float()
-
-    kv_sum = window_sum + cmp_sum
-    valid_count = window_count + cmp_count
-    scores = q[..., 0] * 0.25 * SOFTMAX_SCALE
-    sink = tensors["attn_sink"].float().reshape(TP_SIZE, 1, H)
-    denominator = valid_count.unsqueeze(-1) + torch.exp(sink - scores)
-    head_observed = kv_sum.unsqueeze(2) / denominator.unsqueeze(-1)
-    head_value = torch.zeros(TP_SIZE, local_t, H, HEAD_DIM, dtype=torch.float32)
-    head_value[..., observed_dims] = head_observed
-
-    rope_pair = head_value[..., NOPE_DIM:].unflatten(-1, (-1, 2))
-    rope_even = rope_pair[..., 0]
-    rope_odd = rope_pair[..., 1]
-    cos_half = tensors["freqs_cos"][..., :HALF_ROPE].float().unsqueeze(2)
-    sin_half = tensors["freqs_sin"][..., :HALF_ROPE].float().unsqueeze(2)
-    inverse_even = (rope_even * cos_half + rope_odd * sin_half).to(torch.bfloat16).float()
-    inverse_odd = (rope_odd * cos_half - rope_even * sin_half).to(torch.bfloat16).float()
-    inverse_rope = torch.stack((inverse_even, inverse_odd), dim=-1).flatten(-2)
-    head_value = torch.cat((head_value[..., :NOPE_DIM], inverse_rope), dim=-1).to(torch.bfloat16)
-
-    attention_grouped = head_value.reshape(
-        TP_SIZE, local_t, O_GROUPS, HEADS_PER_GROUP, HEAD_DIM,
-    )
-    attention_grouped = attention_grouped.permute(0, 2, 1, 3, 4)
-    attention_grouped = attention_grouped.reshape(
-        TP_SIZE, O_GROUPS, local_t, O_GROUP_IN,
-    )
-
-    attention_local = torch.zeros(TP_SIZE, LOCAL_O_GROUPS, group_t, O_GROUP_IN, dtype=torch.bfloat16)
-    for destination_rank in range(TP_SIZE):
-        for local_group in range(LOCAL_O_GROUPS):
-            global_group = destination_rank * LOCAL_O_GROUPS + local_group
-            group_rows = attention_grouped[:, global_group].reshape(group_t, O_GROUP_IN)
-            attention_local[destination_rank, local_group] = group_rows
-
-    partials = torch.zeros(TP_SIZE, group_t, D, dtype=torch.float32)
-    for rank in range(TP_SIZE):
-        attention = attention_local[rank].float()
-        o_a = torch.einsum("gti,gri->gtr", attention, tensors["wo_a"][rank].float())
-        row_amax = o_a.abs().amax(dim=-1, keepdim=True).clamp_min(INT8_AMAX_EPS)
-        scale_q = INT8_SCALE_MAX / row_amax
-        o_a_i8 = torch.round(o_a * scale_q).to(torch.int32).to(torch.float16).to(torch.int8)
-        scale_dq = 1.0 / scale_q
-        wo_b = tensors["wo_b"][rank].reshape(D, LOCAL_O_GROUPS, O_LORA)
-        for local_group in range(LOCAL_O_GROUPS):
-            group_i32 = o_a_i8[local_group].to(torch.int32)
-            weight_i32 = wo_b[:, local_group].to(torch.int32)
-            group_partial = group_i32 @ weight_i32.T
-            partials[rank] += group_partial.float() * scale_dq[local_group]
-        partials[rank] *= tensors["wo_b_scale"][rank].float().reshape(1, D)
-
-    reduced = partials.sum(dim=0)
-    tensors["o_local"].fill_(FIXTURE_OUTPUT_SENTINEL)
-    for rank in range(TP_SIZE):
-        row_start = rank * local_t
-        tensors["o_local"][rank, :local_t] = reduced[row_start : row_start + local_t].to(torch.bfloat16)
-
-
-def build_o_local_compare(local_t):
-    """Compare valid token rows and require the poisoned capacity tail to survive."""
-    import torch
-
-    from golden import ratio_allclose
-
-    prefix_compare = ratio_allclose(
-        atol=1e-4, rtol=1.0 / 128, max_error_ratio=0.005,
-        valid_rows=local_t, valid_axis=1,
-    )
-
-    def compare(actual, expected, **kwargs):
-        actual_tail = actual[:, local_t:]
-        expected_tail = expected[:, local_t:]
-        if not torch.equal(actual_tail, expected_tail):
-            mismatch_count = int((actual_tail != expected_tail).sum().item())
-            return False, f"    inactive token tail mismatch count={mismatch_count}"
-        return prefix_compare(actual, expected, **kwargs)
-
-    compare.__name__ = f"csa_output_prefix_and_tail(local_t={local_t})"
-    return compare
 
 
 def golden_decode_csa_tp1(tensors):
@@ -2186,10 +1730,8 @@ if __name__ == "__main__":
     parser.add_argument("--tp", type=int, default=TP_SIZE, choices=list(_TP_CHOICES), help="tensor-parallel world size")
     parser.add_argument(
         "-d", "--device", type=str, default=None,
-        help=f"comma-separated device ids; full/output need {TP_SIZE}, tp1 needs one",
+        help=f"comma-separated device ids; --tp {TP_SIZE} needs {TP_SIZE}",
     )
-    parser.add_argument("--entry", choices=("full", "output", "tp1"), default="full")
-    parser.add_argument("--case", choices=("all", "max", "subcapacity"), default="all")
     parser.add_argument("--compile-only", action="store_true", default=False)
     parser.add_argument("--dump-passes", action="store_true", default=False)
     args = parser.parse_args()
@@ -2197,7 +1739,7 @@ if __name__ == "__main__":
     if args.tp != TP_SIZE:
         parser.error(f"--tp must remain {TP_SIZE} after import-time specialization")
     if args.device is None:
-        args.device = ",".join(str(rank) for rank in range(TP_SIZE)) if args.entry in ("full", "output") else "0"
+        args.device = ",".join(str(rank) for rank in range(TP_SIZE))
     try:
         device_ids = [int(device) for device in args.device.split(",")]
     except ValueError:
@@ -2207,13 +1749,10 @@ if __name__ == "__main__":
     if len(set(device_ids)) != len(device_ids):
         parser.error(f"--device IDs must be distinct, got {device_ids}")
 
-    expected_devices = TP_SIZE if args.entry in ("full", "output") else 1
-    if len(device_ids) != expected_devices:
-        parser.error(f"{args.entry} entry needs exactly {expected_devices} device(s), got {device_ids}")
+    if len(device_ids) != TP_SIZE:
+        parser.error(f"--tp {TP_SIZE} needs exactly {TP_SIZE} device(s), got {device_ids}")
 
-    if args.entry == "tp1":
-        if args.case == "subcapacity":
-            parser.error("--case subcapacity only applies to the full and output entries")
+    if TP_SIZE == 1:
         result = run_jit(
             fn=decode_csa_tp1_test,
             specs=build_tensor_specs(),
@@ -2235,40 +1774,27 @@ if __name__ == "__main__":
             raise SystemExit(1)
         raise SystemExit(0)
 
-    case_local_t = {"max": LOCAL_T, "subcapacity": LOCAL_T - ROPE_CS_T_TILE}
-    selected_cases = tuple(case_local_t) if args.case == "all" else (args.case,)
-    for case in selected_cases:
-        local_t = case_local_t[case]
+    # Capacity, then one row block below it: the dynamic token axis must hold at both.
+    for local_t in (LOCAL_T, LOCAL_T - ROPE_CS_T_TILE):
         compile_cfg = dict(
             dump_passes=args.dump_passes,
             distributed_config=DistributedConfig(device_ids=device_ids, num_sub_workers=0),
         )
-        if args.entry == "full":
-            result = run_jit(
-                fn=l3_decode_csa,
-                specs=build_distributed_tensor_specs(local_t),
-                golden_fn=golden_decode_csa,
-                compile_only=args.compile_only,
-                compile_cfg=compile_cfg,
-                runtime_cfg=dict(platform=args.platform),
-                rtol=1e-2,
-                atol=1e-2,
-                compare_fn=build_full_compare(
-                    (TP_SIZE, local_t),
-                    leading_rank_axis=True,
-                    diagnostic_x_out=args.platform.endswith("sim"),
-                ),
-            )
-        else:
-            result = run_jit(
-                fn=l3_decode_csa_output_test,
-                specs=build_output_tensor_specs(local_t),
-                golden_fn=golden_decode_csa_output,
-                compile_only=args.compile_only,
-                compile_cfg=compile_cfg,
-                runtime_cfg=dict(platform=args.platform),
-                compare_fn={"o_local": build_o_local_compare(local_t)},
-            )
+        result = run_jit(
+            fn=l3_decode_csa,
+            specs=build_distributed_tensor_specs(local_t),
+            golden_fn=golden_decode_csa,
+            compile_only=args.compile_only,
+            compile_cfg=compile_cfg,
+            runtime_cfg=dict(platform=args.platform),
+            rtol=1e-2,
+            atol=1e-2,
+            compare_fn=build_full_compare(
+                (TP_SIZE, local_t),
+                leading_rank_axis=True,
+                diagnostic_x_out=args.platform.endswith("sim"),
+            ),
+        )
         if not result.passed:
             if result.error:
                 print(result.error)

--- a/models/deepseek_v4_flash_dspark/decode_hca.py
+++ b/models/deepseek_v4_flash_dspark/decode_hca.py
@@ -7,7 +7,7 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
 # ci: devices=2  # CI: 2-card run; borrows 2 cards via task-submit --device-num
-"""DeepSeek-V4 HCA full-layer TP, TP1, and tensor-parallel output entries."""
+"""DeepSeek-V4 HCA full-layer TP and TP1 entries."""
 
 
 import sys
@@ -73,9 +73,6 @@ from decode_o_proj import (
 )
 from decode_sparse_attn_hca import (
     CMP_TOPK,
-    HALF_ROPE,
-    NOPE_DIM,
-    ROPE_DIM,
     T_PAD,
     VALID_TOKEN_TILE,
     sparse_attn_hca,
@@ -148,20 +145,41 @@ if T_PAD != LOCAL_T_PAD:
 
 
 @pl.jit.inline
-def decode_hca_output(
-    q: pl.Tensor[[T_DYN, H, HEAD_DIM], pl.BF16],
-    ori_kv: pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
-    window_swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
+def decode_hca(
+    x_hc: pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32],
+    hc_attn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
+    hc_attn_scale: pl.Tensor[[3], pl.FP32],
+    hc_attn_base: pl.Tensor[[MIX_HC], pl.FP32],
+    attn_norm_w: pl.Tensor[[D], pl.BF16],
+    wq_a: pl.Tensor[[D, Q_LORA], pl.BF16],
+    wq_b: pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8],
+    wq_b_scale: pl.Tensor[[H * HEAD_DIM], pl.FP32],
+    wkv: pl.Tensor[[D, HEAD_DIM], pl.BF16],
+    gamma_cq: pl.Tensor[[Q_LORA], pl.BF16],
+    gamma_ckv: pl.Tensor[[HEAD_DIM], pl.BF16],
+    freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    cmp_wkv: pl.Tensor[[MAIN_OUT_DIM, D], pl.BF16],
+    cmp_wgate: pl.Tensor[[MAIN_OUT_DIM, D], pl.BF16],
+    cmp_ape: pl.Tensor[[COMPRESS_RATIO, MAIN_OUT_DIM], pl.FP32],
+    cmp_norm_w: pl.Tensor[[HEAD_DIM], pl.BF16],
+    compress_state: pl.Tensor[[COMPRESS_STATE_BLOCK_NUM_DYN, COMPRESS_STATE_BLOCK_SIZE, COMPRESS_STATE_DIM], pl.FP32],
+    compress_state_block_table: pl.Tensor[[B_DYN, COMPRESS_STATE_MAX_BLOCKS], pl.INT32],
+    kv_cache: pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     cmp_kv: pl.Tensor[[CMP_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     cmp_block_table: pl.Tensor[[B_DYN, CMP_MAX_BLOCKS], pl.INT32],
-    cmp_sparse_indices: pl.Tensor[[T_DYN, CMP_TOPK], pl.INT32],
+    ori_slot_mapping: pl.Tensor[[T_DYN], pl.INT64],
+    window_swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
+    window_swa_lens: pl.Tensor[[T_DYN], pl.INT32],
+    cmp_slot_mapping: pl.Tensor[[T_DYN], pl.INT64],
+    state_slot_mapping: pl.Tensor[[T_DYN], pl.INT64],
+    position_ids: pl.Tensor[[T_DYN], pl.INT32],
+    kv_seq_lens: pl.Tensor[[B_DYN], pl.INT32],
     attn_sink: pl.Tensor[[H], pl.FP32],
-    freqs_cos: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
-    freqs_sin: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
     wo_a: pl.Tensor[[LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
     wo_b: pl.Tensor[[D, LOCAL_O_WIDTH], pl.INT8],
     wo_b_scale: pl.Tensor[[D], pl.FP32],
-    o_local: pl.Tensor[[LOCAL_T_PAD, D], pl.BF16],
+    x_out: pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32],
     attention_window: pld.DistributedTensor[[ATTENTION_WINDOW_ROWS, O_GROUP_IN], pl.BF16],
     attention_signal: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
     o_window: pld.DistributedTensor[[O_WINDOW_ROWS, D], pl.FP32],
@@ -169,14 +187,103 @@ def decode_hca_output(
     group_base: pl.Scalar[pl.INT32],
     tp_rank: pl.Scalar[pl.INT32],
     local_t: pl.Scalar[pl.INT32],
-    cache_ready_dep: pl.Scalar[pl.TASK_ID],
 ):
-    """Run sparse attention and the distributed sharded O projection."""
+    """Run one rank of the complete HCA tensor-parallel layer."""
+    t_dim = pl.tensor.dim(x_hc, 0)
+    b_dim = t_dim // S
+    topk_blocks = t_dim // HCA_TOPK_TOKEN_TILE
+    wb_blocks = t_dim // HCA_WB_TOKEN_TILE
+
+    x_mixed = pl.create_tensor([t_dim, D], dtype=pl.BF16)
+    post_t = pl.create_tensor([t_dim, HC_MULT], dtype=pl.FP32)
+    comb_t = pl.create_tensor([t_dim, HC_MULT * HC_MULT], dtype=pl.FP32)
+    hc_pre(x_hc, hc_attn_fn, hc_attn_scale, hc_attn_base, x_mixed, post_t, comb_t)
+
+    rope_cos_t = pl.create_tensor([t_dim, ROPE_HEAD_DIM], dtype=pl.BF16)
+    rope_sin_t = pl.create_tensor([t_dim, ROPE_HEAD_DIM], dtype=pl.BF16)
+    cmp_cos = pl.create_tensor([B, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
+    cmp_sin = pl.create_tensor([B, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
+    cmp_cos_il = pl.create_tensor([B, ROPE_HEAD_DIM], dtype=pl.FP32)
+    cmp_sin_signed = pl.create_tensor([B, ROPE_HEAD_DIM], dtype=pl.FP32)
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="hca_rope"):
+        for b in pl.range(b_dim):
+            first_t = b * S
+            first_pos_b = pl.read(position_ids, [first_t])
+            cmp_offset_b = COMPRESS_RATIO - (first_pos_b % COMPRESS_RATIO)
+            cmp_pos_b = pl.cast(first_pos_b + cmp_offset_b - COMPRESS_RATIO, pl.INDEX)
+            cmp_cos_row = freqs_cos[cmp_pos_b : cmp_pos_b + 1, 0 : ROPE_HEAD_DIM // 2]
+            cmp_sin_row = freqs_sin[cmp_pos_b : cmp_pos_b + 1, 0 : ROPE_HEAD_DIM // 2]
+            cmp_cos[b : b + 1, 0 : ROPE_HEAD_DIM // 2] = pl.cast(cmp_cos_row, target_type=pl.FP32)
+            cmp_sin[b : b + 1, 0 : ROPE_HEAD_DIM // 2] = pl.cast(cmp_sin_row, target_type=pl.FP32)
+            for s in pl.range(S):
+                t = b * S + s
+                pos_b = pl.cast(pl.read(position_ids, [t]), pl.INDEX)
+                step_cos_row = pl.cast(freqs_cos[pos_b : pos_b + 1, 0 : ROPE_HEAD_DIM], target_type=pl.FP32)
+                step_sin_row = pl.cast(freqs_sin[pos_b : pos_b + 1, 0 : ROPE_HEAD_DIM], target_type=pl.FP32)
+                rope_cos_t[t : t + 1, 0 : ROPE_HEAD_DIM] = pl.cast(step_cos_row, target_type=pl.BF16, mode="rint")
+                rope_sin_t[t : t + 1, 0 : ROPE_HEAD_DIM] = pl.cast(step_sin_row, target_type=pl.BF16, mode="rint")
+
+    rope_interleave(cmp_cos, cmp_sin, cmp_cos_il, cmp_sin_signed)
+
+    x_normed = pl.create_tensor([t_dim, D], dtype=pl.BF16)
+    rms_tid = rms_norm(x_mixed, attn_norm_w, x_normed)
+    late_dep = pl.system.task_dummy(deps=[rms_tid])
+    q = pl.create_tensor([t_dim, H, HEAD_DIM], dtype=pl.BF16)
+    kv = pl.create_tensor([t_dim, HEAD_DIM], dtype=pl.BF16)
+    qr = pl.create_tensor([t_dim, Q_LORA], dtype=pl.INT8)
+    qr_scale = pl.create_tensor([t_dim, 1], dtype=pl.FP32)
+    qkv_proj_rope(
+        x_normed, wq_a, wq_b, wq_b_scale, wkv,
+        rope_cos_t, rope_sin_t, gamma_cq, gamma_ckv,
+        q, kv, qr, qr_scale, late_dep,
+    )
+
+    ori_block_num = pl.tensor.dim(kv_cache, 0)
+    kv_cache_flat = pl.reshape(kv_cache, [ori_block_num * BLOCK_SIZE, HEAD_DIM])
+    with pl.spmd(wb_blocks, name_hint="hca_cache_writeback") as ori_cache_write_tid:
+        wb_blk = pl.tile.get_block_idx()
+        wb_t0 = wb_blk * HCA_WB_TOKEN_TILE
+        for write_dt in pl.range(HCA_WB_TOKEN_TILE):
+            write_t = wb_t0 + write_dt
+            write_row_i64 = pl.read(ori_slot_mapping, [write_t])
+            if write_row_i64 >= 0:
+                write_row = pl.cast(write_row_i64, pl.INDEX)
+                kv_cache_flat[write_row : write_row + 1, 0 : HEAD_DIM] = kv[write_t : write_t + 1, 0 : HEAD_DIM]
+
+    cmp_kv_proj = pl.create_tensor([t_dim, HEAD_DIM], dtype=pl.FP32)
+    cmp_kv_proj, cmp_cache_write_tid = compressor_ratio128(
+        x_normed, cmp_kv_proj,
+        compress_state, compress_state_block_table,
+        cmp_wkv, cmp_wgate, cmp_ape, cmp_norm_w,
+        cmp_cos_il, cmp_sin_signed, cmp_kv,
+        position_ids, cmp_slot_mapping, state_slot_mapping,
+        late_dep,
+    )
+    cache_ready_dep = pl.system.task_dummy(deps=[ori_cache_write_tid, cmp_cache_write_tid])
+
+    topk_all = pl.create_tensor([t_dim, HCA_CMP_TOPK], dtype=pl.INT32)
+    for topk_block in pl.spmd(topk_blocks, name_hint="hca_cache_topk"):
+        topk_t0 = topk_block * HCA_TOPK_TOKEN_TILE
+        for topk_dt in pl.range(HCA_TOPK_TOKEN_TILE):
+            topk_t = topk_t0 + topk_dt
+            if topk_t < t_dim:
+                topk_b = topk_t // S
+                topk_abs_pos = pl.read(position_ids, [topk_t])
+                topk_cmp_valid = pl.min(
+                    HCA_TOPK_LIMIT,
+                    pl.min((topk_abs_pos + 1) // COMPRESS_RATIO, pl.read(kv_seq_lens, [topk_b]) // COMPRESS_RATIO),
+                )
+                for topk_ck in pl.range(HCA_CMP_TOPK):
+                    if topk_ck < topk_cmp_valid:
+                        pl.write(topk_all, [topk_t, topk_ck], pl.cast(topk_ck, pl.INT32))
+                    else:
+                        pl.write(topk_all, [topk_t, topk_ck], pl.cast(-1, pl.INT32))
+
     attention_grouped = pl.create_tensor([O_GROUPS * LOCAL_T_PAD, O_GROUP_IN], dtype=pl.BF16)
     attention_grouped, heads_tid = sparse_attn_hca(
-        q, ori_kv, window_swa_indices,
-        cmp_kv, cmp_block_table, cmp_sparse_indices,
-        attn_sink, freqs_cos, freqs_sin,
+        q, kv_cache, window_swa_indices,
+        cmp_kv, cmp_block_table, topk_all,
+        attn_sink, rope_cos_t, rope_sin_t,
         attention_grouped, cache_ready_dep,
     )
 
@@ -194,29 +301,61 @@ def decode_hca_output(
         wo_a, wo_b, wo_b_scale,
         local_t, o_partial,
     )
+    o_local = pl.create_tensor([LOCAL_T_PAD, D], dtype=pl.BF16)
     o_local, o_signal = o_proj_reduce_scatter(
         o_partial, o_local,
         o_window, o_signal,
         group_base, tp_rank, local_t, projection_tid,
     )
-    return o_local, attention_signal, o_signal
+
+    attn_out = pl.create_tensor([t_dim, D], dtype=pl.BF16)
+    for bridge_block in pl.spmd(t_dim // HCA_WB_TOKEN_TILE, name_hint="hca_output_bridge"):
+        bridge_t0 = bridge_block * HCA_WB_TOKEN_TILE
+        attn_out[bridge_t0 : bridge_t0 + HCA_WB_TOKEN_TILE, 0:D] = o_local[
+            bridge_t0 : bridge_t0 + HCA_WB_TOKEN_TILE,
+            0:D,
+        ]
+
+    hc_post(attn_out, x_hc, post_t, comb_t, x_out)
+    return x_out
 
 
 @pl.jit
-def decode_hca_output_test(
-    q: pl.Tensor[[T_DYN, H, HEAD_DIM], pl.BF16],
-    ori_kv: pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
-    window_swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
-    cmp_kv: pl.Tensor[[CMP_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+def decode_hca_test(
+    x_hc: pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32],
+    hc_attn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
+    hc_attn_scale: pl.Tensor[[3], pl.FP32],
+    hc_attn_base: pl.Tensor[[MIX_HC], pl.FP32],
+    attn_norm_w: pl.Tensor[[D], pl.BF16],
+    wq_a: pl.Tensor[[D, Q_LORA], pl.BF16],
+    wq_b: pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8],
+    wq_b_scale: pl.Tensor[[H * HEAD_DIM], pl.FP32],
+    wkv: pl.Tensor[[D, HEAD_DIM], pl.BF16],
+    gamma_cq: pl.Tensor[[Q_LORA], pl.BF16],
+    gamma_ckv: pl.Tensor[[HEAD_DIM], pl.BF16],
+    freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    cmp_wkv: pl.Tensor[[MAIN_OUT_DIM, D], pl.BF16],
+    cmp_wgate: pl.Tensor[[MAIN_OUT_DIM, D], pl.BF16],
+    cmp_ape: pl.Tensor[[COMPRESS_RATIO, MAIN_OUT_DIM], pl.FP32],
+    cmp_norm_w: pl.Tensor[[HEAD_DIM], pl.BF16],
+    compress_state: pl.InOut[pl.Tensor[[COMPRESS_STATE_BLOCK_NUM_DYN, COMPRESS_STATE_BLOCK_SIZE, COMPRESS_STATE_DIM], pl.FP32]],
+    compress_state_block_table: pl.Tensor[[B_DYN, COMPRESS_STATE_MAX_BLOCKS], pl.INT32],
+    kv_cache: pl.InOut[pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
+    cmp_kv: pl.InOut[pl.Tensor[[CMP_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
     cmp_block_table: pl.Tensor[[B_DYN, CMP_MAX_BLOCKS], pl.INT32],
-    cmp_sparse_indices: pl.Tensor[[T_DYN, CMP_TOPK], pl.INT32],
+    ori_slot_mapping: pl.Tensor[[T_DYN], pl.INT64],
+    window_swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
+    window_swa_lens: pl.Tensor[[T_DYN], pl.INT32],
+    cmp_slot_mapping: pl.Tensor[[T_DYN], pl.INT64],
+    state_slot_mapping: pl.Tensor[[T_DYN], pl.INT64],
+    position_ids: pl.Tensor[[T_DYN], pl.INT32],
+    kv_seq_lens: pl.Tensor[[B_DYN], pl.INT32],
     attn_sink: pl.Tensor[[H], pl.FP32],
-    freqs_cos: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
-    freqs_sin: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
     wo_a: pl.Tensor[[LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
     wo_b: pl.Tensor[[D, LOCAL_O_WIDTH], pl.INT8],
     wo_b_scale: pl.Tensor[[D], pl.FP32],
-    o_local: pl.InOut[pl.Tensor[[LOCAL_T_PAD, D], pl.BF16]],
+    x_out: pl.Out[pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32]],
     attention_window: pld.DistributedTensor[[ATTENTION_WINDOW_ROWS, O_GROUP_IN], pl.BF16],
     attention_signal: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
     o_window: pld.DistributedTensor[[O_WINDOW_ROWS, D], pl.FP32],
@@ -225,52 +364,91 @@ def decode_hca_output_test(
     tp_rank: pl.Scalar[pl.INT32],
     local_t: pl.Scalar[pl.INT32],
 ):
-    """Run the output-only HCA tensor-parallel regression entry."""
-    q.bind_dynamic(0, T_DYN)
-    ori_kv.bind_dynamic(0, ORI_BLOCK_NUM_DYN)
-    window_swa_indices.bind_dynamic(0, T_DYN)
+    """Test one rank of the complete HCA tensor-parallel layer."""
+    x_hc.bind_dynamic(0, T_DYN)
+    compress_state.bind_dynamic(0, COMPRESS_STATE_BLOCK_NUM_DYN)
+    compress_state_block_table.bind_dynamic(0, B_DYN)
+    kv_cache.bind_dynamic(0, ORI_BLOCK_NUM_DYN)
     cmp_kv.bind_dynamic(0, CMP_BLOCK_NUM_DYN)
     cmp_block_table.bind_dynamic(0, B_DYN)
-    cmp_sparse_indices.bind_dynamic(0, T_DYN)
-    freqs_cos.bind_dynamic(0, T_DYN)
-    freqs_sin.bind_dynamic(0, T_DYN)
+    ori_slot_mapping.bind_dynamic(0, T_DYN)
+    window_swa_indices.bind_dynamic(0, T_DYN)
+    window_swa_lens.bind_dynamic(0, T_DYN)
+    cmp_slot_mapping.bind_dynamic(0, T_DYN)
+    state_slot_mapping.bind_dynamic(0, T_DYN)
+    position_ids.bind_dynamic(0, T_DYN)
+    kv_seq_lens.bind_dynamic(0, B_DYN)
+    x_out.bind_dynamic(0, T_DYN)
 
-    cache_ready_dep = pl.system.task_dummy(deps=[])
-    return decode_hca_output(
-        q, ori_kv, window_swa_indices,
-        cmp_kv, cmp_block_table, cmp_sparse_indices,
-        attn_sink, freqs_cos, freqs_sin,
-        wo_a, wo_b, wo_b_scale, o_local,
-        attention_window, attention_signal,
-        o_window, o_signal,
-        group_base, tp_rank, local_t, cache_ready_dep,
+    return decode_hca(
+        x_hc,
+        hc_attn_fn, hc_attn_scale, hc_attn_base,
+        attn_norm_w, wq_a, wq_b, wq_b_scale, wkv, gamma_cq, gamma_ckv,
+        freqs_cos, freqs_sin,
+        cmp_wkv, cmp_wgate, cmp_ape, cmp_norm_w,
+        compress_state, compress_state_block_table,
+        kv_cache, cmp_kv, cmp_block_table,
+        ori_slot_mapping, window_swa_indices, window_swa_lens,
+        cmp_slot_mapping, state_slot_mapping,
+        position_ids, kv_seq_lens,
+        attn_sink,
+        wo_a, wo_b, wo_b_scale,
+        x_out,
+        attention_window, attention_signal, o_window, o_signal,
+        group_base, tp_rank, local_t,
     )
 
 
 @pl.jit.host
-def l3_decode_hca_output_test(
-    q: pl.Tensor[[TP_SIZE, T_DYN, H, HEAD_DIM], pl.BF16],
-    ori_kv: pl.Tensor[[TP_SIZE, ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
-    window_swa_indices: pl.Tensor[[TP_SIZE, T_DYN, WIN], pl.INT32],
-    cmp_kv: pl.Tensor[[TP_SIZE, CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+def l3_decode_hca(
+    x_hc: pl.Tensor[[TP_SIZE, T_DYN, HC_MULT, D], pl.FP32],
+    hc_attn_fn: pl.Tensor[[TP_SIZE, MIX_HC, HC_DIM], pl.FP32],
+    hc_attn_scale: pl.Tensor[[TP_SIZE, 3], pl.FP32],
+    hc_attn_base: pl.Tensor[[TP_SIZE, MIX_HC], pl.FP32],
+    attn_norm_w: pl.Tensor[[TP_SIZE, D], pl.BF16],
+    wq_a: pl.Tensor[[TP_SIZE, D, Q_LORA], pl.BF16],
+    wq_b: pl.Tensor[[TP_SIZE, Q_LORA, H * HEAD_DIM], pl.INT8],
+    wq_b_scale: pl.Tensor[[TP_SIZE, H * HEAD_DIM], pl.FP32],
+    wkv: pl.Tensor[[TP_SIZE, D, HEAD_DIM], pl.BF16],
+    gamma_cq: pl.Tensor[[TP_SIZE, Q_LORA], pl.BF16],
+    gamma_ckv: pl.Tensor[[TP_SIZE, HEAD_DIM], pl.BF16],
+    freqs_cos: pl.Tensor[[TP_SIZE, MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[TP_SIZE, MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    cmp_wkv: pl.Tensor[[TP_SIZE, MAIN_OUT_DIM, D], pl.BF16],
+    cmp_wgate: pl.Tensor[[TP_SIZE, MAIN_OUT_DIM, D], pl.BF16],
+    cmp_ape: pl.Tensor[[TP_SIZE, COMPRESS_RATIO, MAIN_OUT_DIM], pl.FP32],
+    cmp_norm_w: pl.Tensor[[TP_SIZE, HEAD_DIM], pl.BF16],
+    compress_state: pl.InOut[pl.Tensor[[TP_SIZE, COMPRESS_STATE_BLOCK_NUM, COMPRESS_STATE_BLOCK_SIZE, COMPRESS_STATE_DIM], pl.FP32]],
+    compress_state_block_table: pl.Tensor[[TP_SIZE, B_DYN, COMPRESS_STATE_MAX_BLOCKS], pl.INT32],
+    kv_cache: pl.InOut[pl.Tensor[[TP_SIZE, ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
+    cmp_kv: pl.InOut[pl.Tensor[[TP_SIZE, CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
     cmp_block_table: pl.Tensor[[TP_SIZE, B_DYN, CMP_MAX_BLOCKS], pl.INT32],
-    cmp_sparse_indices: pl.Tensor[[TP_SIZE, T_DYN, CMP_TOPK], pl.INT32],
+    ori_slot_mapping: pl.Tensor[[TP_SIZE, T_DYN], pl.INT64],
+    window_swa_indices: pl.Tensor[[TP_SIZE, T_DYN, WIN], pl.INT32],
+    window_swa_lens: pl.Tensor[[TP_SIZE, T_DYN], pl.INT32],
+    cmp_slot_mapping: pl.Tensor[[TP_SIZE, T_DYN], pl.INT64],
+    state_slot_mapping: pl.Tensor[[TP_SIZE, T_DYN], pl.INT64],
+    position_ids: pl.Tensor[[TP_SIZE, T_DYN], pl.INT32],
+    kv_seq_lens: pl.Tensor[[TP_SIZE, B_DYN], pl.INT32],
     attn_sink: pl.Tensor[[TP_SIZE, H], pl.FP32],
-    freqs_cos: pl.Tensor[[TP_SIZE, T_DYN, ROPE_DIM], pl.BF16],
-    freqs_sin: pl.Tensor[[TP_SIZE, T_DYN, ROPE_DIM], pl.BF16],
     wo_a: pl.Tensor[[TP_SIZE, LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
     wo_b: pl.Tensor[[TP_SIZE, D, LOCAL_O_WIDTH], pl.INT8],
     wo_b_scale: pl.Tensor[[TP_SIZE, D], pl.FP32],
-    o_local: pl.InOut[pl.Tensor[[TP_SIZE, LOCAL_T_PAD, D], pl.BF16]],
+    x_out: pl.Out[pl.Tensor[[TP_SIZE, T_DYN, HC_MULT, D], pl.FP32]],
     local_t: pl.Scalar[pl.INT32],
 ):
-    """Launch the output-only HCA path on one TP group."""
-    q.bind_dynamic(1, T_DYN)
-    window_swa_indices.bind_dynamic(1, T_DYN)
+    """Launch the complete HCA layer on one tensor-parallel group."""
+    x_hc.bind_dynamic(1, T_DYN)
+    compress_state_block_table.bind_dynamic(1, B_DYN)
     cmp_block_table.bind_dynamic(1, B_DYN)
-    cmp_sparse_indices.bind_dynamic(1, T_DYN)
-    freqs_cos.bind_dynamic(1, T_DYN)
-    freqs_sin.bind_dynamic(1, T_DYN)
+    ori_slot_mapping.bind_dynamic(1, T_DYN)
+    window_swa_indices.bind_dynamic(1, T_DYN)
+    window_swa_lens.bind_dynamic(1, T_DYN)
+    cmp_slot_mapping.bind_dynamic(1, T_DYN)
+    state_slot_mapping.bind_dynamic(1, T_DYN)
+    position_ids.bind_dynamic(1, T_DYN)
+    kv_seq_lens.bind_dynamic(1, B_DYN)
+    x_out.bind_dynamic(1, T_DYN)
 
     attention_window_buf = pld.alloc_window_buffer([ATTENTION_WINDOW_ROWS, O_GROUP_IN], dtype=pl.BF16)
     attention_signal_buf = pld.alloc_window_buffer([TP_SIZE, 1], dtype=pl.INT32)
@@ -282,11 +460,21 @@ def l3_decode_hca_output_test(
         attention_signal = pld.window(attention_signal_buf, [TP_SIZE, 1], dtype=pl.INT32)
         o_window = pld.window(o_window_buf, [O_WINDOW_ROWS, D], dtype=pl.FP32)
         o_signal = pld.window(o_signal_buf, [TP_SIZE, 1], dtype=pl.INT32)
-        decode_hca_output_test(
-            q[rank], ori_kv[rank], window_swa_indices[rank],
-            cmp_kv[rank], cmp_block_table[rank], cmp_sparse_indices[rank],
-            attn_sink[rank], freqs_cos[rank], freqs_sin[rank],
-            wo_a[rank], wo_b[rank], wo_b_scale[rank], o_local[rank],
+        decode_hca_test(
+            x_hc[rank],
+            hc_attn_fn[rank], hc_attn_scale[rank], hc_attn_base[rank],
+            attn_norm_w[rank], wq_a[rank], wq_b[rank], wq_b_scale[rank],
+            wkv[rank], gamma_cq[rank], gamma_ckv[rank],
+            freqs_cos[rank], freqs_sin[rank],
+            cmp_wkv[rank], cmp_wgate[rank], cmp_ape[rank], cmp_norm_w[rank],
+            compress_state[rank], compress_state_block_table[rank],
+            kv_cache[rank], cmp_kv[rank], cmp_block_table[rank],
+            ori_slot_mapping[rank], window_swa_indices[rank], window_swa_lens[rank],
+            cmp_slot_mapping[rank], state_slot_mapping[rank],
+            position_ids[rank], kv_seq_lens[rank],
+            attn_sink[rank],
+            wo_a[rank], wo_b[rank], wo_b_scale[rank],
+            x_out[rank],
             attention_window, attention_signal, o_window, o_signal,
             0, rank, local_t, device=rank,
         )
@@ -519,595 +707,7 @@ def decode_hca_tp1_test(
     return x_out
 
 
-@pl.jit.inline
-def decode_hca(
-    x_hc: pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32],
-    hc_attn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
-    hc_attn_scale: pl.Tensor[[3], pl.FP32],
-    hc_attn_base: pl.Tensor[[MIX_HC], pl.FP32],
-    attn_norm_w: pl.Tensor[[D], pl.BF16],
-    wq_a: pl.Tensor[[D, Q_LORA], pl.BF16],
-    wq_b: pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8],
-    wq_b_scale: pl.Tensor[[H * HEAD_DIM], pl.FP32],
-    wkv: pl.Tensor[[D, HEAD_DIM], pl.BF16],
-    gamma_cq: pl.Tensor[[Q_LORA], pl.BF16],
-    gamma_ckv: pl.Tensor[[HEAD_DIM], pl.BF16],
-    freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
-    freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
-    cmp_wkv: pl.Tensor[[MAIN_OUT_DIM, D], pl.BF16],
-    cmp_wgate: pl.Tensor[[MAIN_OUT_DIM, D], pl.BF16],
-    cmp_ape: pl.Tensor[[COMPRESS_RATIO, MAIN_OUT_DIM], pl.FP32],
-    cmp_norm_w: pl.Tensor[[HEAD_DIM], pl.BF16],
-    compress_state: pl.Tensor[[COMPRESS_STATE_BLOCK_NUM_DYN, COMPRESS_STATE_BLOCK_SIZE, COMPRESS_STATE_DIM], pl.FP32],
-    compress_state_block_table: pl.Tensor[[B_DYN, COMPRESS_STATE_MAX_BLOCKS], pl.INT32],
-    kv_cache: pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
-    cmp_kv: pl.Tensor[[CMP_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
-    cmp_block_table: pl.Tensor[[B_DYN, CMP_MAX_BLOCKS], pl.INT32],
-    ori_slot_mapping: pl.Tensor[[T_DYN], pl.INT64],
-    window_swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
-    window_swa_lens: pl.Tensor[[T_DYN], pl.INT32],
-    cmp_slot_mapping: pl.Tensor[[T_DYN], pl.INT64],
-    state_slot_mapping: pl.Tensor[[T_DYN], pl.INT64],
-    position_ids: pl.Tensor[[T_DYN], pl.INT32],
-    kv_seq_lens: pl.Tensor[[B_DYN], pl.INT32],
-    attn_sink: pl.Tensor[[H], pl.FP32],
-    wo_a: pl.Tensor[[LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
-    wo_b: pl.Tensor[[D, LOCAL_O_WIDTH], pl.INT8],
-    wo_b_scale: pl.Tensor[[D], pl.FP32],
-    x_out: pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32],
-    attention_window: pld.DistributedTensor[[ATTENTION_WINDOW_ROWS, O_GROUP_IN], pl.BF16],
-    attention_signal: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
-    o_window: pld.DistributedTensor[[O_WINDOW_ROWS, D], pl.FP32],
-    o_signal: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
-    group_base: pl.Scalar[pl.INT32],
-    tp_rank: pl.Scalar[pl.INT32],
-    local_t: pl.Scalar[pl.INT32],
-):
-    """Run one rank of the complete HCA tensor-parallel layer."""
-    t_dim = pl.tensor.dim(x_hc, 0)
-    b_dim = t_dim // S
-    topk_blocks = t_dim // HCA_TOPK_TOKEN_TILE
-    wb_blocks = t_dim // HCA_WB_TOKEN_TILE
-
-    x_mixed = pl.create_tensor([t_dim, D], dtype=pl.BF16)
-    post_t = pl.create_tensor([t_dim, HC_MULT], dtype=pl.FP32)
-    comb_t = pl.create_tensor([t_dim, HC_MULT * HC_MULT], dtype=pl.FP32)
-    hc_pre(x_hc, hc_attn_fn, hc_attn_scale, hc_attn_base, x_mixed, post_t, comb_t)
-
-    rope_cos_t = pl.create_tensor([t_dim, ROPE_HEAD_DIM], dtype=pl.BF16)
-    rope_sin_t = pl.create_tensor([t_dim, ROPE_HEAD_DIM], dtype=pl.BF16)
-    cmp_cos = pl.create_tensor([B, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
-    cmp_sin = pl.create_tensor([B, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
-    cmp_cos_il = pl.create_tensor([B, ROPE_HEAD_DIM], dtype=pl.FP32)
-    cmp_sin_signed = pl.create_tensor([B, ROPE_HEAD_DIM], dtype=pl.FP32)
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="hca_rope"):
-        for b in pl.range(b_dim):
-            first_t = b * S
-            first_pos_b = pl.read(position_ids, [first_t])
-            cmp_offset_b = COMPRESS_RATIO - (first_pos_b % COMPRESS_RATIO)
-            cmp_pos_b = pl.cast(first_pos_b + cmp_offset_b - COMPRESS_RATIO, pl.INDEX)
-            cmp_cos_row = freqs_cos[cmp_pos_b : cmp_pos_b + 1, 0 : ROPE_HEAD_DIM // 2]
-            cmp_sin_row = freqs_sin[cmp_pos_b : cmp_pos_b + 1, 0 : ROPE_HEAD_DIM // 2]
-            cmp_cos[b : b + 1, 0 : ROPE_HEAD_DIM // 2] = pl.cast(cmp_cos_row, target_type=pl.FP32)
-            cmp_sin[b : b + 1, 0 : ROPE_HEAD_DIM // 2] = pl.cast(cmp_sin_row, target_type=pl.FP32)
-            for s in pl.range(S):
-                t = b * S + s
-                pos_b = pl.cast(pl.read(position_ids, [t]), pl.INDEX)
-                step_cos_row = pl.cast(freqs_cos[pos_b : pos_b + 1, 0 : ROPE_HEAD_DIM], target_type=pl.FP32)
-                step_sin_row = pl.cast(freqs_sin[pos_b : pos_b + 1, 0 : ROPE_HEAD_DIM], target_type=pl.FP32)
-                rope_cos_t[t : t + 1, 0 : ROPE_HEAD_DIM] = pl.cast(step_cos_row, target_type=pl.BF16, mode="rint")
-                rope_sin_t[t : t + 1, 0 : ROPE_HEAD_DIM] = pl.cast(step_sin_row, target_type=pl.BF16, mode="rint")
-
-    rope_interleave(cmp_cos, cmp_sin, cmp_cos_il, cmp_sin_signed)
-
-    x_normed = pl.create_tensor([t_dim, D], dtype=pl.BF16)
-    rms_tid = rms_norm(x_mixed, attn_norm_w, x_normed)
-    late_dep = pl.system.task_dummy(deps=[rms_tid])
-    q = pl.create_tensor([t_dim, H, HEAD_DIM], dtype=pl.BF16)
-    kv = pl.create_tensor([t_dim, HEAD_DIM], dtype=pl.BF16)
-    qr = pl.create_tensor([t_dim, Q_LORA], dtype=pl.INT8)
-    qr_scale = pl.create_tensor([t_dim, 1], dtype=pl.FP32)
-    qkv_proj_rope(
-        x_normed, wq_a, wq_b, wq_b_scale, wkv,
-        rope_cos_t, rope_sin_t, gamma_cq, gamma_ckv,
-        q, kv, qr, qr_scale, late_dep,
-    )
-
-    ori_block_num = pl.tensor.dim(kv_cache, 0)
-    kv_cache_flat = pl.reshape(kv_cache, [ori_block_num * BLOCK_SIZE, HEAD_DIM])
-    with pl.spmd(wb_blocks, name_hint="hca_cache_writeback") as ori_cache_write_tid:
-        wb_blk = pl.tile.get_block_idx()
-        wb_t0 = wb_blk * HCA_WB_TOKEN_TILE
-        for write_dt in pl.range(HCA_WB_TOKEN_TILE):
-            write_t = wb_t0 + write_dt
-            write_row_i64 = pl.read(ori_slot_mapping, [write_t])
-            if write_row_i64 >= 0:
-                write_row = pl.cast(write_row_i64, pl.INDEX)
-                kv_cache_flat[write_row : write_row + 1, 0 : HEAD_DIM] = kv[write_t : write_t + 1, 0 : HEAD_DIM]
-
-    cmp_kv_proj = pl.create_tensor([t_dim, HEAD_DIM], dtype=pl.FP32)
-    cmp_kv_proj, cmp_cache_write_tid = compressor_ratio128(
-        x_normed, cmp_kv_proj,
-        compress_state, compress_state_block_table,
-        cmp_wkv, cmp_wgate, cmp_ape, cmp_norm_w,
-        cmp_cos_il, cmp_sin_signed, cmp_kv,
-        position_ids, cmp_slot_mapping, state_slot_mapping,
-        late_dep,
-    )
-    cache_ready_dep = pl.system.task_dummy(deps=[ori_cache_write_tid, cmp_cache_write_tid])
-
-    topk_all = pl.create_tensor([t_dim, HCA_CMP_TOPK], dtype=pl.INT32)
-    for topk_block in pl.spmd(topk_blocks, name_hint="hca_cache_topk"):
-        topk_t0 = topk_block * HCA_TOPK_TOKEN_TILE
-        for topk_dt in pl.range(HCA_TOPK_TOKEN_TILE):
-            topk_t = topk_t0 + topk_dt
-            if topk_t < t_dim:
-                topk_b = topk_t // S
-                topk_abs_pos = pl.read(position_ids, [topk_t])
-                topk_cmp_valid = pl.min(
-                    HCA_TOPK_LIMIT,
-                    pl.min((topk_abs_pos + 1) // COMPRESS_RATIO, pl.read(kv_seq_lens, [topk_b]) // COMPRESS_RATIO),
-                )
-                for topk_ck in pl.range(HCA_CMP_TOPK):
-                    if topk_ck < topk_cmp_valid:
-                        pl.write(topk_all, [topk_t, topk_ck], pl.cast(topk_ck, pl.INT32))
-                    else:
-                        pl.write(topk_all, [topk_t, topk_ck], pl.cast(-1, pl.INT32))
-
-    o_local = pl.create_tensor([LOCAL_T_PAD, D], dtype=pl.BF16)
-    o_local, attention_signal, o_signal = decode_hca_output(
-        q, kv_cache, window_swa_indices,
-        cmp_kv, cmp_block_table, topk_all,
-        attn_sink, rope_cos_t, rope_sin_t,
-        wo_a, wo_b, wo_b_scale, o_local,
-        attention_window, attention_signal,
-        o_window, o_signal,
-        group_base, tp_rank, local_t, cache_ready_dep,
-    )
-
-    attn_out = pl.create_tensor([t_dim, D], dtype=pl.BF16)
-    for bridge_block in pl.spmd(t_dim // HCA_WB_TOKEN_TILE, name_hint="hca_output_bridge"):
-        bridge_t0 = bridge_block * HCA_WB_TOKEN_TILE
-        attn_out[bridge_t0 : bridge_t0 + HCA_WB_TOKEN_TILE, 0:D] = o_local[
-            bridge_t0 : bridge_t0 + HCA_WB_TOKEN_TILE,
-            0:D,
-        ]
-
-    hc_post(attn_out, x_hc, post_t, comb_t, x_out)
-    return x_out
-
-
-@pl.jit
-def decode_hca_test(
-    x_hc: pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32],
-    hc_attn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
-    hc_attn_scale: pl.Tensor[[3], pl.FP32],
-    hc_attn_base: pl.Tensor[[MIX_HC], pl.FP32],
-    attn_norm_w: pl.Tensor[[D], pl.BF16],
-    wq_a: pl.Tensor[[D, Q_LORA], pl.BF16],
-    wq_b: pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8],
-    wq_b_scale: pl.Tensor[[H * HEAD_DIM], pl.FP32],
-    wkv: pl.Tensor[[D, HEAD_DIM], pl.BF16],
-    gamma_cq: pl.Tensor[[Q_LORA], pl.BF16],
-    gamma_ckv: pl.Tensor[[HEAD_DIM], pl.BF16],
-    freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
-    freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
-    cmp_wkv: pl.Tensor[[MAIN_OUT_DIM, D], pl.BF16],
-    cmp_wgate: pl.Tensor[[MAIN_OUT_DIM, D], pl.BF16],
-    cmp_ape: pl.Tensor[[COMPRESS_RATIO, MAIN_OUT_DIM], pl.FP32],
-    cmp_norm_w: pl.Tensor[[HEAD_DIM], pl.BF16],
-    compress_state: pl.InOut[pl.Tensor[[COMPRESS_STATE_BLOCK_NUM_DYN, COMPRESS_STATE_BLOCK_SIZE, COMPRESS_STATE_DIM], pl.FP32]],
-    compress_state_block_table: pl.Tensor[[B_DYN, COMPRESS_STATE_MAX_BLOCKS], pl.INT32],
-    kv_cache: pl.InOut[pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
-    cmp_kv: pl.InOut[pl.Tensor[[CMP_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
-    cmp_block_table: pl.Tensor[[B_DYN, CMP_MAX_BLOCKS], pl.INT32],
-    ori_slot_mapping: pl.Tensor[[T_DYN], pl.INT64],
-    window_swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
-    window_swa_lens: pl.Tensor[[T_DYN], pl.INT32],
-    cmp_slot_mapping: pl.Tensor[[T_DYN], pl.INT64],
-    state_slot_mapping: pl.Tensor[[T_DYN], pl.INT64],
-    position_ids: pl.Tensor[[T_DYN], pl.INT32],
-    kv_seq_lens: pl.Tensor[[B_DYN], pl.INT32],
-    attn_sink: pl.Tensor[[H], pl.FP32],
-    wo_a: pl.Tensor[[LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
-    wo_b: pl.Tensor[[D, LOCAL_O_WIDTH], pl.INT8],
-    wo_b_scale: pl.Tensor[[D], pl.FP32],
-    x_out: pl.Out[pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32]],
-    attention_window: pld.DistributedTensor[[ATTENTION_WINDOW_ROWS, O_GROUP_IN], pl.BF16],
-    attention_signal: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
-    o_window: pld.DistributedTensor[[O_WINDOW_ROWS, D], pl.FP32],
-    o_signal: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
-    group_base: pl.Scalar[pl.INT32],
-    tp_rank: pl.Scalar[pl.INT32],
-    local_t: pl.Scalar[pl.INT32],
-):
-    """Test one rank of the complete HCA tensor-parallel layer."""
-    x_hc.bind_dynamic(0, T_DYN)
-    compress_state.bind_dynamic(0, COMPRESS_STATE_BLOCK_NUM_DYN)
-    compress_state_block_table.bind_dynamic(0, B_DYN)
-    kv_cache.bind_dynamic(0, ORI_BLOCK_NUM_DYN)
-    cmp_kv.bind_dynamic(0, CMP_BLOCK_NUM_DYN)
-    cmp_block_table.bind_dynamic(0, B_DYN)
-    ori_slot_mapping.bind_dynamic(0, T_DYN)
-    window_swa_indices.bind_dynamic(0, T_DYN)
-    window_swa_lens.bind_dynamic(0, T_DYN)
-    cmp_slot_mapping.bind_dynamic(0, T_DYN)
-    state_slot_mapping.bind_dynamic(0, T_DYN)
-    position_ids.bind_dynamic(0, T_DYN)
-    kv_seq_lens.bind_dynamic(0, B_DYN)
-    x_out.bind_dynamic(0, T_DYN)
-
-    return decode_hca(
-        x_hc,
-        hc_attn_fn, hc_attn_scale, hc_attn_base,
-        attn_norm_w, wq_a, wq_b, wq_b_scale, wkv, gamma_cq, gamma_ckv,
-        freqs_cos, freqs_sin,
-        cmp_wkv, cmp_wgate, cmp_ape, cmp_norm_w,
-        compress_state, compress_state_block_table,
-        kv_cache, cmp_kv, cmp_block_table,
-        ori_slot_mapping, window_swa_indices, window_swa_lens,
-        cmp_slot_mapping, state_slot_mapping,
-        position_ids, kv_seq_lens,
-        attn_sink,
-        wo_a, wo_b, wo_b_scale,
-        x_out,
-        attention_window, attention_signal, o_window, o_signal,
-        group_base, tp_rank, local_t,
-    )
-
-
-@pl.jit.host
-def l3_decode_hca(
-    x_hc: pl.Tensor[[TP_SIZE, T_DYN, HC_MULT, D], pl.FP32],
-    hc_attn_fn: pl.Tensor[[TP_SIZE, MIX_HC, HC_DIM], pl.FP32],
-    hc_attn_scale: pl.Tensor[[TP_SIZE, 3], pl.FP32],
-    hc_attn_base: pl.Tensor[[TP_SIZE, MIX_HC], pl.FP32],
-    attn_norm_w: pl.Tensor[[TP_SIZE, D], pl.BF16],
-    wq_a: pl.Tensor[[TP_SIZE, D, Q_LORA], pl.BF16],
-    wq_b: pl.Tensor[[TP_SIZE, Q_LORA, H * HEAD_DIM], pl.INT8],
-    wq_b_scale: pl.Tensor[[TP_SIZE, H * HEAD_DIM], pl.FP32],
-    wkv: pl.Tensor[[TP_SIZE, D, HEAD_DIM], pl.BF16],
-    gamma_cq: pl.Tensor[[TP_SIZE, Q_LORA], pl.BF16],
-    gamma_ckv: pl.Tensor[[TP_SIZE, HEAD_DIM], pl.BF16],
-    freqs_cos: pl.Tensor[[TP_SIZE, MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
-    freqs_sin: pl.Tensor[[TP_SIZE, MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
-    cmp_wkv: pl.Tensor[[TP_SIZE, MAIN_OUT_DIM, D], pl.BF16],
-    cmp_wgate: pl.Tensor[[TP_SIZE, MAIN_OUT_DIM, D], pl.BF16],
-    cmp_ape: pl.Tensor[[TP_SIZE, COMPRESS_RATIO, MAIN_OUT_DIM], pl.FP32],
-    cmp_norm_w: pl.Tensor[[TP_SIZE, HEAD_DIM], pl.BF16],
-    compress_state: pl.InOut[pl.Tensor[[TP_SIZE, COMPRESS_STATE_BLOCK_NUM, COMPRESS_STATE_BLOCK_SIZE, COMPRESS_STATE_DIM], pl.FP32]],
-    compress_state_block_table: pl.Tensor[[TP_SIZE, B_DYN, COMPRESS_STATE_MAX_BLOCKS], pl.INT32],
-    kv_cache: pl.InOut[pl.Tensor[[TP_SIZE, ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
-    cmp_kv: pl.InOut[pl.Tensor[[TP_SIZE, CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
-    cmp_block_table: pl.Tensor[[TP_SIZE, B_DYN, CMP_MAX_BLOCKS], pl.INT32],
-    ori_slot_mapping: pl.Tensor[[TP_SIZE, T_DYN], pl.INT64],
-    window_swa_indices: pl.Tensor[[TP_SIZE, T_DYN, WIN], pl.INT32],
-    window_swa_lens: pl.Tensor[[TP_SIZE, T_DYN], pl.INT32],
-    cmp_slot_mapping: pl.Tensor[[TP_SIZE, T_DYN], pl.INT64],
-    state_slot_mapping: pl.Tensor[[TP_SIZE, T_DYN], pl.INT64],
-    position_ids: pl.Tensor[[TP_SIZE, T_DYN], pl.INT32],
-    kv_seq_lens: pl.Tensor[[TP_SIZE, B_DYN], pl.INT32],
-    attn_sink: pl.Tensor[[TP_SIZE, H], pl.FP32],
-    wo_a: pl.Tensor[[TP_SIZE, LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
-    wo_b: pl.Tensor[[TP_SIZE, D, LOCAL_O_WIDTH], pl.INT8],
-    wo_b_scale: pl.Tensor[[TP_SIZE, D], pl.FP32],
-    x_out: pl.Out[pl.Tensor[[TP_SIZE, T_DYN, HC_MULT, D], pl.FP32]],
-    local_t: pl.Scalar[pl.INT32],
-):
-    """Launch the complete HCA layer on one tensor-parallel group."""
-    x_hc.bind_dynamic(1, T_DYN)
-    compress_state_block_table.bind_dynamic(1, B_DYN)
-    cmp_block_table.bind_dynamic(1, B_DYN)
-    ori_slot_mapping.bind_dynamic(1, T_DYN)
-    window_swa_indices.bind_dynamic(1, T_DYN)
-    window_swa_lens.bind_dynamic(1, T_DYN)
-    cmp_slot_mapping.bind_dynamic(1, T_DYN)
-    state_slot_mapping.bind_dynamic(1, T_DYN)
-    position_ids.bind_dynamic(1, T_DYN)
-    kv_seq_lens.bind_dynamic(1, B_DYN)
-    x_out.bind_dynamic(1, T_DYN)
-
-    attention_window_buf = pld.alloc_window_buffer([ATTENTION_WINDOW_ROWS, O_GROUP_IN], dtype=pl.BF16)
-    attention_signal_buf = pld.alloc_window_buffer([TP_SIZE, 1], dtype=pl.INT32)
-    o_window_buf = pld.alloc_window_buffer([O_WINDOW_ROWS, D], dtype=pl.FP32)
-    o_signal_buf = pld.alloc_window_buffer([TP_SIZE, 1], dtype=pl.INT32)
-
-    for rank in pl.range(pld.world_size()):
-        attention_window = pld.window(attention_window_buf, [ATTENTION_WINDOW_ROWS, O_GROUP_IN], dtype=pl.BF16)
-        attention_signal = pld.window(attention_signal_buf, [TP_SIZE, 1], dtype=pl.INT32)
-        o_window = pld.window(o_window_buf, [O_WINDOW_ROWS, D], dtype=pl.FP32)
-        o_signal = pld.window(o_signal_buf, [TP_SIZE, 1], dtype=pl.INT32)
-        decode_hca_test(
-            x_hc[rank],
-            hc_attn_fn[rank], hc_attn_scale[rank], hc_attn_base[rank],
-            attn_norm_w[rank], wq_a[rank], wq_b[rank], wq_b_scale[rank],
-            wkv[rank], gamma_cq[rank], gamma_ckv[rank],
-            freqs_cos[rank], freqs_sin[rank],
-            cmp_wkv[rank], cmp_wgate[rank], cmp_ape[rank], cmp_norm_w[rank],
-            compress_state[rank], compress_state_block_table[rank],
-            kv_cache[rank], cmp_kv[rank], cmp_block_table[rank],
-            ori_slot_mapping[rank], window_swa_indices[rank], window_swa_lens[rank],
-            cmp_slot_mapping[rank], state_slot_mapping[rank],
-            position_ids[rank], kv_seq_lens[rank],
-            attn_sink[rank],
-            wo_a[rank], wo_b[rank], wo_b_scale[rank],
-            x_out[rank],
-            attention_window, attention_signal, o_window, o_signal,
-            0, rank, local_t, device=rank,
-        )
-
-
 # fixture
-FIXTURE_WINDOW_BLOCKS = (WIN + BLOCK_SIZE - 1) // BLOCK_SIZE
-FIXTURE_CMP_SLOTS = (0, 31, 32, 63, 64, 95, 96, 127)
-FIXTURE_CMP_LOGICAL_BLOCKS = (max(FIXTURE_CMP_SLOTS) + 1 + BLOCK_SIZE - 1) // BLOCK_SIZE
-FIXTURE_CMP_BLOCKS_PER_RANK = CMP_BLOCK_NUM // TP_SIZE
-FIXTURE_OUTPUT_SENTINEL = -7.0
-
-if max(FIXTURE_CMP_SLOTS) >= CMP_TOPK:
-    raise ValueError("HCA fixture compressed slots exceed the configured top-k capacity")
-if FIXTURE_WINDOW_BLOCKS > ORI_BLOCK_NUM:
-    raise ValueError("HCA fixture window exceeds the original KV cache capacity")
-if FIXTURE_CMP_LOGICAL_BLOCKS > CMP_MAX_BLOCKS:
-    raise ValueError("HCA fixture compressed slots exceed the compressed block table")
-if CMP_BLOCK_NUM % TP_SIZE != 0:
-    raise ValueError("HCA fixture requires equal compressed-cache partitions across TP ranks")
-if (LOCAL_T // S) * FIXTURE_CMP_LOGICAL_BLOCKS > FIXTURE_CMP_BLOCKS_PER_RANK:
-    raise ValueError("HCA fixture compressed-cache partition is too small for the local requests")
-if O_LORA < 3 * HEADS_PER_GROUP:
-    raise ValueError("HCA fixture output projection needs three observable rows per local head")
-
-
-def build_output_tensor_specs(local_t):
-    """Build deterministic tensor-parallel HCA output inputs."""
-    import torch
-
-    from golden import ScalarSpec, TensorSpec
-
-    if (local_t < VALID_TOKEN_TILE or local_t > LOCAL_T
-            or local_t % VALID_TOKEN_TILE != 0 or local_t % S != 0):
-        raise ValueError(
-            f"local_t must be a multiple of {VALID_TOKEN_TILE} "
-            f"in [{VALID_TOKEN_TILE}, {LOCAL_T}], got {local_t}"
-        )
-    local_batch = local_t // S
-    cmp_block_table_shape = [TP_SIZE, local_batch, CMP_MAX_BLOCKS]
-
-    def init_q():
-        q = torch.zeros(TP_SIZE, local_t, H, HEAD_DIM, dtype=torch.bfloat16)
-        rank = torch.arange(TP_SIZE, dtype=torch.float32).reshape(TP_SIZE, 1, 1)
-        token = torch.arange(local_t, dtype=torch.float32).reshape(1, local_t, 1)
-        head = torch.arange(H, dtype=torch.float32).reshape(1, 1, H)
-        q[..., 0] = (rank + token * 0.25 + head * 0.0625).to(torch.bfloat16)
-        return q
-
-    def init_ori_kv():
-        shape = (TP_SIZE, ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM)
-        ori_kv = torch.full(shape, float("nan"), dtype=torch.bfloat16)
-        ori_kv[:, :FIXTURE_WINDOW_BLOCKS, :, 0, :] = 0.0
-        ori_kv[:, :FIXTURE_WINDOW_BLOCKS, :, 0, 0] = 0.25
-        return ori_kv
-
-    def init_window_swa_indices():
-        window_row = torch.arange(WIN, dtype=torch.int32)
-        return window_row.reshape(1, 1, WIN).expand(TP_SIZE, local_t, WIN).clone()
-
-    def init_cmp_kv():
-        shape = (TP_SIZE, CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM)
-        cmp_kv = torch.full(shape, float("nan"), dtype=torch.bfloat16)
-        for rank in range(TP_SIZE):
-            rank_block_base = rank * FIXTURE_CMP_BLOCKS_PER_RANK
-            for request in range(local_batch):
-                request_block_base = rank_block_base + request * FIXTURE_CMP_LOGICAL_BLOCKS
-                for slot_index, cmp_slot in enumerate(FIXTURE_CMP_SLOTS):
-                    logical_block = cmp_slot // BLOCK_SIZE
-                    physical_block = request_block_base + FIXTURE_CMP_LOGICAL_BLOCKS - 1 - logical_block
-                    row = cmp_slot % BLOCK_SIZE
-                    cmp_kv[rank, physical_block, row, 0, :] = 0.0
-                    cmp_kv[rank, physical_block, row, 0, 0] = 0.25
-                    nope_value = (rank + 1) * 0.0625 + (request + 1) * 0.015625 + (slot_index + 1) * 0.00390625
-                    block_value = -(logical_block + 1) * 0.0625 + (rank + 1) * 0.0078125 + (request + 1) * 0.001953125
-                    cmp_kv[rank, physical_block, row, 0, NOPE_DIM] = nope_value
-                    cmp_kv[rank, physical_block, row, 0, NOPE_DIM + 1] = block_value
-        return cmp_kv
-
-    def init_cmp_block_table():
-        table = torch.full(cmp_block_table_shape, -1, dtype=torch.int32)
-        for rank in range(TP_SIZE):
-            rank_block_base = rank * FIXTURE_CMP_BLOCKS_PER_RANK
-            for request in range(local_batch):
-                request_block_base = rank_block_base + request * FIXTURE_CMP_LOGICAL_BLOCKS
-                for logical_block in range(FIXTURE_CMP_LOGICAL_BLOCKS):
-                    physical_block = request_block_base + FIXTURE_CMP_LOGICAL_BLOCKS - 1 - logical_block
-                    table[rank, request, logical_block] = physical_block
-        return table
-
-    def init_cmp_sparse_indices():
-        indices = torch.full((TP_SIZE, local_t, CMP_TOPK), -1, dtype=torch.int32)
-        for cmp_slot in FIXTURE_CMP_SLOTS:
-            indices[:, :, cmp_slot] = cmp_slot
-        return indices
-
-    def init_attn_sink():
-        head = torch.arange(H, dtype=torch.int32).remainder(HEADS_PER_GROUP).to(torch.float32)
-        sink = 4.0 + head * 0.125
-        return sink.reshape(1, H).expand(TP_SIZE, H).clone()
-
-    def init_freqs_cos():
-        rank = torch.arange(TP_SIZE, dtype=torch.int32).reshape(TP_SIZE, 1)
-        token = torch.arange(local_t, dtype=torch.int32).reshape(1, local_t)
-        phase = (rank + token).remainder(4)
-        values = torch.tensor((1.0, 0.0, -1.0, 0.0), dtype=torch.bfloat16)
-        return values[phase].unsqueeze(-1).expand(TP_SIZE, local_t, ROPE_DIM).clone()
-
-    def init_freqs_sin():
-        rank = torch.arange(TP_SIZE, dtype=torch.int32).reshape(TP_SIZE, 1)
-        token = torch.arange(local_t, dtype=torch.int32).reshape(1, local_t)
-        phase = (rank + token).remainder(4)
-        values = torch.tensor((0.0, 1.0, 0.0, -1.0), dtype=torch.bfloat16)
-        return values[phase].unsqueeze(-1).expand(TP_SIZE, local_t, ROPE_DIM).clone()
-
-    def init_wo_a():
-        wo_a = torch.zeros(TP_SIZE, LOCAL_O_GROUPS, O_LORA, O_GROUP_IN, dtype=torch.bfloat16)
-        for rank in range(TP_SIZE):
-            for local_group in range(LOCAL_O_GROUPS):
-                shard_scale = (rank + 1) * (local_group + 1) * 0.125
-                for head in range(HEADS_PER_GROUP):
-                    head_col = head * HEAD_DIM
-                    head_scale = shard_scale * (head + 1)
-                    wo_a[rank, local_group, head, head_col] = head_scale
-                    wo_a[rank, local_group, HEADS_PER_GROUP + head, head_col + NOPE_DIM] = head_scale * 0.75
-                    wo_a[rank, local_group, 2 * HEADS_PER_GROUP + head, head_col + NOPE_DIM + 1] = -head_scale * 0.5
-        return wo_a
-
-    def init_wo_b():
-        base = torch.arange(D * LOCAL_O_WIDTH, dtype=torch.int32).reshape(D, LOCAL_O_WIDTH)
-        rank = torch.arange(TP_SIZE, dtype=torch.int32).reshape(TP_SIZE, 1, 1)
-        return (base.unsqueeze(0) + rank).remainder(7).sub(3).to(torch.int8)
-
-    def init_wo_b_scale():
-        channel_scale = torch.arange(D, dtype=torch.int32).remainder(4).to(torch.float32) * 0.25 + 0.5
-        return channel_scale.reshape(1, D).expand(TP_SIZE, D).clone()
-
-    return [
-        TensorSpec("q", [TP_SIZE, local_t, H, HEAD_DIM], torch.bfloat16, init_value=init_q),
-        TensorSpec("ori_kv", [TP_SIZE, ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_ori_kv),
-        TensorSpec("window_swa_indices", [TP_SIZE, local_t, WIN], torch.int32, init_value=init_window_swa_indices),
-        TensorSpec("cmp_kv", [TP_SIZE, CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_cmp_kv),
-        TensorSpec("cmp_block_table", cmp_block_table_shape, torch.int32, init_value=init_cmp_block_table),
-        TensorSpec("cmp_sparse_indices", [TP_SIZE, local_t, CMP_TOPK], torch.int32, init_value=init_cmp_sparse_indices),
-        TensorSpec("attn_sink", [TP_SIZE, H], torch.float32, init_value=init_attn_sink),
-        TensorSpec("freqs_cos", [TP_SIZE, local_t, ROPE_DIM], torch.bfloat16, init_value=init_freqs_cos),
-        TensorSpec("freqs_sin", [TP_SIZE, local_t, ROPE_DIM], torch.bfloat16, init_value=init_freqs_sin),
-        TensorSpec("wo_a", [TP_SIZE, LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], torch.bfloat16, init_value=init_wo_a),
-        TensorSpec("wo_b", [TP_SIZE, D, LOCAL_O_WIDTH], torch.int8, init_value=init_wo_b),
-        TensorSpec("wo_b_scale", [TP_SIZE, D], torch.float32, init_value=init_wo_b_scale),
-        TensorSpec(
-            "o_local", [TP_SIZE, LOCAL_T_PAD, D], torch.bfloat16,
-            init_value=FIXTURE_OUTPUT_SENTINEL, is_output=True,
-        ),
-        ScalarSpec("local_t", torch.int32, local_t),
-    ]
-
-
-def golden_decode_hca_output(tensors):
-    """Compute the controlled HCA heads, sharded O projection, and reduced rows."""
-    import torch
-
-    local_t = int(tensors["local_t"])
-    local_batch = local_t // S
-    group_t = TP_SIZE * local_t
-    q = tensors["q"].float()
-    window_kv = tensors["ori_kv"][:, 0, 0, 0].float()
-
-    cmp_rows_by_request = torch.empty(
-        TP_SIZE, local_batch, len(FIXTURE_CMP_SLOTS), HEAD_DIM,
-        dtype=torch.float32,
-    )
-    for rank in range(TP_SIZE):
-        for request in range(local_batch):
-            token = request * S
-            for row, sparse_position in enumerate(FIXTURE_CMP_SLOTS):
-                cmp_slot = int(tensors["cmp_sparse_indices"][rank, token, sparse_position].item())
-                logical_block = cmp_slot // BLOCK_SIZE
-                physical_block = int(tensors["cmp_block_table"][rank, request, logical_block].item())
-                cmp_rows_by_request[rank, request, row] = tensors[
-                    "cmp_kv"
-                ][rank, physical_block, cmp_slot % BLOCK_SIZE, 0].float()
-    cmp_rows = cmp_rows_by_request.repeat_interleave(S, dim=1)
-
-    window_mi = torch.einsum("rthd,rd->rth", q, window_kv)
-    window_mi = (window_mi * M.softmax_scale).unsqueeze(-1)
-    window_li = torch.full_like(window_mi, float(WIN))
-    window_oi = window_kv.reshape(TP_SIZE, 1, 1, HEAD_DIM) * WIN
-
-    cmp_scores = torch.einsum("rthd,rtkd->rthk", q, cmp_rows)
-    cmp_scores = cmp_scores * M.softmax_scale
-    cmp_mi = cmp_scores.max(dim=-1, keepdim=True).values
-    cmp_exp = torch.exp(cmp_scores - cmp_mi)
-    cmp_li = cmp_exp.sum(dim=-1, keepdim=True)
-    cmp_oi = torch.einsum(
-        "rthk,rtkd->rthd",
-        cmp_exp.to(torch.bfloat16).float(), cmp_rows,
-    )
-
-    score_max = torch.maximum(window_mi, cmp_mi)
-    window_alpha = torch.exp(window_mi - score_max)
-    cmp_beta = torch.exp(cmp_mi - score_max)
-    li = window_alpha * window_li + cmp_beta * cmp_li
-    oi = window_alpha * window_oi + cmp_beta * cmp_oi
-    sink = tensors["attn_sink"].float().reshape(TP_SIZE, 1, H, 1)
-    head_value = oi / (li + torch.exp(sink - score_max))
-
-    rope_pair = head_value[..., NOPE_DIM:].unflatten(-1, (-1, 2))
-    rope_even = rope_pair[..., 0]
-    rope_odd = rope_pair[..., 1]
-    cos_half = tensors["freqs_cos"][..., :HALF_ROPE].float().unsqueeze(2)
-    sin_half = tensors["freqs_sin"][..., :HALF_ROPE].float().unsqueeze(2)
-    inverse_even = (rope_even * cos_half + rope_odd * sin_half).to(torch.bfloat16).float()
-    inverse_odd = (rope_odd * cos_half - rope_even * sin_half).to(torch.bfloat16).float()
-    inverse_rope = torch.stack((inverse_even, inverse_odd), dim=-1).flatten(-2)
-    head_value = torch.cat((head_value[..., :NOPE_DIM], inverse_rope), dim=-1).to(torch.bfloat16)
-
-    attention_grouped = head_value.reshape(
-        TP_SIZE, local_t, O_GROUPS, HEADS_PER_GROUP, HEAD_DIM,
-    )
-    attention_grouped = attention_grouped.permute(0, 2, 1, 3, 4)
-    attention_grouped = attention_grouped.reshape(
-        TP_SIZE, O_GROUPS, local_t, O_GROUP_IN,
-    )
-
-    attention_local = torch.zeros(TP_SIZE, LOCAL_O_GROUPS, group_t, O_GROUP_IN, dtype=torch.bfloat16)
-    for destination_rank in range(TP_SIZE):
-        for local_group in range(LOCAL_O_GROUPS):
-            global_group = destination_rank * LOCAL_O_GROUPS + local_group
-            group_rows = attention_grouped[:, global_group].reshape(group_t, O_GROUP_IN)
-            attention_local[destination_rank, local_group] = group_rows
-
-    partials = torch.zeros(TP_SIZE, group_t, D, dtype=torch.float32)
-    for rank in range(TP_SIZE):
-        attention = attention_local[rank].float()
-        o_a = torch.einsum("gti,gri->gtr", attention, tensors["wo_a"][rank].float())
-        row_amax = o_a.abs().amax(dim=-1, keepdim=True).clamp_min(INT8_AMAX_EPS)
-        scale_q = INT8_SCALE_MAX / row_amax
-        o_a_i8 = torch.round(o_a * scale_q).to(torch.int32).to(torch.float16).to(torch.int8)
-        scale_dq = 1.0 / scale_q
-        wo_b = tensors["wo_b"][rank].reshape(D, LOCAL_O_GROUPS, O_LORA)
-        for local_group in range(LOCAL_O_GROUPS):
-            group_i32 = o_a_i8[local_group].to(torch.int32)
-            weight_i32 = wo_b[:, local_group].to(torch.int32)
-            group_partial = group_i32 @ weight_i32.T
-            partials[rank] += group_partial.float() * scale_dq[local_group]
-        partials[rank] *= tensors["wo_b_scale"][rank].float().reshape(1, D)
-
-    reduced = partials.sum(dim=0)
-    tensors["o_local"].fill_(FIXTURE_OUTPUT_SENTINEL)
-    for rank in range(TP_SIZE):
-        row_start = rank * local_t
-        tensors["o_local"][rank, :local_t] = reduced[row_start : row_start + local_t].to(torch.bfloat16)
-
-
-def build_o_local_compare(local_t):
-    """Compare valid token rows and require the poisoned capacity tail to survive."""
-    import torch
-
-    from golden import ratio_allclose
-
-    prefix_compare = ratio_allclose(
-        atol=1e-4, rtol=1.0 / 128, max_error_ratio=0.005,
-        valid_rows=local_t, valid_axis=1,
-    )
-
-    def compare(actual, expected, **kwargs):
-        actual_tail = actual[:, local_t:]
-        expected_tail = expected[:, local_t:]
-        if not torch.equal(actual_tail, expected_tail):
-            mismatch_count = int((actual_tail != expected_tail).sum().item())
-            return False, f"    inactive token tail mismatch count={mismatch_count}"
-        return prefix_compare(actual, expected, **kwargs)
-
-    compare.__name__ = f"hca_output_prefix_and_tail(local_t={local_t})"
-    return compare
 
 
 def golden_decode_hca_tp1(tensors):
@@ -1632,10 +1232,8 @@ if __name__ == "__main__":
     parser.add_argument("--tp", type=int, default=TP_SIZE, choices=list(_TP_CHOICES), help="tensor-parallel world size")
     parser.add_argument(
         "-d", "--device", type=str, default=None,
-        help=f"comma-separated device ids; full/output need {TP_SIZE}, tp1 needs one",
+        help=f"comma-separated device ids; --tp {TP_SIZE} needs {TP_SIZE}",
     )
-    parser.add_argument("--entry", choices=("full", "output", "tp1"), default="full")
-    parser.add_argument("--case", choices=("all", "max", "subcapacity"), default="all")
     parser.add_argument("--compile-only", action="store_true", default=False)
     parser.add_argument("--dump-passes", action="store_true", default=False)
     args = parser.parse_args()
@@ -1643,7 +1241,7 @@ if __name__ == "__main__":
     if args.tp != TP_SIZE:
         parser.error(f"--tp must remain {TP_SIZE} after import-time specialization")
     if args.device is None:
-        args.device = ",".join(str(rank) for rank in range(TP_SIZE)) if args.entry in ("full", "output") else "0"
+        args.device = ",".join(str(rank) for rank in range(TP_SIZE))
     try:
         device_ids = [int(device) for device in args.device.split(",")]
     except ValueError:
@@ -1653,13 +1251,10 @@ if __name__ == "__main__":
     if len(set(device_ids)) != len(device_ids):
         parser.error(f"--device IDs must be distinct, got {device_ids}")
 
-    expected_devices = TP_SIZE if args.entry in ("full", "output") else 1
-    if len(device_ids) != expected_devices:
-        parser.error(f"{args.entry} entry needs exactly {expected_devices} device(s), got {device_ids}")
+    if len(device_ids) != TP_SIZE:
+        parser.error(f"--tp {TP_SIZE} needs exactly {TP_SIZE} device(s), got {device_ids}")
 
-    if args.entry == "tp1":
-        if args.case == "subcapacity":
-            parser.error("--case subcapacity only applies to the full and output entries")
+    if TP_SIZE == 1:
         result = run_jit(
             fn=decode_hca_tp1_test,
             specs=build_tensor_specs(),
@@ -1694,58 +1289,45 @@ if __name__ == "__main__":
     # The A2A3 simulator's distributed O path uses the CSA-level threshold and near-zero cap.
     full_x_out_diff_thd = 4e-3 if args.platform == "a2a3sim" else 3e-3
     full_x_out_max_diff = 2 if args.platform == "a2a3sim" else 1
-    case_local_t = {"max": LOCAL_T, "subcapacity": LOCAL_T - VALID_TOKEN_TILE}
-    selected_cases = tuple(case_local_t) if args.case == "all" else (args.case,)
-    for case in selected_cases:
-        local_t = case_local_t[case]
+    # Capacity, then one row block below it: the dynamic token axis must hold at both.
+    for local_t in (LOCAL_T, LOCAL_T - VALID_TOKEN_TILE):
         compile_cfg = dict(
             dump_passes=args.dump_passes,
             distributed_config=DistributedConfig(device_ids=device_ids, num_sub_workers=0),
         )
-        if args.entry == "full":
-            mapping_shape = (TP_SIZE, local_t)
-            result = run_jit(
-                fn=l3_decode_hca,
-                specs=build_distributed_tensor_specs(local_t),
-                golden_fn=golden_decode_hca,
-                compile_only=args.compile_only,
-                compile_cfg=compile_cfg,
-                runtime_cfg=dict(platform=args.platform),
-                rtol=1e-3,
-                atol=1e-3,
-                compare_fn={
-                    "compress_state": mapped_pool_ratio_allclose(
-                        "state_slot_mapping", mapping_shape=mapping_shape,
-                        block_size=COMPRESS_STATE_BLOCK_SIZE, leading_rank_axis=True,
-                        pool_name="compressor state", atol=1e-3, rtol=1.0 / 128,
-                    ),
-                    "kv_cache": mapped_pool_ratio_allclose(
-                        "ori_slot_mapping", mapping_shape=mapping_shape,
-                        block_size=BLOCK_SIZE, leading_rank_axis=True,
-                        pool_name="original KV cache", atol=1e-3, rtol=1.0 / 128,
-                    ),
-                    "cmp_kv": mapped_pool_ratio_allclose(
-                        "cmp_slot_mapping", mapping_shape=mapping_shape,
-                        block_size=BLOCK_SIZE, leading_rank_axis=True,
-                        pool_name="compressed KV cache", atol=1e-3, rtol=1.0 / 128,
-                    ),
-                    "x_out": ratio_reldiff(
-                        diff_thd=full_x_out_diff_thd,
-                        pct_thd=0.008,
-                        max_diff_hd=full_x_out_max_diff,
-                    ),
-                },
-            )
-        else:
-            result = run_jit(
-                fn=l3_decode_hca_output_test,
-                specs=build_output_tensor_specs(local_t),
-                golden_fn=golden_decode_hca_output,
-                compile_only=args.compile_only,
-                compile_cfg=compile_cfg,
-                runtime_cfg=dict(platform=args.platform),
-                compare_fn={"o_local": build_o_local_compare(local_t)},
-            )
+        mapping_shape = (TP_SIZE, local_t)
+        result = run_jit(
+            fn=l3_decode_hca,
+            specs=build_distributed_tensor_specs(local_t),
+            golden_fn=golden_decode_hca,
+            compile_only=args.compile_only,
+            compile_cfg=compile_cfg,
+            runtime_cfg=dict(platform=args.platform),
+            rtol=1e-3,
+            atol=1e-3,
+            compare_fn={
+                "compress_state": mapped_pool_ratio_allclose(
+                    "state_slot_mapping", mapping_shape=mapping_shape,
+                    block_size=COMPRESS_STATE_BLOCK_SIZE, leading_rank_axis=True,
+                    pool_name="compressor state", atol=1e-3, rtol=1.0 / 128,
+                ),
+                "kv_cache": mapped_pool_ratio_allclose(
+                    "ori_slot_mapping", mapping_shape=mapping_shape,
+                    block_size=BLOCK_SIZE, leading_rank_axis=True,
+                    pool_name="original KV cache", atol=1e-3, rtol=1.0 / 128,
+                ),
+                "cmp_kv": mapped_pool_ratio_allclose(
+                    "cmp_slot_mapping", mapping_shape=mapping_shape,
+                    block_size=BLOCK_SIZE, leading_rank_axis=True,
+                    pool_name="compressed KV cache", atol=1e-3, rtol=1.0 / 128,
+                ),
+                "x_out": ratio_reldiff(
+                    diff_thd=full_x_out_diff_thd,
+                    pct_thd=0.008,
+                    max_diff_hd=full_x_out_max_diff,
+                ),
+            },
+        )
         if not result.passed:
             if result.error:
                 print(result.error)

--- a/models/deepseek_v4_flash_dspark/decode_swa.py
+++ b/models/deepseek_v4_flash_dspark/decode_swa.py
@@ -7,7 +7,7 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
 # ci: devices=2  # CI: 2-card run; borrows 2 cards via task-submit --device-num
-"""DeepSeek-V4 SWA full-layer TP, TP1, and tensor-parallel output entries."""
+"""DeepSeek-V4 SWA full-layer TP and TP1 entries."""
 
 
 import sys
@@ -119,155 +119,6 @@ if T_PAD != LOCAL_T_PAD:
 
 
 @pl.jit.inline
-def decode_swa_output(
-    q: pl.Tensor[[T_DYN, H, HEAD_DIM], pl.BF16],
-    ori_kv: pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
-    swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
-    sparse_bias: pl.Tensor[[T_DYN, PADDED_TOPK], pl.FP32],
-    attn_sink: pl.Tensor[[H], pl.FP32],
-    freqs_cos: pl.Tensor[[T_DYN, ROPE_HEAD_DIM], pl.BF16],
-    freqs_sin: pl.Tensor[[T_DYN, ROPE_HEAD_DIM], pl.BF16],
-    wo_a: pl.Tensor[[LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
-    wo_b: pl.Tensor[[D, LOCAL_O_WIDTH], pl.INT8],
-    wo_b_scale: pl.Tensor[[D], pl.FP32],
-    o_local: pl.Tensor[[LOCAL_T_PAD, D], pl.BF16],
-    attention_window: pld.DistributedTensor[[ATTENTION_WINDOW_ROWS, O_GROUP_IN], pl.BF16],
-    attention_signal: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
-    o_window: pld.DistributedTensor[[O_WINDOW_ROWS, D], pl.FP32],
-    o_signal: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
-    group_base: pl.Scalar[pl.INT32],
-    tp_rank: pl.Scalar[pl.INT32],
-    local_t: pl.Scalar[pl.INT32],
-):
-    """Run sparse attention and the distributed sharded O projection."""
-    o_packed_heads = pl.create_tensor([O_GROUPS * T_PAD * HEADS_PER_GROUP, HEAD_DIM], dtype=pl.BF16)
-    sparse_attn_swa(
-        q, ori_kv, swa_indices, sparse_bias,
-        attn_sink, freqs_cos, freqs_sin,
-        o_packed_heads,
-    )
-
-    attention_grouped = pl.reshape(o_packed_heads, [O_GROUPS * LOCAL_T_PAD, O_GROUP_IN])
-    attention_local_flat = pl.create_tensor([ATTENTION_WINDOW_ROWS, O_GROUP_IN], dtype=pl.BF16)
-    attention_local_flat, attention_signal = o_group_a2a(
-        attention_grouped, attention_local_flat,
-        attention_window, attention_signal,
-        group_base, tp_rank, local_t,
-    )
-
-    attention_local_groups = pl.reshape(attention_local_flat, [LOCAL_O_GROUPS, GROUP_T_PAD, O_GROUP_IN])
-    o_partial = pl.create_tensor([GROUP_T_PAD, D], dtype=pl.FP32)
-    o_partial, projection_tid = decode_o_proj(
-        attention_local_groups,
-        wo_a, wo_b, wo_b_scale,
-        local_t, o_partial,
-    )
-    o_local, o_signal = o_proj_reduce_scatter(
-        o_partial, o_local,
-        o_window, o_signal,
-        group_base, tp_rank, local_t, projection_tid,
-    )
-    return o_local, attention_signal, o_signal
-
-
-@pl.jit
-def decode_swa_output_test(
-    q: pl.Tensor[[T_DYN, H, HEAD_DIM], pl.BF16],
-    ori_kv: pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
-    swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
-    swa_lens: pl.Tensor[[T_DYN], pl.INT32],
-    attn_sink: pl.Tensor[[H], pl.FP32],
-    freqs_cos: pl.Tensor[[T_DYN, ROPE_HEAD_DIM], pl.BF16],
-    freqs_sin: pl.Tensor[[T_DYN, ROPE_HEAD_DIM], pl.BF16],
-    wo_a: pl.Tensor[[LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
-    wo_b: pl.Tensor[[D, LOCAL_O_WIDTH], pl.INT8],
-    wo_b_scale: pl.Tensor[[D], pl.FP32],
-    o_local: pl.InOut[pl.Tensor[[LOCAL_T_PAD, D], pl.BF16]],
-    attention_window: pld.DistributedTensor[[ATTENTION_WINDOW_ROWS, O_GROUP_IN], pl.BF16],
-    attention_signal: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
-    o_window: pld.DistributedTensor[[O_WINDOW_ROWS, D], pl.FP32],
-    o_signal: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
-    group_base: pl.Scalar[pl.INT32],
-    tp_rank: pl.Scalar[pl.INT32],
-    local_t: pl.Scalar[pl.INT32],
-):
-    """Bind dynamic inputs for standalone SWA output-half validation."""
-    q.bind_dynamic(0, T_DYN)
-    ori_kv.bind_dynamic(0, ORI_BLOCK_NUM_DYN)
-    swa_indices.bind_dynamic(0, T_DYN)
-    swa_lens.bind_dynamic(0, T_DYN)
-    freqs_cos.bind_dynamic(0, T_DYN)
-    freqs_sin.bind_dynamic(0, T_DYN)
-
-    t_dim = pl.tensor.dim(q, 0)
-    sparse_bias = pl.create_tensor([t_dim, PADDED_TOPK], dtype=pl.FP32)
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="swa_valid_bias"):
-        valid_col = pl.cast(pl.arange(0, [1, ATTN_K_TILE], dtype=pl.INT32), target_type=pl.FP32)
-        for bias_block in pl.range(t_dim // BIAS_T_TILE):
-            token_start = bias_block * BIAS_T_TILE
-            zero_rows = pl.full([BIAS_T_TILE, ATTN_K_TILE], dtype=pl.FP32, value=0.0)
-            valid_cols = pl.col_expand(zero_rows, valid_col)
-            lens_slice = swa_lens[token_start : token_start + BIAS_T_TILE]
-            lens_col = pl.reshape(lens_slice, [BIAS_T_TILE, 1])
-            lens_fp32 = pl.cast(lens_col, target_type=pl.FP32)
-            valid = pl.neg(pl.row_expand_sub(valid_cols, lens_fp32))
-            valid = pl.maximum(valid, 0.0)
-            valid = pl.minimum(valid, 1.0)
-            invalid = pl.sub(valid, 1.0)
-            sparse_bias[token_start : token_start + BIAS_T_TILE, 0:ATTN_K_TILE] = pl.mul(invalid, -NEG_INF)
-
-    return decode_swa_output(
-        q, ori_kv, swa_indices, sparse_bias,
-        attn_sink, freqs_cos, freqs_sin,
-        wo_a, wo_b, wo_b_scale, o_local,
-        attention_window, attention_signal, o_window, o_signal,
-        group_base, tp_rank, local_t,
-    )
-
-
-@pl.jit.host
-def l3_decode_swa_output_test(
-    q: pl.Tensor[[TP_SIZE, T_DYN, H, HEAD_DIM], pl.BF16],
-    ori_kv: pl.Tensor[[TP_SIZE, ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
-    swa_indices: pl.Tensor[[TP_SIZE, T_DYN, WIN], pl.INT32],
-    swa_lens: pl.Tensor[[TP_SIZE, T_DYN], pl.INT32],
-    attn_sink: pl.Tensor[[TP_SIZE, H], pl.FP32],
-    freqs_cos: pl.Tensor[[TP_SIZE, T_DYN, ROPE_HEAD_DIM], pl.BF16],
-    freqs_sin: pl.Tensor[[TP_SIZE, T_DYN, ROPE_HEAD_DIM], pl.BF16],
-    wo_a: pl.Tensor[[TP_SIZE, LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
-    wo_b: pl.Tensor[[TP_SIZE, D, LOCAL_O_WIDTH], pl.INT8],
-    wo_b_scale: pl.Tensor[[TP_SIZE, D], pl.FP32],
-    o_local: pl.InOut[pl.Tensor[[TP_SIZE, LOCAL_T_PAD, D], pl.BF16]],
-    local_t: pl.Scalar[pl.INT32],
-):
-    """Launch the SWA output half on one physical TP group."""
-    q.bind_dynamic(1, T_DYN)
-    ori_kv.bind_dynamic(1, ORI_BLOCK_NUM_DYN)
-    swa_indices.bind_dynamic(1, T_DYN)
-    swa_lens.bind_dynamic(1, T_DYN)
-    freqs_cos.bind_dynamic(1, T_DYN)
-    freqs_sin.bind_dynamic(1, T_DYN)
-
-    attention_window_buf = pld.alloc_window_buffer([ATTENTION_WINDOW_ROWS, O_GROUP_IN], dtype=pl.BF16)
-    attention_signal_buf = pld.alloc_window_buffer([TP_SIZE, 1], dtype=pl.INT32)
-    o_window_buf = pld.alloc_window_buffer([O_WINDOW_ROWS, D], dtype=pl.FP32)
-    o_signal_buf = pld.alloc_window_buffer([TP_SIZE, 1], dtype=pl.INT32)
-
-    for rank in pl.range(pld.world_size()):
-        attention_window = pld.window(attention_window_buf, [ATTENTION_WINDOW_ROWS, O_GROUP_IN], dtype=pl.BF16)
-        attention_signal = pld.window(attention_signal_buf, [TP_SIZE, 1], dtype=pl.INT32)
-        o_window = pld.window(o_window_buf, [O_WINDOW_ROWS, D], dtype=pl.FP32)
-        o_signal = pld.window(o_signal_buf, [TP_SIZE, 1], dtype=pl.INT32)
-        decode_swa_output_test(
-            q[rank], ori_kv[rank], swa_indices[rank], swa_lens[rank],
-            attn_sink[rank], freqs_cos[rank], freqs_sin[rank],
-            wo_a[rank], wo_b[rank], wo_b_scale[rank], o_local[rank],
-            attention_window, attention_signal, o_window, o_signal,
-            0, rank, local_t, device=rank,
-        )
-
-
-@pl.jit.inline
 def decode_swa(
     x_hc: pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32],
     # hc_pre weights
@@ -352,14 +203,33 @@ def decode_swa(
             invalid = pl.sub(valid, 1.0)
             sparse_bias[token_start : token_start + BIAS_T_TILE, 0 : ATTN_K_TILE] = pl.mul(invalid, -NEG_INF)
 
-    o_local = pl.create_tensor([LOCAL_T_PAD, D], dtype=pl.BF16)
-    o_local, attention_signal, o_signal = decode_swa_output(
+    o_packed_heads = pl.create_tensor([O_GROUPS * T_PAD * HEADS_PER_GROUP, HEAD_DIM], dtype=pl.BF16)
+    sparse_attn_swa(
         q, kv_cache, swa_indices, sparse_bias,
         attn_sink, freqs_cos, freqs_sin,
-        wo_a, wo_b, wo_b_scale, o_local,
+        o_packed_heads,
+    )
+
+    attention_grouped = pl.reshape(o_packed_heads, [O_GROUPS * LOCAL_T_PAD, O_GROUP_IN])
+    attention_local_flat = pl.create_tensor([ATTENTION_WINDOW_ROWS, O_GROUP_IN], dtype=pl.BF16)
+    attention_local_flat, attention_signal = o_group_a2a(
+        attention_grouped, attention_local_flat,
         attention_window, attention_signal,
-        o_window, o_signal,
         group_base, tp_rank, local_t,
+    )
+
+    attention_local_groups = pl.reshape(attention_local_flat, [LOCAL_O_GROUPS, GROUP_T_PAD, O_GROUP_IN])
+    o_partial = pl.create_tensor([GROUP_T_PAD, D], dtype=pl.FP32)
+    o_partial, projection_tid = decode_o_proj(
+        attention_local_groups,
+        wo_a, wo_b, wo_b_scale,
+        local_t, o_partial,
+    )
+    o_local = pl.create_tensor([LOCAL_T_PAD, D], dtype=pl.BF16)
+    o_local, o_signal = o_proj_reduce_scatter(
+        o_partial, o_local,
+        o_window, o_signal,
+        group_base, tp_rank, local_t, projection_tid,
     )
 
     attn_out = pl.create_tensor([t_dim, D], dtype=pl.BF16)
@@ -647,170 +517,6 @@ def decode_swa_tp1_test(
 
 
 # fixture
-TP_FIXTURE_WINDOW_BLOCKS = (WIN + BLOCK_SIZE - 1) // BLOCK_SIZE
-TP_FIXTURE_OUTPUT_SENTINEL = -7.0
-
-if TP_FIXTURE_WINDOW_BLOCKS > ORI_BLOCK_NUM:
-    raise ValueError("SWA fixture window exceeds the original KV cache capacity")
-
-
-def build_output_tensor_specs(local_t):
-    """Build deterministic tensor-parallel SWA output-half inputs."""
-    import torch
-
-    from golden import ScalarSpec, TensorSpec
-
-    if local_t < BIAS_T_TILE or local_t > LOCAL_T or local_t % BIAS_T_TILE != 0 or local_t % S != 0:
-        raise ValueError(f"local_t must be a multiple of {BIAS_T_TILE} in [{BIAS_T_TILE}, {LOCAL_T}], got {local_t}")
-
-    def init_q():
-        q = torch.zeros(TP_SIZE, local_t, H, HEAD_DIM, dtype=torch.bfloat16)
-        rank = torch.arange(TP_SIZE, dtype=torch.float32).reshape(TP_SIZE, 1, 1)
-        token = torch.arange(local_t, dtype=torch.float32).reshape(1, local_t, 1)
-        head = torch.arange(H, dtype=torch.float32).reshape(1, 1, H)
-        q[..., 0] = (rank + token * 0.25 + head * 0.0625).to(torch.bfloat16)
-        return q
-
-    def init_ori_kv():
-        shape = (ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM)
-        cache = torch.full(shape, float("nan"), dtype=torch.bfloat16)
-        cache[:TP_FIXTURE_WINDOW_BLOCKS, :, 0, :] = 0.0
-        cache[:TP_FIXTURE_WINDOW_BLOCKS, :, 0, 0] = 0.25
-        return cache.unsqueeze(0).expand(TP_SIZE, *shape).clone()
-
-    def init_swa_indices():
-        window_row = torch.arange(WIN, dtype=torch.int32)
-        return window_row.reshape(1, 1, WIN).expand(TP_SIZE, local_t, WIN).clone()
-
-    def init_swa_lens():
-        return torch.full((TP_SIZE, local_t), WIN, dtype=torch.int32)
-
-    def init_attn_sink():
-        head = torch.arange(H, dtype=torch.int32).remainder(HEADS_PER_GROUP).to(torch.float32)
-        sink = 4.0 + head * 0.125
-        return sink.reshape(1, H).expand(TP_SIZE, H).clone()
-
-    def init_freqs_cos():
-        cos = torch.ones(local_t, ROPE_HEAD_DIM, dtype=torch.bfloat16)
-        return cos.unsqueeze(0).expand(TP_SIZE, local_t, ROPE_HEAD_DIM).clone()
-
-    def init_freqs_sin():
-        sin = torch.zeros(local_t, ROPE_HEAD_DIM, dtype=torch.bfloat16)
-        return sin.unsqueeze(0).expand(TP_SIZE, local_t, ROPE_HEAD_DIM).clone()
-
-    def init_wo_a():
-        wo_a = torch.zeros(TP_SIZE, LOCAL_O_GROUPS, O_LORA, O_GROUP_IN, dtype=torch.bfloat16)
-        for rank in range(TP_SIZE):
-            for local_group in range(LOCAL_O_GROUPS):
-                shard_scale = (rank + 1) * (local_group + 1) * 0.125
-                for head in range(HEADS_PER_GROUP):
-                    wo_a[rank, local_group, head, head * HEAD_DIM] = shard_scale * (head + 1)
-        return wo_a
-
-    def init_wo_b():
-        base = torch.arange(D * LOCAL_O_WIDTH, dtype=torch.int32).reshape(D, LOCAL_O_WIDTH)
-        rank = torch.arange(TP_SIZE, dtype=torch.int32).reshape(TP_SIZE, 1, 1)
-        return (base.unsqueeze(0) + rank).remainder(7).sub(3).to(torch.int8)
-
-    def init_wo_b_scale():
-        channel_scale = torch.arange(D, dtype=torch.int32).remainder(4).to(torch.float32) * 0.25 + 0.5
-        return channel_scale.reshape(1, D).expand(TP_SIZE, D).clone()
-
-    specs = [
-        TensorSpec("q", [TP_SIZE, local_t, H, HEAD_DIM], torch.bfloat16, init_value=init_q),
-        TensorSpec("ori_kv", [TP_SIZE, ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_ori_kv),
-        TensorSpec("swa_indices", [TP_SIZE, local_t, WIN], torch.int32, init_value=init_swa_indices),
-        TensorSpec("swa_lens", [TP_SIZE, local_t], torch.int32, init_value=init_swa_lens),
-        TensorSpec("attn_sink", [TP_SIZE, H], torch.float32, init_value=init_attn_sink),
-        TensorSpec("freqs_cos", [TP_SIZE, local_t, ROPE_HEAD_DIM], torch.bfloat16, init_value=init_freqs_cos),
-        TensorSpec("freqs_sin", [TP_SIZE, local_t, ROPE_HEAD_DIM], torch.bfloat16, init_value=init_freqs_sin),
-        TensorSpec("wo_a", [TP_SIZE, LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], torch.bfloat16, init_value=init_wo_a),
-        TensorSpec("wo_b", [TP_SIZE, D, LOCAL_O_WIDTH], torch.int8, init_value=init_wo_b),
-        TensorSpec("wo_b_scale", [TP_SIZE, D], torch.float32, init_value=init_wo_b_scale),
-        TensorSpec(
-            "o_local", [TP_SIZE, LOCAL_T_PAD, D], torch.bfloat16,
-            init_value=TP_FIXTURE_OUTPUT_SENTINEL, is_output=True,
-        ),
-        ScalarSpec("local_t", torch.int32, local_t),
-    ]
-    for spec in specs:
-        if isinstance(spec, TensorSpec):
-            spec.resident = "stacked"
-    return specs
-
-
-def golden_decode_swa_output(tensors):
-    """Compute the controlled SWA heads, sharded O projection, and reduced rows."""
-    import torch
-
-    local_t = tensors["q"].shape[1]
-    group_t = TP_SIZE * local_t
-    q0 = tensors["q"][..., 0].float()
-    kv0 = tensors["ori_kv"][:, 0, 0, 0, 0].float()
-    sink = tensors["attn_sink"].float()
-    score = q0 * kv0.reshape(TP_SIZE, 1, 1) * M.softmax_scale
-    numerator = WIN * kv0.reshape(TP_SIZE, 1, 1)
-    head_value = numerator / (WIN + torch.exp(sink.reshape(TP_SIZE, 1, H) - score))
-    head_value = head_value.to(torch.bfloat16)
-
-    attention_grouped = torch.zeros(TP_SIZE, O_GROUPS, local_t, O_GROUP_IN, dtype=torch.bfloat16)
-    for group in range(O_GROUPS):
-        for head in range(HEADS_PER_GROUP):
-            global_head = group * HEADS_PER_GROUP + head
-            group_col = head * HEAD_DIM
-            attention_grouped[:, group, :, group_col] = head_value[:, :, global_head]
-
-    attention_local = torch.zeros(TP_SIZE, LOCAL_O_GROUPS, group_t, O_GROUP_IN, dtype=torch.bfloat16)
-    for destination_rank in range(TP_SIZE):
-        for local_group in range(LOCAL_O_GROUPS):
-            global_group = destination_rank * LOCAL_O_GROUPS + local_group
-            group_rows = attention_grouped[:, global_group].reshape(group_t, O_GROUP_IN)
-            attention_local[destination_rank, local_group] = group_rows
-
-    partials = torch.zeros(TP_SIZE, group_t, D, dtype=torch.float32)
-    for rank in range(TP_SIZE):
-        attention = attention_local[rank].float()
-        o_a = torch.einsum("gti,gri->gtr", attention, tensors["wo_a"][rank].float())
-        row_amax = o_a.abs().amax(dim=-1, keepdim=True).clamp_min(INT8_AMAX_EPS)
-        scale_q = INT8_SCALE_MAX / row_amax
-        o_a_i8 = torch.round(o_a * scale_q).to(torch.int32).to(torch.float16).to(torch.int8)
-        scale_dq = 1.0 / scale_q
-        wo_b = tensors["wo_b"][rank].reshape(D, LOCAL_O_GROUPS, O_LORA)
-        for local_group in range(LOCAL_O_GROUPS):
-            group_i32 = o_a_i8[local_group].to(torch.int32)
-            weight_i32 = wo_b[:, local_group].to(torch.int32)
-            group_partial = group_i32 @ weight_i32.T
-            partials[rank] += group_partial.float() * scale_dq[local_group]
-        partials[rank] *= tensors["wo_b_scale"][rank].float().reshape(1, D)
-
-    reduced = partials.sum(dim=0)
-    tensors["o_local"].fill_(TP_FIXTURE_OUTPUT_SENTINEL)
-    for rank in range(TP_SIZE):
-        row_start = rank * local_t
-        tensors["o_local"][rank, :local_t] = reduced[row_start : row_start + local_t].to(torch.bfloat16)
-
-
-def build_o_local_compare(local_t):
-    """Compare valid token rows and require the poisoned capacity tail to survive."""
-    import torch
-
-    from golden import ratio_allclose
-
-    prefix_compare = ratio_allclose(
-        atol=1e-4, rtol=1.0 / 128, max_error_ratio=0.0,
-        valid_rows=local_t, valid_axis=1,
-    )
-
-    def compare(actual, expected, **kwargs):
-        actual_tail = actual[:, local_t:]
-        expected_tail = expected[:, local_t:]
-        if not torch.equal(actual_tail, expected_tail):
-            mismatch_count = int((actual_tail != expected_tail).sum().item())
-            return False, f"    inactive token tail mismatch count={mismatch_count}"
-        return prefix_compare(actual, expected, **kwargs)
-
-    compare.__name__ = f"swa_output_prefix_and_tail(local_t={local_t})"
-    return compare
 
 
 def golden_decode_swa_tp1(tensors):
@@ -1199,13 +905,11 @@ if __name__ == "__main__":
     parser.add_argument("--tp", type=int, default=TP_SIZE, choices=list(_TP_CHOICES), help="tensor-parallel world size")
     parser.add_argument(
         "-d", "--device", type=str, default=None,
-        help=f"comma-separated device ids; full/output need {TP_SIZE}, tp1 needs one",
+        help=f"comma-separated device ids; --tp {TP_SIZE} needs {TP_SIZE}",
     )
-    parser.add_argument("--entry", choices=("full", "output", "tp1"), default="full")
-    parser.add_argument("--case", choices=("all", "max", "subcapacity"), default="all")
     parser.add_argument(
         "--start-pos", type=str, default=None,
-        help="absolute decode start position for full or tp1; a scalar sets batch=1, "
+        help="absolute decode start position; a scalar sets batch=1, "
              "and a comma-separated list sets batch to its length",
     )
     parser.add_argument("--enable-l2-swimlane", type=int, choices=(0, 1, 2, 4), default=0)
@@ -1223,7 +927,7 @@ if __name__ == "__main__":
     if args.tp != TP_SIZE:
         parser.error(f"--tp must remain {TP_SIZE} after import-time specialization")
     if args.device is None:
-        args.device = ",".join(str(rank) for rank in range(TP_SIZE)) if args.entry in ("full", "output") else "0"
+        args.device = ",".join(str(rank) for rank in range(TP_SIZE))
     try:
         device_ids = [int(device) for device in args.device.split(",")]
     except ValueError:
@@ -1232,70 +936,57 @@ if __name__ == "__main__":
         parser.error(f"--device IDs must be non-negative, got {device_ids}")
     if len(set(device_ids)) != len(device_ids):
         parser.error(f"--device IDs must be distinct, got {device_ids}")
+    if len(device_ids) != TP_SIZE:
+        parser.error(f"--tp {TP_SIZE} needs exactly {TP_SIZE} device(s), got {device_ids}")
 
-    expected_devices = TP_SIZE if args.entry in ("full", "output") else 1
-    if len(device_ids) != expected_devices:
-        parser.error(f"{args.entry} entry needs exactly {expected_devices} device(s), got {device_ids}")
-
-    if args.entry == "output" and args.start_pos is not None:
-        parser.error("--start-pos does not apply to the output-only entry")
-
-    if args.entry == "tp1":
-        if args.case == "subcapacity":
-            parser.error("--case subcapacity only applies to the full and output entries")
-        batch = len(args.start_pos) if isinstance(args.start_pos, list) else (1 if args.start_pos is not None else B)
-        tokens = batch * S
-        result = run_jit(
-            fn=decode_swa_tp1_test,
-            specs=build_tensor_specs(start_pos=args.start_pos, batch=batch),
-            golden_fn=golden_decode_swa_tp1,
-            compile_only=args.compile_only,
-            compile_cfg=dict(dump_passes=args.dump_passes),
-            runtime_cfg=dict(
-                platform=args.platform,
-                device_id=device_ids[0],
-                enable_l2_swimlane=args.enable_l2_swimlane,
-            ),
-            rtol=1e-2,
-            atol=1e-2,
-            compare_fn={
-                "x_out": ratio_reldiff(diff_thd=3e-3, pct_thd=0.008, max_diff_hd=1),
-                "kv_cache": mapped_pool_ratio_allclose(
-                    "swa_slot_mapping",
-                    mapping_shape=(tokens,),
-                    block_size=BLOCK_SIZE,
-                    pool_name="KV cache",
-                    atol=1e-4,
-                    rtol=1.0 / 128,
-                    max_error_ratio=0.005,
-                ),
-            },
-        )
-        if not result.passed:
-            if result.error:
-                print(result.error)
-            raise SystemExit(1)
-        raise SystemExit(0)
-
-    case_local_t = {"max": LOCAL_T, "subcapacity": LOCAL_T - BIAS_T_TILE}
     if args.start_pos is not None:
         batch = len(args.start_pos) if isinstance(args.start_pos, list) else 1
-        selected_cases = (("positions", batch * S),)
+        token_counts = (batch * S,)
+    elif TP_SIZE == 1:
+        # decode_swa_tp1 sizes its O projection from the static capacity.
+        token_counts = (LOCAL_T,)
     else:
-        case_names = tuple(case_local_t) if args.case == "all" else (args.case,)
-        selected_cases = tuple((case, case_local_t[case]) for case in case_names)
-    for _case, local_t in selected_cases:
-        compile_cfg = dict(
-            dump_passes=args.dump_passes,
-            distributed_config=DistributedConfig(device_ids=device_ids, num_sub_workers=0),
-        )
-        if args.entry == "full":
+        # Capacity, then one row block below it: the dynamic token axis must hold at both.
+        token_counts = (LOCAL_T, LOCAL_T - BIAS_T_TILE)
+
+    for local_t in token_counts:
+        if TP_SIZE == 1:
+            result = run_jit(
+                fn=decode_swa_tp1_test,
+                specs=build_tensor_specs(start_pos=args.start_pos, batch=local_t // S),
+                golden_fn=golden_decode_swa_tp1,
+                compile_only=args.compile_only,
+                compile_cfg=dict(dump_passes=args.dump_passes),
+                runtime_cfg=dict(
+                    platform=args.platform,
+                    device_id=device_ids[0],
+                    enable_l2_swimlane=args.enable_l2_swimlane,
+                ),
+                rtol=1e-2,
+                atol=1e-2,
+                compare_fn={
+                    "x_out": ratio_reldiff(diff_thd=3e-3, pct_thd=0.008, max_diff_hd=1),
+                    "kv_cache": mapped_pool_ratio_allclose(
+                        "swa_slot_mapping",
+                        mapping_shape=(local_t,),
+                        block_size=BLOCK_SIZE,
+                        pool_name="KV cache",
+                        atol=1e-4,
+                        rtol=1.0 / 128,
+                        max_error_ratio=0.005,
+                    ),
+                },
+            )
+        else:
             result = run_jit(
                 fn=l3_decode_swa,
                 specs=build_distributed_tensor_specs(local_t, start_pos=args.start_pos),
                 golden_fn=golden_decode_swa,
                 compile_only=args.compile_only,
-                compile_cfg=compile_cfg,
+                compile_cfg=dict(
+                    dump_passes=args.dump_passes,
+                    distributed_config=DistributedConfig(device_ids=device_ids, num_sub_workers=0),
+                ),
                 runtime_cfg=dict(
                     platform=args.platform,
                     enable_l2_swimlane=args.enable_l2_swimlane,
@@ -1315,19 +1006,6 @@ if __name__ == "__main__":
                         max_error_ratio=0.005,
                     ),
                 },
-            )
-        else:
-            result = run_jit(
-                fn=l3_decode_swa_output_test,
-                specs=build_output_tensor_specs(local_t),
-                golden_fn=golden_decode_swa_output,
-                compile_only=args.compile_only,
-                compile_cfg=compile_cfg,
-                runtime_cfg=dict(
-                    platform=args.platform,
-                    enable_l2_swimlane=args.enable_l2_swimlane,
-                ),
-                compare_fn={"o_local": build_o_local_compare(local_t)},
             )
         if not result.passed:
             if result.error:


### PR DESCRIPTION
- Fold decode_swa_output, decode_hca_output, and decode_csa_output into
  decode_swa, decode_hca, and decode_csa; the sparse attention, group
  all-to-all, sharded O projection, and reduce-scatter steps are now
  written out in the layer that owns them
- Drop the standalone output-half entries decode_*_output_test and
  l3_decode_*_output_test along with the fixtures, goldens, and
  comparators that only served them
- Replace --entry and --case with plain --tp routing: --tp 1 runs the
  single-card tp1 entry, --tp 2 and --tp 4 run the tensor-parallel
  layer at capacity and one row block below it
- Move decode_hca, decode_hca_test, and l3_decode_hca ahead of
  decode_hca_tp1 so all three files lead with the tensor-parallel path
