### PR TITLE
Add: support 1M context in DeepSeek V4 HCA decode

### DIFF
--- a/models/deepseek_v4_flash_dspark/decode_hca.py
+++ b/models/deepseek_v4_flash_dspark/decode_hca.py
@@ -10,6 +10,7 @@
 """DeepSeek-V4 HCA full-layer TP and TP1 entries."""
 
 
+import math
 import sys
 
 import config
@@ -47,8 +48,6 @@ from config import (
     KV_CMP_BLOCK_NUM,
     KV_ORI_BLOCK_NUM,
     HCA_STATE_PHYSICAL_BLOCKS,
-    KV_CMP_MAX_BLOCKS,
-    KV_ORI_MAX_BLOCKS,
     INT8_SCALE_MAX,
     INT8_AMAX_EPS,
 )
@@ -72,7 +71,7 @@ from decode_o_proj import (
     o_proj_reduce_scatter,
 )
 from decode_sparse_attn_hca import (
-    CMP_TOPK,
+    HCA_MAX_COMPRESSED_ROWS,
     T_PAD,
     VALID_TOKEN_TILE,
     sparse_attn_hca,
@@ -83,6 +82,7 @@ B_DYN = pl.dynamic("B_DYN")  # per-request axis
 T_DYN = pl.dynamic("T_DYN")  # T = B * S
 ORI_BLOCK_NUM_DYN = pl.dynamic("ORI_BLOCK_NUM_DYN")
 CMP_BLOCK_NUM_DYN = pl.dynamic("CMP_BLOCK_NUM_DYN")
+CMP_TABLE_BLOCKS_DYN = pl.dynamic("CMP_TABLE_BLOCKS_DYN")
 COMPRESS_STATE_BLOCK_NUM_DYN = pl.dynamic("HCA_STATE_BLOCK_NUM_DYN")
 
 
@@ -104,7 +104,8 @@ MIX_HC = M.mix_hc
 HC_DIM = M.hc_dim
 HC_SINKHORN_ITER = M.hc_sinkhorn_iters
 HC_EPS = M.hc_eps
-MAX_SEQ_LEN = M.max_position_embeddings
+# HCA-local context ceiling. The global Flash model ceiling remains unchanged.
+MAX_SEQ_LEN = 1_048_576
 O_LORA = M.o_lora_rank
 O_GROUPS = M.o_groups
 HEADS_PER_GROUP = H // O_GROUPS
@@ -115,27 +116,18 @@ COMPRESS_RATIO = 128  # HCA
 OVERLAP = COMPRESS_RATIO == 4   # always False for HCA
 COFF = 1 + int(OVERLAP)         # always 1 for HCA
 MAIN_OUT_DIM = COFF * HEAD_DIM
-ORI_MAX_BLOCKS = KV_ORI_MAX_BLOCKS
 ORI_BLOCK_NUM = KV_ORI_BLOCK_NUM
-CMP_MAX_BLOCKS = KV_CMP_MAX_BLOCKS
 CMP_BLOCK_NUM = KV_CMP_BLOCK_NUM
+ORI_TABLE_BLOCKS = (MAX_SEQ_LEN + BLOCK_SIZE - 1) // BLOCK_SIZE
 # Main compressor state pool (kv + score channels merged into one paged FP32 buffer).
 COMPRESS_STATE_BLOCK_SIZE = C128_COMPRESSOR_BLOCK_SIZE
 COMPRESS_STATE_PHYSICAL_BLOCKS = HCA_STATE_PHYSICAL_BLOCKS
 COMPRESS_STATE_MAX_BLOCKS = (MAX_SEQ_LEN + COMPRESS_STATE_BLOCK_SIZE - 1) // COMPRESS_STATE_BLOCK_SIZE
 COMPRESS_STATE_BLOCK_NUM = COMPRESS_STATE_PHYSICAL_BLOCKS
 COMPRESS_STATE_DIM = 2 * MAIN_OUT_DIM
-COMPRESS_TOPK = MAX_SEQ_LEN // COMPRESS_RATIO   # demo 32; flash 128 (= 16384/128); max compressed positions
-# HCA has no indexer; the compressed tail is bounded by cache capacity.
-# Longest context served = COMPRESS_TOPK * COMPRESS_RATIO = MAX_SEQ_LEN.
-HCA_TOPK_LIMIT = COMPRESS_TOPK
-
-HCA_CMP_TOPK = CMP_TOPK
-
 # tiling
 SPARSE_ROPE_TILE = 16
 SPARSE_ROPE_INTERLEAVE_TILE = 2 * SPARSE_ROPE_TILE
-HCA_TOPK_TOKEN_TILE = 8   # tokens per cache-window topk SPMD block
 HCA_WB_TOKEN_TILE = 8  # tokens per cache-writeback SPMD block
 
 if T != LOCAL_T:
@@ -144,7 +136,7 @@ if T_PAD != LOCAL_T_PAD:
     raise ValueError(f"HCA token capacity {T_PAD} must equal TP local token capacity {LOCAL_T_PAD}")
 
 
-@pl.jit.inline
+@pl.jit.inline(auto_scope=False)
 def decode_hca(
     x_hc: pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32],
     hc_attn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
@@ -157,8 +149,10 @@ def decode_hca(
     wkv: pl.Tensor[[D, HEAD_DIM], pl.BF16],
     gamma_cq: pl.Tensor[[Q_LORA], pl.BF16],
     gamma_ckv: pl.Tensor[[HEAD_DIM], pl.BF16],
-    freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
-    freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    freqs_cos: pl.Tensor[[T_DYN, ROPE_HEAD_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[T_DYN, ROPE_HEAD_DIM], pl.BF16],
+    cmp_freqs_cos: pl.Tensor[[B, ROPE_HEAD_DIM // 2], pl.FP32],
+    cmp_freqs_sin: pl.Tensor[[B, ROPE_HEAD_DIM // 2], pl.FP32],
     cmp_wkv: pl.Tensor[[MAIN_OUT_DIM, D], pl.BF16],
     cmp_wgate: pl.Tensor[[MAIN_OUT_DIM, D], pl.BF16],
     cmp_ape: pl.Tensor[[COMPRESS_RATIO, MAIN_OUT_DIM], pl.FP32],
@@ -167,7 +161,7 @@ def decode_hca(
     compress_state_block_table: pl.Tensor[[B_DYN, COMPRESS_STATE_MAX_BLOCKS], pl.INT32],
     kv_cache: pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     cmp_kv: pl.Tensor[[CMP_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
-    cmp_block_table: pl.Tensor[[B_DYN, CMP_MAX_BLOCKS], pl.INT32],
+    cmp_block_table: pl.Tensor[[B_DYN, CMP_TABLE_BLOCKS_DYN], pl.INT32],
     ori_slot_mapping: pl.Tensor[[T_DYN], pl.INT64],
     window_swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
     window_swa_lens: pl.Tensor[[T_DYN], pl.INT32],
@@ -190,8 +184,6 @@ def decode_hca(
 ):
     """Run one rank of the complete HCA tensor-parallel layer."""
     t_dim = pl.tensor.dim(x_hc, 0)
-    b_dim = t_dim // S
-    topk_blocks = t_dim // HCA_TOPK_TOKEN_TILE
     wb_blocks = t_dim // HCA_WB_TOKEN_TILE
 
     x_mixed = pl.create_tensor([t_dim, D], dtype=pl.BF16)
@@ -199,31 +191,9 @@ def decode_hca(
     comb_t = pl.create_tensor([t_dim, HC_MULT * HC_MULT], dtype=pl.FP32)
     hc_pre(x_hc, hc_attn_fn, hc_attn_scale, hc_attn_base, x_mixed, post_t, comb_t)
 
-    rope_cos_t = pl.create_tensor([t_dim, ROPE_HEAD_DIM], dtype=pl.BF16)
-    rope_sin_t = pl.create_tensor([t_dim, ROPE_HEAD_DIM], dtype=pl.BF16)
-    cmp_cos = pl.create_tensor([B, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
-    cmp_sin = pl.create_tensor([B, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
     cmp_cos_il = pl.create_tensor([B, ROPE_HEAD_DIM], dtype=pl.FP32)
     cmp_sin_signed = pl.create_tensor([B, ROPE_HEAD_DIM], dtype=pl.FP32)
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="hca_rope"):
-        for b in pl.range(b_dim):
-            first_t = b * S
-            first_pos_b = pl.read(position_ids, [first_t])
-            cmp_offset_b = COMPRESS_RATIO - (first_pos_b % COMPRESS_RATIO)
-            cmp_pos_b = pl.cast(first_pos_b + cmp_offset_b - COMPRESS_RATIO, pl.INDEX)
-            cmp_cos_row = freqs_cos[cmp_pos_b : cmp_pos_b + 1, 0 : ROPE_HEAD_DIM // 2]
-            cmp_sin_row = freqs_sin[cmp_pos_b : cmp_pos_b + 1, 0 : ROPE_HEAD_DIM // 2]
-            cmp_cos[b : b + 1, 0 : ROPE_HEAD_DIM // 2] = pl.cast(cmp_cos_row, target_type=pl.FP32)
-            cmp_sin[b : b + 1, 0 : ROPE_HEAD_DIM // 2] = pl.cast(cmp_sin_row, target_type=pl.FP32)
-            for s in pl.range(S):
-                t = b * S + s
-                pos_b = pl.cast(pl.read(position_ids, [t]), pl.INDEX)
-                step_cos_row = pl.cast(freqs_cos[pos_b : pos_b + 1, 0 : ROPE_HEAD_DIM], target_type=pl.FP32)
-                step_sin_row = pl.cast(freqs_sin[pos_b : pos_b + 1, 0 : ROPE_HEAD_DIM], target_type=pl.FP32)
-                rope_cos_t[t : t + 1, 0 : ROPE_HEAD_DIM] = pl.cast(step_cos_row, target_type=pl.BF16, mode="rint")
-                rope_sin_t[t : t + 1, 0 : ROPE_HEAD_DIM] = pl.cast(step_sin_row, target_type=pl.BF16, mode="rint")
-
-    rope_interleave(cmp_cos, cmp_sin, cmp_cos_il, cmp_sin_signed)
+    rope_interleave(cmp_freqs_cos, cmp_freqs_sin, cmp_cos_il, cmp_sin_signed)
 
     x_normed = pl.create_tensor([t_dim, D], dtype=pl.BF16)
     rms_tid = rms_norm(x_mixed, attn_norm_w, x_normed)
@@ -234,7 +204,7 @@ def decode_hca(
     qr_scale = pl.create_tensor([t_dim, 1], dtype=pl.FP32)
     qkv_proj_rope(
         x_normed, wq_a, wq_b, wq_b_scale, wkv,
-        rope_cos_t, rope_sin_t, gamma_cq, gamma_ckv,
+        freqs_cos, freqs_sin, gamma_cq, gamma_ckv,
         q, kv, qr, qr_scale, late_dep,
     )
 
@@ -261,40 +231,29 @@ def decode_hca(
     )
     cache_ready_dep = pl.system.task_dummy(deps=[ori_cache_write_tid, cmp_cache_write_tid])
 
-    topk_all = pl.create_tensor([t_dim, HCA_CMP_TOPK], dtype=pl.INT32)
-    for topk_block in pl.spmd(topk_blocks, name_hint="hca_cache_topk"):
-        topk_t0 = topk_block * HCA_TOPK_TOKEN_TILE
-        for topk_dt in pl.range(HCA_TOPK_TOKEN_TILE):
-            topk_t = topk_t0 + topk_dt
-            if topk_t < t_dim:
-                topk_b = topk_t // S
-                topk_abs_pos = pl.read(position_ids, [topk_t])
-                topk_cmp_valid = pl.min(
-                    HCA_TOPK_LIMIT,
-                    pl.min((topk_abs_pos + 1) // COMPRESS_RATIO, pl.read(kv_seq_lens, [topk_b]) // COMPRESS_RATIO),
-                )
-                for topk_ck in pl.range(HCA_CMP_TOPK):
-                    if topk_ck < topk_cmp_valid:
-                        pl.write(topk_all, [topk_t, topk_ck], pl.cast(topk_ck, pl.INT32))
-                    else:
-                        pl.write(topk_all, [topk_t, topk_ck], pl.cast(-1, pl.INT32))
-
-    attention_grouped = pl.create_tensor([O_GROUPS * LOCAL_T_PAD, O_GROUP_IN], dtype=pl.BF16)
-    attention_grouped, heads_tid = sparse_attn_hca(
-        q, kv_cache, window_swa_indices,
-        cmp_kv, cmp_block_table, topk_all,
-        attn_sink, rope_cos_t, rope_sin_t,
-        attention_grouped, cache_ready_dep,
-    )
-
     attention_local_flat = pl.create_tensor([ATTENTION_WINDOW_ROWS, O_GROUP_IN], dtype=pl.BF16)
-    attention_local_flat, attention_signal = o_group_a2a(
-        attention_grouped, attention_local_flat,
-        attention_window, attention_signal,
-        group_base, tp_rank, local_t,
-    )
+    with pl.scope():
+        attention_grouped = pl.create_tensor(
+            [O_GROUPS * LOCAL_T_PAD, O_GROUP_IN],
+            dtype=pl.BF16,
+        )
+        attention_grouped, _heads_tid = sparse_attn_hca(
+            q, kv_cache, window_swa_indices,
+            cmp_kv, cmp_block_table,
+            position_ids, kv_seq_lens,
+            attn_sink, freqs_cos, freqs_sin,
+            attention_grouped, cache_ready_dep,
+        )
+        attention_local_flat, attention_signal = o_group_a2a(
+            attention_grouped, attention_local_flat,
+            attention_window, attention_signal,
+            group_base, tp_rank, local_t,
+        )
 
-    attention_local_groups = pl.reshape(attention_local_flat, [LOCAL_O_GROUPS, GROUP_T_PAD, O_GROUP_IN])
+    attention_local_groups = pl.reshape(
+        attention_local_flat,
+        [LOCAL_O_GROUPS, GROUP_T_PAD, O_GROUP_IN],
+    )
     o_partial = pl.create_tensor([GROUP_T_PAD, D], dtype=pl.FP32)
     o_partial, projection_tid = decode_o_proj(
         attention_local_groups,
@@ -316,7 +275,8 @@ def decode_hca(
             0:D,
         ]
 
-    hc_post(attn_out, x_hc, post_t, comb_t, x_out)
+    with pl.scope():
+        hc_post(attn_out, x_hc, post_t, comb_t, x_out)
     return x_out
 
 
@@ -333,8 +293,10 @@ def decode_hca_test(
     wkv: pl.Tensor[[D, HEAD_DIM], pl.BF16],
     gamma_cq: pl.Tensor[[Q_LORA], pl.BF16],
     gamma_ckv: pl.Tensor[[HEAD_DIM], pl.BF16],
-    freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
-    freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    freqs_cos: pl.Tensor[[T_DYN, ROPE_HEAD_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[T_DYN, ROPE_HEAD_DIM], pl.BF16],
+    cmp_freqs_cos: pl.Tensor[[B, ROPE_HEAD_DIM // 2], pl.FP32],
+    cmp_freqs_sin: pl.Tensor[[B, ROPE_HEAD_DIM // 2], pl.FP32],
     cmp_wkv: pl.Tensor[[MAIN_OUT_DIM, D], pl.BF16],
     cmp_wgate: pl.Tensor[[MAIN_OUT_DIM, D], pl.BF16],
     cmp_ape: pl.Tensor[[COMPRESS_RATIO, MAIN_OUT_DIM], pl.FP32],
@@ -343,7 +305,7 @@ def decode_hca_test(
     compress_state_block_table: pl.Tensor[[B_DYN, COMPRESS_STATE_MAX_BLOCKS], pl.INT32],
     kv_cache: pl.InOut[pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
     cmp_kv: pl.InOut[pl.Tensor[[CMP_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
-    cmp_block_table: pl.Tensor[[B_DYN, CMP_MAX_BLOCKS], pl.INT32],
+    cmp_block_table: pl.Tensor[[B_DYN, CMP_TABLE_BLOCKS_DYN], pl.INT32],
     ori_slot_mapping: pl.Tensor[[T_DYN], pl.INT64],
     window_swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
     window_swa_lens: pl.Tensor[[T_DYN], pl.INT32],
@@ -366,25 +328,28 @@ def decode_hca_test(
 ):
     """Test one rank of the complete HCA tensor-parallel layer."""
     x_hc.bind_dynamic(0, T_DYN)
+    freqs_cos.bind_dynamic(0, T_DYN)
+    freqs_sin.bind_dynamic(0, T_DYN)
     compress_state.bind_dynamic(0, COMPRESS_STATE_BLOCK_NUM_DYN)
     compress_state_block_table.bind_dynamic(0, B_DYN)
     kv_cache.bind_dynamic(0, ORI_BLOCK_NUM_DYN)
     cmp_kv.bind_dynamic(0, CMP_BLOCK_NUM_DYN)
     cmp_block_table.bind_dynamic(0, B_DYN)
+    cmp_block_table.bind_dynamic(1, CMP_TABLE_BLOCKS_DYN)
+    kv_seq_lens.bind_dynamic(0, B_DYN)
     ori_slot_mapping.bind_dynamic(0, T_DYN)
     window_swa_indices.bind_dynamic(0, T_DYN)
     window_swa_lens.bind_dynamic(0, T_DYN)
     cmp_slot_mapping.bind_dynamic(0, T_DYN)
     state_slot_mapping.bind_dynamic(0, T_DYN)
     position_ids.bind_dynamic(0, T_DYN)
-    kv_seq_lens.bind_dynamic(0, B_DYN)
     x_out.bind_dynamic(0, T_DYN)
 
     return decode_hca(
         x_hc,
         hc_attn_fn, hc_attn_scale, hc_attn_base,
         attn_norm_w, wq_a, wq_b, wq_b_scale, wkv, gamma_cq, gamma_ckv,
-        freqs_cos, freqs_sin,
+        freqs_cos, freqs_sin, cmp_freqs_cos, cmp_freqs_sin,
         cmp_wkv, cmp_wgate, cmp_ape, cmp_norm_w,
         compress_state, compress_state_block_table,
         kv_cache, cmp_kv, cmp_block_table,
@@ -412,8 +377,10 @@ def l3_decode_hca(
     wkv: pl.Tensor[[TP_SIZE, D, HEAD_DIM], pl.BF16],
     gamma_cq: pl.Tensor[[TP_SIZE, Q_LORA], pl.BF16],
     gamma_ckv: pl.Tensor[[TP_SIZE, HEAD_DIM], pl.BF16],
-    freqs_cos: pl.Tensor[[TP_SIZE, MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
-    freqs_sin: pl.Tensor[[TP_SIZE, MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    freqs_cos: pl.Tensor[[TP_SIZE, T_DYN, ROPE_HEAD_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[TP_SIZE, T_DYN, ROPE_HEAD_DIM], pl.BF16],
+    cmp_freqs_cos: pl.Tensor[[TP_SIZE, B, ROPE_HEAD_DIM // 2], pl.FP32],
+    cmp_freqs_sin: pl.Tensor[[TP_SIZE, B, ROPE_HEAD_DIM // 2], pl.FP32],
     cmp_wkv: pl.Tensor[[TP_SIZE, MAIN_OUT_DIM, D], pl.BF16],
     cmp_wgate: pl.Tensor[[TP_SIZE, MAIN_OUT_DIM, D], pl.BF16],
     cmp_ape: pl.Tensor[[TP_SIZE, COMPRESS_RATIO, MAIN_OUT_DIM], pl.FP32],
@@ -422,7 +389,7 @@ def l3_decode_hca(
     compress_state_block_table: pl.Tensor[[TP_SIZE, B_DYN, COMPRESS_STATE_MAX_BLOCKS], pl.INT32],
     kv_cache: pl.InOut[pl.Tensor[[TP_SIZE, ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
     cmp_kv: pl.InOut[pl.Tensor[[TP_SIZE, CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
-    cmp_block_table: pl.Tensor[[TP_SIZE, B_DYN, CMP_MAX_BLOCKS], pl.INT32],
+    cmp_block_table: pl.Tensor[[TP_SIZE, B_DYN, CMP_TABLE_BLOCKS_DYN], pl.INT32],
     ori_slot_mapping: pl.Tensor[[TP_SIZE, T_DYN], pl.INT64],
     window_swa_indices: pl.Tensor[[TP_SIZE, T_DYN, WIN], pl.INT32],
     window_swa_lens: pl.Tensor[[TP_SIZE, T_DYN], pl.INT32],
@@ -439,15 +406,18 @@ def l3_decode_hca(
 ):
     """Launch the complete HCA layer on one tensor-parallel group."""
     x_hc.bind_dynamic(1, T_DYN)
+    freqs_cos.bind_dynamic(1, T_DYN)
+    freqs_sin.bind_dynamic(1, T_DYN)
     compress_state_block_table.bind_dynamic(1, B_DYN)
     cmp_block_table.bind_dynamic(1, B_DYN)
+    cmp_block_table.bind_dynamic(2, CMP_TABLE_BLOCKS_DYN)
+    kv_seq_lens.bind_dynamic(1, B_DYN)
     ori_slot_mapping.bind_dynamic(1, T_DYN)
     window_swa_indices.bind_dynamic(1, T_DYN)
     window_swa_lens.bind_dynamic(1, T_DYN)
     cmp_slot_mapping.bind_dynamic(1, T_DYN)
     state_slot_mapping.bind_dynamic(1, T_DYN)
     position_ids.bind_dynamic(1, T_DYN)
-    kv_seq_lens.bind_dynamic(1, B_DYN)
     x_out.bind_dynamic(1, T_DYN)
 
     attention_window_buf = pld.alloc_window_buffer([ATTENTION_WINDOW_ROWS, O_GROUP_IN], dtype=pl.BF16)
@@ -466,6 +436,7 @@ def l3_decode_hca(
             attn_norm_w[rank], wq_a[rank], wq_b[rank], wq_b_scale[rank],
             wkv[rank], gamma_cq[rank], gamma_ckv[rank],
             freqs_cos[rank], freqs_sin[rank],
+            cmp_freqs_cos[rank], cmp_freqs_sin[rank],
             cmp_wkv[rank], cmp_wgate[rank], cmp_ape[rank], cmp_norm_w[rank],
             compress_state[rank], compress_state_block_table[rank],
             kv_cache[rank], cmp_kv[rank], cmp_block_table[rank],
@@ -480,7 +451,7 @@ def l3_decode_hca(
         )
 
 
-@pl.jit.inline
+@pl.jit.inline(auto_scope=False)
 def decode_hca_tp1(
     x_hc: pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32],
     # hc_pre weights
@@ -495,8 +466,10 @@ def decode_hca_tp1(
     wkv: pl.Tensor[[D, HEAD_DIM], pl.BF16],
     gamma_cq: pl.Tensor[[Q_LORA], pl.BF16],
     gamma_ckv: pl.Tensor[[HEAD_DIM], pl.BF16],
-    freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
-    freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    freqs_cos: pl.Tensor[[T_DYN, ROPE_HEAD_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[T_DYN, ROPE_HEAD_DIM], pl.BF16],
+    cmp_freqs_cos: pl.Tensor[[B, ROPE_HEAD_DIM // 2], pl.FP32],
+    cmp_freqs_sin: pl.Tensor[[B, ROPE_HEAD_DIM // 2], pl.FP32],
     # main compressor (head_dim=HEAD_DIM, ratio=128, overlap=False)
     cmp_wkv: pl.Tensor[[MAIN_OUT_DIM, D], pl.BF16],
     cmp_wgate: pl.Tensor[[MAIN_OUT_DIM, D], pl.BF16],
@@ -508,7 +481,7 @@ def decode_hca_tp1(
     # cmp_kv is shared with the compressor: it writes the compressed row directly into this pool.
     kv_cache: pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     cmp_kv: pl.Tensor[[CMP_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
-    cmp_block_table: pl.Tensor[[B_DYN, CMP_MAX_BLOCKS], pl.INT32],
+    cmp_block_table: pl.Tensor[[B_DYN, CMP_TABLE_BLOCKS_DYN], pl.INT32],
     ori_slot_mapping: pl.Tensor[[T_DYN], pl.INT64],
     window_swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
     window_swa_lens: pl.Tensor[[T_DYN], pl.INT32],
@@ -526,40 +499,16 @@ def decode_hca_tp1(
 ):
     """HCA decode orchestration for compress_ratio=128."""
     t_dim = pl.tensor.dim(x_hc, 0)
-    b_dim = t_dim // S
-    topk_blocks = t_dim // HCA_TOPK_TOKEN_TILE
     wb_blocks = t_dim // HCA_WB_TOKEN_TILE
     x_mixed = pl.create_tensor([t_dim, D], dtype=pl.BF16)
     post_t = pl.create_tensor([t_dim, HC_MULT], dtype=pl.FP32)
     comb_t = pl.create_tensor([t_dim, HC_MULT * HC_MULT], dtype=pl.FP32)
     hc_pre(x_hc, hc_attn_fn, hc_attn_scale, hc_attn_base, x_mixed, post_t, comb_t)
 
-    rope_cos_t = pl.create_tensor([t_dim, ROPE_HEAD_DIM], dtype=pl.BF16)
-    rope_sin_t = pl.create_tensor([t_dim, ROPE_HEAD_DIM], dtype=pl.BF16)
-    cmp_cos = pl.create_tensor([B, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
-    cmp_sin = pl.create_tensor([B, ROPE_HEAD_DIM // 2], dtype=pl.FP32)
     # Interleave-duplicated / sign-folded compressed-position rope rows, built once over B rows.
     cmp_cos_il = pl.create_tensor([B, ROPE_HEAD_DIM], dtype=pl.FP32)
     cmp_sin_signed = pl.create_tensor([B, ROPE_HEAD_DIM], dtype=pl.FP32)
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="hca_rope"):
-        for b in pl.range(b_dim):
-            first_t = b * S
-            first_pos_b = pl.read(position_ids, [first_t])
-            cmp_offset_b = COMPRESS_RATIO - (first_pos_b % COMPRESS_RATIO)
-            cmp_pos_b = pl.cast(first_pos_b + cmp_offset_b - COMPRESS_RATIO, pl.INDEX)
-            cmp_cos_row = freqs_cos[cmp_pos_b : cmp_pos_b + 1, 0 : ROPE_HEAD_DIM // 2]
-            cmp_sin_row = freqs_sin[cmp_pos_b : cmp_pos_b + 1, 0 : ROPE_HEAD_DIM // 2]
-            cmp_cos[b : b + 1, 0 : ROPE_HEAD_DIM // 2] = pl.cast(cmp_cos_row, target_type=pl.FP32)
-            cmp_sin[b : b + 1, 0 : ROPE_HEAD_DIM // 2] = pl.cast(cmp_sin_row, target_type=pl.FP32)
-            for s in pl.range(S):
-                t = b * S + s
-                pos_b = pl.cast(pl.read(position_ids, [t]), pl.INDEX)
-                step_cos_row = pl.cast(freqs_cos[pos_b : pos_b + 1, 0 : ROPE_HEAD_DIM], target_type=pl.FP32)
-                step_sin_row = pl.cast(freqs_sin[pos_b : pos_b + 1, 0 : ROPE_HEAD_DIM], target_type=pl.FP32)
-                rope_cos_t[t : t + 1, 0 : ROPE_HEAD_DIM] = pl.cast(step_cos_row, target_type=pl.BF16, mode="rint")
-                rope_sin_t[t : t + 1, 0 : ROPE_HEAD_DIM] = pl.cast(step_sin_row, target_type=pl.BF16, mode="rint")
-
-    rope_interleave(cmp_cos, cmp_sin, cmp_cos_il, cmp_sin_signed)
+    rope_interleave(cmp_freqs_cos, cmp_freqs_sin, cmp_cos_il, cmp_sin_signed)
 
     x_normed = pl.create_tensor([t_dim, D], dtype=pl.BF16)
     rms_tid = rms_norm(x_mixed, attn_norm_w, x_normed)
@@ -571,7 +520,7 @@ def decode_hca_tp1(
     qr_scale = pl.create_tensor([t_dim, 1], dtype=pl.FP32)
     qkv_proj_rope(
         x_normed, wq_a, wq_b, wq_b_scale, wkv,
-        rope_cos_t, rope_sin_t, gamma_cq, gamma_ckv,
+        freqs_cos, freqs_sin, gamma_cq, gamma_ckv,
         q, kv, qr, qr_scale, late_dep,
     )
 
@@ -598,42 +547,28 @@ def decode_hca_tp1(
     )
     cache_ready_dep = pl.system.task_dummy(deps=[ori_cache_write_tid, cmp_cache_write_tid])
 
-    # Sparse-index build over an SPMD of 8 tokens per block: window column k -> ring
-    # slot k, live iff k <= abs_pos, with the compressed-slot ramp fused into the same block.
     attn_out = pl.create_tensor([t_dim, D], dtype=pl.BF16)
-    topk_all = pl.create_tensor([t_dim, HCA_CMP_TOPK], dtype=pl.INT32)
-    for topk_block in pl.spmd(topk_blocks, name_hint="hca_cache_topk"):
-        topk_t0 = topk_block * HCA_TOPK_TOKEN_TILE
-        for topk_dt in pl.range(HCA_TOPK_TOKEN_TILE):
-            topk_t = topk_t0 + topk_dt
-            if topk_t < t_dim:
-                topk_b = topk_t // S
-                topk_abs_pos = pl.read(position_ids, [topk_t])
+    with pl.scope():
+        o_packed_heads = pl.create_tensor(
+            [O_GROUPS * T_PAD, O_GROUP_IN],
+            dtype=pl.BF16,
+        )
+        o_packed_heads, heads_dep = sparse_attn_hca(
+            q, kv_cache, window_swa_indices,
+            cmp_kv, cmp_block_table,
+            position_ids, kv_seq_lens,
+            attn_sink, freqs_cos, freqs_sin,
+            o_packed_heads, cache_ready_dep,
+        )
+        with pl.scope():
+            decode_o_proj_tp1(
+                o_packed_heads,
+                wo_a, wo_b, wo_b_scale,
+                attn_out, heads_dep,
+            )
 
-                topk_cmp_valid = pl.min(
-                    HCA_TOPK_LIMIT,
-                    pl.min((topk_abs_pos + 1) // COMPRESS_RATIO, pl.read(kv_seq_lens, [topk_b]) // COMPRESS_RATIO),
-                )
-                for topk_ck in pl.range(HCA_CMP_TOPK):
-                    if topk_ck < topk_cmp_valid:
-                        pl.write(topk_all, [topk_t, topk_ck], pl.cast(topk_ck, pl.INT32))
-                    else:
-                        pl.write(topk_all, [topk_t, topk_ck], pl.cast(-1, pl.INT32))
-
-    o_packed_heads = pl.create_tensor([O_GROUPS * T_PAD, O_GROUP_IN], dtype=pl.BF16)
-    o_packed_heads, heads_dep = sparse_attn_hca(
-        q, kv_cache, window_swa_indices,
-        cmp_kv, cmp_block_table, topk_all,
-        attn_sink, rope_cos_t, rope_sin_t,
-        o_packed_heads, cache_ready_dep,
-    )
-    attn_out = decode_o_proj_tp1(
-        o_packed_heads,
-        wo_a, wo_b, wo_b_scale,
-        attn_out, heads_dep,
-    )
-
-    hc_post(attn_out, x_hc, post_t, comb_t, x_out)
+    with pl.scope():
+        hc_post(attn_out, x_hc, post_t, comb_t, x_out)
     return x_out
 
 
@@ -650,8 +585,10 @@ def decode_hca_tp1_test(
     wkv: pl.Tensor[[D, HEAD_DIM], pl.BF16],
     gamma_cq: pl.Tensor[[Q_LORA], pl.BF16],
     gamma_ckv: pl.Tensor[[HEAD_DIM], pl.BF16],
-    freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
-    freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    freqs_cos: pl.Tensor[[T_DYN, ROPE_HEAD_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[T_DYN, ROPE_HEAD_DIM], pl.BF16],
+    cmp_freqs_cos: pl.Tensor[[B, ROPE_HEAD_DIM // 2], pl.FP32],
+    cmp_freqs_sin: pl.Tensor[[B, ROPE_HEAD_DIM // 2], pl.FP32],
     cmp_wkv: pl.Tensor[[MAIN_OUT_DIM, D], pl.BF16],
     cmp_wgate: pl.Tensor[[MAIN_OUT_DIM, D], pl.BF16],
     cmp_ape: pl.Tensor[[COMPRESS_RATIO, MAIN_OUT_DIM], pl.FP32],
@@ -660,7 +597,7 @@ def decode_hca_tp1_test(
     compress_state_block_table: pl.Tensor[[B_DYN, COMPRESS_STATE_MAX_BLOCKS], pl.INT32],
     kv_cache: pl.InOut[pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
     cmp_kv: pl.InOut[pl.Tensor[[CMP_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
-    cmp_block_table: pl.Tensor[[B_DYN, CMP_MAX_BLOCKS], pl.INT32],
+    cmp_block_table: pl.Tensor[[B_DYN, CMP_TABLE_BLOCKS_DYN], pl.INT32],
     ori_slot_mapping: pl.Tensor[[T_DYN], pl.INT64],
     window_swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
     window_swa_lens: pl.Tensor[[T_DYN], pl.INT32],
@@ -675,6 +612,8 @@ def decode_hca_tp1_test(
     x_out: pl.Out[pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32]],
 ):
     x_hc.bind_dynamic(0, T_DYN)
+    freqs_cos.bind_dynamic(0, T_DYN)
+    freqs_sin.bind_dynamic(0, T_DYN)
     compress_state.bind_dynamic(0, COMPRESS_STATE_BLOCK_NUM_DYN)
     kv_cache.bind_dynamic(0, ORI_BLOCK_NUM_DYN)
     cmp_kv.bind_dynamic(0, CMP_BLOCK_NUM_DYN)
@@ -684,16 +623,17 @@ def decode_hca_tp1_test(
     cmp_slot_mapping.bind_dynamic(0, T_DYN)
     state_slot_mapping.bind_dynamic(0, T_DYN)
     position_ids.bind_dynamic(0, T_DYN)
-    kv_seq_lens.bind_dynamic(0, B_DYN)
     compress_state_block_table.bind_dynamic(0, B_DYN)
     cmp_block_table.bind_dynamic(0, B_DYN)
+    cmp_block_table.bind_dynamic(1, CMP_TABLE_BLOCKS_DYN)
+    kv_seq_lens.bind_dynamic(0, B_DYN)
     x_out.bind_dynamic(0, T_DYN)
 
     decode_hca_tp1(
         x_hc,
         hc_attn_fn, hc_attn_scale, hc_attn_base,
         attn_norm_w, wq_a, wq_b, wq_b_scale, wkv, gamma_cq, gamma_ckv,
-        freqs_cos, freqs_sin,
+        freqs_cos, freqs_sin, cmp_freqs_cos, cmp_freqs_sin,
         cmp_wkv, cmp_wgate, cmp_ape, cmp_norm_w,
         compress_state, compress_state_block_table,
         kv_cache, cmp_kv, cmp_block_table,
@@ -707,13 +647,10 @@ def decode_hca_tp1_test(
     return x_out
 
 
-# fixture
-
-
 def golden_decode_hca_tp1(tensors):
     """End-to-end orchestration for the ratio=128 (HCA) layers.
     Mirrors Block.hc_pre + Attention.forward (decode branch, ratio==128 path: main compressor only,
-    no indexer, compress_topk_idxs computed deterministically) + Block.hc_post."""
+    no indexer) + Block.hc_post."""
     import torch
 
     from hc_pre import golden_hc_pre
@@ -741,20 +678,11 @@ def golden_decode_hca_tp1(tensors):
         "comb": comb_t,
     })
 
-    # Attention.forward, ratio==128 branch
+    # Attention.forward, ratio==128 branch. The wrapper receives token-local
+    # QKV/attention RoPE rows and static padded boundary rows for the compressor.
     position_ids = tensors["position_ids"].to(torch.int64)
-    kv_seq_lens = tensors["kv_seq_lens"].to(torch.int64)
-    ratio = COMPRESS_RATIO
-    rd = ROPE_HEAD_DIM
-
-    freqs_cos = tensors["freqs_cos"]
-    freqs_sin = tensors["freqs_sin"]
-    rope_cos_T = torch.empty(tokens, rd, dtype=freqs_cos.dtype)
-    rope_sin_T = torch.empty(tokens, rd, dtype=freqs_sin.dtype)
-    for t in range(tokens):
-        pos = int(position_ids[t].item())
-        rope_cos_T[t] = freqs_cos[pos]
-        rope_sin_T[t] = freqs_sin[pos]
+    rope_cos_T = tensors["freqs_cos"]
+    rope_sin_T = tensors["freqs_sin"]
 
     # q + win kv (W8A8 q_proj)
     q = torch.zeros(tokens, H, HEAD_DIM, dtype=torch.bfloat16)
@@ -782,15 +710,8 @@ def golden_decode_hca_tp1(tensors):
     window_swa_indices = tensors["window_swa_indices"]
     cmp_kv = tensors["cmp_kv"]
     cmp_block_table = tensors["cmp_block_table"]
-    half_rd = rd // 2
-    cmp_cos = torch.empty(batch, half_rd, dtype=torch.float32)
-    cmp_sin = torch.empty(batch, half_rd, dtype=torch.float32)
-    for b in range(batch):
-        first_pos_b = int(position_ids[b * S].item())
-        cmp_offset_b = ratio - (first_pos_b % ratio)
-        cmp_pos_b = first_pos_b + cmp_offset_b - ratio
-        cmp_cos[b] = freqs_cos[cmp_pos_b, :half_rd].float()
-        cmp_sin[b] = freqs_sin[cmp_pos_b, :half_rd].float()
+    cmp_cos = tensors["cmp_freqs_cos"][:batch]
+    cmp_sin = tensors["cmp_freqs_sin"][:batch]
 
     # The compressor ABI is token-major flat.
     cmp_kv_proj = torch.zeros(tokens, HEAD_DIM, dtype=torch.float32)
@@ -822,14 +743,6 @@ def golden_decode_hca_tp1(tensors):
             write_intra = write_row % BLOCK_SIZE
             kv_cache[write_blk, write_intra, 0] = kv[t]
 
-    topk_all = torch.full((tokens, HCA_CMP_TOPK), -1, dtype=torch.int32)
-    for t in range(tokens):
-        b = t // S
-        abs_pos = int(position_ids[t].item())
-        cmp_valid = min(HCA_TOPK_LIMIT, (abs_pos + 1) // ratio, int(kv_seq_lens[b].item()) // ratio)
-        if cmp_valid:
-            topk_all[t, :cmp_valid] = torch.arange(cmp_valid, dtype=torch.int32)
-
     o_packed_heads = torch.zeros(O_GROUPS, T_PAD, O_GROUP_IN, dtype=torch.bfloat16)
     golden_sparse_attn({
         "q": q,
@@ -837,7 +750,8 @@ def golden_decode_hca_tp1(tensors):
         "window_swa_indices": window_swa_indices,
         "cmp_kv": cmp_kv,
         "cmp_block_table": cmp_block_table,
-        "cmp_sparse_indices": topk_all,
+        "position_ids": position_ids_flat,
+        "kv_seq_lens": tensors["kv_seq_lens"],
         "attn_sink": tensors["attn_sink"],
         "freqs_cos": rope_cos_T,
         "freqs_sin": rope_sin_T,
@@ -878,24 +792,140 @@ def golden_decode_hca(tensors):
         golden_decode_hca_tp1(rank_tensors)
 
 
+def _hca_start_positions(start_pos, *, batch):
+    """Resolve scalar/list HCA start positions against the local 1M ceiling."""
+    import torch
+
+    from utils import hca_decode_start_set
+
+    if start_pos is None:
+        starts = hca_decode_start_set(
+            batch=batch,
+            compress_ratio=COMPRESS_RATIO,
+            state_block_size=COMPRESS_STATE_BLOCK_SIZE,
+        )
+    elif isinstance(start_pos, (list, tuple)):
+        if len(start_pos) != batch:
+            raise ValueError(f"HCA start-position list has {len(start_pos)} rows, expected batch={batch}")
+        starts = torch.tensor([int(value) for value in start_pos], dtype=torch.int32)
+    else:
+        starts = torch.full((batch,), int(start_pos), dtype=torch.int32)
+    if bool((starts < 0).any()) or bool((starts.to(torch.int64) + S > MAX_SEQ_LEN).any()):
+        raise ValueError(f"HCA start positions plus S={S} must fit MAX_SEQ_LEN={MAX_SEQ_LEN}")
+    return starts.contiguous()
+
+
+def _hca_token_rope_tables(positions):
+    """Materialize only requested HCA YaRN RoPE rows, never a 1M host table."""
+    import torch
+
+    dim = ROPE_HEAD_DIM
+    half_dim = dim // 2
+    base = float(M.compress_rope_theta)
+    original_seq_len = int(M.original_max_position_embeddings)
+    inv_freq = 1.0 / (
+        base ** (torch.arange(0, dim, 2, dtype=torch.float32) / dim)
+    )
+    low = math.floor(
+        dim * math.log(original_seq_len / (int(M.beta_fast) * 2 * math.pi))
+        / (2 * math.log(base))
+    )
+    high = math.ceil(
+        dim * math.log(original_seq_len / (int(M.beta_slow) * 2 * math.pi))
+        / (2 * math.log(base))
+    )
+    low = max(low, 0)
+    high = min(high, dim - 1)
+    if low == high:
+        high += 0.001
+    ramp = torch.clamp(
+        (torch.arange(half_dim, dtype=torch.float32) - low) / (high - low), 0, 1
+)
+    smooth = 1 - ramp
+    inv_freq = inv_freq / float(M.rope_factor) * (1 - smooth) + inv_freq * smooth
+    angles = torch.outer(positions.to(torch.float32).reshape(-1), inv_freq)
+    cos_half = torch.cos(angles)
+    sin_half = torch.sin(angles)
+    return (
+        torch.cat((cos_half, cos_half), dim=-1).to(torch.bfloat16).contiguous(),
+        torch.cat((sin_half, sin_half), dim=-1).to(torch.bfloat16).contiguous(),
+    )
+
+
+def _hca_cmp_block_table(starts):
+    """Allocate rank-local ratio-128 pages without request-to-request aliasing."""
+    import torch
+
+    batch = starts.numel()
+    page_counts = []
+    for start in starts.tolist():
+        visible_rows = min((int(start) + S) // COMPRESS_RATIO, HCA_MAX_COMPRESSED_ROWS)
+        page_counts.append((visible_rows + BLOCK_SIZE - 1) // BLOCK_SIZE)
+
+    table_blocks = max(max(page_counts, default=0), 1)
+    table = torch.full((batch, table_blocks), -1, dtype=torch.int32)
+    cursor = 0
+    for request, page_count in enumerate(page_counts):
+        if cursor + page_count > CMP_BLOCK_NUM:
+            raise ValueError(
+                f"HCA compressed pool needs {cursor + page_count} pages for batch={batch}, "
+                f"capacity is {CMP_BLOCK_NUM}"
+            )
+        if page_count:
+            table[request, :page_count] = torch.arange(cursor, cursor + page_count, dtype=torch.int32)
+        cursor += page_count
+    return table
+
+
+def _hca_raw_block_table(positions):
+    """Map only the raw pages visible to this decode step into the fixed ring pool."""
+    import torch
+
+    batch = positions.shape[0]
+    table = torch.full((batch, ORI_TABLE_BLOCKS), -1, dtype=torch.int32)
+    cursor = 0
+    for request in range(batch):
+        first = max(0, int(positions[request, 0].item()) - WIN + 1)
+        last = int(positions[request, -1].item())
+        first_page = first // BLOCK_SIZE
+        last_page = last // BLOCK_SIZE
+        page_count = last_page - first_page + 1
+        if cursor + page_count > ORI_BLOCK_NUM:
+            raise ValueError(
+                f"HCA raw pool needs {cursor + page_count} pages for batch={batch}, "
+                f"capacity is {ORI_BLOCK_NUM}"
+            )
+        table[request, first_page:last_page + 1] = torch.arange(
+            cursor, cursor + page_count, dtype=torch.int32
+        )
+        cursor += page_count
+    return table
+
+
 def build_tensor_specs(start_pos=None, batch=B):
     tokens = batch * S
     import torch
     from utils import (
         block_table,
         compressed_slot_mapping,
-        hca_decode_start_set,
-        kv_seq_lens_from_starts,
         ori_slot_mapping,
         position_ids_from_starts,
-        resolve_start_positions,
         state_slot_mapping,
         swa_indices_and_lens,
     )
     from golden import TensorSpec
-    from utils import build_rope_tables
 
-    shared_freqs_cos, shared_freqs_sin = build_rope_tables(M, COMPRESS_RATIO, dtype=torch.bfloat16)
+    starts = _hca_start_positions(start_pos, batch=batch)
+    positions = position_ids_from_starts(starts, seq=S).contiguous()
+    token_freqs_cos, token_freqs_sin = _hca_token_rope_tables(positions)
+    boundary_positions = starts.to(torch.int64) - starts.to(torch.int64).remainder(COMPRESS_RATIO)
+    boundary_cos, boundary_sin = _hca_token_rope_tables(boundary_positions)
+    cmp_freqs_cos = torch.zeros(B, ROPE_HEAD_DIM // 2, dtype=torch.float32)
+    cmp_freqs_sin = torch.zeros(B, ROPE_HEAD_DIM // 2, dtype=torch.float32)
+    cmp_freqs_cos[:batch] = boundary_cos[:, :ROPE_HEAD_DIM // 2].float()
+    cmp_freqs_sin[:batch] = boundary_sin[:, :ROPE_HEAD_DIM // 2].float()
+    window_block_table = _hca_raw_block_table(positions)
+    cmp_block_table = _hca_cmp_block_table(starts)
 
     def quant_w_per_output_channel(w):
         amax = w.float().abs().amax(dim=0).clamp_min(INT8_AMAX_EPS)
@@ -944,9 +974,13 @@ def build_tensor_specs(start_pos=None, batch=B):
     def init_gamma_ckv():
         return torch.ones(HEAD_DIM)
     def init_freqs_cos():
-        return shared_freqs_cos.clone()
+        return token_freqs_cos.clone()
     def init_freqs_sin():
-        return shared_freqs_sin.clone()
+        return token_freqs_sin.clone()
+    def init_cmp_freqs_cos():
+        return cmp_freqs_cos.clone()
+    def init_cmp_freqs_sin():
+        return cmp_freqs_sin.clone()
     def init_normalized_cache(shape):
         cache = torch.randn(*shape)
         denom = cache.float().pow(2).mean(dim=-1, keepdim=True).sqrt().clamp_min(EPS)
@@ -958,9 +992,9 @@ def build_tensor_specs(start_pos=None, batch=B):
             table_blocks=COMPRESS_STATE_MAX_BLOCKS,
             physical_blocks=COMPRESS_STATE_PHYSICAL_BLOCKS,
         )
-        positions = position_ids_from_starts(init_start_pos(), seq=S).to(torch.int64)
+        state_positions = positions.to(torch.int64)
         mapping = state_slot_mapping(
-            positions,
+            state_positions,
             table,
             state_block_size=COMPRESS_STATE_BLOCK_SIZE,
         )
@@ -971,7 +1005,7 @@ def build_tensor_specs(start_pos=None, batch=B):
         occupancy = [0] * COMPRESS_STATE_PHYSICAL_BLOCKS
         for request in range(batch):
             logical_masks = {}
-            for position in positions[request].tolist():
+            for position in state_positions[request].tolist():
                 logical_block = position // COMPRESS_STATE_BLOCK_SIZE
                 intra = position % COMPRESS_STATE_BLOCK_SIZE
                 logical_masks[logical_block] = logical_masks.get(logical_block, 0) | (1 << intra)
@@ -998,7 +1032,7 @@ def build_tensor_specs(start_pos=None, batch=B):
                 occupancy[physical_block] |= row_mask
 
         mapping = state_slot_mapping(
-            positions,
+            state_positions,
             table,
             state_block_size=COMPRESS_STATE_BLOCK_SIZE,
         )
@@ -1027,42 +1061,26 @@ def build_tensor_specs(start_pos=None, batch=B):
         return init_normalized_cache((CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM))
 
     def init_window_block_table():
-        return block_table(batch=batch, table_blocks=ORI_MAX_BLOCKS, physical_blocks=ORI_BLOCK_NUM)
+        return window_block_table.clone()
 
     def init_cmp_block_table():
-        return block_table(
-            batch=batch,
-            table_blocks=CMP_MAX_BLOCKS,
-            physical_blocks=CMP_BLOCK_NUM,
-        )
+        return cmp_block_table.clone()
 
     def init_attn_sink():
         return torch.zeros(H)
-    def init_default_start_pos():
-        # Canonical HCA start-position set (ratio-128 compressor branches + 8k long-context).
-        return hca_decode_start_set(
-            batch=batch, compress_ratio=COMPRESS_RATIO, state_block_size=COMPRESS_STATE_BLOCK_SIZE)
-    def init_start_pos():
-        return resolve_start_positions(
-            start_pos,
-            batch=batch,
-            seq=S,
-            max_seq_len=MAX_SEQ_LEN,
-            default_fn=init_default_start_pos,
-        )
     def init_position_ids():
-        return position_ids_from_starts(init_start_pos(), seq=S).reshape(-1).contiguous()
+        return positions.reshape(-1).clone()
     def init_kv_seq_lens():
-        return kv_seq_lens_from_starts(init_start_pos(), seq=S)
+        return positions[:, -1].to(torch.int64).add(1).to(torch.int32).contiguous()
     def init_ori_slot_mapping():
         return ori_slot_mapping(
-            position_ids_from_starts(init_start_pos(), seq=S),
+            positions,
             init_window_block_table(),
             block_size=BLOCK_SIZE,
         ).reshape(-1).contiguous()
     def init_window_swa_metadata():
         return swa_indices_and_lens(
-            position_ids_from_starts(init_start_pos(), seq=S),
+            positions,
             init_window_block_table(),
             block_size=BLOCK_SIZE,
             window=WIN,
@@ -1072,7 +1090,6 @@ def build_tensor_specs(start_pos=None, batch=B):
     def init_window_swa_lens():
         return init_window_swa_metadata()[1].contiguous()
     def init_cmp_slot_mapping():
-        positions = position_ids_from_starts(init_start_pos(), seq=S)
         return compressed_slot_mapping(
             positions,
             init_cmp_block_table(),
@@ -1081,7 +1098,7 @@ def build_tensor_specs(start_pos=None, batch=B):
         ).reshape(-1).contiguous()
     def init_state_slot_mapping():
         return state_slot_mapping(
-            position_ids_from_starts(init_start_pos(), seq=S),
+            positions,
             init_compress_state_block_table(),
             state_block_size=COMPRESS_STATE_BLOCK_SIZE,
         ).reshape(-1).contiguous()
@@ -1107,8 +1124,10 @@ def build_tensor_specs(start_pos=None, batch=B):
         TensorSpec("wkv", [D, HEAD_DIM], torch.bfloat16, init_value=init_wkv),
         TensorSpec("gamma_cq", [Q_LORA], torch.bfloat16, init_value=init_gamma_cq),
         TensorSpec("gamma_ckv", [HEAD_DIM], torch.bfloat16, init_value=init_gamma_ckv),
-        TensorSpec("freqs_cos", [MAX_SEQ_LEN, ROPE_HEAD_DIM], torch.bfloat16, init_value=init_freqs_cos),
-        TensorSpec("freqs_sin", [MAX_SEQ_LEN, ROPE_HEAD_DIM], torch.bfloat16, init_value=init_freqs_sin),
+        TensorSpec("freqs_cos", [tokens, ROPE_HEAD_DIM], torch.bfloat16, init_value=init_freqs_cos),
+        TensorSpec("freqs_sin", [tokens, ROPE_HEAD_DIM], torch.bfloat16, init_value=init_freqs_sin),
+        TensorSpec("cmp_freqs_cos", [B, ROPE_HEAD_DIM // 2], torch.float32, init_value=init_cmp_freqs_cos),
+        TensorSpec("cmp_freqs_sin", [B, ROPE_HEAD_DIM // 2], torch.float32, init_value=init_cmp_freqs_sin),
         TensorSpec("cmp_wkv", [MAIN_OUT_DIM, D], torch.bfloat16, init_value=init_cmp_wkv),
         TensorSpec("cmp_wgate", [MAIN_OUT_DIM, D], torch.bfloat16, init_value=init_cmp_wgate),
         TensorSpec("cmp_ape", [COMPRESS_RATIO, MAIN_OUT_DIM], torch.float32, init_value=init_cmp_ape),
@@ -1117,7 +1136,7 @@ def build_tensor_specs(start_pos=None, batch=B):
         TensorSpec("compress_state_block_table", [batch, COMPRESS_STATE_MAX_BLOCKS], torch.int32, init_value=init_compress_state_block_table),
         TensorSpec("kv_cache", [ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_kv_cache, is_output=True),
         TensorSpec("cmp_kv", [CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_cmp_kv, is_output=True),
-        TensorSpec("cmp_block_table", [batch, CMP_MAX_BLOCKS], torch.int32, init_value=init_cmp_block_table),
+        TensorSpec("cmp_block_table", list(cmp_block_table.shape), torch.int32, init_value=init_cmp_block_table),
         TensorSpec("ori_slot_mapping", [tokens], torch.int64, init_value=init_ori_slot_mapping),
         TensorSpec("window_swa_indices", [tokens, WIN], torch.int32, init_value=init_window_swa_indices),
         TensorSpec("window_swa_lens", [tokens], torch.int32, init_value=init_window_swa_lens),
@@ -1133,7 +1152,7 @@ def build_tensor_specs(start_pos=None, batch=B):
     ]
 
 
-def build_distributed_tensor_specs(local_t):
+def build_distributed_tensor_specs(local_t, start_pos=None):
     """Build one canonical HCA full-layer fixture per tensor-parallel rank."""
     import torch
 
@@ -1148,7 +1167,7 @@ def build_distributed_tensor_specs(local_t):
 
     with torch.random.fork_rng():
         torch.manual_seed(20260819)
-        base_specs = build_tensor_specs(batch=local_t // S)
+        base_specs = build_tensor_specs(start_pos=start_pos, batch=local_t // S)
     base_by_name = {spec.name: spec for spec in base_specs}
 
     def materialize(name):
@@ -1210,7 +1229,7 @@ def build_distributed_tensor_specs(local_t):
     resident_names = frozenset({
         "hc_attn_fn", "hc_attn_scale", "hc_attn_base",
         "attn_norm_w", "wq_a", "wq_b", "wq_b_scale", "wkv", "gamma_cq", "gamma_ckv",
-        "freqs_cos", "freqs_sin",
+        "freqs_cos", "freqs_sin", "cmp_freqs_cos", "cmp_freqs_sin",
         "cmp_wkv", "cmp_wgate", "cmp_ape", "cmp_norm_w",
         "compress_state", "kv_cache", "cmp_kv", "attn_sink",
         "wo_a", "wo_b", "wo_b_scale",
@@ -1234,9 +1253,24 @@ if __name__ == "__main__":
         "-d", "--device", type=str, default=None,
         help=f"comma-separated device ids; --tp {TP_SIZE} needs {TP_SIZE}",
     )
+    parser.add_argument(
+        "--start-pos", type=str, default=None,
+        help="absolute decode start position; a scalar sets batch=1, "
+             "and a comma-separated list sets batch to its length",
+    )
+    parser.add_argument("--enable-l2-swimlane", type=int, choices=(0, 1, 2, 4), default=0)
     parser.add_argument("--compile-only", action="store_true", default=False)
     parser.add_argument("--dump-passes", action="store_true", default=False)
     args = parser.parse_args()
+
+    if args.start_pos is not None:
+        parts = [part.strip() for part in args.start_pos.split(",") if part.strip()]
+        if not parts:
+            parser.error("--start-pos must contain at least one integer")
+        try:
+            args.start_pos = int(parts[0]) if len(parts) == 1 else [int(part) for part in parts]
+        except ValueError:
+            parser.error(f"--start-pos must be an integer or comma-separated integer list, got {args.start_pos!r}")
 
     if args.tp != TP_SIZE:
         parser.error(f"--tp must remain {TP_SIZE} after import-time specialization")
@@ -1250,84 +1284,95 @@ if __name__ == "__main__":
         parser.error(f"--device IDs must be non-negative, got {device_ids}")
     if len(set(device_ids)) != len(device_ids):
         parser.error(f"--device IDs must be distinct, got {device_ids}")
-
     if len(device_ids) != TP_SIZE:
         parser.error(f"--tp {TP_SIZE} needs exactly {TP_SIZE} device(s), got {device_ids}")
 
-    if TP_SIZE == 1:
-        result = run_jit(
-            fn=decode_hca_tp1_test,
-            specs=build_tensor_specs(),
-            golden_fn=golden_decode_hca_tp1,
-            compile_only=args.compile_only,
-            compile_cfg=dict(dump_passes=args.dump_passes),
-            runtime_cfg=dict(platform=args.platform, device_id=device_ids[0]),
-            rtol=1e-3,
-            atol=1e-3,
-            compare_fn={
-                "compress_state": mapped_pool_ratio_allclose(
-                    "state_slot_mapping", mapping_shape=(T,), block_size=COMPRESS_STATE_BLOCK_SIZE,
-                    pool_name="compressor state", atol=1e-3, rtol=1.0 / 128,
-                ),
-                "kv_cache": mapped_pool_ratio_allclose(
-                    "ori_slot_mapping", mapping_shape=(T,), block_size=BLOCK_SIZE,
-                    pool_name="original KV cache", atol=1e-3, rtol=1.0 / 128,
-                ),
-                "cmp_kv": mapped_pool_ratio_allclose(
-                    "cmp_slot_mapping", mapping_shape=(T,), block_size=BLOCK_SIZE,
-                    pool_name="compressed KV cache", atol=1e-3, rtol=1.0 / 128,
-                ),
-                "x_out": ratio_reldiff(diff_thd=3e-3, pct_thd=0.008, max_diff_hd=1),
-            },
-        )
-        if not result.passed:
-            if result.error:
-                print(result.error)
-            raise SystemExit(1)
-        raise SystemExit(0)
+    if args.start_pos is not None:
+        batch = len(args.start_pos) if isinstance(args.start_pos, list) else 1
+        token_counts = (batch * S,)
+    elif TP_SIZE == 1:
+        token_counts = (LOCAL_T,)
+    else:
+        # Capacity, then one row block below it: the dynamic token axis must hold at both.
+        token_counts = (LOCAL_T, LOCAL_T - VALID_TOKEN_TILE)
 
-    # The A2A3 simulator's distributed O path uses the CSA-level threshold and near-zero cap.
-    full_x_out_diff_thd = 4e-3 if args.platform == "a2a3sim" else 3e-3
-    full_x_out_max_diff = 2 if args.platform == "a2a3sim" else 1
-    # Capacity, then one row block below it: the dynamic token axis must hold at both.
-    for local_t in (LOCAL_T, LOCAL_T - VALID_TOKEN_TILE):
-        compile_cfg = dict(
-            dump_passes=args.dump_passes,
-            distributed_config=DistributedConfig(device_ids=device_ids, num_sub_workers=0),
-        )
-        mapping_shape = (TP_SIZE, local_t)
-        result = run_jit(
-            fn=l3_decode_hca,
-            specs=build_distributed_tensor_specs(local_t),
-            golden_fn=golden_decode_hca,
-            compile_only=args.compile_only,
-            compile_cfg=compile_cfg,
-            runtime_cfg=dict(platform=args.platform),
-            rtol=1e-3,
-            atol=1e-3,
-            compare_fn={
-                "compress_state": mapped_pool_ratio_allclose(
-                    "state_slot_mapping", mapping_shape=mapping_shape,
-                    block_size=COMPRESS_STATE_BLOCK_SIZE, leading_rank_axis=True,
-                    pool_name="compressor state", atol=1e-3, rtol=1.0 / 128,
+    for local_t in token_counts:
+        if TP_SIZE == 1:
+            result = run_jit(
+                fn=decode_hca_tp1_test,
+                specs=build_tensor_specs(start_pos=args.start_pos, batch=local_t // S),
+                golden_fn=golden_decode_hca_tp1,
+                compile_only=args.compile_only,
+                compile_cfg=dict(dump_passes=args.dump_passes),
+                runtime_cfg=dict(
+                    platform=args.platform,
+                    device_id=device_ids[0],
+                    enable_l2_swimlane=args.enable_l2_swimlane,
                 ),
-                "kv_cache": mapped_pool_ratio_allclose(
-                    "ori_slot_mapping", mapping_shape=mapping_shape,
-                    block_size=BLOCK_SIZE, leading_rank_axis=True,
-                    pool_name="original KV cache", atol=1e-3, rtol=1.0 / 128,
+                rtol=1e-3,
+                atol=1e-3,
+                compare_fn={
+                    "compress_state": mapped_pool_ratio_allclose(
+                        "state_slot_mapping", mapping_shape=(local_t,),
+                        block_size=COMPRESS_STATE_BLOCK_SIZE,
+                        pool_name="compressor state", atol=1e-3, rtol=1.0 / 128,
+                    ),
+                    "kv_cache": mapped_pool_ratio_allclose(
+                        "ori_slot_mapping", mapping_shape=(local_t,),
+                        block_size=BLOCK_SIZE,
+                        pool_name="original KV cache", atol=1e-3, rtol=1.0 / 128,
+                    ),
+                    "cmp_kv": mapped_pool_ratio_allclose(
+                        "cmp_slot_mapping", mapping_shape=(local_t,),
+                        block_size=BLOCK_SIZE,
+                        pool_name="compressed KV cache", atol=1e-3, rtol=1.0 / 128,
+                    ),
+                    "x_out": ratio_reldiff(diff_thd=3e-3, pct_thd=0.008, max_diff_hd=1),
+                },
+            )
+        else:
+            # The A2A3 simulator's distributed O path uses the CSA-level threshold and near-zero cap.
+            full_x_out_diff_thd = 4e-3 if args.platform == "a2a3sim" else 3e-3
+            full_x_out_max_diff = 2 if args.platform == "a2a3sim" else 1
+            mapping_shape = (TP_SIZE, local_t)
+            result = run_jit(
+                fn=l3_decode_hca,
+                specs=build_distributed_tensor_specs(local_t, start_pos=args.start_pos),
+                golden_fn=golden_decode_hca,
+                compile_only=args.compile_only,
+                compile_cfg=dict(
+                    dump_passes=args.dump_passes,
+                    distributed_config=DistributedConfig(device_ids=device_ids, num_sub_workers=0),
                 ),
-                "cmp_kv": mapped_pool_ratio_allclose(
-                    "cmp_slot_mapping", mapping_shape=mapping_shape,
-                    block_size=BLOCK_SIZE, leading_rank_axis=True,
-                    pool_name="compressed KV cache", atol=1e-3, rtol=1.0 / 128,
+                runtime_cfg=dict(
+                    platform=args.platform,
+                    enable_chip_swimlane=args.enable_l2_swimlane,
                 ),
-                "x_out": ratio_reldiff(
-                    diff_thd=full_x_out_diff_thd,
-                    pct_thd=0.008,
-                    max_diff_hd=full_x_out_max_diff,
-                ),
-            },
-        )
+                rtol=1e-3,
+                atol=1e-3,
+                compare_fn={
+                    "compress_state": mapped_pool_ratio_allclose(
+                        "state_slot_mapping", mapping_shape=mapping_shape,
+                        block_size=COMPRESS_STATE_BLOCK_SIZE, leading_rank_axis=True,
+                        pool_name="compressor state", atol=1e-3, rtol=1.0 / 128,
+                    ),
+                    "kv_cache": mapped_pool_ratio_allclose(
+                        "ori_slot_mapping", mapping_shape=mapping_shape,
+                        block_size=BLOCK_SIZE, leading_rank_axis=True,
+                        pool_name="original KV cache", atol=1e-3, rtol=1.0 / 128,
+                    ),
+                    "cmp_kv": mapped_pool_ratio_allclose(
+                        "cmp_slot_mapping", mapping_shape=mapping_shape,
+                        block_size=BLOCK_SIZE, leading_rank_axis=True,
+                        pool_name="compressed KV cache", atol=1e-3, rtol=1.0 / 128,
+                    ),
+                    "x_out": ratio_reldiff(
+                        diff_thd=full_x_out_diff_thd,
+                        pct_thd=0.008,
+                        max_diff_hd=full_x_out_max_diff,
+                    ),
+                },
+            )
         if not result.passed:
             if result.error:
                 print(result.error)

--- a/models/deepseek_v4_flash_dspark/decode_hca.py
+++ b/models/deepseek_v4_flash_dspark/decode_hca.py
@@ -798,6 +798,8 @@ def _hca_start_positions(start_pos, *, batch):
 
     from utils import hca_decode_start_set
 
+    if batch < 1 or batch > B:
+        raise ValueError(f"HCA batch must be in [1, {B}], got {batch}")
     if start_pos is None:
         starts = hca_decode_start_set(
             batch=batch,
@@ -813,6 +815,16 @@ def _hca_start_positions(start_pos, *, batch):
     if bool((starts < 0).any()) or bool((starts.to(torch.int64) + S > MAX_SEQ_LEN).any()):
         raise ValueError(f"HCA start positions plus S={S} must fit MAX_SEQ_LEN={MAX_SEQ_LEN}")
     return starts.contiguous()
+
+
+def _validate_hca_token_count(token_count):
+    """Validate the dynamic token extent shared by TP1 and distributed HCA."""
+    if (token_count < VALID_TOKEN_TILE or token_count > LOCAL_T
+            or token_count % VALID_TOKEN_TILE != 0 or token_count % S != 0):
+        raise ValueError(
+            f"HCA token count must be a multiple of {VALID_TOKEN_TILE} and S={S} "
+            f"in [{VALID_TOKEN_TILE}, {LOCAL_T}], got {token_count}"
+        )
 
 
 def _hca_token_rope_tables(positions):
@@ -916,6 +928,7 @@ def build_tensor_specs(start_pos=None, batch=B):
     from golden import TensorSpec
 
     starts = _hca_start_positions(start_pos, batch=batch)
+    _validate_hca_token_count(tokens)
     positions = position_ids_from_starts(starts, seq=S).contiguous()
     token_freqs_cos, token_freqs_sin = _hca_token_rope_tables(positions)
     boundary_positions = starts.to(torch.int64) - starts.to(torch.int64).remainder(COMPRESS_RATIO)
@@ -1158,12 +1171,7 @@ def build_distributed_tensor_specs(local_t, start_pos=None):
 
     from golden import ScalarSpec, TensorSpec
 
-    if (local_t < VALID_TOKEN_TILE or local_t > LOCAL_T
-            or local_t % VALID_TOKEN_TILE != 0 or local_t % S != 0):
-        raise ValueError(
-            f"local_t must be a multiple of {VALID_TOKEN_TILE} "
-            f"in [{VALID_TOKEN_TILE}, {LOCAL_T}], got {local_t}"
-        )
+    _validate_hca_token_count(local_t)
 
     with torch.random.fork_rng():
         torch.manual_seed(20260819)

--- a/models/deepseek_v4_flash_dspark/decode_sparse_attn_hca.py
+++ b/models/deepseek_v4_flash_dspark/decode_sparse_attn_hca.py
@@ -6,11 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-"""DeepSeek-V4 HCA sparse attention with grouped output projection (decode).
-
-Ratio-128 deterministic compressed tail plus the sliding window; no indexer.
-The SWA and CSA variants live in sibling modules.
-"""
+"""DeepSeek-V4 HCA sparse attention over the sliding window and ratio-128 compressed cache."""
 
 
 import pypto.language as pl
@@ -23,7 +19,6 @@ from config import (
     BLOCK_SIZE,
     KV_CMP_BLOCK_NUM,
     KV_ORI_BLOCK_NUM,
-    KV_CMP_MAX_BLOCKS,
     KV_ORI_MAX_BLOCKS,
 )
 
@@ -33,21 +28,19 @@ B_DYN = pl.dynamic("B_DYN")  # per-request axis (block tables)
 T_DYN = pl.dynamic("T_DYN")  # T = B * S
 ORI_BLOCK_NUM_DYN = pl.dynamic("ORI_BLOCK_NUM_DYN")
 CMP_BLOCK_NUM_DYN = pl.dynamic("CMP_BLOCK_NUM_DYN")
+CMP_TABLE_BLOCKS_DYN = pl.dynamic("CMP_TABLE_BLOCKS_DYN")
 
 # model config
 B = DECODE_BATCH // TP
 S = DECODE_SEQ
 T = B * S
-D = M.hidden_size
 H = M.num_attention_heads
 HEAD_DIM = M.head_dim
 ROPE_DIM = M.qk_rope_head_dim
 HALF_ROPE = ROPE_DIM // 2
 NOPE_DIM = M.nope_head_dim
 WIN = M.sliding_window
-MAX_SEQ_LEN = M.max_position_embeddings
 SOFTMAX_SCALE = M.softmax_scale
-O_LORA = M.o_lora_rank
 O_GROUPS = M.o_groups
 HEADS_PER_GROUP = H // O_GROUPS
 O_GROUP_IN = HEADS_PER_GROUP * HEAD_DIM
@@ -58,319 +51,719 @@ NEG_INF = -1.0e20
 # paged KV cache
 ORI_MAX_BLOCKS = KV_ORI_MAX_BLOCKS
 ORI_BLOCK_NUM = KV_ORI_BLOCK_NUM
-CMP_MAX_BLOCKS = KV_CMP_MAX_BLOCKS
 CMP_BLOCK_NUM = KV_CMP_BLOCK_NUM
+HCA_MAX_COMPRESSED_ROWS = CMP_BLOCK_NUM * BLOCK_SIZE
 
 # tiling
 VALID_TOKEN_TILE = 8
-GATHER_SEGS = 4          # gather blocks per token; T*GATHER_SEGS co-resides with qproj_dequant
-# Each segment carries BOTH a window slice and a compressed-tail slice, whose
-# per-row costs are opposite (bulk-run window vs scattered per-row topk).
-GATHER_RUN = 16          # window sub-tile probed for physical contiguity -> one bulk DMA
-H_TILE = 16
-QK_M_TILE = 32           # qk_pv M rows per QK/PV matmul; QK_M_TILE/H_TILE-way KV L1->L0 reuse
+GATHER_SEGMENTS = 4
+GATHER_RUN_TILE = 16
+GATHER_WINDOW_TILE = WIN // GATHER_SEGMENTS
+RAW_K_TILE = BLOCK_SIZE
 ATTN_K_TILE = 128
+ATTN_D_TILE = 256
+H_TILE = 16
+QK_M_TILE = 32
+CMP_PAGES_PER_WORK = ATTN_K_TILE // BLOCK_SIZE
 ROPE_TILE = 16
 ROPE_INTERLEAVE_TILE = 2 * ROPE_TILE
-T_PAD = ((T + 16 - 1) // 16) * 16  # T padded up to the 16-row cube M floor
-ROPE_CS_T_TILE = 8    # rope cos/sin row block; T is a multiple of 8 by the batch contract
+ROPE_CS_T_TILE = 8
+T_PAD = ((T + 16 - 1) // 16) * 16
 
-# Compressed-cache capacity: the ratio-128 layer has no indexer, so its compressed
-# tail is the deterministic full compressed cache, one slot per COMPRESS_RATIO
-# tokens. `index_topk` is the ratio-4 indexer's budget and does NOT bound this.
-CMP_CAPACITY = MAX_SEQ_LEN // COMPRESS_RATIO
-# Rounded up to a whole sparse block so TOPK needs no padding (PADDED_TOPK == TOPK).
-CMP_TOPK = ((CMP_CAPACITY + ATTN_K_TILE - 1) // ATTN_K_TILE) * ATTN_K_TILE
-# Longest context this build serves; past it the tail drops its NEWEST slots and
-# leaves a hole between the compressed history and the window.
-MAX_SUPPORTED_SEQ = CMP_TOPK * COMPRESS_RATIO
-CMP_BLOCKS_PER_REQ = (CMP_TOPK + BLOCK_SIZE - 1) // BLOCK_SIZE
-TOPK = WIN + CMP_TOPK    # cache-first window slots + the ratio-128 compressed tail
-# Floor to 2: a single sparse-K block miscompiles in pypto (S-stride cross-token
-# output mixup); a 2-block build with an all-invalid 2nd block is bit-exact.
-SPARSE_BLOCKS = max(2, (TOPK + ATTN_K_TILE - 1) // ATTN_K_TILE)
-PADDED_TOPK = SPARSE_BLOCKS * ATTN_K_TILE
-GATHER_WIN_ROWS = WIN // GATHER_SEGS
-GATHER_CMP_ROWS = (PADDED_TOPK - WIN) // GATHER_SEGS
-
-assert CMP_BLOCKS_PER_REQ <= CMP_MAX_BLOCKS, (
-    f"compressed block table ({CMP_MAX_BLOCKS} blocks) must index the whole "
-    f"{CMP_TOPK}-slot tail; MAX_SUPPORTED_SEQ={MAX_SUPPORTED_SEQ}")
-assert B * CMP_BLOCKS_PER_REQ <= CMP_BLOCK_NUM, (
-    f"compressed KV pool ({CMP_BLOCK_NUM} blocks) must hold B={B} requests x "
-    f"{CMP_BLOCKS_PER_REQ} blocks; MAX_SUPPORTED_SEQ={MAX_SUPPORTED_SEQ}")
-assert WIN == ATTN_K_TILE, f"HCA window tile requires WIN ({WIN}) == ATTN_K_TILE ({ATTN_K_TILE})"
-assert BLOCK_SIZE % GATHER_RUN == 0, "a contiguous run must not straddle two paged blocks by construction"
+assert WIN == ATTN_K_TILE, "HCA raw window must form one baseline-sized attention tile"
+assert ATTN_K_TILE % BLOCK_SIZE == 0, "HCA work must contain complete cache pages"
+assert H % QK_M_TILE == 0 and QK_M_TILE % H_TILE == 0
+assert BLOCK_SIZE % GATHER_RUN_TILE == 0, "a contiguous gather run must stay inside one cache block"
+assert HEAD_DIM == 2 * ATTN_D_TILE, "HCA stream matmuls split the head width into exactly two bounded tiles"
 
 
-@pl.jit.inline
+@pl.jit.inline(auto_scope=False)
 def sparse_attn_hca(
     q: pl.Tensor[[T_DYN, H, HEAD_DIM], pl.BF16],
     ori_kv: pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     window_swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
     cmp_kv: pl.Tensor[[CMP_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
-    cmp_block_table: pl.Tensor[[B_DYN, CMP_MAX_BLOCKS], pl.INT32],
-    cmp_sparse_indices: pl.Tensor[[T_DYN, CMP_TOPK], pl.INT32],
+    cmp_block_table: pl.Tensor[[B_DYN, CMP_TABLE_BLOCKS_DYN], pl.INT32],
+    position_ids: pl.Tensor[[T_DYN], pl.INT32],
+    kv_seq_lens: pl.Tensor[[B_DYN], pl.INT32],
     attn_sink: pl.Tensor[[H], pl.FP32],
     freqs_cos: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
     freqs_sin: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
     o_packed_heads: pl.Tensor[[O_GROUPS * T_PAD, O_GROUP_IN], pl.BF16],
     cache_ready_dep: pl.Scalar[pl.TASK_ID],
 ) -> tuple[pl.Tensor, pl.Scalar[pl.TASK_ID]]:
-    """Write HCA heads as ``[group, T_PAD, O_GROUP_IN]`` slabs.
-
-    Only the first runtime ``t_dim`` rows in each group are valid. The
-    returned task ID covers every write to the packed output tensor.
-    """
-    # Gather the historical/current window + compressed-cache rows.
-    # Compressed index contract:
-    #   -1              invalid
-    #   [0, ...)        compressed KV slots
+    """Write HCA heads as grouped ``[T_PAD, O_GROUP_IN]`` slabs."""
     t_dim = pl.tensor.dim(q, 0)
-    t_heads = t_dim * H
-    t_sparse = t_dim * PADDED_TOPK
-    t_gather = t_dim * GATHER_SEGS
-    t_qk = t_dim * SPARSE_BLOCKS
-    t_hblocks = t_dim * (H // H_TILE)
-    valid_blocks = t_dim // VALID_TOKEN_TILE
     rope_cs_blocks = t_dim // ROPE_CS_T_TILE
     ori_block_num = pl.tensor.dim(ori_kv, 0)
     cmp_block_num = pl.tensor.dim(cmp_kv, 0)
+    cmp_table_blocks = pl.tensor.dim(cmp_block_table, 1)
+    cmp_work_count = (cmp_table_blocks + CMP_PAGES_PER_WORK - 1) // CMP_PAGES_PER_WORK
     ori_kv_flat = pl.reshape(ori_kv, [ori_block_num * BLOCK_SIZE, HEAD_DIM])
     cmp_kv_flat = pl.reshape(cmp_kv, [cmp_block_num * BLOCK_SIZE, HEAD_DIM])
-    sparse_bias = pl.create_tensor([t_dim, PADDED_TOPK], dtype=pl.FP32)
+    q_flat = pl.reshape(q, [t_dim * H, HEAD_DIM])
+    attn_sink_col = pl.reshape(attn_sink, [H, 1])
+    request_count = pl.tensor.dim(cmp_block_table, 0)
+    raw_gather_count = t_dim * GATHER_SEGMENTS
+    raw_tile_count = t_dim * (WIN // RAW_K_TILE)
+    stream_block_count = t_dim * (H // H_TILE)
+    cmp_gather_count = request_count * cmp_work_count
+    cmp_qk_block_count = t_dim * cmp_work_count
+    cmp_partial_rows = t_dim * (H // H_TILE) * cmp_work_count * H_TILE
 
-    # Additive softmax bias (0 valid / NEG_INF invalid) that qk_pv adds onto the
-    # scaled scores, so invalid lanes exp to ~0 with no per-block mask multiply.
-    for v_blk in pl.spmd(valid_blocks, name_hint="build_valid", allow_early_resolve=True):
-        v_t0 = v_blk * VALID_TOKEN_TILE
-        v_win_f = pl.cast(window_swa_indices[v_t0 : v_t0 + VALID_TOKEN_TILE, 0 : WIN], target_type=pl.FP32)
-        v_idx_f = pl.cast(cmp_sparse_indices[v_t0 : v_t0 + VALID_TOKEN_TILE, 0 : CMP_TOPK], target_type=pl.FP32)
-        v_win_valid = pl.minimum(pl.maximum(pl.add(v_win_f, 1.0), 0.0), 1.0)
-        v_cmp_valid = pl.minimum(pl.maximum(pl.add(v_idx_f, 1.0), 0.0), 1.0)
-        sparse_bias[v_t0 : v_t0 + VALID_TOKEN_TILE, 0 : WIN] = pl.mul(pl.sub(v_win_valid, 1.0), -NEG_INF)
-        sparse_bias[v_t0 : v_t0 + VALID_TOKEN_TILE, WIN : TOPK] = pl.mul(pl.sub(v_cmp_valid, 1.0), -NEG_INF)
-        if PADDED_TOPK > TOPK:
-            sparse_bias[v_t0 : v_t0 + VALID_TOKEN_TILE, TOPK : PADDED_TOPK] = pl.full(
-                [VALID_TOKEN_TILE, PADDED_TOPK - TOPK], dtype=pl.FP32, value=NEG_INF)
-
-    # Sparse-K gather, hoisted out of qk_pv into its own grid, writing one token's
-    # sparse-K rows into the contiguous hca_kv_flat buffer. Every block carries a
-    # GATHER_WIN_ROWS slice of the window AND a GATHER_CMP_ROWS slice of the
-    # compressed tail, so the cheap bulk runs and the costly scattered rows are
-    # spread evenly. Invalid (-1) and padded lanes are zero-filled to match the
-    # golden's zero rows; the NEG_INF bias then kills them in the softmax.
-    hca_kv_flat = pl.create_tensor([t_sparse, HEAD_DIM], dtype=pl.BF16)
-    with pl.spmd(t_gather, name_hint="hca_gather_kv", deps=[cache_ready_dep]) as gather_tid:
-        g_task = pl.tile.get_block_idx()
-        g_t = g_task // GATHER_SEGS
-        g_seg = g_task - g_t * GATHER_SEGS
-        g_b = g_t // S
-        g_row0 = g_t * PADDED_TOPK
-
-        # Window slice: probe each sub-tile's first/last slot. Endpoints that are
-        # GATHER_RUN-1 apart mean the whole run sits in one paged block.
-        g_wk0 = g_seg * GATHER_WIN_ROWS
-        for g_sub in pl.range(GATHER_WIN_ROWS // GATHER_RUN):
-            g_sk0 = g_wk0 + g_sub * GATHER_RUN
-            g_sdst = g_row0 + g_sk0
-            g_first = pl.read(window_swa_indices, [g_t, g_sk0])
-            g_last = pl.read(window_swa_indices, [g_t, g_sk0 + GATHER_RUN - 1])
-            # A -1 slot anywhere in the run pins g_run_ok below the match value,
-            # so an invalid or block-straddling run takes the per-row path.
-            g_run_ok = (g_last - g_first) + pl.min(g_first, 0) * GATHER_RUN
-            if g_run_ok == GATHER_RUN - 1:
-                g_run_src = pl.cast(g_first, pl.INDEX)
-                hca_kv_flat[g_sdst : g_sdst + GATHER_RUN, 0:HEAD_DIM] = ori_kv_flat[
-                    g_run_src : g_run_src + GATHER_RUN, 0:HEAD_DIM
-                ]
-            else:
-                for g_dr in pl.range(GATHER_RUN):
-                    g_wdst = g_sdst + g_dr
-                    g_win_slot_i32 = pl.read(window_swa_indices, [g_t, g_sk0 + g_dr])
-                    if g_win_slot_i32 >= 0:
-                        g_win_slot = pl.cast(g_win_slot_i32, pl.INDEX)
-                        hca_kv_flat[g_wdst : g_wdst + 1, 0:HEAD_DIM] = ori_kv_flat[
-                            g_win_slot : g_win_slot + 1, 0:HEAD_DIM
-                        ]
-                    else:
-                        hca_kv_flat[g_wdst : g_wdst + 1, 0:HEAD_DIM] = pl.full(
-                            [1, HEAD_DIM], dtype=pl.BF16, value=0.0)
-
-        # Compressed slice: topk slots are scattered, so each row is its own
-        # block-table lookup + copy.
-        g_ck0 = g_seg * GATHER_CMP_ROWS
-        g_cdst0 = g_row0 + WIN + g_ck0
-        for g_dr in pl.range(GATHER_CMP_ROWS):
-            g_dst = g_cdst0 + g_dr
-            g_cmp_k = g_ck0 + g_dr
-            if g_cmp_k < CMP_TOPK:
-                g_ridx = pl.read(cmp_sparse_indices, [g_t, g_cmp_k])
-                if g_ridx >= 0:
-                    g_cblk = pl.cast(pl.read(cmp_block_table, [g_b, g_ridx // BLOCK_SIZE]), pl.INDEX)
-                    g_csrc = g_cblk * BLOCK_SIZE + g_ridx % BLOCK_SIZE
-                    hca_kv_flat[g_dst : g_dst + 1, 0:HEAD_DIM] = cmp_kv_flat[g_csrc : g_csrc + 1, 0:HEAD_DIM]
-                else:
-                    hca_kv_flat[g_dst : g_dst + 1, 0:HEAD_DIM] = pl.full([1, HEAD_DIM], dtype=pl.BF16, value=0.0)
-            else:
-                hca_kv_flat[g_dst : g_dst + 1, 0:HEAD_DIM] = pl.full([1, HEAD_DIM], dtype=pl.BF16, value=0.0)
-
-    # qk_pv writes per-tile (mi, li, oi) to GM; merge_norm reads them back. Not
-    # fused on a2a3: the PV output (Acc) -> online rescale (Vec) needs an
-    # unsupported tmov, and a [H_TILE, HEAD_DIM] carry overflows the Vec buffer.
-    q_flat = pl.reshape(q, [t_heads, HEAD_DIM])
-    sparse_blk_mi = pl.create_tensor([T * (H // H_TILE) * SPARSE_BLOCKS * H_TILE, 1], dtype=pl.FP32)
-    sparse_blk_li = pl.create_tensor([T * (H // H_TILE) * SPARSE_BLOCKS * H_TILE, 1], dtype=pl.FP32)
-    sparse_blk_oi = pl.create_tensor([T * (H // H_TILE) * SPARSE_BLOCKS * H_TILE, HEAD_DIM], dtype=pl.FP32)
-
-    with pl.spmd(t_qk, name_hint="qk_pv", deps=[gather_tid], allow_early_resolve=True) as _qk_tid:
-        qk_item = pl.tile.get_block_idx()
-        qk_t = qk_item // SPARSE_BLOCKS
-        qk_sb = qk_item - qk_t * SPARSE_BLOCKS
-        qk_token_base = qk_t * (H // H_TILE) * SPARSE_BLOCKS * H_TILE
-        # Sparse-block OUTER / head-tile INNER: both head-batches' QK (b_trans)
-        # and PV consume the SAME pre-gathered KV tile.
-        qk_s0 = qk_sb * ATTN_K_TILE
-        qk_bias_row = sparse_bias[qk_t : qk_t + 1, qk_s0 : qk_s0 + ATTN_K_TILE]
-        qk_base = qk_t * PADDED_TOPK + qk_s0
-        qk_kv = hca_kv_flat[qk_base : qk_base + ATTN_K_TILE, 0:HEAD_DIM]
-
-        # Cube-batch QK_M_TILE head rows per QK/PV matmul so the shared KV
-        # tile is extracted L1->L0 once per QK_M_TILE/H_TILE head-tiles
-        # (2x reuse at QK_M_TILE=32) instead of per head-tile. The
-        # [QK_M_TILE, ...] softmax result is sliced back into H_TILE-row
-        # stores at the SAME offsets as the per-head-tile path
-        # (qk_h_idx == qk_hb * (QK_M_TILE // H_TILE) + qk_sub), so the
-        # sparse_blk_* layout and merge_norm are bit-identical.
-        for qk_hb in pl.pipeline(H // QK_M_TILE, stage=2):
-            qk_h0 = qk_hb * QK_M_TILE
-            qk_head_row = qk_t * H + qk_h0
-            qk_q_tile = q_flat[qk_head_row : qk_head_row + QK_M_TILE, 0 : HEAD_DIM]
-            qk_raw = pl.matmul(qk_q_tile, qk_kv, b_trans=True, out_dtype=pl.FP32)
-            qk_scaled = pl.mul(qk_raw, SOFTMAX_SCALE)
-            qk_scores = pl.add(qk_scaled, pl.col_expand(pl.full([QK_M_TILE, ATTN_K_TILE], dtype=pl.FP32, value=0.0), qk_bias_row))
-            qk_mi = pl.row_max(qk_scores)
-            # Invalid lanes (NEG_INF bias, zero kv rows) exp to ~0; all-invalid
-            # blocks die in the merge alpha/beta -- no mask multiply needed.
-            qk_exp = pl.exp(pl.row_expand_sub(qk_scores, qk_mi))
-            qk_li = pl.row_sum(qk_exp)
-            qk_exp_bf16 = pl.cast(qk_exp, target_type=pl.BF16, mode="rint")
-            qk_oi = pl.matmul(qk_exp_bf16, qk_kv, out_dtype=pl.FP32)
-            for qk_sub in pl.unroll(QK_M_TILE // H_TILE):
-                qk_h_idx = qk_hb * (QK_M_TILE // H_TILE) + qk_sub
-                qk_r0 = qk_sub * H_TILE
-                qk_blk_base = qk_token_base + qk_h_idx * SPARSE_BLOCKS * H_TILE
-                qk_row = qk_blk_base + qk_sb * H_TILE
-                sparse_blk_mi[qk_row : qk_row + H_TILE, 0 : 1] = qk_mi[qk_r0 : qk_r0 + H_TILE, 0 : 1]
-                sparse_blk_li[qk_row : qk_row + H_TILE, 0 : 1] = qk_li[qk_r0 : qk_r0 + H_TILE, 0 : 1]
-                sparse_blk_oi[qk_row : qk_row + H_TILE, 0 : HEAD_DIM] = qk_oi[qk_r0 : qk_r0 + H_TILE, 0 : HEAD_DIM]
-
-    # Precompute the head-invariant interleaved cos and sign*sin once: they depend
-    # only on (token, column), not head, so building them per head would repeat the
-    # same dup-gather H times on the bottleneck Vec engine. sign is folded into sin
-    # (multiply by +/-1). The conjugate (inverse) rotation is:
-    #   out[j] = x[j]*cos_il[j] + x[j^1]*sign[j]*sin_il[j]
-    # Hoisted ABOVE merge_norm (which now fuses the rotation): independent of qk_pv,
-    # so it overlaps it and is off merge_norm's critical path.
+    stream_state_m = pl.create_tensor([t_dim * H, 1], dtype=pl.FP32)
+    stream_state_l = pl.create_tensor([t_dim * H, 1], dtype=pl.FP32)
+    stream_heads = pl.create_tensor([t_dim * H, HEAD_DIM], dtype=pl.FP32)
+    cmp_partial_m = pl.create_tensor([cmp_partial_rows, 8], dtype=pl.FP32)
+    cmp_partial_l = pl.create_tensor([cmp_partial_rows, 8], dtype=pl.FP32)
+    cmp_partial_o = pl.create_tensor([cmp_partial_rows, HEAD_DIM], dtype=pl.FP32)
     rope_cos_il = pl.create_tensor([T_PAD, ROPE_DIM], dtype=pl.FP32)
     rope_sin_signed = pl.create_tensor([T_PAD, ROPE_DIM], dtype=pl.FP32)
-    # The j^1 lane-swap index for merge_norm's rotation gather is a pure constant
-    # (no token/head dependence), so it is built once here instead of rebuilding
-    # the same arange/cast chain on each of the T*(H//H_TILE) merge blocks. Shaped
-    # [H_TILE, ROPE_DIM] because gather's index must match its source rows. It gets
-    # its own single-task scope because rope_cs below is an spmd over rope column
-    # tiles -- no single block there owns a column-invariant constant.
-    rope_swap_idx = pl.create_tensor([H_TILE, ROPE_DIM], dtype=pl.INT32)
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="rope_swap"):
-        sw_col = pl.col_expand_mul(
-            pl.full([H_TILE, ROPE_DIM], dtype=pl.FP32, value=1.0),
-            pl.cast(pl.arange(0, [1, ROPE_DIM], dtype=pl.INT32), target_type=pl.FP32))
-        sw_dup_f = pl.cast(pl.cast(pl.mul(sw_col, 0.5), target_type=pl.INT32, mode="trunc"), target_type=pl.FP32)
-        sw_lane = pl.sub(sw_col, pl.mul(sw_dup_f, 2.0))                                           # j%2
-        rope_swap_idx[0:H_TILE, 0:ROPE_DIM] = pl.cast(
-            pl.sub(pl.add(sw_col, 1.0), pl.mul(sw_lane, 2.0)), target_type=pl.INT32)              # j^1
+    rope_swap_idx = pl.create_tensor([1, ROPE_DIM], dtype=pl.INT32)
+    raw_branch_tids = pl.array.create(1, pl.TASK_ID)
+    cmp_branch_tids = pl.array.create(1, pl.TASK_ID)
+    rope_swap_tids = pl.array.create(1, pl.TASK_ID)
+    rope_cs_tids = pl.array.create(1, pl.TASK_ID)
 
-    for cp in pl.spmd(HALF_ROPE // ROPE_TILE, name_hint="rope_cs"):
-        cp_r0 = cp * ROPE_TILE
-        cp_c0 = 2 * cp_r0
-        cs_col = pl.col_expand_mul(
-            pl.full([ROPE_CS_T_TILE, ROPE_INTERLEAVE_TILE], dtype=pl.FP32, value=1.0),
-            pl.cast(pl.arange(0, [1, ROPE_INTERLEAVE_TILE], dtype=pl.INT32), target_type=pl.FP32))
-        cs_dup_f = pl.cast(pl.cast(pl.mul(cs_col, 0.5), target_type=pl.INT32, mode="trunc"), target_type=pl.FP32)
-        cs_dup_idx = pl.cast(cs_dup_f, target_type=pl.INT32)                                      # j>>1
-        cs_lane = pl.sub(cs_col, pl.mul(cs_dup_f, 2.0))                                           # j%2
-        cs_sign = pl.neg(pl.sub(pl.mul(cs_lane, 2.0), 1.0))                                       # [+1,-1,...] (conjugate)
-        for cs_rb in pl.range(rope_cs_blocks):
-            cs_t0 = cs_rb * ROPE_CS_T_TILE
-            cs_cos = pl.cast(freqs_cos[cs_t0 : cs_t0 + ROPE_CS_T_TILE, cp_r0 : cp_r0 + ROPE_TILE], target_type=pl.FP32)
-            cs_sin = pl.cast(freqs_sin[cs_t0 : cs_t0 + ROPE_CS_T_TILE, cp_r0 : cp_r0 + ROPE_TILE], target_type=pl.FP32)
-            cs_cos_dup = pl.gather(cs_cos, dim=-1, index=cs_dup_idx)
-            cs_sin_dup = pl.gather(cs_sin, dim=-1, index=cs_dup_idx)
-            cs_sin_signed = pl.mul(cs_sin_dup, cs_sign)
-            rope_cos_il[cs_t0 : cs_t0 + ROPE_CS_T_TILE, cp_c0 : cp_c0 + ROPE_INTERLEAVE_TILE] = cs_cos_dup
-            rope_sin_signed[cs_t0 : cs_t0 + ROPE_CS_T_TILE, cp_c0 : cp_c0 + ROPE_INTERLEAVE_TILE] = cs_sin_signed
+    with pl.scope():
+        raw_kv = pl.create_tensor([t_dim * WIN, HEAD_DIM], dtype=pl.BF16)
+        raw_kv_t = pl.create_tensor(
+            [raw_tile_count * HEAD_DIM, RAW_K_TILE],
+            dtype=pl.BF16,
+        )
+        raw_valid = pl.create_tensor([t_dim, WIN], dtype=pl.FP32)
+        with pl.spmd(
+            raw_gather_count,
+            name_hint="hca_gather_kv",
+            deps=[cache_ready_dep],
+        ) as raw_gather_tid:
+            g_task = pl.tile.get_block_idx()
+            g_t = g_task // GATHER_SEGMENTS
+            g_seg = g_task - g_t * GATHER_SEGMENTS
+            g_wk0 = g_seg * GATHER_WINDOW_TILE
+            g_row0 = g_t * WIN
+            for g_sub in pl.range(GATHER_WINDOW_TILE // GATHER_RUN_TILE):
+                g_sk0 = g_wk0 + g_sub * GATHER_RUN_TILE
+                g_sdst = g_row0 + g_sk0
+                g_first = pl.read(window_swa_indices, [g_t, g_sk0])
+                g_last = pl.read(
+                    window_swa_indices,
+                    [g_t, g_sk0 + GATHER_RUN_TILE - 1],
+                )
+                g_run_ok = (g_last - g_first) + pl.min(g_first, 0) * GATHER_RUN_TILE
+                if g_run_ok == GATHER_RUN_TILE - 1:
+                    g_run_src = pl.cast(g_first, pl.INDEX)
+                    raw_kv[
+                        g_sdst : g_sdst + GATHER_RUN_TILE,
+                        0:HEAD_DIM,
+                    ] = ori_kv_flat[
+                        g_run_src : g_run_src + GATHER_RUN_TILE,
+                        0:HEAD_DIM,
+                    ]
+                    for g_dr in pl.unroll(GATHER_RUN_TILE):
+                        pl.write(raw_valid, [g_t, g_sk0 + g_dr], 1.0)
+                else:
+                    for g_dr in pl.range(GATHER_RUN_TILE):
+                        g_lane = g_sk0 + g_dr
+                        g_dst = g_row0 + g_lane
+                        g_slot_i32 = pl.read(window_swa_indices, [g_t, g_lane])
+                        if g_slot_i32 >= 0:
+                            g_slot = pl.cast(g_slot_i32, pl.INDEX)
+                            raw_kv[g_dst : g_dst + 1, 0:HEAD_DIM] = ori_kv_flat[
+                                g_slot : g_slot + 1,
+                                0:HEAD_DIM,
+                            ]
+                            pl.write(raw_valid, [g_t, g_lane], 1.0)
+                        else:
+                            raw_kv[g_dst : g_dst + 1, 0:HEAD_DIM] = pl.full(
+                                [1, HEAD_DIM],
+                                dtype=pl.BF16,
+                                value=0.0,
+                            )
+                            pl.write(raw_valid, [g_t, g_lane], 0.0)
 
-    # Online-softmax merge across sparse-K tiles, sink-norm, then fused inverse RoPE.
-    # One spmd block per (token, head-tile) -- T*(H//H_TILE) blocks -- so the merge
-    # fans out over that many AIVs instead of T blocks each running a serial head-tile
-    # loop. The inverse-RoPE rotation + rope-column pack is fused in (was a separate
-    # "rope" spmd reading an attn_rope_stage GM round-trip): the head-tile's fp32 rope
-    # segment is rotated in UB and packed straight into the output group's rope columns.
-    # with-form spmd so the dispatch TaskId (merge_tid) can be an explicit dep of
-    # the downstream proj_a tasks (which read merge_norm's packed output columns).
-    with pl.spmd(t_hblocks, name_hint="merge_norm") as merge_tid:
-        m_idx = pl.tile.get_block_idx()
-        m_t = m_idx // (H // H_TILE)
-        m_h_idx = m_idx - m_t * (H // H_TILE)
-        m_h0 = m_h_idx * H_TILE
-        m_blk_base = m_idx * SPARSE_BLOCKS * H_TILE
-        m_mi = sparse_blk_mi[m_blk_base : m_blk_base + H_TILE, 0 : 1]
-        m_li = sparse_blk_li[m_blk_base : m_blk_base + H_TILE, 0 : 1]
-        m_oi = sparse_blk_oi[m_blk_base : m_blk_base + H_TILE, 0 : HEAD_DIM]
+        with pl.spmd(
+            raw_tile_count,
+            name_hint="hca_raw_transpose",
+            deps=[raw_gather_tid],
+        ) as raw_transpose_tid:
+            raw_tile = pl.tile.get_block_idx()
+            raw_row = raw_tile * RAW_K_TILE
+            raw_t_row = raw_tile * HEAD_DIM
+            raw_kv_t[
+                raw_t_row : raw_t_row + HEAD_DIM,
+                0:RAW_K_TILE,
+            ] = pl.transpose(
+                raw_kv[raw_row : raw_row + RAW_K_TILE, 0:HEAD_DIM],
+                axis1=0,
+                axis2=1,
+            )
 
-        # SPARSE_BLOCKS is max(2, ...) here, so the merge loop always runs -- no
-        # SWA-style guard needed. Software-pipelined so each iteration's
-        # sparse_blk_* loads overlap the previous iteration's rescale math.
-        for m_sb in pl.pipeline(1, SPARSE_BLOCKS, stage=2):
-            m_row = m_blk_base + m_sb * H_TILE
-            m_cur_mi = sparse_blk_mi[m_row : m_row + H_TILE, 0 : 1]
-            m_cur_li = sparse_blk_li[m_row : m_row + H_TILE, 0 : 1]
-            m_cur_oi = sparse_blk_oi[m_row : m_row + H_TILE, 0 : HEAD_DIM]
-            m_mi_new = pl.maximum(m_mi, m_cur_mi)
-            m_alpha = pl.exp(pl.sub(m_mi, m_mi_new))
-            m_beta = pl.exp(pl.sub(m_cur_mi, m_mi_new))
-            m_li = pl.add(pl.mul(m_alpha, m_li), pl.mul(m_beta, m_cur_li))
-            m_oi = pl.add(pl.row_expand_mul(m_oi, m_alpha), pl.row_expand_mul(m_cur_oi, m_beta))
-            m_mi = m_mi_new
+        with pl.spmd(1, name_hint="rope_swap") as rope_swap_tid:
+            sw_block = pl.tile.get_block_idx()
+            sw_one = pl.full([1, ROPE_DIM], dtype=pl.FP32, value=1.0)
+            sw_index_i32 = pl.arange(0, [1, ROPE_DIM], dtype=pl.INT32)
+            sw_index = pl.cast(sw_index_i32, target_type=pl.FP32)
+            sw_col = pl.col_expand_mul(sw_one, sw_index)
+            sw_dup = pl.mul(sw_col, 0.5)
+            sw_dup_i32 = pl.cast(sw_dup, target_type=pl.INT32, mode="trunc")
+            sw_dup_f = pl.cast(sw_dup_i32, target_type=pl.FP32)
+            sw_lane = pl.sub(sw_col, pl.mul(sw_dup_f, 2.0))
+            sw_next = pl.add(sw_col, 1.0)
+            sw_lane_offset = pl.mul(sw_lane, 2.0)
+            sw_swap = pl.sub(sw_next, sw_lane_offset)
+            rope_swap_idx[
+                sw_block : sw_block + 1,
+                0:ROPE_DIM,
+            ] = pl.cast(sw_swap, target_type=pl.INT32)
 
-        n_sink_bias = pl.reshape(attn_sink[m_h0 : m_h0 + H_TILE], [H_TILE, 1])
-        n_sink_tile = pl.add(pl.sub(m_mi, m_mi), n_sink_bias)
-        n_denom = pl.add(m_li, pl.exp(pl.sub(n_sink_tile, m_mi)))
-        n_full = pl.row_expand_div(m_oi, n_denom)[0 : H_TILE, 0 : HEAD_DIM]
-        n_bf16 = pl.cast(n_full, target_type=pl.BF16, mode="rint")
+        with pl.spmd(
+            HALF_ROPE // ROPE_TILE,
+            name_hint="rope_cs",
+        ) as rope_cs_tid:
+            cp = pl.tile.get_block_idx()
+            cp_r0 = cp * ROPE_TILE
+            cp_c0 = 2 * cp_r0
+            cs_one = pl.full(
+                [ROPE_CS_T_TILE, ROPE_INTERLEAVE_TILE],
+                dtype=pl.FP32,
+                value=1.0,
+            )
+            cs_index_i32 = pl.arange(
+                0,
+                [1, ROPE_INTERLEAVE_TILE],
+                dtype=pl.INT32,
+            )
+            cs_index = pl.cast(cs_index_i32, target_type=pl.FP32)
+            cs_col = pl.col_expand_mul(cs_one, cs_index)
+            cs_dup = pl.mul(cs_col, 0.5)
+            cs_dup_idx = pl.cast(cs_dup, target_type=pl.INT32, mode="trunc")
+            cs_dup_f = pl.cast(cs_dup_idx, target_type=pl.FP32)
+            cs_lane = pl.sub(cs_col, pl.mul(cs_dup_f, 2.0))
+            cs_sign = pl.neg(pl.sub(pl.mul(cs_lane, 2.0), 1.0))
+            for cs_rb in pl.range(rope_cs_blocks):
+                cs_t0 = cs_rb * ROPE_CS_T_TILE
+                cs_cos_bf16 = freqs_cos[
+                    cs_t0 : cs_t0 + ROPE_CS_T_TILE,
+                    cp_r0 : cp_r0 + ROPE_TILE,
+                ]
+                cs_sin_bf16 = freqs_sin[
+                    cs_t0 : cs_t0 + ROPE_CS_T_TILE,
+                    cp_r0 : cp_r0 + ROPE_TILE,
+                ]
+                cs_cos = pl.cast(cs_cos_bf16, target_type=pl.FP32)
+                cs_sin = pl.cast(cs_sin_bf16, target_type=pl.FP32)
+                cs_cos_dup = pl.gather(cs_cos, dim=-1, index=cs_dup_idx)
+                cs_sin_dup = pl.gather(cs_sin, dim=-1, index=cs_dup_idx)
+                cs_sin_signed = pl.mul(cs_sin_dup, cs_sign)
+                rope_cos_il[
+                    cs_t0 : cs_t0 + ROPE_CS_T_TILE,
+                    cp_c0 : cp_c0 + ROPE_INTERLEAVE_TILE,
+                ] = cs_cos_dup
+                rope_sin_signed[
+                    cs_t0 : cs_t0 + ROPE_CS_T_TILE,
+                    cp_c0 : cp_c0 + ROPE_INTERLEAVE_TILE,
+                ] = cs_sin_signed
 
-        # Inverse RoPE on this head-tile's fp32 rope segment. cos_il / sign*sin are
-        # head-invariant for token m_t, so col_expand them over the H_TILE head rows;
-        # rope_swap_idx (j^1, prebuilt above) pairs the interleaved real/imag lanes.
-        # Rounded to bf16 (golden also rounds inverse-RoPE to bf16) and packed into
-        # the packed output's rope columns.
-        m_rope = n_full[0 : H_TILE, NOPE_DIM : HEAD_DIM]
-        m_cos_il = rope_cos_il[m_t : m_t + 1, 0 : ROPE_DIM]
-        m_sin_signed = rope_sin_signed[m_t : m_t + 1, 0 : ROPE_DIM]
-        m_swapped = pl.gather(m_rope, dim=-1, index=rope_swap_idx[0:H_TILE, 0:ROPE_DIM])
-        m_rot = pl.add(pl.col_expand_mul(m_rope, m_cos_il), pl.col_expand_mul(m_swapped, m_sin_signed))
-        n_rope_bf16 = pl.cast(m_rot, target_type=pl.BF16, mode="rint")
-        n_full_bf16 = pl.concat(n_bf16[:, : NOPE_DIM], n_rope_bf16)
+        with pl.spmd(
+            stream_block_count,
+            name_hint="hca_raw_attn",
+            deps=[raw_transpose_tid],
+        ) as raw_heads_tid:
+            stream_idx = pl.tile.get_block_idx()
+            stream_t = stream_idx // (H // H_TILE)
+            stream_h_tile = stream_idx - stream_t * (H // H_TILE)
+            stream_h0 = stream_h_tile * H_TILE
+            stream_state_row = stream_t * H + stream_h0
+            stream_q = pl.load(
+                q_flat,
+                [stream_state_row, 0],
+                [H_TILE, HEAD_DIM],
+                target_memory=pl.MemorySpace.Vec,
+            )
+            stream_row_max_tmp = pl.create_tile(
+                [H_TILE, RAW_K_TILE],
+                dtype=pl.FP32,
+                target_memory=pl.MemorySpace.Vec,
+            )
+            stream_row_sum_tmp = pl.create_tile(
+                [H_TILE, RAW_K_TILE],
+                dtype=pl.FP32,
+                target_memory=pl.MemorySpace.Vec,
+            )
+            for stream_raw_item in pl.unroll(WIN // RAW_K_TILE):
+                stream_raw_begin = stream_t * WIN + stream_raw_item * RAW_K_TILE
+                stream_valid_begin = stream_raw_item * RAW_K_TILE
+                stream_raw_kv = pl.load(
+                    raw_kv,
+                    [stream_raw_begin, 0],
+                    [RAW_K_TILE, HEAD_DIM],
+                    target_memory=pl.MemorySpace.Vec,
+                )
+                stream_raw_t_begin = (
+                    stream_t * (WIN // RAW_K_TILE) + stream_raw_item
+                ) * HEAD_DIM
+                stream_raw_kv_t_left = pl.load(
+                    raw_kv_t,
+                    [stream_raw_t_begin, 0],
+                    [ATTN_D_TILE, RAW_K_TILE],
+                    target_memory=pl.MemorySpace.Vec,
+                )
+                stream_raw_kv_t_right = pl.load(
+                    raw_kv_t,
+                    [stream_raw_t_begin + ATTN_D_TILE, 0],
+                    [ATTN_D_TILE, RAW_K_TILE],
+                    target_memory=pl.MemorySpace.Vec,
+                )
+                stream_raw_valid_row = pl.load(
+                    raw_valid,
+                    [stream_t, stream_valid_begin],
+                    [1, RAW_K_TILE],
+                    target_memory=pl.MemorySpace.Vec,
+                )
+                stream_raw_valid_zero = pl.tile.full(
+                    [H_TILE, RAW_K_TILE],
+                    dtype=pl.FP32,
+                    value=0.0,
+                )
+                stream_raw_valid = pl.col_expand_add(
+                    stream_raw_valid_zero,
+                    stream_raw_valid_row,
+                )
+                stream_raw_bias = pl.mul(
+                    pl.sub(stream_raw_valid, 1.0),
+                    -NEG_INF,
+                )
+                stream_raw_scores = pl.matmul(
+                    stream_q[:, 0:ATTN_D_TILE],
+                    stream_raw_kv_t_left,
+                    out_dtype=pl.FP32,
+                )
+                stream_raw_scores = pl.matmul_acc(
+                    stream_raw_scores,
+                    stream_q[:, ATTN_D_TILE:HEAD_DIM],
+                    stream_raw_kv_t_right,
+                )
+                stream_raw_scores = pl.add(
+                    pl.mul(stream_raw_scores, SOFTMAX_SCALE),
+                    stream_raw_bias,
+                )
+                stream_raw_mi_col = pl.row_max(
+                    stream_raw_scores,
+                    stream_row_max_tmp,
+                )
+                stream_raw_exp = pl.exp(
+                    pl.row_expand_sub(stream_raw_scores, stream_raw_mi_col)
+                )
+                stream_raw_exp = pl.mul(stream_raw_exp, stream_raw_valid)
+                stream_raw_li_col = pl.row_sum(
+                    stream_raw_exp,
+                    stream_row_sum_tmp,
+                )
+                stream_raw_exp_bf16 = pl.cast(
+                    stream_raw_exp,
+                    target_type=pl.BF16,
+                    mode="rint",
+                )
+                stream_raw_oi_left = pl.matmul(
+                    stream_raw_exp_bf16,
+                    stream_raw_kv[:, 0:ATTN_D_TILE],
+                    out_dtype=pl.FP32,
+                )
+                stream_raw_oi_right = pl.matmul(
+                    stream_raw_exp_bf16,
+                    stream_raw_kv[:, ATTN_D_TILE : 2 * ATTN_D_TILE],
+                    out_dtype=pl.FP32,
+                )
+                stream_raw_oi = pl.concat(
+                    stream_raw_oi_left,
+                    stream_raw_oi_right,
+                )
+                if stream_raw_item == 0:
+                    pl.store(
+                        stream_raw_mi_col,
+                        [stream_state_row, 0],
+                        stream_state_m,
+                    )
+                    pl.store(
+                        stream_raw_li_col,
+                        [stream_state_row, 0],
+                        stream_state_l,
+                    )
+                    pl.store(
+                        stream_raw_oi,
+                        [stream_state_row, 0],
+                        stream_heads,
+                    )
+                else:
+                    stream_m = pl.load(
+                        stream_state_m,
+                        [stream_state_row, 0],
+                        [H_TILE, 1],
+                        target_memory=pl.MemorySpace.Vec,
+                    )
+                    stream_l = pl.load(
+                        stream_state_l,
+                        [stream_state_row, 0],
+                        [H_TILE, 1],
+                        target_memory=pl.MemorySpace.Vec,
+                    )
+                    stream_o = pl.load(
+                        stream_heads,
+                        [stream_state_row, 0],
+                        [H_TILE, HEAD_DIM],
+                        target_memory=pl.MemorySpace.Vec,
+                    )
+                    stream_m_new = pl.maximum(stream_m, stream_raw_mi_col)
+                    stream_alpha = pl.exp(pl.sub(stream_m, stream_m_new))
+                    stream_beta = pl.exp(
+                        pl.sub(stream_raw_mi_col, stream_m_new)
+                    )
+                    stream_l_new = pl.add(
+                        pl.mul(stream_alpha, stream_l),
+                        pl.mul(stream_beta, stream_raw_li_col),
+                    )
+                    stream_o_new = pl.add(
+                        pl.row_expand_mul(stream_o, stream_alpha),
+                        pl.row_expand_mul(stream_raw_oi, stream_beta),
+                    )
+                    pl.store(
+                        stream_m_new,
+                        [stream_state_row, 0],
+                        stream_state_m,
+                    )
+                    pl.store(
+                        stream_l_new,
+                        [stream_state_row, 0],
+                        stream_state_l,
+                    )
+                    pl.store(
+                        stream_o_new,
+                        [stream_state_row, 0],
+                        stream_heads,
+                    )
 
+        raw_branch_tids[0] = raw_heads_tid
+        rope_swap_tids[0] = rope_swap_tid
+        rope_cs_tids[0] = rope_cs_tid
+
+    with pl.scope():
+        cmp_work_kv = pl.create_tensor(
+            [cmp_gather_count * ATTN_K_TILE, HEAD_DIM],
+            dtype=pl.BF16,
+        )
+        with pl.spmd(
+            cmp_gather_count,
+            name_hint="hca_cmp_work_gather",
+            deps=[cache_ready_dep],
+        ) as cmp_gather_tid:
+            gather_item = pl.tile.get_block_idx()
+            gather_request = gather_item // cmp_work_count
+            gather_work = gather_item - gather_request * cmp_work_count
+            gather_first_col = gather_work * CMP_PAGES_PER_WORK
+            gather_dst0 = gather_item * ATTN_K_TILE
+            for gather_page in pl.unroll(CMP_PAGES_PER_WORK):
+                gather_page_col = gather_first_col + gather_page
+                if gather_page_col < cmp_table_blocks:
+                    gather_page_i32 = pl.read(
+                        cmp_block_table,
+                        [gather_request, gather_page_col],
+                    )
+                    if gather_page_i32 >= 0:
+                        if gather_page_i32 < cmp_block_num:
+                            gather_page_id = pl.cast(gather_page_i32, pl.INDEX)
+                            gather_src = gather_page_id * BLOCK_SIZE
+                            gather_dst = gather_dst0 + gather_page * BLOCK_SIZE
+                            cmp_work_kv[
+                                gather_dst : gather_dst + BLOCK_SIZE,
+                                0:HEAD_DIM,
+                            ] = cmp_kv_flat[
+                                gather_src : gather_src + BLOCK_SIZE,
+                                0:HEAD_DIM,
+                            ]
+
+        with pl.spmd(
+            cmp_qk_block_count,
+            name_hint="hca_cmp_qk_pv",
+            deps=[cmp_gather_tid],
+        ) as cmp_qk_tid:
+            qk_item = pl.tile.get_block_idx()
+            qk_t = qk_item // cmp_work_count
+            qk_work = qk_item - qk_t * cmp_work_count
+            qk_request = qk_t // S
+            qk_work_row = qk_work * ATTN_K_TILE
+            qk_token_base = qk_t * (H // H_TILE) * cmp_work_count * H_TILE
+            qk_neutral_m = pl.tile.full(
+                [H_TILE, 8],
+                dtype=pl.FP32,
+                value=NEG_INF,
+            )
+            qk_neutral_l = pl.tile.full(
+                [H_TILE, 8],
+                dtype=pl.FP32,
+                value=0.0,
+            )
+            qk_neutral_o = pl.tile.full(
+                [H_TILE, HEAD_DIM],
+                dtype=pl.FP32,
+                value=0.0,
+            )
+            for qk_h_idx in pl.unroll(H // H_TILE):
+                qk_row = (
+                    qk_token_base
+                    + qk_h_idx * cmp_work_count * H_TILE
+                    + qk_work * H_TILE
+                )
+                pl.store(qk_neutral_m, [qk_row, 0], cmp_partial_m)
+                pl.store(qk_neutral_l, [qk_row, 0], cmp_partial_l)
+                pl.store(qk_neutral_o, [qk_row, 0], cmp_partial_o)
+
+            qk_rows = pl.cast(0, pl.INDEX)
+            qk_position_i32 = pl.read(position_ids, [qk_t])
+            if qk_request < request_count:
+                qk_kv_len_i32 = pl.read(kv_seq_lens, [qk_request])
+                if qk_position_i32 >= 0:
+                    if qk_kv_len_i32 >= 0:
+                        qk_position = pl.cast(qk_position_i32, pl.INDEX)
+                        qk_kv_len = pl.cast(qk_kv_len_i32, pl.INDEX)
+                        qk_position_rows = (qk_position + 1) // COMPRESS_RATIO
+                        qk_kv_rows = qk_kv_len // COMPRESS_RATIO
+                        qk_rows = pl.min(
+                            HCA_MAX_COMPRESSED_ROWS,
+                            pl.min(qk_position_rows, qk_kv_rows),
+                        )
+
+            if qk_work_row < qk_rows:
+                qk_first_col = qk_work * CMP_PAGES_PER_WORK
+                qk_first_page_i32 = pl.read(
+                    cmp_block_table,
+                    [qk_request, qk_first_col],
+                )
+                if qk_first_page_i32 >= 0:
+                    if qk_first_page_i32 < cmp_block_num:
+                        qk_work_src = (
+                            qk_request * cmp_work_count + qk_work
+                        ) * ATTN_K_TILE
+                        qk_kv = pl.load(
+                            cmp_work_kv,
+                            [qk_work_src, 0],
+                            [ATTN_K_TILE, HEAD_DIM],
+                            target_memory=pl.MemorySpace.Mat,
+                        )
+                        qk_valid_rows = pl.min(
+                            ATTN_K_TILE,
+                            qk_rows - qk_work_row,
+                        )
+                        qk_kv_t = pl.tile.transpose_view(qk_kv)
+                        qk_row_max_tmp = pl.create_tile(
+                            [QK_M_TILE, ATTN_K_TILE],
+                            dtype=pl.FP32,
+                            target_memory=pl.MemorySpace.Vec,
+                        )
+                        qk_row_sum_tmp = pl.create_tile(
+                            [QK_M_TILE, ATTN_K_TILE],
+                            dtype=pl.FP32,
+                            target_memory=pl.MemorySpace.Vec,
+                        )
+                        for qk_hb in pl.pipeline(H // QK_M_TILE, stage=2):
+                            qk_h0 = qk_hb * QK_M_TILE
+                            qk_head_row = qk_t * H + qk_h0
+                            qk_q = pl.load(
+                                q_flat,
+                                [qk_head_row, 0],
+                                [QK_M_TILE, HEAD_DIM],
+                                target_memory=pl.MemorySpace.Mat,
+                            )
+                            qk_scores = pl.matmul(
+                                qk_q,
+                                qk_kv_t,
+                                out_dtype=pl.FP32,
+                            )
+                            qk_scores = pl.mul(qk_scores, SOFTMAX_SCALE)
+                            qk_scores = pl.set_validshape(
+                                qk_scores,
+                                QK_M_TILE,
+                                qk_valid_rows,
+                            )
+                            qk_scores = pl.fillpad(
+                                qk_scores,
+                                pad_value=pl.PadValue.min,
+                            )
+                            qk_mi = pl.row_max(qk_scores, qk_row_max_tmp)
+                            qk_exp = pl.exp(
+                                pl.row_expand_sub(qk_scores, qk_mi)
+                            )
+                            qk_li = pl.row_sum(qk_exp, qk_row_sum_tmp)
+                            qk_exp_bf16 = pl.cast(
+                                qk_exp,
+                                target_type=pl.BF16,
+                                mode="rint",
+                            )
+                            qk_oi_left = pl.matmul(
+                                qk_exp_bf16,
+                                qk_kv[:, 0:ATTN_D_TILE],
+                                out_dtype=pl.FP32,
+                            )
+                            qk_oi_right = pl.matmul(
+                                qk_exp_bf16,
+                                qk_kv[:, ATTN_D_TILE:HEAD_DIM],
+                                out_dtype=pl.FP32,
+                            )
+                            qk_oi = pl.concat(qk_oi_left, qk_oi_right)
+                            qk_h_idx0 = qk_hb * (QK_M_TILE // H_TILE)
+                            qk_row0 = (
+                                qk_token_base
+                                + qk_h_idx0 * cmp_work_count * H_TILE
+                                + qk_work * H_TILE
+                            )
+                            qk_row1 = qk_row0 + cmp_work_count * H_TILE
+                            pl.store(
+                                qk_mi[0:H_TILE, 0:1],
+                                [qk_row0, 0],
+                                cmp_partial_m,
+                            )
+                            pl.store(
+                                qk_li[0:H_TILE, 0:1],
+                                [qk_row0, 0],
+                                cmp_partial_l,
+                            )
+                            pl.store(
+                                qk_oi[0:H_TILE, 0:HEAD_DIM],
+                                [qk_row0, 0],
+                                cmp_partial_o,
+                            )
+                            pl.store(
+                                qk_mi[H_TILE:QK_M_TILE, 0:1],
+                                [qk_row1, 0],
+                                cmp_partial_m,
+                            )
+                            pl.store(
+                                qk_li[H_TILE:QK_M_TILE, 0:1],
+                                [qk_row1, 0],
+                                cmp_partial_l,
+                            )
+                            pl.store(
+                                qk_oi[H_TILE:QK_M_TILE, 0:HEAD_DIM],
+                                [qk_row1, 0],
+                                cmp_partial_o,
+                            )
+
+        cmp_branch_tids[0] = cmp_qk_tid
+
+    with pl.spmd(
+        stream_block_count,
+        name_hint="hca_stream_merge",
+        deps=[raw_branch_tids[0], cmp_branch_tids[0]],
+    ) as stream_heads_tid:
+        stream_idx = pl.tile.get_block_idx()
+        stream_t = stream_idx // (H // H_TILE)
+        stream_h_tile = stream_idx - stream_t * (H // H_TILE)
+        stream_h0 = stream_h_tile * H_TILE
+        stream_state_row = stream_t * H + stream_h0
+        stream_m = pl.load(
+            stream_state_m,
+            [stream_state_row, 0],
+            [H_TILE, 1],
+            target_memory=pl.MemorySpace.Vec,
+        )
+        stream_l = pl.load(
+            stream_state_l,
+            [stream_state_row, 0],
+            [H_TILE, 1],
+            target_memory=pl.MemorySpace.Vec,
+        )
+        stream_o = pl.load(
+            stream_heads,
+            [stream_state_row, 0],
+            [H_TILE, HEAD_DIM],
+            target_memory=pl.MemorySpace.Vec,
+        )
+        stream_token_base = stream_t * (H // H_TILE) * cmp_work_count * H_TILE
+        for stream_work in pl.range(cmp_work_count):
+            stream_partial_row = (
+                stream_token_base
+                + stream_h_tile * cmp_work_count * H_TILE
+                + stream_work * H_TILE
+            )
+            stream_cmp_m_aligned = pl.load(
+                cmp_partial_m,
+                [stream_partial_row, 0],
+                [H_TILE, 8],
+                target_memory=pl.MemorySpace.Vec,
+            )
+            stream_cmp_l_aligned = pl.load(
+                cmp_partial_l,
+                [stream_partial_row, 0],
+                [H_TILE, 8],
+                target_memory=pl.MemorySpace.Vec,
+            )
+            stream_cmp_m = stream_cmp_m_aligned[0:H_TILE, 0:1]
+            stream_cmp_l = stream_cmp_l_aligned[0:H_TILE, 0:1]
+            stream_cmp_o = pl.load(
+                cmp_partial_o,
+                [stream_partial_row, 0],
+                [H_TILE, HEAD_DIM],
+                target_memory=pl.MemorySpace.Vec,
+            )
+            stream_m_new = pl.maximum(stream_m, stream_cmp_m)
+            stream_alpha = pl.exp(pl.sub(stream_m, stream_m_new))
+            stream_beta = pl.exp(pl.sub(stream_cmp_m, stream_m_new))
+            stream_l = pl.add(
+                pl.mul(stream_alpha, stream_l),
+                pl.mul(stream_beta, stream_cmp_l),
+            )
+            stream_o = pl.add(
+                pl.row_expand_mul(stream_o, stream_alpha),
+                pl.row_expand_mul(stream_cmp_o, stream_beta),
+            )
+            stream_m = stream_m_new
+        stream_sink = pl.load(
+            attn_sink_col,
+            [stream_h0, 0],
+            [H_TILE, 1],
+            target_memory=pl.MemorySpace.Vec,
+        )
+        stream_sink_tile = pl.add(pl.sub(stream_m, stream_m), stream_sink)
+        stream_denom = pl.add(stream_l, pl.exp(pl.sub(stream_sink_tile, stream_m)))
+        stream_output = pl.row_expand_div(stream_o, stream_denom)
+        pl.store(stream_output, [stream_state_row, 0], stream_heads)
+
+    with pl.spmd(
+        stream_block_count,
+        name_hint="hca_stream_pack",
+        deps=[stream_heads_tid, rope_swap_tids[0], rope_cs_tids[0]],
+    ) as heads_tid:
+        stream_idx = pl.tile.get_block_idx()
+        stream_t = stream_idx // (H // H_TILE)
+        stream_h_tile = stream_idx - stream_t * (H // H_TILE)
+        stream_h0 = stream_h_tile * H_TILE
+        stream_state_row = stream_t * H + stream_h0
+        stream_output = stream_heads[
+            stream_state_row : stream_state_row + H_TILE, 0:HEAD_DIM
+        ]
+        stream_bf16 = pl.cast(stream_output, target_type=pl.BF16, mode="rint")
+        stream_rope = stream_output[0:H_TILE, NOPE_DIM:HEAD_DIM]
+        stream_cos_il = rope_cos_il[stream_t : stream_t + 1, 0:ROPE_DIM]
+        stream_sin_signed = rope_sin_signed[stream_t : stream_t + 1, 0:ROPE_DIM]
+        stream_swap_zero = pl.full([H_TILE, ROPE_DIM], dtype=pl.INT32, value=0)
+        stream_swap_idx = pl.col_expand_add(stream_swap_zero, rope_swap_idx[0:1, 0:ROPE_DIM])
+        stream_swapped = pl.gather(stream_rope, dim=-1, index=stream_swap_idx)
+        stream_rot = pl.add(
+            pl.col_expand_mul(stream_rope, stream_cos_il),
+            pl.col_expand_mul(stream_swapped, stream_sin_signed),
+        )
+        n_rope_bf16 = pl.cast(stream_rot, target_type=pl.BF16, mode="rint")
+        n_full_bf16 = pl.concat(stream_bf16[0:H_TILE, 0:NOPE_DIM], n_rope_bf16)
         for n_hi in pl.unroll(H_TILE):
-            n_pack_row = ((m_h0 + n_hi) // HEADS_PER_GROUP) * T_PAD + m_t
-            n_col = ((m_h0 + n_hi) % HEADS_PER_GROUP) * HEAD_DIM
-            # one HEAD_DIM-wide store per head row instead of two: concat the nope and
-            # inverse-RoPE halves on chip so the packed tensor takes one contiguous write.
-            n_full_head = n_full_bf16[n_hi : n_hi + 1, :]
-            o_packed_heads[n_pack_row : n_pack_row + 1, n_col : n_col + HEAD_DIM] = n_full_head
+            n_head = stream_h0 + n_hi
+            n_pack_row = (n_head // HEADS_PER_GROUP) * T_PAD + stream_t
+            n_col = (n_head % HEADS_PER_GROUP) * HEAD_DIM
+            o_packed_heads[
+                n_pack_row : n_pack_row + 1,
+                n_col : n_col + HEAD_DIM,
+            ] = n_full_bf16[n_hi : n_hi + 1, 0:HEAD_DIM]
 
-    return o_packed_heads, merge_tid
+    return o_packed_heads, heads_tid
 
 
 @pl.jit
@@ -379,8 +772,9 @@ def sparse_attn_hca_test(
     ori_kv: pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     window_swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
     cmp_kv: pl.Tensor[[CMP_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
-    cmp_block_table: pl.Tensor[[B_DYN, CMP_MAX_BLOCKS], pl.INT32],
-    cmp_sparse_indices: pl.Tensor[[T_DYN, CMP_TOPK], pl.INT32],
+    cmp_block_table: pl.Tensor[[B_DYN, CMP_TABLE_BLOCKS_DYN], pl.INT32],
+    position_ids: pl.Tensor[[T_DYN], pl.INT32],
+    kv_seq_lens: pl.Tensor[[B_DYN], pl.INT32],
     attn_sink: pl.Tensor[[H], pl.FP32],
     freqs_cos: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
     freqs_sin: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
@@ -388,16 +782,19 @@ def sparse_attn_hca_test(
 ):
     q.bind_dynamic(0, T_DYN)
     cmp_block_table.bind_dynamic(0, B_DYN)
+    cmp_block_table.bind_dynamic(1, CMP_TABLE_BLOCKS_DYN)
     window_swa_indices.bind_dynamic(0, T_DYN)
-    cmp_sparse_indices.bind_dynamic(0, T_DYN)
+    position_ids.bind_dynamic(0, T_DYN)
+    kv_seq_lens.bind_dynamic(0, B_DYN)
     freqs_cos.bind_dynamic(0, T_DYN)
     freqs_sin.bind_dynamic(0, T_DYN)
 
     cache_ready_dep = pl.system.task_dummy(deps=[])
     o_packed_flat = pl.reshape(o_packed_heads, [O_GROUPS * T_PAD, O_GROUP_IN])
-    o_packed_flat, heads_tid = sparse_attn_hca(
+    o_packed_flat, _heads_tid = sparse_attn_hca(
         q, ori_kv, window_swa_indices,
-        cmp_kv, cmp_block_table, cmp_sparse_indices,
+        cmp_kv, cmp_block_table,
+        position_ids, kv_seq_lens,
         attn_sink, freqs_cos, freqs_sin,
         o_packed_flat, cache_ready_dep,
     )
@@ -415,60 +812,68 @@ def golden_sparse_attn(tensors):
     window_swa_indices = tensors["window_swa_indices"]
     cmp_kv = tensors["cmp_kv"].float()
     cmp_block_table = tensors["cmp_block_table"]
-    cmp_sparse_indices = tensors["cmp_sparse_indices"]
+    position_ids = tensors["position_ids"].to(torch.int64)
+    kv_seq_lens = tensors["kv_seq_lens"].to(torch.int64)
     attn_sink = tensors["attn_sink"].float()
     cos = tensors["freqs_cos"].float()
     sin = tensors["freqs_sin"].float()
 
     o = torch.zeros(tokens, H, HEAD_DIM)
 
-    # Per-query-token attention. The window prefix is driven by window_swa_indices;
-    # cmp_sparse_indices contains compressed-cache slots only.
     for t in range(tokens):
         b = t // S
-        kv_rows = []
-        valid = []
+        item_rows = []
+        item_valid = []
+        raw_rows = []
+        raw_valid = []
 
         for raw in window_swa_indices[t].tolist():
             slot = int(raw)
             if slot >= 0:
                 blk_id = slot // BLOCK_SIZE
                 intra = slot % BLOCK_SIZE
-                kv_rows.append(ori_kv[blk_id, intra, 0])
-                valid.append(True)
+                raw_rows.append(ori_kv[blk_id, intra, 0])
+                raw_valid.append(True)
             else:
-                kv_rows.append(torch.zeros(HEAD_DIM, dtype=ori_kv.dtype))
+                raw_rows.append(torch.zeros(HEAD_DIM, dtype=ori_kv.dtype))
+                raw_valid.append(False)
+        raw_rows = torch.stack(raw_rows, dim=0)
+        raw_valid = torch.tensor(raw_valid, dtype=torch.bool)
+        for row_begin in range(0, WIN, ATTN_K_TILE):
+            item_rows.append(raw_rows[row_begin : row_begin + ATTN_K_TILE])
+            item_valid.append(raw_valid[row_begin : row_begin + ATTN_K_TILE])
+
+        compressed_rows = min(
+            (int(position_ids[t].item()) + 1) // COMPRESS_RATIO,
+            int(kv_seq_lens[b].item()) // COMPRESS_RATIO,
+            HCA_MAX_COMPRESSED_ROWS,
+        )
+        for row_begin in range(0, max(compressed_rows, 0), ATTN_K_TILE):
+            valid_rows = min(ATTN_K_TILE, compressed_rows - row_begin)
+            rows = []
+            valid = []
+            for lane in range(ATTN_K_TILE):
+                logical_row = row_begin + lane
+                if lane < valid_rows:
+                    logical_page = logical_row // BLOCK_SIZE
+                    physical_page = -1
+                    if logical_page < cmp_block_table.shape[1]:
+                        physical_page = int(cmp_block_table[b, logical_page].item())
+                    if 0 <= physical_page < cmp_kv.shape[0]:
+                        rows.append(cmp_kv[physical_page, logical_row % BLOCK_SIZE, 0])
+                        valid.append(True)
+                        continue
+                rows.append(torch.zeros(HEAD_DIM, dtype=cmp_kv.dtype))
                 valid.append(False)
+            item_rows.append(torch.stack(rows, dim=0))
+            item_valid.append(torch.tensor(valid, dtype=torch.bool))
 
-        for raw in cmp_sparse_indices[t].tolist():
-            if raw < 0:
-                kv_rows.append(torch.zeros(HEAD_DIM, dtype=ori_kv.dtype))
-                valid.append(False)
-                continue
-            cmp_slot = int(raw)
-            blk_id = int(cmp_block_table[b, cmp_slot // BLOCK_SIZE].item())
-            intra = cmp_slot % BLOCK_SIZE
-            kv_rows.append(cmp_kv[blk_id, intra, 0])
-            valid.append(True)
-
-        if not any(valid):
-            continue
-
-        pad_k = PADDED_TOPK - TOPK
-        if pad_k:
-            kv_rows.extend(torch.zeros(HEAD_DIM, dtype=ori_kv.dtype) for _ in range(pad_k))
-            valid.extend(False for _ in range(pad_k))
-
-        kv_b = torch.stack(kv_rows, dim=0)
-        valid_b = torch.tensor(valid, dtype=torch.bool)
         q_t = q[t]
 
         block_mi = []
         block_li = []
         block_oi = []
-        for tile_start in range(0, PADDED_TOPK, ATTN_K_TILE):
-            kv_tile = kv_b[tile_start:tile_start + ATTN_K_TILE]
-            valid_tile = valid_b[tile_start:tile_start + ATTN_K_TILE]
+        for kv_tile, valid_tile in zip(item_rows, item_valid):
             scores = (q_t @ kv_tile.T) * SOFTMAX_SCALE
             scores = scores.masked_fill(~valid_tile.unsqueeze(0), NEG_INF)
             mi = scores.max(dim=-1, keepdim=True).values
@@ -514,6 +919,7 @@ def build_tensor_specs(
     mixed_topk_fixture: bool = False,
     cache_window_replacement_fixture: bool = False,
     batch: int = B,
+    compressed_rows: int = 128,
 ):
     """Build deterministic demo tensors for the HCA standalone harness."""
     import torch
@@ -522,7 +928,34 @@ def build_tensor_specs(
 
     tokens = batch * S
 
-    cmp_valid = min(CMP_CAPACITY, TOPK - WIN)
+    if mixed_topk_fixture:
+        if batch != 4:
+            raise ValueError("mixed HCA length fixture requires batch=4")
+        compressed_rows_by_request = torch.tensor(
+            [128, 128, 1024, 4096], dtype=torch.int32
+        )
+    else:
+        compressed_rows_by_request = torch.full(
+            (batch,), compressed_rows, dtype=torch.int32
+        )
+
+    if bool((compressed_rows_by_request < 0).any()) or bool(
+        (compressed_rows_by_request > HCA_MAX_COMPRESSED_ROWS).any()
+    ):
+        raise ValueError(
+            f"compressed_rows must be in [0, {HCA_MAX_COMPRESSED_ROWS}], "
+            f"got {compressed_rows_by_request.tolist()}"
+        )
+    pages_per_request = (
+        (compressed_rows_by_request.to(torch.int64) + BLOCK_SIZE - 1) // BLOCK_SIZE
+    )
+    table_blocks = max(int(pages_per_request.max().item()), 1)
+    required_pages = int(pages_per_request.sum().item())
+    if required_pages > CMP_BLOCK_NUM:
+        raise ValueError(
+            f"HCA compressed pool needs {required_pages} pages, "
+            f"capacity is {CMP_BLOCK_NUM}"
+        )
 
     def init_q():
         """Initialize the query tensor used by the decode attention stage."""
@@ -567,30 +1000,29 @@ def build_tensor_specs(
 
     def init_cmp_block_table():
         """Build the demo block table for the compressed-cache pages."""
-        return block_table(batch=batch, table_blocks=CMP_MAX_BLOCKS, physical_blocks=CMP_BLOCK_NUM)
+        table = torch.full((batch, table_blocks), -1, dtype=torch.int32)
+        cursor = 0
+        for request in range(batch):
+            for logical_page in range(int(pages_per_request[request].item())):
+                table[request, logical_page] = (cursor * 7 + 3) % CMP_BLOCK_NUM
+                cursor += 1
+        return table
 
-    def init_cmp_sparse_indices():
-        """Build the sparse index list with a full window prefix and padded compressed tail.
-
-        The compressed tail width follows the active specialization (TOPK - WIN):
-        the pruned build narrows it to `cmp_valid` columns, the full-blocks
-        baseline keeps the whole CMP_TOPK-wide tail.
-        """
-        indices = torch.full((tokens, CMP_TOPK), -1, dtype=torch.int32)
-        if cmp_valid:
-            indices[:, :cmp_valid] = torch.arange(cmp_valid, dtype=torch.int32)
-        if short_window_fixture:
-            indices[:, :] = -1
-        if mixed_topk_fixture:
-            indices[:, :] = -1
-            mixed_cmp_valid = cmp_valid
-            if mixed_cmp_valid:
-                indices[:, :mixed_cmp_valid] = torch.arange(mixed_cmp_valid, dtype=torch.int32)
-        if cache_window_replacement_fixture:
-            indices[:, :] = -1
+    def query_compressed_rows():
+        rows = compressed_rows_by_request.repeat_interleave(S)
+        if short_window_fixture or cache_window_replacement_fixture:
+            rows.zero_()
         if causal_regression_fixture:
-            indices[0, :] = -1
-        return indices
+            rows[0] = 0
+        return rows
+
+    def init_position_ids():
+        rows = query_compressed_rows().to(torch.int64)
+        return torch.clamp(rows * COMPRESS_RATIO - 1, min=0).to(torch.int32)
+
+    def init_kv_seq_lens():
+        rows = query_compressed_rows().reshape(batch, S)
+        return (rows.max(dim=1).values.to(torch.int64) * COMPRESS_RATIO).to(torch.int32)
 
     def init_cos():
         """Build the split-half cosine table used by the inverse-RoPE reference."""
@@ -609,8 +1041,9 @@ def build_tensor_specs(
         TensorSpec("ori_kv", [ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_ori_kv),
         TensorSpec("window_swa_indices", [tokens, WIN], torch.int32, init_value=init_window_swa_indices),
         TensorSpec("cmp_kv", [CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], torch.bfloat16, init_value=init_cmp_kv),
-        TensorSpec("cmp_block_table", [batch, CMP_MAX_BLOCKS], torch.int32, init_value=init_cmp_block_table),
-        TensorSpec("cmp_sparse_indices", [tokens, CMP_TOPK], torch.int32, init_value=init_cmp_sparse_indices),
+        TensorSpec("cmp_block_table", [batch, table_blocks], torch.int32, init_value=init_cmp_block_table),
+        TensorSpec("position_ids", [tokens], torch.int32, init_value=init_position_ids),
+        TensorSpec("kv_seq_lens", [batch], torch.int32, init_value=init_kv_seq_lens),
         TensorSpec("attn_sink", [H], torch.float32, init_value=init_attn_sink),
         TensorSpec("freqs_cos", [tokens, ROPE_DIM], torch.bfloat16, init_value=init_cos),
         TensorSpec("freqs_sin", [tokens, ROPE_DIM], torch.bfloat16, init_value=init_sin),
@@ -626,15 +1059,17 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3", choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
     parser.add_argument("-b", "--batch", type=int, default=B,
-                        help=f"runtime request count; a multiple of 4 up to {B} (the compile-time "
+                        help=f"runtime request count in [1, {B}] (the compile-time "
                              "upper bound). The token axis is pl.dynamic, so one compiled program "
                              "serves every value.")
+    parser.add_argument("--compressed-rows", type=int, default=128,
+                        help="visible ratio-128 rows per query; use 8192 for the 1M ceiling")
     parser.add_argument("--causal-regression-fixture", action="store_true", default=False,
                         help="Amplify the S=2 future-window-slot regression.")
     parser.add_argument("--short-window-fixture", action="store_true", default=False,
                         help="Use a short-window topk row with valid prefix + -1 padding.")
     parser.add_argument("--mixed-topk-fixture", action="store_true", default=False,
-                        help="Use -1-padded window slots with valid compressed raw indices.")
+                        help="Use B=4 compressed histories for 16K, 16K, 128K, and 512K.")
     parser.add_argument("--cache-window-replacement-fixture", action="store_true", default=False,
                         help="Place a sentinel row inside the cache window prefix.")
     parser.add_argument("--golden-data", type=str, default=None)
@@ -645,10 +1080,17 @@ if __name__ == "__main__":
     parser.add_argument("--enable-pmu", nargs="?", const=2, default=0, type=int, choices=[0, 1, 2, 4])
     parser.add_argument("--dump-passes", action="store_true", default=False)
     args = parser.parse_args()
-    if args.batch < 4 or args.batch > B or args.batch % 4 != 0:
-        parser.error(f"--batch must be a multiple of 4 in [4, {B}], got {args.batch}")
+    if args.batch < 1 or args.batch > B:
+        parser.error(f"--batch must be in [1, {B}], got {args.batch}")
 
-    print(f"compress_ratio={COMPRESS_RATIO} -> TOPK={TOPK} SPARSE_BLOCKS={SPARSE_BLOCKS} PADDED_TOPK={PADDED_TOPK}", flush=True)
+    if args.mixed_topk_fixture:
+        workload = "compressed_rows/request=[128,128,1024,4096]"
+    else:
+        workload = (
+            f"compressed_rows={args.compressed_rows} "
+            f"work/query={(args.compressed_rows + ATTN_K_TILE - 1) // ATTN_K_TILE}"
+        )
+    print(f"compress_ratio={COMPRESS_RATIO} {workload}", flush=True)
 
     result = run_jit(
         fn=sparse_attn_hca_test,
@@ -658,6 +1100,7 @@ if __name__ == "__main__":
             args.mixed_topk_fixture,
             args.cache_window_replacement_fixture,
             batch=args.batch,
+            compressed_rows=args.compressed_rows,
         ),
         golden_fn=golden_sparse_attn,
         golden_data=args.golden_data,

--- a/models/deepseek_v4_flash_dspark/decode_sparse_attn_hca.py
+++ b/models/deepseek_v4_flash_dspark/decode_sparse_attn_hca.py
@@ -52,7 +52,11 @@ NEG_INF = -1.0e20
 ORI_MAX_BLOCKS = KV_ORI_MAX_BLOCKS
 ORI_BLOCK_NUM = KV_ORI_BLOCK_NUM
 CMP_BLOCK_NUM = KV_CMP_BLOCK_NUM
-HCA_MAX_COMPRESSED_ROWS = CMP_BLOCK_NUM * BLOCK_SIZE
+# The logical limit is per request; the physical pool is shared by the batch.
+# Host metadata builders below admit requests only while their summed page count
+# fits HCA_COMPRESSED_POOL_ROWS.
+HCA_MAX_COMPRESSED_ROWS = 1_048_576 // COMPRESS_RATIO
+HCA_COMPRESSED_POOL_ROWS = CMP_BLOCK_NUM * BLOCK_SIZE
 
 # tiling
 VALID_TOKEN_TILE = 8
@@ -71,10 +75,12 @@ ROPE_CS_T_TILE = 8
 T_PAD = ((T + 16 - 1) // 16) * 16
 
 assert WIN == ATTN_K_TILE, "HCA raw window must form one baseline-sized attention tile"
+assert HCA_MAX_COMPRESSED_ROWS <= HCA_COMPRESSED_POOL_ROWS
 assert ATTN_K_TILE % BLOCK_SIZE == 0, "HCA work must contain complete cache pages"
 assert H % QK_M_TILE == 0 and QK_M_TILE % H_TILE == 0
 assert BLOCK_SIZE % GATHER_RUN_TILE == 0, "a contiguous gather run must stay inside one cache block"
 assert HEAD_DIM == 2 * ATTN_D_TILE, "HCA stream matmuls split the head width into exactly two bounded tiles"
+assert S % ROPE_CS_T_TILE == 0, "each request must contain complete inverse-RoPE token tiles"
 
 
 @pl.jit.inline(auto_scope=False)
@@ -146,12 +152,14 @@ def sparse_attn_hca(
                 g_sk0 = g_wk0 + g_sub * GATHER_RUN_TILE
                 g_sdst = g_row0 + g_sk0
                 g_first = pl.read(window_swa_indices, [g_t, g_sk0])
-                g_last = pl.read(
-                    window_swa_indices,
-                    [g_t, g_sk0 + GATHER_RUN_TILE - 1],
-                )
-                g_run_ok = (g_last - g_first) + pl.min(g_first, 0) * GATHER_RUN_TILE
-                if g_run_ok == GATHER_RUN_TILE - 1:
+                g_run_matches = pl.cast(g_first >= 0, pl.INT32)
+                for g_dr in pl.unroll(GATHER_RUN_TILE):
+                    g_slot_i32 = pl.read(window_swa_indices, [g_t, g_sk0 + g_dr])
+                    g_run_matches = g_run_matches * pl.cast(
+                        g_slot_i32 == g_first + g_dr,
+                        pl.INT32,
+                    )
+                if g_run_matches == 1:
                     g_run_src = pl.cast(g_first, pl.INDEX)
                     raw_kv[
                         g_sdst : g_sdst + GATHER_RUN_TILE,
@@ -464,6 +472,15 @@ def sparse_attn_hca(
             gather_dst0 = gather_item * ATTN_K_TILE
             for gather_page in pl.unroll(CMP_PAGES_PER_WORK):
                 gather_page_col = gather_first_col + gather_page
+                gather_dst = gather_dst0 + gather_page * BLOCK_SIZE
+                cmp_work_kv[
+                    gather_dst : gather_dst + BLOCK_SIZE,
+                    0:HEAD_DIM,
+                ] = pl.full(
+                    [BLOCK_SIZE, HEAD_DIM],
+                    dtype=pl.BF16,
+                    value=0.0,
+                )
                 if gather_page_col < cmp_table_blocks:
                     gather_page_i32 = pl.read(
                         cmp_block_table,
@@ -473,7 +490,6 @@ def sparse_attn_hca(
                         if gather_page_i32 < cmp_block_num:
                             gather_page_id = pl.cast(gather_page_i32, pl.INDEX)
                             gather_src = gather_page_id * BLOCK_SIZE
-                            gather_dst = gather_dst0 + gather_page * BLOCK_SIZE
                             cmp_work_kv[
                                 gather_dst : gather_dst + BLOCK_SIZE,
                                 0:HEAD_DIM,
@@ -927,6 +943,14 @@ def build_tensor_specs(
     from utils import block_table
 
     tokens = batch * S
+
+    if batch < 1 or batch > B:
+        raise ValueError(f"HCA sparse-attention batch must be in [1, {B}], got {batch}")
+    if tokens % ROPE_CS_T_TILE != 0:
+        raise ValueError(
+            f"HCA sparse-attention token count {tokens} must be divisible by "
+            f"ROPE_CS_T_TILE={ROPE_CS_T_TILE}"
+        )
 
     if mixed_topk_fixture:
         if batch != 4:


### PR DESCRIPTION
- raise the HCA decode context ceiling to 1M without moving the global
  Flash model ceiling
- pass token-local QKV RoPE rows as `[T_DYN, ROPE_HEAD_DIM]` and
  compressed-boundary rows as a separate `[B, ROPE_HEAD_DIM // 2]`
  argument, so no 1M RoPE table is materialized on host or device
- drop the `cmp_sparse_indices` argument; `sparse_attn_hca` now takes
  `position_ids` and `kv_seq_lens` and derives each token's visible
  compressed row count itself
- size compressed work from the runtime `cmp_block_table` width as
  page-aligned 128-row items; work past a token's visible rows stores
  neutral softmax partials and skips its QK/PV matmuls
- split raw gather/transpose, compressed work, streaming merge, output
  projection, and HC-post lifetimes with manual scopes
- separate the per-request context ceiling `HCA_MAX_COMPRESSED_ROWS`
  from the batch-shared pool capacity `HCA_COMPRESSED_POOL_ROWS`
- zero-fill every compressed work page before its block-table lookup so
  an unmapped page cannot feed unwritten rows to the softmax
- compare every lane of a contiguous gather run instead of its two
  endpoints, so an interior unmapped slot takes the masked path
- share one token-count check between the TP1 and distributed fixtures
  and reject a request count outside `[1, B]`
- retain the `--tp` routing and inlined distributed output structure
  from #1003
- validated on A2/A3 at TP1, TP2, and TP4 for 128, 16K, and 1M contexts
  and the mixed `(16K, 16K, 128K, 512K)` fixture

The ratio-128 path has no indexer, so its compressed tail is the
deterministic full cache and the old Top-K list was always an identity
permutation whose length scaled with `MAX_SEQ_LEN`. Deriving the row
count from `position_ids` and `kv_seq_lens` turns that compile-time
bound into a runtime one and lets short requests skip matmuls a data
mask could not. Related to #962.