### PR TITLE
Add: DeepSeek-V4 dspark context-parallel prefill SWA, HCA and CSA

### DIFF
--- a/models/deepseek_v4_flash_dspark/prefill_csa.py
+++ b/models/deepseek_v4_flash_dspark/prefill_csa.py
@@ -6,6 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
+# ci: devices=2  # CI: 2-card run; borrows 2 cards via task-submit --device-num
 """DeepSeek-V4 packed prefill CSA attention: HC pre/post, ratio-4 compressor, indexer, sparse attention, cache writeback."""
 
 import functools
@@ -44,12 +45,14 @@ from prefill_indexer import (
     gen_shared_weight,
     golden_prefill_indexer_core,
     prefill_indexer,
+    prefill_indexer_query,
     topk_prefix_contract_error,
 )
 from prefill_indexer_compressor import (
     INNER_STATE_BLOCK_NUM,
     INNER_STATE_BLOCK_SIZE,
     INNER_STATE_MAX_BLOCKS,
+    prefill_indexer_compressor,
 )
 from qkv_proj_rope import golden_qkv_proj_rope, materialize_rope_rows_dynamic, qkv_proj_rope
 from rmsnorm import golden_rms_norm, rms_norm
@@ -63,12 +66,23 @@ from prefill_sparse_attn import (
     sparse_attn_physical,
 )
 
+import pypto.language.distributed as pld
+
+from prefill_kv_allgather import (
+    PREFILL_GROUP_CAP,
+    TP_SIZE,
+    prefill_kv_token_allgather_step,
+)
+from qkv_proj_rope import kv_proj_rope, q_proj_rope, rope_prepare
+
 
 # Largest runtime token count the prefill path accepts (Issue #905 P4).
 PREFILL_MAX_TOKENS = 8192
 
 # Dynamic shape variables.
 T_DYN = pl.dynamic("PREFILL_CSA_T_DYN")
+CP_Q_T_DYN = pl.dynamic("PREFILL_CSA_CP_Q_T_DYN")
+CP_KV_T_DYN = pl.dynamic("PREFILL_CSA_CP_KV_T_DYN")
 ORI_BLOCK_NUM_DYN = pl.dynamic("PREFILL_ORI_BLOCK_NUM_DYN")
 CMP_BLOCK_NUM_DYN = pl.dynamic("PREFILL_CMP_BLOCK_NUM_DYN")
 IDX_BLOCK_NUM_DYN = pl.dynamic("PREFILL_IDX_BLOCK_NUM_DYN")
@@ -1160,8 +1174,598 @@ def _quant_w_per_output_channel_local(w):
     return w_i32.to(torch.float16).to(torch.int8), (1.0 / scale_quant).float()
 
 
+
+@pl.jit.inline
+def prefill_attention_csa_cp(
+    x_hc_local: pl.Tensor[[CP_Q_T_DYN, HC_MULT, D], pl.FP32],
+    hc_attn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
+    hc_attn_scale: pl.Tensor[[3], pl.FP32],
+    hc_attn_base: pl.Tensor[[MIX_HC], pl.FP32],
+    attn_norm_w: pl.Tensor[[D], pl.BF16],
+    wq_a: pl.Tensor[[D, Q_LORA], pl.BF16],
+    wq_b: pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8],
+    wq_b_scale: pl.Tensor[[H * HEAD_DIM], pl.FP32],
+    wkv: pl.Tensor[[D, HEAD_DIM], pl.BF16],
+    gamma_cq: pl.Tensor[[Q_LORA], pl.BF16],
+    gamma_ckv: pl.Tensor[[HEAD_DIM], pl.BF16],
+    freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    cmp_wkv: pl.Tensor[[MAIN_OUT_DIM, D], pl.BF16],
+    cmp_wgate: pl.Tensor[[MAIN_OUT_DIM, D], pl.BF16],
+    cmp_ape: pl.Tensor[[COMPRESS_RATIO, MAIN_OUT_DIM], pl.FP32],
+    cmp_norm_w: pl.Tensor[[HEAD_DIM], pl.BF16],
+    compress_state: pl.Tensor[
+        [MAIN_STATE_BLOCK_NUM_DYN, CSA_STATE_BLOCK_SIZE, MAIN_COMPRESS_STATE_DIM], pl.FP32
+    ],
+    compress_state_block_table: pl.Tensor[[CSA_STATE_MAX_BLOCKS], pl.INT32],
+    hadamard_idx: pl.Tensor[[IDX_HEAD_DIM, IDX_HEAD_DIM], pl.BF16],
+    idx_wq_b: pl.Tensor[[Q_LORA, IDX_N_HEADS * IDX_HEAD_DIM], pl.INT8],
+    idx_wq_b_scale: pl.Tensor[[IDX_N_HEADS * IDX_HEAD_DIM], pl.FP32],
+    idx_weights_proj: pl.Tensor[[D, IDX_N_HEADS], pl.BF16],
+    inner_wkv: pl.Tensor[[INNER_OUT_DIM, D], pl.BF16],
+    inner_wgate: pl.Tensor[[INNER_OUT_DIM, D], pl.BF16],
+    inner_ape: pl.Tensor[[COMPRESS_RATIO, INNER_OUT_DIM], pl.FP32],
+    inner_norm_w: pl.Tensor[[IDX_HEAD_DIM], pl.BF16],
+    inner_compress_state: pl.Tensor[
+        [INNER_STATE_BLOCK_NUM_DYN, INNER_STATE_BLOCK_SIZE, INNER_COMPRESS_STATE_DIM], pl.FP32
+    ],
+    inner_compress_state_block_table: pl.Tensor[[INNER_STATE_MAX_BLOCKS], pl.INT32],
+    kv_cache: pl.InOut[pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
+    ori_block_table: pl.Tensor[[SPARSE_ORI_MAX_BLOCKS], pl.INT32],
+    ori_slot_mapping_full: pl.Tensor[[CP_KV_T_DYN], pl.INT64],
+    cmp_kv: pl.InOut[pl.Tensor[[CMP_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
+    cmp_block_table: pl.Tensor[[SPARSE_CMP_MAX_BLOCKS], pl.INT32],
+    idx_kv_cache: pl.InOut[pl.Tensor[[IDX_BLOCK_NUM_DYN, BLOCK_SIZE, 1, IDX_HEAD_DIM], pl.INT8]],
+    idx_kv_scale: pl.InOut[pl.Tensor[[IDX_BLOCK_NUM_DYN, BLOCK_SIZE, 1, 1], pl.FP32]],
+    idx_block_table: pl.Tensor[[IDX_CACHE_MAX_BLOCKS], pl.INT32],
+    position_ids_local: pl.Tensor[[CP_Q_T_DYN], pl.INT32],
+    position_ids_full: pl.Tensor[[CP_KV_T_DYN], pl.INT32],
+    cmp_slot_mapping_full: pl.Tensor[[CP_KV_T_DYN], pl.INT64],
+    idx_slot_mapping_full: pl.Tensor[[CP_KV_T_DYN], pl.INT64],
+    state_slot_mapping_full: pl.Tensor[[CP_KV_T_DYN], pl.INT64],
+    inner_state_slot_mapping_full: pl.Tensor[[CP_KV_T_DYN], pl.INT64],
+    attn_sink: pl.Tensor[[H], pl.FP32],
+    wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
+    wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
+    wo_b_scale: pl.Tensor[[D], pl.FP32],
+    x_out_local: pl.Out[pl.Tensor[[CP_Q_T_DYN, HC_MULT, D], pl.FP32]],
+    gather_window: pld.DistributedTensor[[PREFILL_GROUP_CAP, D], pl.BF16],
+    gather_signal: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
+    group_base: pl.Scalar[pl.INT32],
+    tp_rank: pl.Scalar[pl.INT32],
+):
+    """CSA block on one CP rank: local queries and indexer scoring; KV, compressor and indexer cache on the gathered stream."""
+    q_dim = pl.tensor.dim(x_hc_local, 0)
+    kv_dim = pl.tensor.dim(position_ids_full, 0)
+
+    x_mixed = pl.create_tensor([q_dim, D], dtype=pl.BF16)
+    post = pl.create_tensor([q_dim, HC_MULT], dtype=pl.FP32)
+    comb = pl.create_tensor([q_dim, HC_MULT * HC_MULT], dtype=pl.FP32)
+    hc_pre(x_hc_local, hc_attn_fn, hc_attn_scale, hc_attn_base, x_mixed, post, comb)
+
+    x_normed_local = pl.create_tensor([q_dim, D], dtype=pl.BF16)
+    rms_tid = rms_norm(x_mixed, attn_norm_w, x_normed_local)
+    late_dep = pl.system.task_dummy(deps=[rms_tid])
+
+    x_normed_full = pl.create_tensor([kv_dim, D], dtype=pl.BF16)
+    x_normed_full, gather_signal = prefill_kv_token_allgather_step(
+        x_normed_local, x_normed_full, gather_window, gather_signal, group_base, tp_rank,
+    )
+
+    rope_cos_local = pl.create_tensor([q_dim, ROPE_HEAD_DIM], dtype=pl.BF16)
+    rope_sin_local = pl.create_tensor([q_dim, ROPE_HEAD_DIM], dtype=pl.BF16)
+    materialize_rope_rows_dynamic(freqs_cos, freqs_sin, position_ids_local, rope_cos_local, rope_sin_local)
+    q_cos_il = pl.create_tensor([q_dim, ROPE_HEAD_DIM], dtype=pl.FP32)
+    q_sin_signed = pl.create_tensor([q_dim, ROPE_HEAD_DIM], dtype=pl.FP32)
+    q_swap_idx = pl.create_tensor([q_dim, ROPE_HEAD_DIM], dtype=pl.INT32)
+    rope_prepare(rope_cos_local, rope_sin_local, q_cos_il, q_sin_signed, q_swap_idx)
+
+    q = pl.create_tensor([q_dim, H, HEAD_DIM], dtype=pl.BF16)
+    qr = pl.create_tensor([q_dim, Q_LORA], dtype=pl.INT8)
+    qr_scale = pl.create_tensor([q_dim, 1], dtype=pl.FP32)
+    q_proj_rope(
+        x_normed_local, wq_a, wq_b, wq_b_scale, gamma_cq,
+        q_cos_il, q_sin_signed, q_swap_idx,
+        q, qr, qr_scale,
+    )
+
+    rope_cos_full = pl.create_tensor([kv_dim, ROPE_HEAD_DIM], dtype=pl.BF16)
+    rope_sin_full = pl.create_tensor([kv_dim, ROPE_HEAD_DIM], dtype=pl.BF16)
+    materialize_rope_rows_dynamic(freqs_cos, freqs_sin, position_ids_full, rope_cos_full, rope_sin_full)
+    kv_cos_il = pl.create_tensor([kv_dim, ROPE_HEAD_DIM], dtype=pl.FP32)
+    kv_sin_signed = pl.create_tensor([kv_dim, ROPE_HEAD_DIM], dtype=pl.FP32)
+    kv_swap_idx = pl.create_tensor([kv_dim, ROPE_HEAD_DIM], dtype=pl.INT32)
+    rope_prepare(rope_cos_full, rope_sin_full, kv_cos_il, kv_sin_signed, kv_swap_idx)
+
+    kv_full = pl.create_tensor([kv_dim, HEAD_DIM], dtype=pl.BF16)
+    kv_proj_rope(
+        x_normed_full, wkv, gamma_ckv,
+        kv_cos_il, kv_sin_signed, kv_swap_idx,
+        kv_full, late_dep,
+    )
+
+    ori_block_num = pl.tensor.dim(kv_cache, 0)
+    ori_cache_rows = ori_block_num * BLOCK_SIZE
+    kv_cache_flat = pl.reshape(kv_cache, [ori_cache_rows, HEAD_DIM])
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_csa_cp_cache_write"):
+        for write_t in pl.range(kv_dim):
+            write_row_raw = pl.read(ori_slot_mapping_full, [write_t])
+            if write_row_raw >= 0:
+                write_row = pl.cast(write_row_raw, pl.INDEX)
+                kv_cache_flat[write_row : write_row + 1, :] = kv_full[write_t : write_t + 1, :]
+
+    compressor_ratio4(
+        x_normed_full,
+        compress_state,
+        compress_state_block_table,
+        cmp_wkv,
+        cmp_wgate,
+        cmp_ape,
+        cmp_norm_w,
+        freqs_cos,
+        freqs_sin,
+        cmp_kv,
+        position_ids_full,
+        cmp_slot_mapping_full,
+        state_slot_mapping_full,
+    )
+
+    # Indexer cache half: gathered stream, global positions, unsliced mappings.
+    prefill_indexer_compressor(
+        x_normed_full,
+        inner_compress_state,
+        inner_compress_state_block_table,
+        inner_wkv,
+        inner_wgate,
+        inner_ape,
+        inner_norm_w,
+        freqs_cos,
+        freqs_sin,
+        hadamard_idx,
+        idx_kv_cache,
+        idx_kv_scale,
+        idx_block_table,
+        position_ids_full,
+        idx_slot_mapping_full,
+        inner_state_slot_mapping_full,
+    )
+
+    # Indexer query half: local rows only, half-width FP32 RoPE at local positions.
+    idx_cos = pl.create_tensor([q_dim, HALF_ROPE], dtype=pl.FP32)
+    idx_sin = pl.create_tensor([q_dim, HALF_ROPE], dtype=pl.FP32)
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_csa_cp_idx_halfrope"):
+        for idx_t in pl.range(q_dim):
+            idx_pos = pl.cast(pl.read(position_ids_local, [idx_t]), pl.INDEX)
+            idx_cos[idx_t : idx_t + 1, 0:HALF_ROPE] = pl.cast(
+                freqs_cos[idx_pos : idx_pos + 1, 0:HALF_ROPE], target_type=pl.FP32
+            )
+            idx_sin[idx_t : idx_t + 1, 0:HALF_ROPE] = pl.cast(
+                freqs_sin[idx_pos : idx_pos + 1, 0:HALF_ROPE], target_type=pl.FP32
+            )
+
+    cmp_topk_indices = pl.create_tensor([q_dim, IDX_TOPK], dtype=pl.INT32)
+    idx_score_unused = pl.create_tensor([q_dim, INDEXER_SCORE_CAP], dtype=pl.FP32)
+    idx_score_unused, cmp_topk_indices = prefill_indexer_query(
+        x_normed_local,
+        qr,
+        qr_scale,
+        idx_wq_b,
+        idx_wq_b_scale,
+        idx_weights_proj,
+        idx_cos,
+        idx_sin,
+        hadamard_idx,
+        idx_kv_cache,
+        idx_kv_scale,
+        idx_block_table,
+        idx_score_unused,
+        cmp_topk_indices,
+        position_ids_local,
+    )
+
+    swa_indices = pl.create_tensor([q_dim, WIN], dtype=pl.INT32)
+    valid_block_mask = pl.create_tensor([q_dim, VALID_BLOCK_MASK_COLS], dtype=pl.INT32)
+    csa_topk_blocks = (q_dim + CSA_TOPK_TOKEN_TILE - 1) // CSA_TOPK_TOKEN_TILE
+    for topk_block in pl.spmd(csa_topk_blocks, name_hint="prefill_csa_cp_sparse_idx_tile"):
+        topk_t0 = topk_block * CSA_TOPK_TOKEN_TILE
+        for topk_dt in pl.range(CSA_TOPK_TOKEN_TILE):
+            t_idx = topk_t0 + topk_dt
+            swa_row = pl.full([1, WIN], dtype=pl.INT32, value=-1)
+            mask_row = pl.full([1, VALID_BLOCK_MASK_COLS], dtype=pl.INT32, value=0)
+            if t_idx < q_dim:
+                abs_pos = pl.read(position_ids_local, [t_idx])
+                visible_cmp = pl.min((abs_pos + 1) // COMPRESS_RATIO, pl.cast(INDEXER_TOPK_CAP, pl.INT32))
+                for mask_sb in pl.unroll(PREFILL_ATTN_BLOCKS):
+                    cmp_lo = pl.max(mask_sb * PREFILL_ATTN_TILE - WIN, pl.cast(0, pl.INT32))
+                    cmp_hi = pl.min(
+                        (mask_sb + 1) * PREFILL_ATTN_TILE - WIN, pl.cast(SPARSE_CMP_BIAS_COLS, pl.INT32)
+                    )
+                    if cmp_lo < cmp_hi:
+                        if visible_cmp > cmp_lo:
+                            pl.write(mask_row, [0, mask_sb], pl.cast(1, pl.INT32))
+                window_valid = pl.min(pl.cast(WIN, pl.INT32), abs_pos + 1)
+                key_start_abs = abs_pos + 1 - window_valid
+                for win_col in pl.range(WIN):
+                    win_col_i32 = pl.cast(win_col, pl.INT32)
+                    if win_col_i32 < window_valid:
+                        key_abs = key_start_abs + win_col_i32
+                        blk_slot = key_abs // BLOCK_SIZE
+                        blk = pl.read(ori_block_table, [pl.cast(blk_slot, pl.INDEX)])
+                        if blk >= 0:
+                            row = pl.cast(blk * BLOCK_SIZE + (key_abs - blk_slot * BLOCK_SIZE), pl.INT32)
+                            pl.write(swa_row, [0, win_col], row)
+                            pl.write(mask_row, [0, win_col // PREFILL_ATTN_TILE], pl.cast(1, pl.INT32))
+                swa_indices[t_idx : t_idx + 1, 0:WIN] = swa_row
+                valid_block_mask[t_idx : t_idx + 1, 0:VALID_BLOCK_MASK_COLS] = mask_row
+
+    attn_out = pl.create_tensor([q_dim, D], dtype=pl.BF16)
+    sparse_attn_physical(
+        q,
+        kv_cache,
+        swa_indices,
+        cmp_kv,
+        cmp_block_table,
+        cmp_topk_indices,
+        valid_block_mask,
+        attn_sink,
+        rope_cos_local,
+        rope_sin_local,
+        wo_a,
+        wo_b,
+        wo_b_scale,
+        attn_out,
+    )
+
+    hc_post(attn_out, x_hc_local, post, comb, x_out_local)
+    return x_out_local, gather_signal
+
+
+@pl.jit
+def prefill_attention_csa_cp_test(
+    x_hc_local: pl.Tensor[[CP_Q_T_DYN, HC_MULT, D], pl.FP32],
+    hc_attn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
+    hc_attn_scale: pl.Tensor[[3], pl.FP32],
+    hc_attn_base: pl.Tensor[[MIX_HC], pl.FP32],
+    attn_norm_w: pl.Tensor[[D], pl.BF16],
+    wq_a: pl.Tensor[[D, Q_LORA], pl.BF16],
+    wq_b: pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8],
+    wq_b_scale: pl.Tensor[[H * HEAD_DIM], pl.FP32],
+    wkv: pl.Tensor[[D, HEAD_DIM], pl.BF16],
+    gamma_cq: pl.Tensor[[Q_LORA], pl.BF16],
+    gamma_ckv: pl.Tensor[[HEAD_DIM], pl.BF16],
+    freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    cmp_wkv: pl.Tensor[[MAIN_OUT_DIM, D], pl.BF16],
+    cmp_wgate: pl.Tensor[[MAIN_OUT_DIM, D], pl.BF16],
+    cmp_ape: pl.Tensor[[COMPRESS_RATIO, MAIN_OUT_DIM], pl.FP32],
+    cmp_norm_w: pl.Tensor[[HEAD_DIM], pl.BF16],
+    compress_state: pl.InOut[pl.Tensor[[MAIN_STATE_BLOCK_NUM_DYN, CSA_STATE_BLOCK_SIZE, MAIN_COMPRESS_STATE_DIM], pl.FP32]],
+    compress_state_block_table: pl.Tensor[[CSA_STATE_MAX_BLOCKS], pl.INT32],
+    hadamard_idx: pl.Tensor[[IDX_HEAD_DIM, IDX_HEAD_DIM], pl.BF16],
+    idx_wq_b: pl.Tensor[[Q_LORA, IDX_N_HEADS * IDX_HEAD_DIM], pl.INT8],
+    idx_wq_b_scale: pl.Tensor[[IDX_N_HEADS * IDX_HEAD_DIM], pl.FP32],
+    idx_weights_proj: pl.Tensor[[D, IDX_N_HEADS], pl.BF16],
+    inner_wkv: pl.Tensor[[INNER_OUT_DIM, D], pl.BF16],
+    inner_wgate: pl.Tensor[[INNER_OUT_DIM, D], pl.BF16],
+    inner_ape: pl.Tensor[[COMPRESS_RATIO, INNER_OUT_DIM], pl.FP32],
+    inner_norm_w: pl.Tensor[[IDX_HEAD_DIM], pl.BF16],
+    inner_compress_state: pl.InOut[pl.Tensor[[INNER_STATE_BLOCK_NUM_DYN, INNER_STATE_BLOCK_SIZE, INNER_COMPRESS_STATE_DIM], pl.FP32]],
+    inner_compress_state_block_table: pl.Tensor[[INNER_STATE_MAX_BLOCKS], pl.INT32],
+    kv_cache: pl.InOut[pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
+    ori_block_table: pl.Tensor[[SPARSE_ORI_MAX_BLOCKS], pl.INT32],
+    ori_slot_mapping_full: pl.Tensor[[CP_KV_T_DYN], pl.INT64],
+    cmp_kv: pl.InOut[pl.Tensor[[CMP_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
+    cmp_block_table: pl.Tensor[[SPARSE_CMP_MAX_BLOCKS], pl.INT32],
+    idx_kv_cache: pl.InOut[pl.Tensor[[IDX_BLOCK_NUM_DYN, BLOCK_SIZE, 1, IDX_HEAD_DIM], pl.INT8]],
+    idx_kv_scale: pl.InOut[pl.Tensor[[IDX_BLOCK_NUM_DYN, BLOCK_SIZE, 1, 1], pl.FP32]],
+    idx_block_table: pl.Tensor[[IDX_CACHE_MAX_BLOCKS], pl.INT32],
+    position_ids_local: pl.Tensor[[CP_Q_T_DYN], pl.INT32],
+    position_ids_full: pl.Tensor[[CP_KV_T_DYN], pl.INT32],
+    cmp_slot_mapping_full: pl.Tensor[[CP_KV_T_DYN], pl.INT64],
+    idx_slot_mapping_full: pl.Tensor[[CP_KV_T_DYN], pl.INT64],
+    state_slot_mapping_full: pl.Tensor[[CP_KV_T_DYN], pl.INT64],
+    inner_state_slot_mapping_full: pl.Tensor[[CP_KV_T_DYN], pl.INT64],
+    attn_sink: pl.Tensor[[H], pl.FP32],
+    wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
+    wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
+    wo_b_scale: pl.Tensor[[D], pl.FP32],
+    x_out_local: pl.Out[pl.Tensor[[CP_Q_T_DYN, HC_MULT, D], pl.FP32]],
+    gather_window: pld.DistributedTensor[[PREFILL_GROUP_CAP, D], pl.BF16],
+    gather_signal: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
+    group_base: pl.Scalar[pl.INT32],
+    tp_rank: pl.Scalar[pl.INT32],
+):
+    """Run one CP rank's share of a CSA block."""
+    x_hc_local.bind_dynamic(0, CP_Q_T_DYN)
+    compress_state.bind_dynamic(0, MAIN_STATE_BLOCK_NUM_DYN)
+    inner_compress_state.bind_dynamic(0, INNER_STATE_BLOCK_NUM_DYN)
+    kv_cache.bind_dynamic(0, ORI_BLOCK_NUM_DYN)
+    cmp_kv.bind_dynamic(0, CMP_BLOCK_NUM_DYN)
+    idx_kv_cache.bind_dynamic(0, IDX_BLOCK_NUM_DYN)
+    idx_kv_scale.bind_dynamic(0, IDX_BLOCK_NUM_DYN)
+    ori_slot_mapping_full.bind_dynamic(0, CP_KV_T_DYN)
+    position_ids_local.bind_dynamic(0, CP_Q_T_DYN)
+    position_ids_full.bind_dynamic(0, CP_KV_T_DYN)
+    cmp_slot_mapping_full.bind_dynamic(0, CP_KV_T_DYN)
+    idx_slot_mapping_full.bind_dynamic(0, CP_KV_T_DYN)
+    state_slot_mapping_full.bind_dynamic(0, CP_KV_T_DYN)
+    inner_state_slot_mapping_full.bind_dynamic(0, CP_KV_T_DYN)
+    x_out_local.bind_dynamic(0, CP_Q_T_DYN)
+    x_out_local, gather_signal = prefill_attention_csa_cp(
+        x_hc_local,
+        hc_attn_fn,
+        hc_attn_scale,
+        hc_attn_base,
+        attn_norm_w,
+        wq_a,
+        wq_b,
+        wq_b_scale,
+        wkv,
+        gamma_cq,
+        gamma_ckv,
+        freqs_cos,
+        freqs_sin,
+        cmp_wkv,
+        cmp_wgate,
+        cmp_ape,
+        cmp_norm_w,
+        compress_state,
+        compress_state_block_table,
+        hadamard_idx,
+        idx_wq_b,
+        idx_wq_b_scale,
+        idx_weights_proj,
+        inner_wkv,
+        inner_wgate,
+        inner_ape,
+        inner_norm_w,
+        inner_compress_state,
+        inner_compress_state_block_table,
+        kv_cache,
+        ori_block_table,
+        ori_slot_mapping_full,
+        cmp_kv,
+        cmp_block_table,
+        idx_kv_cache,
+        idx_kv_scale,
+        idx_block_table,
+        position_ids_local,
+        position_ids_full,
+        cmp_slot_mapping_full,
+        idx_slot_mapping_full,
+        state_slot_mapping_full,
+        inner_state_slot_mapping_full,
+        attn_sink,
+        wo_a,
+        wo_b,
+        wo_b_scale,
+        x_out_local,
+        gather_window, gather_signal, group_base, tp_rank,
+    )
+    return x_out_local
+
+
+@pl.jit.host
+def l3_prefill_attention_csa_cp(
+    x_hc_local: pl.Tensor[[TP_SIZE, CP_Q_T_DYN, HC_MULT, D], pl.FP32],
+    hc_attn_fn: pl.Tensor[[TP_SIZE, MIX_HC, HC_DIM], pl.FP32],
+    hc_attn_scale: pl.Tensor[[TP_SIZE, 3], pl.FP32],
+    hc_attn_base: pl.Tensor[[TP_SIZE, MIX_HC], pl.FP32],
+    attn_norm_w: pl.Tensor[[TP_SIZE, D], pl.BF16],
+    wq_a: pl.Tensor[[TP_SIZE, D, Q_LORA], pl.BF16],
+    wq_b: pl.Tensor[[TP_SIZE, Q_LORA, H * HEAD_DIM], pl.INT8],
+    wq_b_scale: pl.Tensor[[TP_SIZE, H * HEAD_DIM], pl.FP32],
+    wkv: pl.Tensor[[TP_SIZE, D, HEAD_DIM], pl.BF16],
+    gamma_cq: pl.Tensor[[TP_SIZE, Q_LORA], pl.BF16],
+    gamma_ckv: pl.Tensor[[TP_SIZE, HEAD_DIM], pl.BF16],
+    freqs_cos: pl.Tensor[[TP_SIZE, MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[TP_SIZE, MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    cmp_wkv: pl.Tensor[[TP_SIZE, MAIN_OUT_DIM, D], pl.BF16],
+    cmp_wgate: pl.Tensor[[TP_SIZE, MAIN_OUT_DIM, D], pl.BF16],
+    cmp_ape: pl.Tensor[[TP_SIZE, COMPRESS_RATIO, MAIN_OUT_DIM], pl.FP32],
+    cmp_norm_w: pl.Tensor[[TP_SIZE, HEAD_DIM], pl.BF16],
+    compress_state: pl.InOut[pl.Tensor[[TP_SIZE, MAIN_STATE_BLOCK_NUM_DYN, CSA_STATE_BLOCK_SIZE, MAIN_COMPRESS_STATE_DIM], pl.FP32]],
+    compress_state_block_table: pl.Tensor[[TP_SIZE, CSA_STATE_MAX_BLOCKS], pl.INT32],
+    hadamard_idx: pl.Tensor[[TP_SIZE, IDX_HEAD_DIM, IDX_HEAD_DIM], pl.BF16],
+    idx_wq_b: pl.Tensor[[TP_SIZE, Q_LORA, IDX_N_HEADS * IDX_HEAD_DIM], pl.INT8],
+    idx_wq_b_scale: pl.Tensor[[TP_SIZE, IDX_N_HEADS * IDX_HEAD_DIM], pl.FP32],
+    idx_weights_proj: pl.Tensor[[TP_SIZE, D, IDX_N_HEADS], pl.BF16],
+    inner_wkv: pl.Tensor[[TP_SIZE, INNER_OUT_DIM, D], pl.BF16],
+    inner_wgate: pl.Tensor[[TP_SIZE, INNER_OUT_DIM, D], pl.BF16],
+    inner_ape: pl.Tensor[[TP_SIZE, COMPRESS_RATIO, INNER_OUT_DIM], pl.FP32],
+    inner_norm_w: pl.Tensor[[TP_SIZE, IDX_HEAD_DIM], pl.BF16],
+    inner_compress_state: pl.InOut[pl.Tensor[[TP_SIZE, INNER_STATE_BLOCK_NUM_DYN, INNER_STATE_BLOCK_SIZE, INNER_COMPRESS_STATE_DIM], pl.FP32]],
+    inner_compress_state_block_table: pl.Tensor[[TP_SIZE, INNER_STATE_MAX_BLOCKS], pl.INT32],
+    kv_cache: pl.InOut[pl.Tensor[[TP_SIZE, ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
+    ori_block_table: pl.Tensor[[TP_SIZE, SPARSE_ORI_MAX_BLOCKS], pl.INT32],
+    ori_slot_mapping_full: pl.Tensor[[TP_SIZE, CP_KV_T_DYN], pl.INT64],
+    cmp_kv: pl.InOut[pl.Tensor[[TP_SIZE, CMP_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
+    cmp_block_table: pl.Tensor[[TP_SIZE, SPARSE_CMP_MAX_BLOCKS], pl.INT32],
+    idx_kv_cache: pl.InOut[pl.Tensor[[TP_SIZE, IDX_BLOCK_NUM_DYN, BLOCK_SIZE, 1, IDX_HEAD_DIM], pl.INT8]],
+    idx_kv_scale: pl.InOut[pl.Tensor[[TP_SIZE, IDX_BLOCK_NUM_DYN, BLOCK_SIZE, 1, 1], pl.FP32]],
+    idx_block_table: pl.Tensor[[TP_SIZE, IDX_CACHE_MAX_BLOCKS], pl.INT32],
+    position_ids_local: pl.Tensor[[TP_SIZE, CP_Q_T_DYN], pl.INT32],
+    position_ids_full: pl.Tensor[[TP_SIZE, CP_KV_T_DYN], pl.INT32],
+    cmp_slot_mapping_full: pl.Tensor[[TP_SIZE, CP_KV_T_DYN], pl.INT64],
+    idx_slot_mapping_full: pl.Tensor[[TP_SIZE, CP_KV_T_DYN], pl.INT64],
+    state_slot_mapping_full: pl.Tensor[[TP_SIZE, CP_KV_T_DYN], pl.INT64],
+    inner_state_slot_mapping_full: pl.Tensor[[TP_SIZE, CP_KV_T_DYN], pl.INT64],
+    attn_sink: pl.Tensor[[TP_SIZE, H], pl.FP32],
+    wo_a: pl.Tensor[[TP_SIZE, O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
+    wo_b: pl.Tensor[[TP_SIZE, D, O_GROUPS * O_LORA], pl.INT8],
+    wo_b_scale: pl.Tensor[[TP_SIZE, D], pl.FP32],
+    x_out_local: pl.Out[pl.Tensor[[TP_SIZE, CP_Q_T_DYN, HC_MULT, D], pl.FP32]],
+):
+    """Launch one CP group's CSA block, one child per rank."""
+    x_hc_local.bind_dynamic(1, CP_Q_T_DYN)
+    compress_state.bind_dynamic(1, MAIN_STATE_BLOCK_NUM_DYN)
+    inner_compress_state.bind_dynamic(1, INNER_STATE_BLOCK_NUM_DYN)
+    kv_cache.bind_dynamic(1, ORI_BLOCK_NUM_DYN)
+    cmp_kv.bind_dynamic(1, CMP_BLOCK_NUM_DYN)
+    idx_kv_cache.bind_dynamic(1, IDX_BLOCK_NUM_DYN)
+    idx_kv_scale.bind_dynamic(1, IDX_BLOCK_NUM_DYN)
+    ori_slot_mapping_full.bind_dynamic(1, CP_KV_T_DYN)
+    position_ids_local.bind_dynamic(1, CP_Q_T_DYN)
+    position_ids_full.bind_dynamic(1, CP_KV_T_DYN)
+    cmp_slot_mapping_full.bind_dynamic(1, CP_KV_T_DYN)
+    idx_slot_mapping_full.bind_dynamic(1, CP_KV_T_DYN)
+    state_slot_mapping_full.bind_dynamic(1, CP_KV_T_DYN)
+    inner_state_slot_mapping_full.bind_dynamic(1, CP_KV_T_DYN)
+    x_out_local.bind_dynamic(1, CP_Q_T_DYN)
+    gather_window_buf = pld.alloc_window_buffer([PREFILL_GROUP_CAP, D], dtype=pl.BF16)
+    gather_signal_buf = pld.alloc_window_buffer([TP_SIZE, 1], dtype=pl.INT32)
+
+    for rank in pl.range(pld.world_size()):
+        gather_window = pld.window(gather_window_buf, [PREFILL_GROUP_CAP, D], dtype=pl.BF16)
+        gather_signal = pld.window(gather_signal_buf, [TP_SIZE, 1], dtype=pl.INT32)
+        prefill_attention_csa_cp_test(
+            x_hc_local[rank],
+            hc_attn_fn[rank],
+            hc_attn_scale[rank],
+            hc_attn_base[rank],
+            attn_norm_w[rank],
+            wq_a[rank],
+            wq_b[rank],
+            wq_b_scale[rank],
+            wkv[rank],
+            gamma_cq[rank],
+            gamma_ckv[rank],
+            freqs_cos[rank],
+            freqs_sin[rank],
+            cmp_wkv[rank],
+            cmp_wgate[rank],
+            cmp_ape[rank],
+            cmp_norm_w[rank],
+            compress_state[rank],
+            compress_state_block_table[rank],
+            hadamard_idx[rank],
+            idx_wq_b[rank],
+            idx_wq_b_scale[rank],
+            idx_weights_proj[rank],
+            inner_wkv[rank],
+            inner_wgate[rank],
+            inner_ape[rank],
+            inner_norm_w[rank],
+            inner_compress_state[rank],
+            inner_compress_state_block_table[rank],
+            kv_cache[rank],
+            ori_block_table[rank],
+            ori_slot_mapping_full[rank],
+            cmp_kv[rank],
+            cmp_block_table[rank],
+            idx_kv_cache[rank],
+            idx_kv_scale[rank],
+            idx_block_table[rank],
+            position_ids_local[rank],
+            position_ids_full[rank],
+            cmp_slot_mapping_full[rank],
+            idx_slot_mapping_full[rank],
+            state_slot_mapping_full[rank],
+            inner_state_slot_mapping_full[rank],
+            attn_sink[rank],
+            wo_a[rank],
+            wo_b[rank],
+            wo_b_scale[rank],
+            x_out_local[rank],
+            gather_window, gather_signal, 0, rank,
+            device=rank,
+        )
+
+
+
+def build_cp_tensor_specs(
+    start_pos: int = START_POS,
+    token_count: int = PREFILL_SEQ,
+    tp_size: int = TP_SIZE,
+):
+    """Split the single-die specs across the group: query side per rank, KV side whole."""
+    from golden import TensorSpec
+    from prefill_kv_allgather import cp_stack, materialize_spec
+
+    if token_count % tp_size != 0:
+        raise ValueError(f"token_count={token_count} must be a multiple of tp_size={tp_size}")
+    local_t = token_count // tp_size
+
+    full_names = (
+        "ori_slot_mapping",
+        "cmp_slot_mapping",
+        "idx_slot_mapping",
+        "state_slot_mapping",
+        "inner_state_slot_mapping",
+    )
+
+    specs = []
+    for spec in build_tensor_specs(start_pos, token_count):
+        value = materialize_spec(spec)
+        if spec.name == "x_hc":
+            specs.append(TensorSpec(
+                "x_hc_local", [tp_size, local_t, HC_MULT, D], spec.dtype,
+                init_value=value.reshape(tp_size, local_t, HC_MULT, D).contiguous(),
+            ))
+        elif spec.name in full_names:
+            specs.append(TensorSpec(
+                f"{spec.name}_full", [tp_size, token_count], spec.dtype,
+                init_value=cp_stack(value, tp_size),
+            ))
+        elif spec.name == "position_ids":
+            specs.append(TensorSpec(
+                "position_ids_local", [tp_size, local_t], spec.dtype,
+                init_value=value.reshape(tp_size, local_t).contiguous(),
+            ))
+            specs.append(TensorSpec(
+                "position_ids_full", [tp_size, token_count], spec.dtype,
+                init_value=cp_stack(value, tp_size),
+            ))
+        elif spec.name == "x_out":
+            specs.append(TensorSpec(
+                "x_out_local", [tp_size, local_t, HC_MULT, D], spec.dtype, is_output=True,
+            ))
+        else:
+            specs.append(TensorSpec(
+                spec.name, [tp_size, *spec.shape], spec.dtype,
+                init_value=cp_stack(value, tp_size), is_output=spec.is_output,
+            ))
+    return specs
+
+
+def golden_prefill_attention_csa_cp(tensors):
+    """Single-die reference over the whole stream, sliced per rank; replicated caches compared too."""
+    import torch
+
+    tp_size, local_t = tensors["x_hc_local"].shape[0], tensors["x_hc_local"].shape[1]
+    token_count = tp_size * local_t
+
+    shared = (
+        "hc_attn_fn", "hc_attn_scale", "hc_attn_base", "attn_norm_w",
+        "wq_a", "wq_b", "wq_b_scale", "wkv", "gamma_cq", "gamma_ckv",
+        "freqs_cos", "freqs_sin", "cmp_wkv", "cmp_wgate", "cmp_ape", "cmp_norm_w",
+        "compress_state_block_table", "hadamard_idx", "idx_wq_b", "idx_wq_b_scale",
+        "idx_weights_proj", "inner_wkv", "inner_wgate", "inner_ape", "inner_norm_w",
+        "inner_compress_state_block_table", "ori_block_table", "cmp_block_table",
+        "idx_block_table", "attn_sink", "wo_a", "wo_b", "wo_b_scale",
+    )
+    full = {name: tensors[name][0] for name in shared}
+    full["x_hc"] = tensors["x_hc_local"].reshape(token_count, HC_MULT, D)
+    for name in ("compress_state", "inner_compress_state", "kv_cache", "cmp_kv",
+                 "idx_kv_cache", "idx_kv_scale"):
+        full[name] = tensors[name][0].clone()
+    for name in ("ori_slot_mapping", "cmp_slot_mapping", "idx_slot_mapping",
+                 "state_slot_mapping", "inner_state_slot_mapping"):
+        full[name] = tensors[f"{name}_full"][0]
+    full["position_ids"] = tensors["position_ids_full"][0]
+    full["x_out"] = torch.zeros(token_count, HC_MULT, D, dtype=torch.float32)
+
+    golden_prefill_attention_csa(full)
+
+    tensors["x_out_local"][:] = full["x_out"].reshape(tp_size, local_t, HC_MULT, D)
+    for name in ("compress_state", "inner_compress_state", "kv_cache", "cmp_kv",
+                 "idx_kv_cache", "idx_kv_scale"):
+        tensors[name][:] = full[name].unsqueeze(0).expand(tp_size, *full[name].shape)
+
+
 if __name__ == "__main__":
     import argparse
+
     from golden import ratio_allclose, ratio_reldiff, run_jit
 
     parser = argparse.ArgumentParser(
@@ -1170,67 +1774,100 @@ if __name__ == "__main__":
     parser.add_argument(
         "-p", "--platform", type=str, default="a2a3", choices=["a2a3", "a2a3sim", "a5", "a5sim"]
     )
-    parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--compile-only", action="store_true", default=False)
     parser.add_argument(
-        "--start-pos",
-        type=int,
-        default=START_POS,
-        help="context_len (multiple of S=WIN); fixture-only, lowered into token metadata.",
+        "-d", "--device", type=str, default=",".join(str(i) for i in range(TP_SIZE)),
+        help="comma-separated rank group; one ID at --tp 1",
     )
     parser.add_argument(
-        "--token-count",
-        "--num-tokens",
-        dest="token_count",
-        type=int,
-        default=PREFILL_SEQ,
-        help="Physical query-token extent, up to 8192.",
+        "--tp", type=int, default=TP_SIZE, help="rank-group size; must match the import-time --tp"
+    )
+    parser.add_argument("--compile-only", action="store_true", default=False)
+    parser.add_argument("--start-pos", type=int, default=START_POS)
+    parser.add_argument(
+        "--token-count", "--num-tokens", dest="token_count", type=int, default=PREFILL_SEQ,
+        help="Physical query-token extent across the group; must divide by --tp.",
     )
     parser.add_argument("--enable-chip-swimlane", action="store_true", default=False)
     parser.add_argument("--enable-dep-gen", action="store_true", default=False)
     parser.add_argument("--dump-passes", action="store_true", default=False)
     args = parser.parse_args()
-    # A start_pos suffix attends WIN + up-to-INDEXER_SCORE_CAP compressed rows. The sparse-attn PV
-    # matmul casts the softmax probabilities to BF16 (prefill_sparse_attn), so accumulating over
-    # more rows adds ~1 extra BF16 ULP of x_out drift vs full prefill -- the bad points cluster at
-    # ~2 BF16 ULP. Measured at start_pos=896 (the 8-block worst case) the bad fraction is only
-    # 0.058% at diff_thd=8e-3 (vs 0.5% at 1/128). So bump the per-point bar to 8e-3 (== kv_cache
-    # rtol = 2 BF16 ULP) and the single-point cap to 2 (worst rdiff 1.37, from benign near-zero
-    # elements), but keep the 0.5% fraction bar identical to full prefill.
-    x_out_diff_thd, x_out_max_diff = (8e-3, 2) if args.start_pos else (5e-3, 1)
 
-    result = run_jit(
-        fn=prefill_attention_csa_test,
-        specs=build_tensor_specs(
-            args.start_pos,
-            args.token_count,
-        ),
-        golden_fn=golden_prefill_attention_csa,
-        compile_cfg=dict(dump_passes=args.dump_passes),
-        runtime_cfg=dict(
-            platform=args.platform,
-            device_id=args.device,
-            enable_chip_swimlane=args.enable_chip_swimlane,
-            enable_dep_gen=args.enable_dep_gen,
-        ),
-        rtol=1e-2,
-        atol=1e-2,
-        compile_only=args.compile_only,
-        compare_fn={
-            "x_out": ratio_reldiff(
+    # A start_pos suffix attends WIN + up-to-INDEXER_SCORE_CAP compressed rows, so the BF16 PV
+    # accumulation drifts by ~1 extra ULP; bump the per-point bar and the single-point cap but
+    # keep the 0.5% fraction bar identical to full prefill.
+    x_out_diff_thd, x_out_max_diff = (8e-3, 2) if args.start_pos else (5e-3, 1)
+    cache_compare = {
+        "kv_cache": ratio_allclose(atol=1e-4, rtol=1.0 / 128),
+        "cmp_kv": ratio_allclose(atol=1e-4, rtol=1.0 / 128),
+        "compress_state": ratio_allclose(atol=1e-3, rtol=1e-3),
+        "inner_compress_state": ratio_allclose(atol=1e-3, rtol=1e-3),
+        # INT8 quant-on-write: one LSB of rounding drift on a bounded row fraction.
+        "idx_kv_cache": ratio_allclose(atol=1, rtol=0, max_error_ratio=0.01),
+        "idx_kv_scale": ratio_allclose(atol=1e-4, rtol=1.0 / 128, max_error_ratio=0.01),
+    }
+
+    if args.tp != TP_SIZE:
+        raise SystemExit(f"--tp={args.tp} does not match import-time TP_SIZE={TP_SIZE}")
+    device_ids = [int(device) for device in args.device.split(",")]
+    if len(device_ids) != TP_SIZE:
+        parser.error(f"need exactly {TP_SIZE} devices, got {device_ids}")
+    if args.token_count % TP_SIZE != 0:
+        parser.error(f"--token-count must be a multiple of --tp={TP_SIZE}, got {args.token_count}")
+
+    if TP_SIZE == 1:
+        result = run_jit(
+            fn=prefill_attention_csa_test,
+            specs=build_tensor_specs(args.start_pos, args.token_count),
+            golden_fn=golden_prefill_attention_csa,
+            compile_cfg=dict(dump_passes=args.dump_passes),
+            runtime_cfg=dict(
+                platform=args.platform,
+                device_id=device_ids[0],
+                enable_chip_swimlane=args.enable_chip_swimlane,
+                enable_dep_gen=args.enable_dep_gen,
+            ),
+            compile_only=args.compile_only,
+            rtol=1e-2,
+            atol=1e-2,
+            compare_fn={
+                "x_out": ratio_reldiff(
                 diff_thd=x_out_diff_thd,
                 pct_thd=0.005,
                 max_diff_hd=x_out_max_diff,
+                ),
+                "kv_cache": ratio_allclose(atol=1e-4, rtol=1.0 / 128),
+                "cmp_kv": ratio_allclose(atol=1e-4, rtol=1.0 / 128),
+                "compress_state": ratio_allclose(atol=1e-3, rtol=1e-3),
+                "inner_compress_state": ratio_allclose(atol=1e-3, rtol=1e-3),
+                # INT8 quant-on-write: one LSB of rounding drift on a bounded row fraction.
+                "idx_kv_cache": ratio_allclose(atol=1, rtol=0, max_error_ratio=0.01),
+                "idx_kv_scale": ratio_allclose(atol=1e-4, rtol=1.0 / 128, max_error_ratio=0.01),
+            },
+        )
+    else:
+        from pypto.ir.distributed_compiled_program import DistributedConfig
+
+        result = run_jit(
+            fn=l3_prefill_attention_csa_cp,
+            specs=build_cp_tensor_specs(args.start_pos, args.token_count, TP_SIZE),
+            golden_fn=golden_prefill_attention_csa_cp,
+            compile_cfg=dict(
+                dump_passes=args.dump_passes,
+                distributed_config=DistributedConfig(device_ids=device_ids, num_sub_workers=0),
             ),
-            "kv_cache": ratio_allclose(atol=1e-4, rtol=1.0 / 128),
-            "cmp_kv": ratio_allclose(atol=1e-4, rtol=1.0 / 128),
-            "compress_state": ratio_allclose(atol=1e-3, rtol=1e-3),
-            "inner_compress_state": ratio_allclose(atol=1e-3, rtol=1e-3),
-            # INT8 quant-on-write: one LSB of rounding drift on a bounded row fraction.
-            "idx_kv_cache": ratio_allclose(atol=1, rtol=0, max_error_ratio=0.01),
-            "idx_kv_scale": ratio_allclose(atol=1e-4, rtol=1.0 / 128, max_error_ratio=0.01),
-        },
-    )
+            runtime_cfg=dict(platform=args.platform),
+            compile_only=args.compile_only,
+            rtol=1e-2,
+            atol=1e-2,
+            compare_fn={
+                "x_out_local": ratio_reldiff(
+                diff_thd=x_out_diff_thd,
+                pct_thd=0.005,
+                max_diff_hd=x_out_max_diff,
+                ),
+                **cache_compare,
+            },
+        )
     if not result.passed:
         if result.error:
             print(result.error)

--- a/models/deepseek_v4_flash_dspark/prefill_hca.py
+++ b/models/deepseek_v4_flash_dspark/prefill_hca.py
@@ -6,6 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
+# ci: devices=2  # CI: 2-card run; borrows 2 cards via task-submit --device-num
 """DeepSeek-V4 packed prefill HCA (ratio-128) attention over one contiguous run of <=T tokens."""
 
 import functools
@@ -44,9 +45,20 @@ from prefill_sparse_attn import (
     sparse_attn_physical,
 )
 
+import pypto.language.distributed as pld
+
+from prefill_kv_allgather import (
+    PREFILL_GROUP_CAP,
+    TP_SIZE,
+    prefill_kv_token_allgather_step,
+)
+from qkv_proj_rope import kv_proj_rope, q_proj_rope, rope_prepare
+
 
 # Dynamic shape variables.
 T_DYN = pl.dynamic("PREFILL_HCA_T_DYN")
+CP_Q_T_DYN = pl.dynamic("PREFILL_HCA_CP_Q_T_DYN")
+CP_KV_T_DYN = pl.dynamic("PREFILL_HCA_CP_KV_T_DYN")
 ORI_BLOCK_NUM_DYN = pl.dynamic("PREFILL_ORI_BLOCK_NUM_DYN")
 CMP_BLOCK_NUM_DYN = pl.dynamic("PREFILL_CMP_BLOCK_NUM_DYN")
 STATE_BLOCK_NUM_DYN = pl.dynamic("PREFILL_HCA_STATE_BLOCK_NUM_DYN")
@@ -761,8 +773,412 @@ def build_tensor_specs(start_pos: int = START_POS, token_count: int = PREFILL_SE
     ]
 
 
+
+@pl.jit.inline
+def prefill_attention_hca_cp(
+    x_hc_local: pl.Tensor[[CP_Q_T_DYN, HC_MULT, D], pl.FP32],
+    hc_attn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
+    hc_attn_scale: pl.Tensor[[3], pl.FP32],
+    hc_attn_base: pl.Tensor[[MIX_HC], pl.FP32],
+    attn_norm_w: pl.Tensor[[D], pl.BF16],
+    wq_a: pl.Tensor[[D, Q_LORA], pl.BF16],
+    wq_b: pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8],
+    wq_b_scale: pl.Tensor[[H * HEAD_DIM], pl.FP32],
+    wkv: pl.Tensor[[D, HEAD_DIM], pl.BF16],
+    gamma_cq: pl.Tensor[[Q_LORA], pl.BF16],
+    gamma_ckv: pl.Tensor[[HEAD_DIM], pl.BF16],
+    freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    cmp_wkv: pl.Tensor[[MAIN_OUT_DIM, D], pl.BF16],
+    cmp_wgate: pl.Tensor[[MAIN_OUT_DIM, D], pl.BF16],
+    cmp_ape: pl.Tensor[[COMPRESS_RATIO, MAIN_OUT_DIM], pl.FP32],
+    cmp_norm_w: pl.Tensor[[HEAD_DIM], pl.BF16],
+    compress_state: pl.Tensor[[STATE_BLOCK_NUM_DYN, HCA_STATE_BLOCK_SIZE, MAIN_COMPRESS_STATE_DIM], pl.FP32],
+    compress_state_block_table: pl.Tensor[[HCA_STATE_MAX_BLOCKS], pl.INT32],
+    kv_cache: pl.InOut[pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
+    ori_slot_mapping_full: pl.Tensor[[CP_KV_T_DYN], pl.INT64],
+    ori_block_table: pl.Tensor[[SPARSE_ORI_MAX_BLOCKS], pl.INT32],
+    cmp_kv: pl.InOut[pl.Tensor[[CMP_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
+    cmp_block_table: pl.Tensor[[SPARSE_CMP_MAX_BLOCKS], pl.INT32],
+    position_ids_local: pl.Tensor[[CP_Q_T_DYN], pl.INT32],
+    position_ids_full: pl.Tensor[[CP_KV_T_DYN], pl.INT32],
+    cmp_slot_mapping_full: pl.Tensor[[CP_KV_T_DYN], pl.INT64],
+    state_slot_mapping_full: pl.Tensor[[CP_KV_T_DYN], pl.INT64],
+    attn_sink: pl.Tensor[[H], pl.FP32],
+    wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
+    wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
+    wo_b_scale: pl.Tensor[[D], pl.FP32],
+    x_out_local: pl.Out[pl.Tensor[[CP_Q_T_DYN, HC_MULT, D], pl.FP32]],
+    gather_window: pld.DistributedTensor[[PREFILL_GROUP_CAP, D], pl.BF16],
+    gather_signal: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
+    group_base: pl.Scalar[pl.INT32],
+    tp_rank: pl.Scalar[pl.INT32],
+):
+    """HCA block on one CP rank: local queries; KV and the ratio-128 compressor on the gathered stream."""
+    q_dim = pl.tensor.dim(x_hc_local, 0)
+    kv_dim = pl.tensor.dim(position_ids_full, 0)
+
+    x_mixed = pl.create_tensor([q_dim, D], dtype=pl.BF16)
+    post = pl.create_tensor([q_dim, HC_MULT], dtype=pl.FP32)
+    comb = pl.create_tensor([q_dim, HC_MULT * HC_MULT], dtype=pl.FP32)
+    hc_pre(x_hc_local, hc_attn_fn, hc_attn_scale, hc_attn_base, x_mixed, post, comb)
+
+    x_normed_local = pl.create_tensor([q_dim, D], dtype=pl.BF16)
+    rms_tid = rms_norm(x_mixed, attn_norm_w, x_normed_local)
+    late_dep = pl.system.task_dummy(deps=[rms_tid])
+
+    x_normed_full = pl.create_tensor([kv_dim, D], dtype=pl.BF16)
+    x_normed_full, gather_signal = prefill_kv_token_allgather_step(
+        x_normed_local, x_normed_full, gather_window, gather_signal, group_base, tp_rank,
+    )
+
+    rope_cos_local = pl.create_tensor([q_dim, ROPE_DIM], dtype=pl.BF16)
+    rope_sin_local = pl.create_tensor([q_dim, ROPE_DIM], dtype=pl.BF16)
+    materialize_rope_rows_dynamic(freqs_cos, freqs_sin, position_ids_local, rope_cos_local, rope_sin_local)
+    q_cos_il = pl.create_tensor([q_dim, ROPE_DIM], dtype=pl.FP32)
+    q_sin_signed = pl.create_tensor([q_dim, ROPE_DIM], dtype=pl.FP32)
+    q_swap_idx = pl.create_tensor([q_dim, ROPE_DIM], dtype=pl.INT32)
+    rope_prepare(rope_cos_local, rope_sin_local, q_cos_il, q_sin_signed, q_swap_idx)
+
+    q = pl.create_tensor([q_dim, H, HEAD_DIM], dtype=pl.BF16)
+    qr = pl.create_tensor([q_dim, Q_LORA], dtype=pl.INT8)
+    qr_scale = pl.create_tensor([q_dim, 1], dtype=pl.FP32)
+    q_proj_rope(
+        x_normed_local, wq_a, wq_b, wq_b_scale, gamma_cq,
+        q_cos_il, q_sin_signed, q_swap_idx,
+        q, qr, qr_scale,
+    )
+
+    rope_cos_full = pl.create_tensor([kv_dim, ROPE_DIM], dtype=pl.BF16)
+    rope_sin_full = pl.create_tensor([kv_dim, ROPE_DIM], dtype=pl.BF16)
+    materialize_rope_rows_dynamic(freqs_cos, freqs_sin, position_ids_full, rope_cos_full, rope_sin_full)
+    kv_cos_il = pl.create_tensor([kv_dim, ROPE_DIM], dtype=pl.FP32)
+    kv_sin_signed = pl.create_tensor([kv_dim, ROPE_DIM], dtype=pl.FP32)
+    kv_swap_idx = pl.create_tensor([kv_dim, ROPE_DIM], dtype=pl.INT32)
+    rope_prepare(rope_cos_full, rope_sin_full, kv_cos_il, kv_sin_signed, kv_swap_idx)
+
+    kv_full = pl.create_tensor([kv_dim, HEAD_DIM], dtype=pl.BF16)
+    kv_proj_rope(
+        x_normed_full, wkv, gamma_ckv,
+        kv_cos_il, kv_sin_signed, kv_swap_idx,
+        kv_full, late_dep,
+    )
+
+    ori_block_num = pl.tensor.dim(kv_cache, 0)
+    ori_cache_rows = ori_block_num * BLOCK_SIZE
+    kv_cache_flat = pl.reshape(kv_cache, [ori_cache_rows, HEAD_DIM])
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_hca_cp_cache_write"):
+        for write_t in pl.range(kv_dim):
+            write_row_raw = pl.read(ori_slot_mapping_full, [write_t])
+            if write_row_raw >= 0:
+                write_row = pl.cast(write_row_raw, pl.INDEX)
+                kv_cache_flat[write_row : write_row + 1, :] = kv_full[write_t : write_t + 1, :]
+
+    prefill_compressor_ratio128(
+        x_normed_full,
+        compress_state,
+        compress_state_block_table,
+        cmp_wkv,
+        cmp_wgate,
+        cmp_ape,
+        cmp_norm_w,
+        freqs_cos,
+        freqs_sin,
+        cmp_kv,
+        position_ids_full,
+        cmp_slot_mapping_full,
+        state_slot_mapping_full,
+    )
+
+    swa_indices = pl.create_tensor([q_dim, WIN], dtype=pl.INT32)
+    cmp_indices = pl.create_tensor([q_dim, IDX_TOPK], dtype=pl.INT32)
+    valid_block_mask = pl.create_tensor([q_dim, VALID_BLOCK_MASK_COLS], dtype=pl.INT32)
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_hca_cp_sparse_indices"):
+        for idx_t in pl.range(q_dim):
+            swa_row = pl.full([1, WIN], dtype=pl.INT32, value=-1)
+            cmp_row = pl.full([1, IDX_TOPK], dtype=pl.INT32, value=-1)
+            mask_row = pl.full([1, VALID_BLOCK_MASK_COLS], dtype=pl.INT32, value=0)
+            abs_pos = pl.read(position_ids_local, [idx_t])
+            window_valid = pl.min(pl.cast(WIN, pl.INT32), abs_pos + 1)
+            key_start_abs = abs_pos + 1 - window_valid
+            for win_col in pl.range(WIN):
+                win_col_i32 = pl.cast(win_col, pl.INT32)
+                if win_col_i32 < window_valid:
+                    key_abs = key_start_abs + win_col_i32
+                    blk_slot = key_abs // BLOCK_SIZE
+                    blk = pl.read(ori_block_table, [pl.cast(blk_slot, pl.INDEX)])
+                    if blk >= 0:
+                        row = pl.cast(blk * BLOCK_SIZE + (key_abs - blk_slot * BLOCK_SIZE), pl.INT32)
+                        pl.write(swa_row, [0, win_col], row)
+                        if win_col < SPARSE_BIAS_COLS:
+                            pl.write(mask_row, [0, win_col // PREFILL_ATTN_TILE], pl.cast(1, pl.INT32))
+            visible_cmp = (abs_pos + 1) // COMPRESS_RATIO
+            for cmp_col in pl.range(IDX_TOPK):
+                cmp_col_i32 = pl.cast(cmp_col, pl.INT32)
+                if cmp_col_i32 < visible_cmp:
+                    if cmp_col_i32 < pl.cast(SPARSE_CMP_MAX_BLOCKS * BLOCK_SIZE, pl.INT32):
+                        pl.write(cmp_row, [0, cmp_col], cmp_col_i32)
+                        sparse_col = WIN + cmp_col
+                        if sparse_col < SPARSE_BIAS_COLS:
+                            pl.write(mask_row, [0, sparse_col // PREFILL_ATTN_TILE], pl.cast(1, pl.INT32))
+            swa_indices[idx_t : idx_t + 1, 0:WIN] = swa_row
+            cmp_indices[idx_t : idx_t + 1, 0:IDX_TOPK] = cmp_row
+            valid_block_mask[idx_t : idx_t + 1, 0:VALID_BLOCK_MASK_COLS] = mask_row
+
+    attn_out = pl.create_tensor([q_dim, D], dtype=pl.BF16)
+    sparse_attn_physical(
+        q,
+        kv_cache,
+        swa_indices,
+        cmp_kv,
+        cmp_block_table,
+        cmp_indices,
+        valid_block_mask,
+        attn_sink,
+        rope_cos_local,
+        rope_sin_local,
+        wo_a,
+        wo_b,
+        wo_b_scale,
+        attn_out,
+    )
+
+    hc_post(attn_out, x_hc_local, post, comb, x_out_local)
+    return x_out_local, gather_signal
+
+
+@pl.jit
+def prefill_attention_hca_cp_test(
+    x_hc_local: pl.Tensor[[CP_Q_T_DYN, HC_MULT, D], pl.FP32],
+    hc_attn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
+    hc_attn_scale: pl.Tensor[[3], pl.FP32],
+    hc_attn_base: pl.Tensor[[MIX_HC], pl.FP32],
+    attn_norm_w: pl.Tensor[[D], pl.BF16],
+    wq_a: pl.Tensor[[D, Q_LORA], pl.BF16],
+    wq_b: pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8],
+    wq_b_scale: pl.Tensor[[H * HEAD_DIM], pl.FP32],
+    wkv: pl.Tensor[[D, HEAD_DIM], pl.BF16],
+    gamma_cq: pl.Tensor[[Q_LORA], pl.BF16],
+    gamma_ckv: pl.Tensor[[HEAD_DIM], pl.BF16],
+    freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    cmp_wkv: pl.Tensor[[MAIN_OUT_DIM, D], pl.BF16],
+    cmp_wgate: pl.Tensor[[MAIN_OUT_DIM, D], pl.BF16],
+    cmp_ape: pl.Tensor[[COMPRESS_RATIO, MAIN_OUT_DIM], pl.FP32],
+    cmp_norm_w: pl.Tensor[[HEAD_DIM], pl.BF16],
+    compress_state: pl.InOut[
+        pl.Tensor[[STATE_BLOCK_NUM_DYN, HCA_STATE_BLOCK_SIZE, MAIN_COMPRESS_STATE_DIM], pl.FP32]
+    ],
+    compress_state_block_table: pl.Tensor[[HCA_STATE_MAX_BLOCKS], pl.INT32],
+    kv_cache: pl.InOut[pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
+    ori_slot_mapping_full: pl.Tensor[[CP_KV_T_DYN], pl.INT64],
+    ori_block_table: pl.Tensor[[SPARSE_ORI_MAX_BLOCKS], pl.INT32],
+    cmp_kv: pl.InOut[pl.Tensor[[CMP_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
+    cmp_block_table: pl.Tensor[[SPARSE_CMP_MAX_BLOCKS], pl.INT32],
+    position_ids_local: pl.Tensor[[CP_Q_T_DYN], pl.INT32],
+    position_ids_full: pl.Tensor[[CP_KV_T_DYN], pl.INT32],
+    cmp_slot_mapping_full: pl.Tensor[[CP_KV_T_DYN], pl.INT64],
+    state_slot_mapping_full: pl.Tensor[[CP_KV_T_DYN], pl.INT64],
+    attn_sink: pl.Tensor[[H], pl.FP32],
+    wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
+    wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
+    wo_b_scale: pl.Tensor[[D], pl.FP32],
+    x_out_local: pl.Out[pl.Tensor[[CP_Q_T_DYN, HC_MULT, D], pl.FP32]],
+    gather_window: pld.DistributedTensor[[PREFILL_GROUP_CAP, D], pl.BF16],
+    gather_signal: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
+    group_base: pl.Scalar[pl.INT32],
+    tp_rank: pl.Scalar[pl.INT32],
+):
+    """Run one CP rank's share of an HCA block."""
+    x_hc_local.bind_dynamic(0, CP_Q_T_DYN)
+    compress_state.bind_dynamic(0, STATE_BLOCK_NUM_DYN)
+    kv_cache.bind_dynamic(0, ORI_BLOCK_NUM_DYN)
+    cmp_kv.bind_dynamic(0, CMP_BLOCK_NUM_DYN)
+    ori_slot_mapping_full.bind_dynamic(0, CP_KV_T_DYN)
+    position_ids_local.bind_dynamic(0, CP_Q_T_DYN)
+    position_ids_full.bind_dynamic(0, CP_KV_T_DYN)
+    cmp_slot_mapping_full.bind_dynamic(0, CP_KV_T_DYN)
+    state_slot_mapping_full.bind_dynamic(0, CP_KV_T_DYN)
+    x_out_local.bind_dynamic(0, CP_Q_T_DYN)
+
+    x_out_local, gather_signal = prefill_attention_hca_cp(
+        x_hc_local,
+        hc_attn_fn, hc_attn_scale, hc_attn_base,
+        attn_norm_w, wq_a, wq_b, wq_b_scale, wkv, gamma_cq, gamma_ckv,
+        freqs_cos, freqs_sin,
+        cmp_wkv, cmp_wgate, cmp_ape, cmp_norm_w,
+        compress_state, compress_state_block_table,
+        kv_cache, ori_slot_mapping_full, ori_block_table,
+        cmp_kv, cmp_block_table,
+        position_ids_local, position_ids_full,
+        cmp_slot_mapping_full, state_slot_mapping_full,
+        attn_sink, wo_a, wo_b, wo_b_scale,
+        x_out_local,
+        gather_window, gather_signal, group_base, tp_rank,
+    )
+    return x_out_local
+
+
+@pl.jit.host
+def l3_prefill_attention_hca_cp(
+    x_hc_local: pl.Tensor[[TP_SIZE, CP_Q_T_DYN, HC_MULT, D], pl.FP32],
+    hc_attn_fn: pl.Tensor[[TP_SIZE, MIX_HC, HC_DIM], pl.FP32],
+    hc_attn_scale: pl.Tensor[[TP_SIZE, 3], pl.FP32],
+    hc_attn_base: pl.Tensor[[TP_SIZE, MIX_HC], pl.FP32],
+    attn_norm_w: pl.Tensor[[TP_SIZE, D], pl.BF16],
+    wq_a: pl.Tensor[[TP_SIZE, D, Q_LORA], pl.BF16],
+    wq_b: pl.Tensor[[TP_SIZE, Q_LORA, H * HEAD_DIM], pl.INT8],
+    wq_b_scale: pl.Tensor[[TP_SIZE, H * HEAD_DIM], pl.FP32],
+    wkv: pl.Tensor[[TP_SIZE, D, HEAD_DIM], pl.BF16],
+    gamma_cq: pl.Tensor[[TP_SIZE, Q_LORA], pl.BF16],
+    gamma_ckv: pl.Tensor[[TP_SIZE, HEAD_DIM], pl.BF16],
+    freqs_cos: pl.Tensor[[TP_SIZE, MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[TP_SIZE, MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    cmp_wkv: pl.Tensor[[TP_SIZE, MAIN_OUT_DIM, D], pl.BF16],
+    cmp_wgate: pl.Tensor[[TP_SIZE, MAIN_OUT_DIM, D], pl.BF16],
+    cmp_ape: pl.Tensor[[TP_SIZE, COMPRESS_RATIO, MAIN_OUT_DIM], pl.FP32],
+    cmp_norm_w: pl.Tensor[[TP_SIZE, HEAD_DIM], pl.BF16],
+    compress_state: pl.InOut[
+        pl.Tensor[[TP_SIZE, STATE_BLOCK_NUM_DYN, HCA_STATE_BLOCK_SIZE, MAIN_COMPRESS_STATE_DIM], pl.FP32]
+    ],
+    compress_state_block_table: pl.Tensor[[TP_SIZE, HCA_STATE_MAX_BLOCKS], pl.INT32],
+    kv_cache: pl.InOut[pl.Tensor[[TP_SIZE, ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
+    ori_slot_mapping_full: pl.Tensor[[TP_SIZE, CP_KV_T_DYN], pl.INT64],
+    ori_block_table: pl.Tensor[[TP_SIZE, SPARSE_ORI_MAX_BLOCKS], pl.INT32],
+    cmp_kv: pl.InOut[pl.Tensor[[TP_SIZE, CMP_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
+    cmp_block_table: pl.Tensor[[TP_SIZE, SPARSE_CMP_MAX_BLOCKS], pl.INT32],
+    position_ids_local: pl.Tensor[[TP_SIZE, CP_Q_T_DYN], pl.INT32],
+    position_ids_full: pl.Tensor[[TP_SIZE, CP_KV_T_DYN], pl.INT32],
+    cmp_slot_mapping_full: pl.Tensor[[TP_SIZE, CP_KV_T_DYN], pl.INT64],
+    state_slot_mapping_full: pl.Tensor[[TP_SIZE, CP_KV_T_DYN], pl.INT64],
+    attn_sink: pl.Tensor[[TP_SIZE, H], pl.FP32],
+    wo_a: pl.Tensor[[TP_SIZE, O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
+    wo_b: pl.Tensor[[TP_SIZE, D, O_GROUPS * O_LORA], pl.INT8],
+    wo_b_scale: pl.Tensor[[TP_SIZE, D], pl.FP32],
+    x_out_local: pl.Out[pl.Tensor[[TP_SIZE, CP_Q_T_DYN, HC_MULT, D], pl.FP32]],
+):
+    """Launch one CP group's HCA block, one child per rank."""
+    x_hc_local.bind_dynamic(1, CP_Q_T_DYN)
+    compress_state.bind_dynamic(1, STATE_BLOCK_NUM_DYN)
+    kv_cache.bind_dynamic(1, ORI_BLOCK_NUM_DYN)
+    cmp_kv.bind_dynamic(1, CMP_BLOCK_NUM_DYN)
+    ori_slot_mapping_full.bind_dynamic(1, CP_KV_T_DYN)
+    position_ids_local.bind_dynamic(1, CP_Q_T_DYN)
+    position_ids_full.bind_dynamic(1, CP_KV_T_DYN)
+    cmp_slot_mapping_full.bind_dynamic(1, CP_KV_T_DYN)
+    state_slot_mapping_full.bind_dynamic(1, CP_KV_T_DYN)
+    x_out_local.bind_dynamic(1, CP_Q_T_DYN)
+
+    gather_window_buf = pld.alloc_window_buffer([PREFILL_GROUP_CAP, D], dtype=pl.BF16)
+    gather_signal_buf = pld.alloc_window_buffer([TP_SIZE, 1], dtype=pl.INT32)
+
+    for rank in pl.range(pld.world_size()):
+        gather_window = pld.window(gather_window_buf, [PREFILL_GROUP_CAP, D], dtype=pl.BF16)
+        gather_signal = pld.window(gather_signal_buf, [TP_SIZE, 1], dtype=pl.INT32)
+        prefill_attention_hca_cp_test(
+            x_hc_local[rank],
+            hc_attn_fn[rank], hc_attn_scale[rank], hc_attn_base[rank],
+            attn_norm_w[rank], wq_a[rank], wq_b[rank], wq_b_scale[rank],
+            wkv[rank], gamma_cq[rank], gamma_ckv[rank],
+            freqs_cos[rank], freqs_sin[rank],
+            cmp_wkv[rank], cmp_wgate[rank], cmp_ape[rank], cmp_norm_w[rank],
+            compress_state[rank], compress_state_block_table[rank],
+            kv_cache[rank], ori_slot_mapping_full[rank], ori_block_table[rank],
+            cmp_kv[rank], cmp_block_table[rank],
+            position_ids_local[rank], position_ids_full[rank],
+            cmp_slot_mapping_full[rank], state_slot_mapping_full[rank],
+            attn_sink[rank], wo_a[rank], wo_b[rank], wo_b_scale[rank],
+            x_out_local[rank],
+            gather_window, gather_signal, 0, rank,
+            device=rank,
+        )
+
+
+
+def build_cp_tensor_specs(
+    start_pos: int = START_POS,
+    token_count: int = PREFILL_SEQ,
+    tp_size: int = TP_SIZE,
+):
+    """Split the single-die specs across the group: query side per rank, KV side whole."""
+    from golden import TensorSpec
+    from prefill_kv_allgather import cp_stack, materialize_spec
+
+    if token_count % tp_size != 0:
+        raise ValueError(f"token_count={token_count} must be a multiple of tp_size={tp_size}")
+    local_t = token_count // tp_size
+
+    # Token-major KV-side inputs: replicated whole, never sliced.
+    full_names = ("ori_slot_mapping", "cmp_slot_mapping", "state_slot_mapping")
+
+    specs = []
+    for spec in build_tensor_specs(start_pos, token_count):
+        value = materialize_spec(spec)
+        if spec.name == "x_hc":
+            specs.append(TensorSpec(
+                "x_hc_local", [tp_size, local_t, HC_MULT, D], spec.dtype,
+                init_value=value.reshape(tp_size, local_t, HC_MULT, D).contiguous(),
+            ))
+        elif spec.name in full_names:
+            specs.append(TensorSpec(
+                f"{spec.name}_full", [tp_size, token_count], spec.dtype,
+                init_value=cp_stack(value, tp_size),
+            ))
+        elif spec.name == "position_ids":
+            specs.append(TensorSpec(
+                "position_ids_local", [tp_size, local_t], spec.dtype,
+                init_value=value.reshape(tp_size, local_t).contiguous(),
+            ))
+            specs.append(TensorSpec(
+                "position_ids_full", [tp_size, token_count], spec.dtype,
+                init_value=cp_stack(value, tp_size),
+            ))
+        elif spec.name == "x_out":
+            specs.append(TensorSpec(
+                "x_out_local", [tp_size, local_t, HC_MULT, D], spec.dtype, is_output=True,
+            ))
+        else:
+            specs.append(TensorSpec(
+                spec.name, [tp_size, *spec.shape], spec.dtype,
+                init_value=cp_stack(value, tp_size), is_output=spec.is_output,
+            ))
+    return specs
+
+
+def golden_prefill_attention_hca_cp(tensors):
+    """Single-die reference over the whole stream, sliced per rank; replicated caches compared too."""
+    import torch
+
+    tp_size, local_t = tensors["x_hc_local"].shape[0], tensors["x_hc_local"].shape[1]
+    token_count = tp_size * local_t
+
+    full = {name: tensors[name][0] for name in (
+        "hc_attn_fn", "hc_attn_scale", "hc_attn_base", "attn_norm_w",
+        "wq_a", "wq_b", "wq_b_scale", "wkv", "gamma_cq", "gamma_ckv",
+        "freqs_cos", "freqs_sin", "cmp_wkv", "cmp_wgate", "cmp_ape", "cmp_norm_w",
+        "compress_state_block_table", "ori_block_table", "cmp_block_table",
+        "attn_sink", "wo_a", "wo_b", "wo_b_scale",
+    )}
+    full["x_hc"] = tensors["x_hc_local"].reshape(token_count, HC_MULT, D)
+    full["compress_state"] = tensors["compress_state"][0].clone()
+    full["kv_cache"] = tensors["kv_cache"][0].clone()
+    full["cmp_kv"] = tensors["cmp_kv"][0].clone()
+    full["ori_slot_mapping"] = tensors["ori_slot_mapping_full"][0]
+    full["cmp_slot_mapping"] = tensors["cmp_slot_mapping_full"][0]
+    full["state_slot_mapping"] = tensors["state_slot_mapping_full"][0]
+    full["position_ids"] = tensors["position_ids_full"][0]
+    full["x_out"] = torch.zeros(token_count, HC_MULT, D, dtype=torch.float32)
+
+    golden_prefill_attention_hca(full)
+
+    tensors["x_out_local"][:] = full["x_out"].reshape(tp_size, local_t, HC_MULT, D)
+    for name in ("kv_cache", "cmp_kv", "compress_state"):
+        tensors[name][:] = full[name].unsqueeze(0).expand(tp_size, *full[name].shape)
+
+
 if __name__ == "__main__":
     import argparse
+
     from golden import ratio_allclose, ratio_reldiff, run_jit
 
     parser = argparse.ArgumentParser(
@@ -771,47 +1187,76 @@ if __name__ == "__main__":
     parser.add_argument(
         "-p", "--platform", type=str, default="a2a3", choices=["a2a3", "a2a3sim", "a5", "a5sim"]
     )
-    parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--compile-only", action="store_true", default=False)
     parser.add_argument(
-        "--start-pos",
-        type=int,
-        default=START_POS,
-        help="context_len (multiple of S=WIN); fixture-only, lowered into token metadata.",
+        "-d", "--device", type=str, default=",".join(str(i) for i in range(TP_SIZE)),
+        help="comma-separated rank group; one ID at --tp 1",
     )
     parser.add_argument(
-        "--token-count",
-        "--num-tokens",
-        dest="token_count",
-        type=int,
-        default=PREFILL_SEQ,
-        help="Physical query-token extent, up to 8192.",
+        "--tp", type=int, default=TP_SIZE, help="rank-group size; must match the import-time --tp"
+    )
+    parser.add_argument("--compile-only", action="store_true", default=False)
+    parser.add_argument("--start-pos", type=int, default=START_POS)
+    parser.add_argument(
+        "--token-count", "--num-tokens", dest="token_count", type=int, default=PREFILL_SEQ,
+        help="Physical query-token extent across the group; must divide by --tp.",
     )
     parser.add_argument("--enable-chip-swimlane", action="store_true", default=False)
     parser.add_argument("--enable-dep-gen", action="store_true", default=False)
     parser.add_argument("--dump-passes", action="store_true", default=False)
     args = parser.parse_args()
-    result = run_jit(
-        fn=prefill_attention_hca_test,
-        specs=build_tensor_specs(args.start_pos, args.token_count),
-        golden_fn=golden_prefill_attention_hca,
-        compile_cfg=dict(dump_passes=args.dump_passes),
-        runtime_cfg=dict(
-            platform=args.platform,
-            device_id=args.device,
-            enable_chip_swimlane=args.enable_chip_swimlane,
-            enable_dep_gen=args.enable_dep_gen,
-        ),
-        rtol=1e-2,
-        atol=1e-2,
-        compile_only=args.compile_only,
-        compare_fn={
-            "x_out": ratio_reldiff(diff_thd=5e-3, pct_thd=0.005, max_diff_hd=1),
-            "kv_cache": ratio_allclose(atol=1e-4, rtol=1.0 / 128),
-            "cmp_kv": ratio_allclose(atol=1e-4, rtol=1.0 / 128),
-            "compress_state": ratio_allclose(atol=1e-3, rtol=1e-3),
-        },
-    )
+
+    if args.tp != TP_SIZE:
+        raise SystemExit(f"--tp={args.tp} does not match import-time TP_SIZE={TP_SIZE}")
+    device_ids = [int(device) for device in args.device.split(",")]
+    if len(device_ids) != TP_SIZE:
+        parser.error(f"need exactly {TP_SIZE} devices, got {device_ids}")
+    if args.token_count % TP_SIZE != 0:
+        parser.error(f"--token-count must be a multiple of --tp={TP_SIZE}, got {args.token_count}")
+
+    if TP_SIZE == 1:
+        result = run_jit(
+            fn=prefill_attention_hca_test,
+            specs=build_tensor_specs(args.start_pos, args.token_count),
+            golden_fn=golden_prefill_attention_hca,
+            compile_cfg=dict(dump_passes=args.dump_passes),
+            runtime_cfg=dict(
+                platform=args.platform,
+                device_id=device_ids[0],
+                enable_chip_swimlane=args.enable_chip_swimlane,
+                enable_dep_gen=args.enable_dep_gen,
+            ),
+            compile_only=args.compile_only,
+            rtol=1e-2,
+            atol=1e-2,
+            compare_fn={
+                "x_out": ratio_reldiff(diff_thd=5e-3, pct_thd=0.005, max_diff_hd=1),
+                "kv_cache": ratio_allclose(atol=1e-4, rtol=1.0 / 128),
+                "cmp_kv": ratio_allclose(atol=1e-4, rtol=1.0 / 128),
+                "compress_state": ratio_allclose(atol=1e-3, rtol=1e-3),
+            },
+        )
+    else:
+        from pypto.ir.distributed_compiled_program import DistributedConfig
+
+        result = run_jit(
+            fn=l3_prefill_attention_hca_cp,
+            specs=build_cp_tensor_specs(args.start_pos, args.token_count, TP_SIZE),
+            golden_fn=golden_prefill_attention_hca_cp,
+            compile_cfg=dict(
+                dump_passes=args.dump_passes,
+                distributed_config=DistributedConfig(device_ids=device_ids, num_sub_workers=0),
+            ),
+            runtime_cfg=dict(platform=args.platform),
+            compile_only=args.compile_only,
+            rtol=1e-2,
+            atol=1e-2,
+            compare_fn={
+                "x_out_local": ratio_reldiff(diff_thd=5e-3, pct_thd=0.005, max_diff_hd=1),
+                "kv_cache": ratio_allclose(atol=1e-4, rtol=1.0 / 128),
+                "cmp_kv": ratio_allclose(atol=1e-4, rtol=1.0 / 128),
+                "compress_state": ratio_allclose(atol=1e-3, rtol=1e-3),
+            },
+        )
     if not result.passed:
         if result.error:
             print(result.error)

--- a/models/deepseek_v4_flash_dspark/prefill_indexer.py
+++ b/models/deepseek_v4_flash_dspark/prefill_indexer.py
@@ -41,6 +41,10 @@ PREFILL_DENSE_TILE = 512
 
 # Dynamic shape variables.
 T_DYN = pl.dynamic("PREFILL_INDEXER_T_DYN")
+# Query-side token axis. Under context parallelism the cache half runs on the
+# gathered stream while the query half stays on the local slice, so the two
+# cannot share one symbol -- the same split #924 made in qkv_proj_rope.
+Q_T_DYN = pl.dynamic("PREFILL_INDEXER_Q_T_DYN")
 IDX_BLOCK_NUM_DYN = pl.dynamic("PREFILL_IDX_BLOCK_NUM_DYN")
 INNER_STATE_BLOCK_NUM_DYN = pl.dynamic("PREFILL_INNER_STATE_BLOCK_NUM_DYN")
 
@@ -594,9 +598,12 @@ def prefill_indexer(
     idx_slot_mapping: pl.Tensor[[T_DYN], pl.INT64],
     inner_state_slot_mapping: pl.Tensor[[T_DYN], pl.INT64],
 ):
-    """Canonical P4 indexer over one contiguous, position-monotonic token run."""
-    t_dim = pl.tensor.dim(x, 0)
+    """Canonical P4 indexer over one contiguous, position-monotonic token run.
 
+    A thin wrapper over the two halves below, kept so every existing caller is
+    untouched. Context parallelism calls them separately, because the cache half
+    consumes the gathered stream while the query half stays on the local slice.
+    """
     idx_kv_cache_out, idx_kv_scale_out, inner_compress_state_out = prefill_indexer_compressor(
         x,
         inner_compress_state,
@@ -615,6 +622,54 @@ def prefill_indexer(
         idx_slot_mapping,
         inner_state_slot_mapping,
     )
+
+    score, cmp_topk_indices = prefill_indexer_query(
+        x,
+        qr,
+        qr_scale,
+        wq_b,
+        wq_b_scale,
+        weights_proj,
+        cos,
+        sin,
+        hadamard,
+        idx_kv_cache,
+        idx_kv_scale,
+        idx_block_table,
+        score,
+        cmp_topk_indices,
+        position_ids,
+    )
+    return idx_kv_cache_out, idx_kv_scale_out, score, cmp_topk_indices
+
+
+@pl.jit.inline(auto_scope=False)
+def prefill_indexer_query(
+    x: pl.Tensor[[Q_T_DYN, D], pl.BF16],
+    qr: pl.Tensor[[Q_T_DYN, Q_LORA], pl.INT8],
+    qr_scale: pl.Tensor[[Q_T_DYN, 1], pl.FP32],
+    wq_b: pl.Tensor[[Q_LORA, IDX_N_HEADS * IDX_HEAD_DIM], pl.INT8],
+    wq_b_scale: pl.Tensor[[IDX_N_HEADS * IDX_HEAD_DIM], pl.FP32],
+    weights_proj: pl.Tensor[[D, IDX_N_HEADS], pl.BF16],
+    cos: pl.Tensor[[Q_T_DYN, ROPE_HEAD_DIM // 2], pl.FP32],
+    sin: pl.Tensor[[Q_T_DYN, ROPE_HEAD_DIM // 2], pl.FP32],
+    hadamard: pl.Tensor[[IDX_HEAD_DIM, IDX_HEAD_DIM], pl.BF16],
+    idx_kv_cache: pl.Tensor[[IDX_BLOCK_NUM_DYN, BLOCK_SIZE, 1, IDX_HEAD_DIM], pl.INT8],
+    idx_kv_scale: pl.Tensor[[IDX_BLOCK_NUM_DYN, BLOCK_SIZE, 1, 1], pl.FP32],
+    idx_block_table: pl.Tensor[[IDX_CACHE_MAX_BLOCKS], pl.INT32],
+    score: pl.Out[pl.Tensor[[Q_T_DYN, INDEXER_SCORE_CAP], pl.FP32]],
+    cmp_topk_indices: pl.Out[pl.Tensor[[Q_T_DYN, IDX_TOPK], pl.INT32]],
+    position_ids: pl.Tensor[[Q_T_DYN], pl.INT32],
+):
+    """Score this rank's queries against the indexer cache and select their top-k.
+
+    Query-side half of the indexer: it reads the cache but never writes it, so
+    under context parallelism it runs on the local slice while
+    `prefill_indexer_compressor` fills the same cache from the gathered stream.
+    Its token axis is a separate symbol for exactly that reason -- the two
+    halves carry different extents in one program.
+    """
+    t_dim = pl.tensor.dim(x, 0)
 
     last_pos = pl.read(position_ids, [t_dim - 1])
     max_visible = pl.cast(
@@ -673,7 +728,7 @@ def prefill_indexer(
                 max_visible,
             )
 
-    return idx_kv_cache_out, idx_kv_scale_out, score, cmp_topk_indices
+    return score, cmp_topk_indices
 
 
 @pl.jit.inline

--- a/models/deepseek_v4_flash_dspark/prefill_swa.py
+++ b/models/deepseek_v4_flash_dspark/prefill_swa.py
@@ -6,9 +6,11 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-"""DeepSeek-V4 packed prefill SWA attention over one contiguous run of <=T tokens."""
+# ci: devices=2  # CI: 2-card run; borrows 2 cards via task-submit --device-num
+"""DeepSeek-V4 packed prefill SWA attention: single-die at --tp 1, context-parallel above it."""
 
 import pypto.language as pl
+import pypto.language.distributed as pld
 
 from config import (
     BLOCK_SIZE,
@@ -23,8 +25,13 @@ from config import (
 
 from hc_post import golden_hc_post, hc_post
 from hc_pre import golden_hc_pre, hc_pre
-from qkv_proj_rope import golden_qkv_proj_rope, materialize_rope_rows_dynamic, qkv_proj_rope
-from rmsnorm import golden_rms_norm, rms_norm
+from prefill_kv_allgather import (
+    PREFILL_GROUP_CAP,
+    TP_SIZE,
+    cp_stack,
+    materialize_spec,
+    prefill_kv_token_allgather_step,
+)
 from prefill_sparse_attn import (
     PREFILL_ATTN_TILE,
     SPARSE_BIAS_COLS,
@@ -32,11 +39,23 @@ from prefill_sparse_attn import (
     golden_prefill_sparse_attn,
     sparse_attn_physical,
 )
+from qkv_proj_rope import (
+    golden_qkv_proj_rope,
+    kv_proj_rope,
+    materialize_rope_rows_dynamic,
+    q_proj_rope,
+    qkv_proj_rope,
+    rope_prepare,
+)
+from rmsnorm import golden_rms_norm, rms_norm
 
 
-
-# Dynamic shape variables.
+# Dynamic shape variables. The single-die path runs on one token axis; the
+# context-parallel path needs two, because the query slice and the gathered KV
+# stream carry different extents in one program.
 T_DYN = pl.dynamic("PREFILL_SWA_T_DYN")
+CP_Q_T_DYN = pl.dynamic("PREFILL_SWA_CP_Q_T_DYN")
+CP_KV_T_DYN = pl.dynamic("PREFILL_SWA_CP_KV_T_DYN")
 BLOCK_NUM_DYN = pl.dynamic("PREFILL_ORI_BLOCK_NUM_DYN")
 
 # model config
@@ -62,6 +81,8 @@ BLOCK_NUM = KV_ORI_BLOCK_NUM
 CMP_BLOCK_NUM = KV_CMP_BLOCK_NUM
 SPARSE_CMP_MAX_BLOCKS = KV_CMP_MAX_BLOCKS
 START_POS = 0
+
+
 @pl.jit.inline
 def prefill_attention_swa(
     x_hc: pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32],
@@ -206,6 +227,246 @@ def prefill_attention_swa_test(
         x_out,
     )
     return kv_cache, x_out
+
+
+@pl.jit.inline
+def prefill_attention_swa_cp(
+    x_hc_local: pl.Tensor[[CP_Q_T_DYN, HC_MULT, D], pl.FP32],
+    hc_attn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
+    hc_attn_scale: pl.Tensor[[3], pl.FP32],
+    hc_attn_base: pl.Tensor[[MIX_HC], pl.FP32],
+    attn_norm_w: pl.Tensor[[D], pl.BF16],
+    wq_a: pl.Tensor[[D, Q_LORA], pl.BF16],
+    wq_b: pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8],
+    wq_b_scale: pl.Tensor[[H * HEAD_DIM], pl.FP32],
+    wkv: pl.Tensor[[D, HEAD_DIM], pl.BF16],
+    gamma_cq: pl.Tensor[[Q_LORA], pl.BF16],
+    gamma_ckv: pl.Tensor[[HEAD_DIM], pl.BF16],
+    freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    kv_cache: pl.InOut[pl.Tensor[[BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
+    block_table: pl.Tensor[[BLOCK_NUM], pl.INT32],
+    ori_slot_mapping_full: pl.Tensor[[CP_KV_T_DYN], pl.INT64],
+    position_ids_local: pl.Tensor[[CP_Q_T_DYN], pl.INT32],
+    position_ids_full: pl.Tensor[[CP_KV_T_DYN], pl.INT32],
+    attn_sink: pl.Tensor[[H], pl.FP32],
+    wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
+    wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
+    wo_b_scale: pl.Tensor[[D], pl.FP32],
+    x_out_local: pl.Out[pl.Tensor[[CP_Q_T_DYN, HC_MULT, D], pl.FP32]],
+    gather_window: pld.DistributedTensor[[PREFILL_GROUP_CAP, D], pl.BF16],
+    gather_signal: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
+    group_base: pl.Scalar[pl.INT32],
+    tp_rank: pl.Scalar[pl.INT32],
+):
+    """SWA block on one CP rank: local queries, KV built from the gathered stream."""
+    q_dim = pl.tensor.dim(x_hc_local, 0)
+    kv_dim = pl.tensor.dim(position_ids_full, 0)
+
+    x_mixed = pl.create_tensor([q_dim, D], dtype=pl.BF16)
+    post = pl.create_tensor([q_dim, HC_MULT], dtype=pl.FP32)
+    comb = pl.create_tensor([q_dim, HC_MULT * HC_MULT], dtype=pl.FP32)
+    hc_pre(x_hc_local, hc_attn_fn, hc_attn_scale, hc_attn_base, x_mixed, post, comb)
+
+    x_normed_local = pl.create_tensor([q_dim, D], dtype=pl.BF16)
+    rms_tid = rms_norm(x_mixed, attn_norm_w, x_normed_local)
+    late_dep = pl.system.task_dummy(deps=[rms_tid])
+
+    # The layer's one activation collective.
+    x_normed_full = pl.create_tensor([kv_dim, D], dtype=pl.BF16)
+    x_normed_full, gather_signal = prefill_kv_token_allgather_step(
+        x_normed_local, x_normed_full, gather_window, gather_signal, group_base, tp_rank,
+    )
+
+    rope_cos_local = pl.create_tensor([q_dim, ROPE_HEAD_DIM], dtype=pl.BF16)
+    rope_sin_local = pl.create_tensor([q_dim, ROPE_HEAD_DIM], dtype=pl.BF16)
+    materialize_rope_rows_dynamic(freqs_cos, freqs_sin, position_ids_local, rope_cos_local, rope_sin_local)
+    q_cos_il = pl.create_tensor([q_dim, ROPE_HEAD_DIM], dtype=pl.FP32)
+    q_sin_signed = pl.create_tensor([q_dim, ROPE_HEAD_DIM], dtype=pl.FP32)
+    q_swap_idx = pl.create_tensor([q_dim, ROPE_HEAD_DIM], dtype=pl.INT32)
+    rope_prepare(rope_cos_local, rope_sin_local, q_cos_il, q_sin_signed, q_swap_idx)
+
+    q = pl.create_tensor([q_dim, H, HEAD_DIM], dtype=pl.BF16)
+    qr = pl.create_tensor([q_dim, Q_LORA], dtype=pl.INT8)
+    qr_scale = pl.create_tensor([q_dim, 1], dtype=pl.FP32)
+    q_proj_rope(
+        x_normed_local, wq_a, wq_b, wq_b_scale, gamma_cq,
+        q_cos_il, q_sin_signed, q_swap_idx,
+        q, qr, qr_scale,
+    )
+
+    rope_cos_full = pl.create_tensor([kv_dim, ROPE_HEAD_DIM], dtype=pl.BF16)
+    rope_sin_full = pl.create_tensor([kv_dim, ROPE_HEAD_DIM], dtype=pl.BF16)
+    materialize_rope_rows_dynamic(freqs_cos, freqs_sin, position_ids_full, rope_cos_full, rope_sin_full)
+    kv_cos_il = pl.create_tensor([kv_dim, ROPE_HEAD_DIM], dtype=pl.FP32)
+    kv_sin_signed = pl.create_tensor([kv_dim, ROPE_HEAD_DIM], dtype=pl.FP32)
+    kv_swap_idx = pl.create_tensor([kv_dim, ROPE_HEAD_DIM], dtype=pl.INT32)
+    rope_prepare(rope_cos_full, rope_sin_full, kv_cos_il, kv_sin_signed, kv_swap_idx)
+
+    kv_full = pl.create_tensor([kv_dim, HEAD_DIM], dtype=pl.BF16)
+    kv_proj_rope(
+        x_normed_full, wkv, gamma_ckv,
+        kv_cos_il, kv_sin_signed, kv_swap_idx,
+        kv_full, late_dep,
+    )
+
+    block_num = pl.tensor.dim(kv_cache, 0)
+    kv_cache_flat = pl.reshape(kv_cache, [block_num * BLOCK_SIZE, HEAD_DIM])
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_swa_cp_cache_write"):
+        for write_t in pl.range(kv_dim):
+            write_row_raw = pl.read(ori_slot_mapping_full, [write_t])
+            if write_row_raw >= 0:
+                write_row = pl.cast(write_row_raw, pl.INDEX)
+                kv_cache_flat[write_row : write_row + 1, :] = kv_full[write_t : write_t + 1, :]
+
+    swa_indices = pl.create_tensor([q_dim, WIN], dtype=pl.INT32)
+    valid_block_mask = pl.create_tensor([q_dim, VALID_BLOCK_MASK_COLS], dtype=pl.INT32)
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_swa_cp_window_indices"):
+        for idx_t in pl.range(q_dim):
+            idx_row = pl.full([1, WIN], dtype=pl.INT32, value=-1)
+            mask_row = pl.full([1, VALID_BLOCK_MASK_COLS], dtype=pl.INT32, value=0)
+            abs_pos = pl.read(position_ids_local, [idx_t])
+            window_valid = pl.min(pl.cast(WIN, pl.INT32), abs_pos + 1)
+            key_start_abs = abs_pos + 1 - window_valid
+            for win_col in pl.range(WIN):
+                win_col_i32 = pl.cast(win_col, pl.INT32)
+                if win_col_i32 < window_valid:
+                    key_abs = key_start_abs + win_col_i32
+                    blk_slot = key_abs // BLOCK_SIZE
+                    blk = pl.read(block_table, [pl.cast(blk_slot, pl.INDEX)])
+                    if blk >= 0:
+                        row = pl.cast(blk * BLOCK_SIZE + (key_abs - blk_slot * BLOCK_SIZE), pl.INT32)
+                        pl.write(idx_row, [0, win_col], row)
+                        if win_col < SPARSE_BIAS_COLS:
+                            block_col = win_col // PREFILL_ATTN_TILE
+                            pl.write(mask_row, [0, block_col], pl.cast(1, pl.INT32))
+            swa_indices[idx_t : idx_t + 1, 0:WIN] = idx_row
+            valid_block_mask[idx_t : idx_t + 1, 0:VALID_BLOCK_MASK_COLS] = mask_row
+
+    cmp_block_table_dummy = pl.create_tensor([SPARSE_CMP_MAX_BLOCKS], dtype=pl.INT32, init_value=0)
+    cmp_kv_dummy = pl.create_tensor([CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], dtype=pl.BF16)
+    cmp_indices_dummy = pl.create_tensor([q_dim, IDX_TOPK], dtype=pl.INT32, init_value=-1)
+    attn_out = pl.create_tensor([q_dim, D], dtype=pl.BF16)
+    sparse_attn_physical(
+        q, kv_cache, swa_indices,
+        cmp_kv_dummy, cmp_block_table_dummy,
+        cmp_indices_dummy,
+        valid_block_mask,
+        attn_sink,
+        rope_cos_local, rope_sin_local,
+        wo_a, wo_b, wo_b_scale, attn_out,
+    )
+
+    hc_post(attn_out, x_hc_local, post, comb, x_out_local)
+    return kv_cache, x_out_local, gather_signal
+
+
+@pl.jit
+def prefill_attention_swa_cp_test(
+    x_hc_local: pl.Tensor[[CP_Q_T_DYN, HC_MULT, D], pl.FP32],
+    hc_attn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
+    hc_attn_scale: pl.Tensor[[3], pl.FP32],
+    hc_attn_base: pl.Tensor[[MIX_HC], pl.FP32],
+    attn_norm_w: pl.Tensor[[D], pl.BF16],
+    wq_a: pl.Tensor[[D, Q_LORA], pl.BF16],
+    wq_b: pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8],
+    wq_b_scale: pl.Tensor[[H * HEAD_DIM], pl.FP32],
+    wkv: pl.Tensor[[D, HEAD_DIM], pl.BF16],
+    gamma_cq: pl.Tensor[[Q_LORA], pl.BF16],
+    gamma_ckv: pl.Tensor[[HEAD_DIM], pl.BF16],
+    freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    kv_cache: pl.InOut[pl.Tensor[[BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
+    block_table: pl.Tensor[[BLOCK_NUM], pl.INT32],
+    ori_slot_mapping_full: pl.Tensor[[CP_KV_T_DYN], pl.INT64],
+    position_ids_local: pl.Tensor[[CP_Q_T_DYN], pl.INT32],
+    position_ids_full: pl.Tensor[[CP_KV_T_DYN], pl.INT32],
+    attn_sink: pl.Tensor[[H], pl.FP32],
+    wo_a: pl.Tensor[[O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
+    wo_b: pl.Tensor[[D, O_GROUPS * O_LORA], pl.INT8],
+    wo_b_scale: pl.Tensor[[D], pl.FP32],
+    x_out_local: pl.Out[pl.Tensor[[CP_Q_T_DYN, HC_MULT, D], pl.FP32]],
+    gather_window: pld.DistributedTensor[[PREFILL_GROUP_CAP, D], pl.BF16],
+    gather_signal: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
+    group_base: pl.Scalar[pl.INT32],
+    tp_rank: pl.Scalar[pl.INT32],
+):
+    """Run one CP rank's share of an SWA block."""
+    x_hc_local.bind_dynamic(0, CP_Q_T_DYN)
+    kv_cache.bind_dynamic(0, BLOCK_NUM_DYN)
+    ori_slot_mapping_full.bind_dynamic(0, CP_KV_T_DYN)
+    position_ids_local.bind_dynamic(0, CP_Q_T_DYN)
+    position_ids_full.bind_dynamic(0, CP_KV_T_DYN)
+    x_out_local.bind_dynamic(0, CP_Q_T_DYN)
+
+    kv_cache, x_out_local, gather_signal = prefill_attention_swa_cp(
+        x_hc_local,
+        hc_attn_fn, hc_attn_scale, hc_attn_base,
+        attn_norm_w, wq_a, wq_b, wq_b_scale, wkv, gamma_cq, gamma_ckv,
+        freqs_cos, freqs_sin,
+        kv_cache, block_table, ori_slot_mapping_full,
+        position_ids_local, position_ids_full,
+        attn_sink, wo_a, wo_b, wo_b_scale,
+        x_out_local,
+        gather_window, gather_signal, group_base, tp_rank,
+    )
+    return kv_cache, x_out_local
+
+
+@pl.jit.host
+def l3_prefill_attention_swa_cp(
+    x_hc_local: pl.Tensor[[TP_SIZE, CP_Q_T_DYN, HC_MULT, D], pl.FP32],
+    hc_attn_fn: pl.Tensor[[TP_SIZE, MIX_HC, HC_DIM], pl.FP32],
+    hc_attn_scale: pl.Tensor[[TP_SIZE, 3], pl.FP32],
+    hc_attn_base: pl.Tensor[[TP_SIZE, MIX_HC], pl.FP32],
+    attn_norm_w: pl.Tensor[[TP_SIZE, D], pl.BF16],
+    wq_a: pl.Tensor[[TP_SIZE, D, Q_LORA], pl.BF16],
+    wq_b: pl.Tensor[[TP_SIZE, Q_LORA, H * HEAD_DIM], pl.INT8],
+    wq_b_scale: pl.Tensor[[TP_SIZE, H * HEAD_DIM], pl.FP32],
+    wkv: pl.Tensor[[TP_SIZE, D, HEAD_DIM], pl.BF16],
+    gamma_cq: pl.Tensor[[TP_SIZE, Q_LORA], pl.BF16],
+    gamma_ckv: pl.Tensor[[TP_SIZE, HEAD_DIM], pl.BF16],
+    freqs_cos: pl.Tensor[[TP_SIZE, MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[TP_SIZE, MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16],
+    kv_cache: pl.InOut[pl.Tensor[[TP_SIZE, BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
+    block_table: pl.Tensor[[TP_SIZE, BLOCK_NUM], pl.INT32],
+    ori_slot_mapping_full: pl.Tensor[[TP_SIZE, CP_KV_T_DYN], pl.INT64],
+    position_ids_local: pl.Tensor[[TP_SIZE, CP_Q_T_DYN], pl.INT32],
+    position_ids_full: pl.Tensor[[TP_SIZE, CP_KV_T_DYN], pl.INT32],
+    attn_sink: pl.Tensor[[TP_SIZE, H], pl.FP32],
+    wo_a: pl.Tensor[[TP_SIZE, O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
+    wo_b: pl.Tensor[[TP_SIZE, D, O_GROUPS * O_LORA], pl.INT8],
+    wo_b_scale: pl.Tensor[[TP_SIZE, D], pl.FP32],
+    x_out_local: pl.Out[pl.Tensor[[TP_SIZE, CP_Q_T_DYN, HC_MULT, D], pl.FP32]],
+):
+    """Launch one CP group's SWA block, one child per rank."""
+    x_hc_local.bind_dynamic(1, CP_Q_T_DYN)
+    kv_cache.bind_dynamic(1, BLOCK_NUM_DYN)
+    ori_slot_mapping_full.bind_dynamic(1, CP_KV_T_DYN)
+    position_ids_local.bind_dynamic(1, CP_Q_T_DYN)
+    position_ids_full.bind_dynamic(1, CP_KV_T_DYN)
+    x_out_local.bind_dynamic(1, CP_Q_T_DYN)
+
+    gather_window_buf = pld.alloc_window_buffer([PREFILL_GROUP_CAP, D], dtype=pl.BF16)
+    gather_signal_buf = pld.alloc_window_buffer([TP_SIZE, 1], dtype=pl.INT32)
+
+    for rank in pl.range(pld.world_size()):
+        gather_window = pld.window(gather_window_buf, [PREFILL_GROUP_CAP, D], dtype=pl.BF16)
+        gather_signal = pld.window(gather_signal_buf, [TP_SIZE, 1], dtype=pl.INT32)
+        prefill_attention_swa_cp_test(
+            x_hc_local[rank],
+            hc_attn_fn[rank], hc_attn_scale[rank], hc_attn_base[rank],
+            attn_norm_w[rank], wq_a[rank], wq_b[rank], wq_b_scale[rank],
+            wkv[rank], gamma_cq[rank], gamma_ckv[rank],
+            freqs_cos[rank], freqs_sin[rank],
+            kv_cache[rank], block_table[rank], ori_slot_mapping_full[rank],
+            position_ids_local[rank], position_ids_full[rank],
+            attn_sink[rank], wo_a[rank], wo_b[rank], wo_b_scale[rank],
+            x_out_local[rank],
+            gather_window, gather_signal, 0, rank,
+            device=rank,
+        )
+
 
 
 def _quant_w_per_output_channel(w):
@@ -439,43 +700,159 @@ def build_tensor_specs(
     ]
 
 
+
+def build_cp_tensor_specs(
+    start_pos: int = START_POS,
+    token_count: int = PREFILL_SEQ,
+    tp_size: int = TP_SIZE,
+):
+    """Split the single-die specs across the group: query side per rank, KV side whole."""
+    from golden import TensorSpec
+
+    if token_count % tp_size != 0:
+        raise ValueError(f"token_count={token_count} must be a multiple of tp_size={tp_size}")
+    local_t = token_count // tp_size
+
+    specs = []
+    for spec in build_tensor_specs(start_pos, token_count):
+        value = materialize_spec(spec)
+        if spec.name == "x_hc":
+            specs.append(TensorSpec(
+                "x_hc_local", [tp_size, local_t, HC_MULT, D], spec.dtype,
+                init_value=value.reshape(tp_size, local_t, HC_MULT, D).contiguous(),
+            ))
+        elif spec.name == "ori_slot_mapping":
+            specs.append(TensorSpec(
+                "ori_slot_mapping_full", [tp_size, token_count], spec.dtype, init_value=cp_stack(value, tp_size),
+            ))
+        elif spec.name == "position_ids":
+            specs.append(TensorSpec(
+                "position_ids_local", [tp_size, local_t], spec.dtype,
+                init_value=value.reshape(tp_size, local_t).contiguous(),
+            ))
+            specs.append(TensorSpec(
+                "position_ids_full", [tp_size, token_count], spec.dtype, init_value=cp_stack(value, tp_size),
+            ))
+        elif spec.name == "x_out":
+            specs.append(TensorSpec(
+                "x_out_local", [tp_size, local_t, HC_MULT, D], spec.dtype, is_output=True,
+            ))
+        else:
+            specs.append(TensorSpec(
+                spec.name, [tp_size, *spec.shape], spec.dtype,
+                init_value=cp_stack(value, tp_size), is_output=spec.is_output,
+            ))
+    return specs
+
+
+def golden_prefill_attention_swa_cp(tensors):
+    """Single-die reference over the whole stream, sliced per rank."""
+    import torch
+
+    tp_size, local_t = tensors["x_hc_local"].shape[0], tensors["x_hc_local"].shape[1]
+    token_count = tp_size * local_t
+
+    full = {
+        "x_hc": tensors["x_hc_local"].reshape(token_count, HC_MULT, D),
+        "hc_attn_fn": tensors["hc_attn_fn"][0],
+        "hc_attn_scale": tensors["hc_attn_scale"][0],
+        "hc_attn_base": tensors["hc_attn_base"][0],
+        "attn_norm_w": tensors["attn_norm_w"][0],
+        "wq_a": tensors["wq_a"][0],
+        "wq_b": tensors["wq_b"][0],
+        "wq_b_scale": tensors["wq_b_scale"][0],
+        "wkv": tensors["wkv"][0],
+        "gamma_cq": tensors["gamma_cq"][0],
+        "gamma_ckv": tensors["gamma_ckv"][0],
+        "freqs_cos": tensors["freqs_cos"][0],
+        "freqs_sin": tensors["freqs_sin"][0],
+        "kv_cache": tensors["kv_cache"][0].clone(),
+        "block_table": tensors["block_table"][0],
+        "ori_slot_mapping": tensors["ori_slot_mapping_full"][0],
+        "position_ids": tensors["position_ids_full"][0],
+        "attn_sink": tensors["attn_sink"][0],
+        "wo_a": tensors["wo_a"][0],
+        "wo_b": tensors["wo_b"][0],
+        "wo_b_scale": tensors["wo_b_scale"][0],
+        "x_out": torch.zeros(token_count, HC_MULT, D, dtype=torch.float32),
+    }
+    golden_prefill_attention_swa(full)
+
+    tensors["x_out_local"][:] = full["x_out"].reshape(tp_size, local_t, HC_MULT, D)
+    tensors["kv_cache"][:] = full["kv_cache"].unsqueeze(0).expand(tp_size, *full["kv_cache"].shape)
+
 if __name__ == "__main__":
     import argparse
+
     from golden import ratio_allclose, ratio_reldiff, run_jit
 
-    parser = argparse.ArgumentParser(description="Standalone DeepSeek V4 packed prefill SWA correctness test.")
+    parser = argparse.ArgumentParser(
+        description="Standalone DeepSeek V4 packed prefill SWA correctness test."
+    )
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
-    parser.add_argument("-d", "--device", type=int, default=0)
+    parser.add_argument("-d", "--device", type=str, default=",".join(str(i) for i in range(TP_SIZE)),
+                        help="comma-separated rank group; one ID at --tp 1")
+    parser.add_argument("--tp", type=int, default=TP_SIZE,
+                        help="rank-group size; must match the import-time --tp")
     parser.add_argument("--compile-only", action="store_true", default=False)
     parser.add_argument("--start-pos", type=int, default=START_POS,
                         help="Absolute position of the first physical query token.")
     parser.add_argument("--token-count", "--num-tokens", dest="token_count", type=int, default=PREFILL_SEQ,
-                        help="Physical query-token extent; --num-tokens is a compatibility alias.")
+                        help="Physical query-token extent across the group; must divide by --tp.")
     parser.add_argument("--enable-chip-swimlane", action="store_true", default=False)
     parser.add_argument("--enable-dep-gen", action="store_true", default=False)
     parser.add_argument("--dump-passes", action="store_true", default=False)
     args = parser.parse_args()
 
-    result = run_jit(
-        fn=prefill_attention_swa_test,
-        specs=build_tensor_specs(args.start_pos, args.token_count),
-        golden_fn=golden_prefill_attention_swa,
-        compile_cfg=dict(dump_passes=args.dump_passes),
-        runtime_cfg=dict(
-            platform=args.platform,
-            device_id=args.device,
-            enable_chip_swimlane=args.enable_chip_swimlane,
-            enable_dep_gen=args.enable_dep_gen,
-        ),
-        compile_only=args.compile_only,
-        rtol=1e-2,
-        atol=1e-2,
-        compare_fn={
-            "x_out": ratio_reldiff(diff_thd=3e-3, pct_thd=0.005, max_diff_hd=1),
-            "kv_cache": ratio_allclose(atol=1e-4, rtol=1e-2),
-        },
-    )
+    if args.tp != TP_SIZE:
+        raise SystemExit(f"--tp={args.tp} does not match import-time TP_SIZE={TP_SIZE}")
+    device_ids = [int(device) for device in args.device.split(",")]
+    if len(device_ids) != TP_SIZE:
+        parser.error(f"need exactly {TP_SIZE} devices, got {device_ids}")
+    if args.token_count % TP_SIZE != 0:
+        parser.error(f"--token-count must be a multiple of --tp={TP_SIZE}, got {args.token_count}")
+
+    if TP_SIZE == 1:
+        result = run_jit(
+            fn=prefill_attention_swa_test,
+            specs=build_tensor_specs(args.start_pos, args.token_count),
+            golden_fn=golden_prefill_attention_swa,
+            compile_cfg=dict(dump_passes=args.dump_passes),
+            runtime_cfg=dict(
+                platform=args.platform,
+                device_id=device_ids[0],
+                enable_chip_swimlane=args.enable_chip_swimlane,
+                enable_dep_gen=args.enable_dep_gen,
+            ),
+            compile_only=args.compile_only,
+            rtol=1e-2,
+            atol=1e-2,
+            compare_fn={
+                "x_out": ratio_reldiff(diff_thd=3e-3, pct_thd=0.005, max_diff_hd=1),
+                "kv_cache": ratio_allclose(atol=1e-4, rtol=1e-2),
+            },
+        )
+    else:
+        from pypto.ir.distributed_compiled_program import DistributedConfig
+
+        result = run_jit(
+            fn=l3_prefill_attention_swa_cp,
+            specs=build_cp_tensor_specs(args.start_pos, args.token_count, TP_SIZE),
+            golden_fn=golden_prefill_attention_swa_cp,
+            compile_cfg=dict(
+                dump_passes=args.dump_passes,
+                distributed_config=DistributedConfig(device_ids=device_ids, num_sub_workers=0),
+            ),
+            runtime_cfg=dict(platform=args.platform),
+            compile_only=args.compile_only,
+            rtol=1e-2,
+            atol=1e-2,
+            compare_fn={
+                "x_out_local": ratio_reldiff(diff_thd=3e-3, pct_thd=0.005, max_diff_hd=1),
+                "kv_cache": ratio_allclose(atol=1e-4, rtol=1e-2),
+            },
+        )
     if not result.passed:
         if result.error:
             print(result.error)


### PR DESCRIPTION
- Route prefill_swa, prefill_hca and prefill_csa by --tp, the shape
  decode_swa already uses: --tp 1 keeps the single-die tree untouched,
  --tp 2/4 runs the context-parallel one.
- Keep queries on each rank's local token slice and build KV from the
  gathered stream through unsliced slot mappings, so every rank rebuilds
  the same cache. The token all-gather is each block's only activation
  collective.
- Give each block a second dynamic token axis (CP_Q_T_DYN, CP_KV_T_DYN),
  because the query slice and the gathered stream carry different extents
  in one program.
- Put the ratio-128 (HCA) and ratio-4 (CSA) compressors and the indexer
  cache on the gathered stream at global positions; leave compressed
  visibility, indexer scoring and top-k, window indices, attention, o_proj
  and hc_post on the local slice.
- Split the indexer's scoring half into prefill_indexer_query with a token
  axis of its own, leaving prefill_indexer a wrapper over the compressor
  and that half with signature, parameter order and return unchanged, so
  existing callers are untouched.
- Compare all six replicated caches (kv_cache, cmp_kv, compress_state,
  inner_compress_state, idx_kv_cache, idx_kv_scale) on top of the layer
  output in the CP goldens, so a segment fed the wrong positions cannot
  compress the wrong windows silently.

This squash lands the stacked SWA (#1007) and HCA (#1009) branches
together with CSA, since the CSA branch builds on both. Part of #1004 and
#905 (P5).