### PR TITLE
Add: DeepSeek-V4 dspark context-parallel prefill SWA

### DIFF
--- a/models/deepseek_v4_flash_dspark/prefill_swa.py
+++ b/models/deepseek_v4_flash_dspark/prefill_swa.py
@@ -6,9 +6,11 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-"""DeepSeek-V4 packed prefill SWA attention over one contiguous run of <=T tokens."""
+# ci: devices=2  # CI: 2-card run; borrows 2 cards via task-submit --device-num
+"""DeepSeek-V4 packed prefill SWA attention: single-die at --tp 1, context-parallel above it."""
 
 import pypto.language as pl
+import pypto.language.distributed as pld
 
 from config import (
     BLOCK_SIZE,
@@ -23,8 +25,13 @@ from config import (
 
 from hc_post import golden_hc_post, hc_post
 from hc_pre import golden_hc_pre, hc_pre
-from qkv_proj_rope import golden_qkv_proj_rope, materialize_rope_rows_dynamic, qkv_proj_rope
-from rmsnorm import golden_rms_norm, rms_norm
+from prefill_kv_allgather import (
+    PREFILL_GROUP_CAP,
+    TP_SIZE,
+    cp_stack,
+    materialize_spec,
+    prefill_kv_token_allgather_step,
+)
 from prefill_sparse_attn import (
     PREFILL_ATTN_TILE,
     SPARSE_BIAS_COLS,
@@ -32,11 +39,23 @@ from prefill_sparse_attn import (
     golden_prefill_sparse_attn,
     sparse_attn_physical,
 )
+from qkv_proj_rope import (
+    golden_qkv_proj_rope,
+    kv_proj_rope,
+    materialize_rope_rows_dynamic,
+    q_proj_rope,
+    qkv_proj_rope,
+    rope_prepare,
+)
+from rmsnorm import golden_rms_norm, rms_norm
 
 
-
-# Dynamic shape variables.
+# Dynamic shape variables. The single-die path runs on one token axis; the
+# context-parallel path needs two, because the query slice and the gathered KV
+# stream carry different extents in one program.
 T_DYN = pl.dynamic("PREFILL_SWA_T_DYN")
+CP_Q_T_DYN = pl.dynamic("PREFILL_SWA_CP_Q_T_DYN")
+CP_KV_T_DYN = pl.dynamic("PREFILL_SWA_CP_KV_T_DYN")
 BLOCK_NUM_DYN = pl.dynamic("PREFILL_ORI_BLOCK_NUM_DYN")
 
 # model config
@@ -62,6 +81,8 @@ BLOCK_NUM = KV_ORI_BLOCK_NUM
 CMP_BLOCK_NUM = KV_CMP_BLOCK_NUM
 SPARSE_CMP_MAX_BLOCKS = KV_CMP_MAX_BLOCKS
 START_POS = 0
+
+
 @pl.jit.inline
 def prefill_attention_swa(
     x_hc: pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32],
@@ -206,6 +227,246 @@ def prefill_attention_swa_test(
         x_out,
     )
     return kv_cache, x_out
+
+
+@pl.jit.inline
+def prefill_attention_swa_cp(
+    x_hc_local: pl.Tensor[[CP_Q_T_DYN, HC_MULT, D], pl.FP32],
+    hc_attn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
+    hc_attn_scale: pl.Tensor[[3], pl.FP32],
+    hc_attn_base: pl.Tensor[[MIX_HC], pl.FP32],
+    attn_norm_w: pl.Tensor[[D], pl.BF16],
+    wq_a: pl.Tensor[[D, Q_LORA], pl.BF16],
+    wq_b: pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8],
+    wq_b_scale: pl.Tensor[[H * HEAD_DIM], pl.FP32],
+    wkv: pl.Tensor[[D, HEAD_DIM], pl.BF16],
+    gamma_cq: pl.Tensor[[Q_LORA], pl.BF16],
+    gamma_ckv: pl.Tensor[[HEAD_DIM], pl.BF16],
+    freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    kv_cache: pl.InOut[pl.Tensor[[BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
+    block_table: pl.Tensor[[BLOCK_NUM], pl.INT32],
+    ori_slot_mapping_full: pl.Tensor[[CP_KV_T_DYN], pl.INT64],
+    position_ids_local: pl.Tensor[[CP_Q_T_DYN], pl.INT32],
+    position_ids_full: pl.Tensor[[CP_KV_T_DYN], pl.INT32],
+    attn_sink: pl.Tensor[[H], pl.FP32],
+    wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
+    wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
+    wo_b_scale: pl.Tensor[[D], pl.FP32],
+    x_out_local: pl.Out[pl.Tensor[[CP_Q_T_DYN, HC_MULT, D], pl.FP32]],
+    gather_window: pld.DistributedTensor[[PREFILL_GROUP_CAP, D], pl.BF16],
+    gather_signal: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
+    group_base: pl.Scalar[pl.INT32],
+    tp_rank: pl.Scalar[pl.INT32],
+):
+    """SWA block on one CP rank: local queries, KV built from the gathered stream."""
+    q_dim = pl.tensor.dim(x_hc_local, 0)
+    kv_dim = pl.tensor.dim(position_ids_full, 0)
+
+    x_mixed = pl.create_tensor([q_dim, D], dtype=pl.BF16)
+    post = pl.create_tensor([q_dim, HC_MULT], dtype=pl.FP32)
+    comb = pl.create_tensor([q_dim, HC_MULT * HC_MULT], dtype=pl.FP32)
+    hc_pre(x_hc_local, hc_attn_fn, hc_attn_scale, hc_attn_base, x_mixed, post, comb)
+
+    x_normed_local = pl.create_tensor([q_dim, D], dtype=pl.BF16)
+    rms_tid = rms_norm(x_mixed, attn_norm_w, x_normed_local)
+    late_dep = pl.system.task_dummy(deps=[rms_tid])
+
+    # The layer's one activation collective.
+    x_normed_full = pl.create_tensor([kv_dim, D], dtype=pl.BF16)
+    x_normed_full, gather_signal = prefill_kv_token_allgather_step(
+        x_normed_local, x_normed_full, gather_window, gather_signal, group_base, tp_rank,
+    )
+
+    rope_cos_local = pl.create_tensor([q_dim, ROPE_HEAD_DIM], dtype=pl.BF16)
+    rope_sin_local = pl.create_tensor([q_dim, ROPE_HEAD_DIM], dtype=pl.BF16)
+    materialize_rope_rows_dynamic(freqs_cos, freqs_sin, position_ids_local, rope_cos_local, rope_sin_local)
+    q_cos_il = pl.create_tensor([q_dim, ROPE_HEAD_DIM], dtype=pl.FP32)
+    q_sin_signed = pl.create_tensor([q_dim, ROPE_HEAD_DIM], dtype=pl.FP32)
+    q_swap_idx = pl.create_tensor([q_dim, ROPE_HEAD_DIM], dtype=pl.INT32)
+    rope_prepare(rope_cos_local, rope_sin_local, q_cos_il, q_sin_signed, q_swap_idx)
+
+    q = pl.create_tensor([q_dim, H, HEAD_DIM], dtype=pl.BF16)
+    qr = pl.create_tensor([q_dim, Q_LORA], dtype=pl.INT8)
+    qr_scale = pl.create_tensor([q_dim, 1], dtype=pl.FP32)
+    q_proj_rope(
+        x_normed_local, wq_a, wq_b, wq_b_scale, gamma_cq,
+        q_cos_il, q_sin_signed, q_swap_idx,
+        q, qr, qr_scale,
+    )
+
+    rope_cos_full = pl.create_tensor([kv_dim, ROPE_HEAD_DIM], dtype=pl.BF16)
+    rope_sin_full = pl.create_tensor([kv_dim, ROPE_HEAD_DIM], dtype=pl.BF16)
+    materialize_rope_rows_dynamic(freqs_cos, freqs_sin, position_ids_full, rope_cos_full, rope_sin_full)
+    kv_cos_il = pl.create_tensor([kv_dim, ROPE_HEAD_DIM], dtype=pl.FP32)
+    kv_sin_signed = pl.create_tensor([kv_dim, ROPE_HEAD_DIM], dtype=pl.FP32)
+    kv_swap_idx = pl.create_tensor([kv_dim, ROPE_HEAD_DIM], dtype=pl.INT32)
+    rope_prepare(rope_cos_full, rope_sin_full, kv_cos_il, kv_sin_signed, kv_swap_idx)
+
+    kv_full = pl.create_tensor([kv_dim, HEAD_DIM], dtype=pl.BF16)
+    kv_proj_rope(
+        x_normed_full, wkv, gamma_ckv,
+        kv_cos_il, kv_sin_signed, kv_swap_idx,
+        kv_full, late_dep,
+    )
+
+    block_num = pl.tensor.dim(kv_cache, 0)
+    kv_cache_flat = pl.reshape(kv_cache, [block_num * BLOCK_SIZE, HEAD_DIM])
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_swa_cp_cache_write"):
+        for write_t in pl.range(kv_dim):
+            write_row_raw = pl.read(ori_slot_mapping_full, [write_t])
+            if write_row_raw >= 0:
+                write_row = pl.cast(write_row_raw, pl.INDEX)
+                kv_cache_flat[write_row : write_row + 1, :] = kv_full[write_t : write_t + 1, :]
+
+    swa_indices = pl.create_tensor([q_dim, WIN], dtype=pl.INT32)
+    valid_block_mask = pl.create_tensor([q_dim, VALID_BLOCK_MASK_COLS], dtype=pl.INT32)
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_swa_cp_window_indices"):
+        for idx_t in pl.range(q_dim):
+            idx_row = pl.full([1, WIN], dtype=pl.INT32, value=-1)
+            mask_row = pl.full([1, VALID_BLOCK_MASK_COLS], dtype=pl.INT32, value=0)
+            abs_pos = pl.read(position_ids_local, [idx_t])
+            window_valid = pl.min(pl.cast(WIN, pl.INT32), abs_pos + 1)
+            key_start_abs = abs_pos + 1 - window_valid
+            for win_col in pl.range(WIN):
+                win_col_i32 = pl.cast(win_col, pl.INT32)
+                if win_col_i32 < window_valid:
+                    key_abs = key_start_abs + win_col_i32
+                    blk_slot = key_abs // BLOCK_SIZE
+                    blk = pl.read(block_table, [pl.cast(blk_slot, pl.INDEX)])
+                    if blk >= 0:
+                        row = pl.cast(blk * BLOCK_SIZE + (key_abs - blk_slot * BLOCK_SIZE), pl.INT32)
+                        pl.write(idx_row, [0, win_col], row)
+                        if win_col < SPARSE_BIAS_COLS:
+                            block_col = win_col // PREFILL_ATTN_TILE
+                            pl.write(mask_row, [0, block_col], pl.cast(1, pl.INT32))
+            swa_indices[idx_t : idx_t + 1, 0:WIN] = idx_row
+            valid_block_mask[idx_t : idx_t + 1, 0:VALID_BLOCK_MASK_COLS] = mask_row
+
+    cmp_block_table_dummy = pl.create_tensor([SPARSE_CMP_MAX_BLOCKS], dtype=pl.INT32, init_value=0)
+    cmp_kv_dummy = pl.create_tensor([CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], dtype=pl.BF16)
+    cmp_indices_dummy = pl.create_tensor([q_dim, IDX_TOPK], dtype=pl.INT32, init_value=-1)
+    attn_out = pl.create_tensor([q_dim, D], dtype=pl.BF16)
+    sparse_attn_physical(
+        q, kv_cache, swa_indices,
+        cmp_kv_dummy, cmp_block_table_dummy,
+        cmp_indices_dummy,
+        valid_block_mask,
+        attn_sink,
+        rope_cos_local, rope_sin_local,
+        wo_a, wo_b, wo_b_scale, attn_out,
+    )
+
+    hc_post(attn_out, x_hc_local, post, comb, x_out_local)
+    return kv_cache, x_out_local, gather_signal
+
+
+@pl.jit
+def prefill_attention_swa_cp_test(
+    x_hc_local: pl.Tensor[[CP_Q_T_DYN, HC_MULT, D], pl.FP32],
+    hc_attn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
+    hc_attn_scale: pl.Tensor[[3], pl.FP32],
+    hc_attn_base: pl.Tensor[[MIX_HC], pl.FP32],
+    attn_norm_w: pl.Tensor[[D], pl.BF16],
+    wq_a: pl.Tensor[[D, Q_LORA], pl.BF16],
+    wq_b: pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8],
+    wq_b_scale: pl.Tensor[[H * HEAD_DIM], pl.FP32],
+    wkv: pl.Tensor[[D, HEAD_DIM], pl.BF16],
+    gamma_cq: pl.Tensor[[Q_LORA], pl.BF16],
+    gamma_ckv: pl.Tensor[[HEAD_DIM], pl.BF16],
+    freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    kv_cache: pl.InOut[pl.Tensor[[BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
+    block_table: pl.Tensor[[BLOCK_NUM], pl.INT32],
+    ori_slot_mapping_full: pl.Tensor[[CP_KV_T_DYN], pl.INT64],
+    position_ids_local: pl.Tensor[[CP_Q_T_DYN], pl.INT32],
+    position_ids_full: pl.Tensor[[CP_KV_T_DYN], pl.INT32],
+    attn_sink: pl.Tensor[[H], pl.FP32],
+    wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
+    wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
+    wo_b_scale: pl.Tensor[[D], pl.FP32],
+    x_out_local: pl.Out[pl.Tensor[[CP_Q_T_DYN, HC_MULT, D], pl.FP32]],
+    gather_window: pld.DistributedTensor[[PREFILL_GROUP_CAP, D], pl.BF16],
+    gather_signal: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
+    group_base: pl.Scalar[pl.INT32],
+    tp_rank: pl.Scalar[pl.INT32],
+):
+    """Run one CP rank's share of an SWA block."""
+    x_hc_local.bind_dynamic(0, CP_Q_T_DYN)
+    kv_cache.bind_dynamic(0, BLOCK_NUM_DYN)
+    ori_slot_mapping_full.bind_dynamic(0, CP_KV_T_DYN)
+    position_ids_local.bind_dynamic(0, CP_Q_T_DYN)
+    position_ids_full.bind_dynamic(0, CP_KV_T_DYN)
+    x_out_local.bind_dynamic(0, CP_Q_T_DYN)
+
+    kv_cache, x_out_local, gather_signal = prefill_attention_swa_cp(
+        x_hc_local,
+        hc_attn_fn, hc_attn_scale, hc_attn_base,
+        attn_norm_w, wq_a, wq_b, wq_b_scale, wkv, gamma_cq, gamma_ckv,
+        freqs_cos, freqs_sin,
+        kv_cache, block_table, ori_slot_mapping_full,
+        position_ids_local, position_ids_full,
+        attn_sink, wo_a, wo_b, wo_b_scale,
+        x_out_local,
+        gather_window, gather_signal, group_base, tp_rank,
+    )
+    return kv_cache, x_out_local
+
+
+@pl.jit.host
+def l3_prefill_attention_swa_cp(
+    x_hc_local: pl.Tensor[[TP_SIZE, CP_Q_T_DYN, HC_MULT, D], pl.FP32],
+    hc_attn_fn: pl.Tensor[[TP_SIZE, MIX_HC, HC_DIM], pl.FP32],
+    hc_attn_scale: pl.Tensor[[TP_SIZE, 3], pl.FP32],
+    hc_attn_base: pl.Tensor[[TP_SIZE, MIX_HC], pl.FP32],
+    attn_norm_w: pl.Tensor[[TP_SIZE, D], pl.BF16],
+    wq_a: pl.Tensor[[TP_SIZE, D, Q_LORA], pl.BF16],
+    wq_b: pl.Tensor[[TP_SIZE, Q_LORA, H * HEAD_DIM], pl.INT8],
+    wq_b_scale: pl.Tensor[[TP_SIZE, H * HEAD_DIM], pl.FP32],
+    wkv: pl.Tensor[[TP_SIZE, D, HEAD_DIM], pl.BF16],
+    gamma_cq: pl.Tensor[[TP_SIZE, Q_LORA], pl.BF16],
+    gamma_ckv: pl.Tensor[[TP_SIZE, HEAD_DIM], pl.BF16],
+    freqs_cos: pl.Tensor[[TP_SIZE, MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[TP_SIZE, MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    kv_cache: pl.InOut[pl.Tensor[[TP_SIZE, BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
+    block_table: pl.Tensor[[TP_SIZE, BLOCK_NUM], pl.INT32],
+    ori_slot_mapping_full: pl.Tensor[[TP_SIZE, CP_KV_T_DYN], pl.INT64],
+    position_ids_local: pl.Tensor[[TP_SIZE, CP_Q_T_DYN], pl.INT32],
+    position_ids_full: pl.Tensor[[TP_SIZE, CP_KV_T_DYN], pl.INT32],
+    attn_sink: pl.Tensor[[TP_SIZE, H], pl.FP32],
+    wo_a: pl.Tensor[[TP_SIZE, O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
+    wo_b: pl.Tensor[[TP_SIZE, D, O_GROUPS * O_LORA], pl.INT8],
+    wo_b_scale: pl.Tensor[[TP_SIZE, D], pl.FP32],
+    x_out_local: pl.Out[pl.Tensor[[TP_SIZE, CP_Q_T_DYN, HC_MULT, D], pl.FP32]],
+):
+    """Launch one CP group's SWA block, one child per rank."""
+    x_hc_local.bind_dynamic(1, CP_Q_T_DYN)
+    kv_cache.bind_dynamic(1, BLOCK_NUM_DYN)
+    ori_slot_mapping_full.bind_dynamic(1, CP_KV_T_DYN)
+    position_ids_local.bind_dynamic(1, CP_Q_T_DYN)
+    position_ids_full.bind_dynamic(1, CP_KV_T_DYN)
+    x_out_local.bind_dynamic(1, CP_Q_T_DYN)
+
+    gather_window_buf = pld.alloc_window_buffer([PREFILL_GROUP_CAP, D], dtype=pl.BF16)
+    gather_signal_buf = pld.alloc_window_buffer([TP_SIZE, 1], dtype=pl.INT32)
+
+    for rank in pl.range(pld.world_size()):
+        gather_window = pld.window(gather_window_buf, [PREFILL_GROUP_CAP, D], dtype=pl.BF16)
+        gather_signal = pld.window(gather_signal_buf, [TP_SIZE, 1], dtype=pl.INT32)
+        prefill_attention_swa_cp_test(
+            x_hc_local[rank],
+            hc_attn_fn[rank], hc_attn_scale[rank], hc_attn_base[rank],
+            attn_norm_w[rank], wq_a[rank], wq_b[rank], wq_b_scale[rank],
+            wkv[rank], gamma_cq[rank], gamma_ckv[rank],
+            freqs_cos[rank], freqs_sin[rank],
+            kv_cache[rank], block_table[rank], ori_slot_mapping_full[rank],
+            position_ids_local[rank], position_ids_full[rank],
+            attn_sink[rank], wo_a[rank], wo_b[rank], wo_b_scale[rank],
+            x_out_local[rank],
+            gather_window, gather_signal, 0, rank,
+            device=rank,
+        )
+
 
 
 def _quant_w_per_output_channel(w):
@@ -439,43 +700,159 @@ def build_tensor_specs(
     ]
 
 
+
+def build_cp_tensor_specs(
+    start_pos: int = START_POS,
+    token_count: int = PREFILL_SEQ,
+    tp_size: int = TP_SIZE,
+):
+    """Split the single-die specs across the group: query side per rank, KV side whole."""
+    from golden import TensorSpec
+
+    if token_count % tp_size != 0:
+        raise ValueError(f"token_count={token_count} must be a multiple of tp_size={tp_size}")
+    local_t = token_count // tp_size
+
+    specs = []
+    for spec in build_tensor_specs(start_pos, token_count):
+        value = materialize_spec(spec)
+        if spec.name == "x_hc":
+            specs.append(TensorSpec(
+                "x_hc_local", [tp_size, local_t, HC_MULT, D], spec.dtype,
+                init_value=value.reshape(tp_size, local_t, HC_MULT, D).contiguous(),
+            ))
+        elif spec.name == "ori_slot_mapping":
+            specs.append(TensorSpec(
+                "ori_slot_mapping_full", [tp_size, token_count], spec.dtype, init_value=cp_stack(value, tp_size),
+            ))
+        elif spec.name == "position_ids":
+            specs.append(TensorSpec(
+                "position_ids_local", [tp_size, local_t], spec.dtype,
+                init_value=value.reshape(tp_size, local_t).contiguous(),
+            ))
+            specs.append(TensorSpec(
+                "position_ids_full", [tp_size, token_count], spec.dtype, init_value=cp_stack(value, tp_size),
+            ))
+        elif spec.name == "x_out":
+            specs.append(TensorSpec(
+                "x_out_local", [tp_size, local_t, HC_MULT, D], spec.dtype, is_output=True,
+            ))
+        else:
+            specs.append(TensorSpec(
+                spec.name, [tp_size, *spec.shape], spec.dtype,
+                init_value=cp_stack(value, tp_size), is_output=spec.is_output,
+            ))
+    return specs
+
+
+def golden_prefill_attention_swa_cp(tensors):
+    """Single-die reference over the whole stream, sliced per rank."""
+    import torch
+
+    tp_size, local_t = tensors["x_hc_local"].shape[0], tensors["x_hc_local"].shape[1]
+    token_count = tp_size * local_t
+
+    full = {
+        "x_hc": tensors["x_hc_local"].reshape(token_count, HC_MULT, D),
+        "hc_attn_fn": tensors["hc_attn_fn"][0],
+        "hc_attn_scale": tensors["hc_attn_scale"][0],
+        "hc_attn_base": tensors["hc_attn_base"][0],
+        "attn_norm_w": tensors["attn_norm_w"][0],
+        "wq_a": tensors["wq_a"][0],
+        "wq_b": tensors["wq_b"][0],
+        "wq_b_scale": tensors["wq_b_scale"][0],
+        "wkv": tensors["wkv"][0],
+        "gamma_cq": tensors["gamma_cq"][0],
+        "gamma_ckv": tensors["gamma_ckv"][0],
+        "freqs_cos": tensors["freqs_cos"][0],
+        "freqs_sin": tensors["freqs_sin"][0],
+        "kv_cache": tensors["kv_cache"][0].clone(),
+        "block_table": tensors["block_table"][0],
+        "ori_slot_mapping": tensors["ori_slot_mapping_full"][0],
+        "position_ids": tensors["position_ids_full"][0],
+        "attn_sink": tensors["attn_sink"][0],
+        "wo_a": tensors["wo_a"][0],
+        "wo_b": tensors["wo_b"][0],
+        "wo_b_scale": tensors["wo_b_scale"][0],
+        "x_out": torch.zeros(token_count, HC_MULT, D, dtype=torch.float32),
+    }
+    golden_prefill_attention_swa(full)
+
+    tensors["x_out_local"][:] = full["x_out"].reshape(tp_size, local_t, HC_MULT, D)
+    tensors["kv_cache"][:] = full["kv_cache"].unsqueeze(0).expand(tp_size, *full["kv_cache"].shape)
+
 if __name__ == "__main__":
     import argparse
+
     from golden import ratio_allclose, ratio_reldiff, run_jit
 
-    parser = argparse.ArgumentParser(description="Standalone DeepSeek V4 packed prefill SWA correctness test.")
+    parser = argparse.ArgumentParser(
+        description="Standalone DeepSeek V4 packed prefill SWA correctness test."
+    )
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
-    parser.add_argument("-d", "--device", type=int, default=0)
+    parser.add_argument("-d", "--device", type=str, default=",".join(str(i) for i in range(TP_SIZE)),
+                        help="comma-separated rank group; one ID at --tp 1")
+    parser.add_argument("--tp", type=int, default=TP_SIZE,
+                        help="rank-group size; must match the import-time --tp")
     parser.add_argument("--compile-only", action="store_true", default=False)
     parser.add_argument("--start-pos", type=int, default=START_POS,
                         help="Absolute position of the first physical query token.")
     parser.add_argument("--token-count", "--num-tokens", dest="token_count", type=int, default=PREFILL_SEQ,
-                        help="Physical query-token extent; --num-tokens is a compatibility alias.")
+                        help="Physical query-token extent across the group; must divide by --tp.")
     parser.add_argument("--enable-chip-swimlane", action="store_true", default=False)
     parser.add_argument("--enable-dep-gen", action="store_true", default=False)
     parser.add_argument("--dump-passes", action="store_true", default=False)
     args = parser.parse_args()
 
-    result = run_jit(
-        fn=prefill_attention_swa_test,
-        specs=build_tensor_specs(args.start_pos, args.token_count),
-        golden_fn=golden_prefill_attention_swa,
-        compile_cfg=dict(dump_passes=args.dump_passes),
-        runtime_cfg=dict(
-            platform=args.platform,
-            device_id=args.device,
-            enable_chip_swimlane=args.enable_chip_swimlane,
-            enable_dep_gen=args.enable_dep_gen,
-        ),
-        compile_only=args.compile_only,
-        rtol=1e-2,
-        atol=1e-2,
-        compare_fn={
-            "x_out": ratio_reldiff(diff_thd=3e-3, pct_thd=0.005, max_diff_hd=1),
-            "kv_cache": ratio_allclose(atol=1e-4, rtol=1e-2),
-        },
-    )
+    if args.tp != TP_SIZE:
+        raise SystemExit(f"--tp={args.tp} does not match import-time TP_SIZE={TP_SIZE}")
+    device_ids = [int(device) for device in args.device.split(",")]
+    if len(device_ids) != TP_SIZE:
+        parser.error(f"need exactly {TP_SIZE} devices, got {device_ids}")
+    if args.token_count % TP_SIZE != 0:
+        parser.error(f"--token-count must be a multiple of --tp={TP_SIZE}, got {args.token_count}")
+
+    if TP_SIZE == 1:
+        result = run_jit(
+            fn=prefill_attention_swa_test,
+            specs=build_tensor_specs(args.start_pos, args.token_count),
+            golden_fn=golden_prefill_attention_swa,
+            compile_cfg=dict(dump_passes=args.dump_passes),
+            runtime_cfg=dict(
+                platform=args.platform,
+                device_id=device_ids[0],
+                enable_chip_swimlane=args.enable_chip_swimlane,
+                enable_dep_gen=args.enable_dep_gen,
+            ),
+            compile_only=args.compile_only,
+            rtol=1e-2,
+            atol=1e-2,
+            compare_fn={
+                "x_out": ratio_reldiff(diff_thd=3e-3, pct_thd=0.005, max_diff_hd=1),
+                "kv_cache": ratio_allclose(atol=1e-4, rtol=1e-2),
+            },
+        )
+    else:
+        from pypto.ir.distributed_compiled_program import DistributedConfig
+
+        result = run_jit(
+            fn=l3_prefill_attention_swa_cp,
+            specs=build_cp_tensor_specs(args.start_pos, args.token_count, TP_SIZE),
+            golden_fn=golden_prefill_attention_swa_cp,
+            compile_cfg=dict(
+                dump_passes=args.dump_passes,
+                distributed_config=DistributedConfig(device_ids=device_ids, num_sub_workers=0),
+            ),
+            runtime_cfg=dict(platform=args.platform),
+            compile_only=args.compile_only,
+            rtol=1e-2,
+            atol=1e-2,
+            compare_fn={
+                "x_out_local": ratio_reldiff(diff_thd=3e-3, pct_thd=0.005, max_diff_hd=1),
+                "kv_cache": ratio_allclose(atol=1e-4, rtol=1e-2),
+            },
+        )
     if not result.passed:
         if result.error:
             print(result.error)


### PR DESCRIPTION
## Summary

Bring the SWA prefill block — the layers with `compress_ratio = 0`, sliding
window only, no compressor — under DSA context parallelism, per #905 P5.

`prefill_swa.py` now routes by `--tp`, the shape `decode_swa.py` already uses:
`--tp 1` runs the single-die tree, `--tp 2` / `--tp 4` the context-parallel one.
No new file.

## What it does

Queries stay on the local token slice; KV is built from the gathered stream.
**Nothing is re-implemented** — every stage is the same inline the single-die
path calls. What differs is the token extent each stage runs at, and the one
all-gather between them:

- **query side, local** — `hc_pre`, the Q projection, the window indices,
  attention, `o_proj`, `hc_post`;
- **KV side, gathered** — `wkv` and the cache write, at global positions through
  an unsliced slot mapping.

The two views need separate dynamic token symbols because they carry different
extents in one program. `q_proj_rope` and `kv_proj_rope` already take separate
axes since #924, so the split needs no change there.

Feeding the KV side a local slice or local positions would not fail loudly — it
would write the wrong cache rows — so the golden compares `kv_cache` as well as
the layer output.

`o_proj` needs no work: a standalone prefill program already holds the full
weight and emits no all-to-all or reduce-scatter, so P5's inverted `o_proj`
strategy holds by construction.

## Why two trees rather than one

The single-die tree is kept, not replaced, because at `--tp 1` the CP body would
cost a self-addressed all-gather and would lose the fused `qkv_proj_rope`, whose
q and kv branches share one tile loop and one rope table.

A compile-time `if TP_SIZE == 1` inside the body does not avoid that:
`@pl.jit.inline` rewrites Python `if` into a device-side conditional, so both
arms are type-checked and `--tp 1` fails on `Cannot reassign 'kv_full' with a
different type: was [q_dim, 512], got [kv_dim, 512]`. `decode_swa.py` carries two
trees for the same reason.

The diff reflects this: **no line of the existing kernel body, golden or specs is
deleted**. The 27 deleted lines are the module docstring, the import block, the
dynamic-symbol header and the old `__main__`.

## Validation

The golden is the existing single-die reference run over the whole stream and
sliced per rank, not a second implementation. Replicated KV makes the two
**element-wise equal**: each die sees exactly the KV a single die would, and
attention is row-independent with the reduction along K.

a2a3:

| Mode | Tokens | Result |
|---|---|---|
| `--tp 1` | 512 | PASS |
| `--tp 2` | 128, 512 | PASS |
| `--tp 4` | 128, 512 | PASS |

The `--tp 1` case is the regression that shows the single-die tree still behaves
as it did.

`ruff check --config ruff.toml`, `check_headers.py` and `check_english_only.py`
are clean.

## Note on the default

`_TP_DEFAULT` is 2, inherited from `prefill_kv_allgather.py` and matching
`decode_swa.py`, so a bare `python prefill_swa.py -p a2a3` now runs the
context-parallel tree on two cards. `# ci: devices=2` follows from that.

Part of #1004, #905 (P5).
