### PR TITLE
Refactor: resolve pto-isa from the pin, not PTO_ISA_ROOT

### DIFF
--- a/.claude/rules/problem-handling.md
+++ b/.claude/rules/problem-handling.md
@@ -55,7 +55,7 @@ Name the owner in the entry; `unclear` is a valid answer.
 | `pypto` | `$PYPTO_ROOT` | IR generation, lowering, codegen |
 | `simpler` | `$PYPTO_ROOT/runtime` | on-device / sim execution, task-graph build & execute (AICPU + AICore) |
 | `ptoas` | `$PTOAS_ROOT` | PTO bytecode assembly & optimization |
-| `pto-isa` | `$PTO_ISA_ROOT` | virtual tile-ISA implementations |
+| `pto-isa` | simpler's managed checkout — resolve with `pypto.runtime.ensure_pto_isa_root()` | virtual tile-ISA implementations |
 
 A runtime crash / hang / AICPU error is a **simpler** issue, not a pypto one.
 

--- a/.claude/skills/create-issue/SKILL.md
+++ b/.claude/skills/create-issue/SKILL.md
@@ -59,7 +59,12 @@ jump to Step 7.
 | pypto | `hw-native-sys/pypto` | `$PYPTO_ROOT` | IR generation, lowering, codegen |
 | simpler | `hw-native-sys/simpler` | `$PYPTO_ROOT/runtime` | on-device / sim execution, task-graph build/execute (AICPU + AICore) |
 | ptoas | `hw-native-sys/PTOAS` | `$PTOAS_ROOT` (binary) / `../PTOAS` (source) | PTO bytecode assembly & optimization |
-| pto-isa | `hw-native-sys/pto-isa` | `$PTO_ISA_ROOT` | virtual tile-ISA implementations |
+| pto-isa | `hw-native-sys/pto-isa` | `$PTO_ISA_CHECKOUT` (see below) | virtual tile-ISA implementations |
+
+There is no pto-isa root to export: simpler owns that checkout and
+`runtime/pto_isa.pin` is the only thing that selects it. Resolve it once with
+`PTO_ISA_CHECKOUT="$(python -c 'from pypto.runtime import ensure_pto_isa_root; print(ensure_pto_isa_root())')"`
+before running the commands below.
 
 `simpler` is the pypto **runtime** submodule (submodule name `simpler`, path
 `$PYPTO_ROOT/runtime`). It tracks `hw-native-sys/simpler`, and it is a
@@ -100,9 +105,10 @@ git -C "$PYPTO_ROOT" branch --show-current
 git -C "$PYPTO_ROOT/runtime" rev-parse --short HEAD
 git -C "$PYPTO_ROOT/runtime" branch --show-current   # often empty (detached)
 
-# pto-isa (usually detached HEAD)
-git -C "$PTO_ISA_ROOT" rev-parse --short HEAD
-git -C "$PTO_ISA_ROOT" branch --show-current         # often empty (detached)
+# pto-isa (simpler-managed checkout; usually detached HEAD)
+PTO_ISA_CHECKOUT="$(python -c 'from pypto.runtime import ensure_pto_isa_root; print(ensure_pto_isa_root())')"
+git -C "$PTO_ISA_CHECKOUT" rev-parse --short HEAD
+git -C "$PTO_ISA_CHECKOUT" branch --show-current     # often empty (detached)
 
 # ptoas version. Probe in pypto's own order (backend/_ptoas_locate.py): the
 # three entries are not interchangeable, and from v0.55 only ptoas.sh selects
@@ -325,7 +331,7 @@ git -C "$PYPTO_ROOT/runtime" rev-parse HEAD
 
 # pto-isa: pin is a FULL 40-char hash; compare against the full actual HEAD
 tr -d '[:space:]' < "$PYPTO_ROOT/runtime/pto_isa.pin"
-git -C "$PTO_ISA_ROOT" rev-parse HEAD
+git -C "$PTO_ISA_CHECKOUT" rev-parse HEAD
 
 # ptoas: normalize both sides to a bare version, then compare
 ( . "$PYPTO_ROOT/toolchain/versions.env" && echo "${PTOAS_VERSION#v}" )

--- a/.claude/skills/incore-profiling/incore_profile.py
+++ b/.claude/skills/incore-profiling/incore_profile.py
@@ -86,7 +86,16 @@ def resolve_generate_testcase(ptoas_root: Path | None) -> Path:
 
 
 def default_pto_isa_root() -> Path:
-    return repo_path(os.environ.get("PTO_ISA_ROOT", str(Path.home() / "pto-isa")))
+    """Resolve the pto-isa checkout pypto pins via ``runtime/pto_isa.pin``.
+
+    An ambient ``PTO_ISA_ROOT`` is not the pin -- pypto stopped reading it, so
+    the pin-backed resolver is the only supported source for this path.
+    """
+    # Imported here so `--help` and the pure-report paths keep working in a
+    # checkout without pypto installed.
+    from pypto.runtime import ensure_pto_isa_root
+
+    return Path(ensure_pto_isa_root())
 
 
 def discover_cann_set_env() -> Path | None:
@@ -736,7 +745,9 @@ def parse_args(argv: list[str]) -> tuple[argparse.Namespace, list[str]]:
         "when omitted, the bundled .pto-driven gen_profiling_case.py is used",
     )
     tool_group.add_argument(
-        "--pto-isa-root", default=default_pto_isa_root(), help="pto-isa root passed to CMake"
+        "--pto-isa-root",
+        default=None,
+        help="pto-isa root passed to CMake; resolved from pypto's pin when omitted",
     )
     tool_group.add_argument(
         "--soc-version",
@@ -802,7 +813,9 @@ def parse_args(argv: list[str]) -> tuple[argparse.Namespace, list[str]]:
     if case_args and case_args[0] == "--":
         case_args = case_args[1:]
     args.ptoas_root = repo_path(args.ptoas_root) if args.ptoas_root else None
-    args.pto_isa_root = repo_path(args.pto_isa_root)
+    # Left None when omitted: resolving the pin imports pypto and may clone, and
+    # `--list-funcs --build-dir` is filesystem-only. validate_toolchain() fills it in.
+    args.pto_isa_root = repo_path(args.pto_isa_root) if args.pto_isa_root else None
     args.generate_testcase = resolve_generate_testcase(args.ptoas_root)
     if args.dynamic_dim <= 0:
         parser.error("--dynamic-dim must be greater than zero")
@@ -1128,6 +1141,8 @@ def validate_toolchain(args: argparse.Namespace) -> dict[str, str]:
             raise StepError("CANN set_env.sh not found; pass --cann-set-env explicitly")
     if not args.generate_testcase.is_file():
         raise StepError(f"generate_testcase.py not found: {args.generate_testcase}")
+    if args.pto_isa_root is None:
+        args.pto_isa_root = default_pto_isa_root()
     if not args.pto_isa_root.exists():
         raise StepError(f"--pto-isa-root not found: {args.pto_isa_root}")
     env = source_env(args.cann_set_env, os.environ.copy())

--- a/.claude/skills/setup-env/SKILL.md
+++ b/.claude/skills/setup-env/SKILL.md
@@ -34,8 +34,8 @@ this skill.
    - take `PTOAS_VERSION` from that revision's `toolchain/versions.env`, never
      from a log or a previous session;
    - install PyPTO, then unpack that PTOAS release under `PTOAS_ROOT`;
-   - leave PTO ISA alone unless the user maintains their own checkout — PyPTO
-     and simpler each clone and pin one on first use.
+   - leave PTO ISA alone — simpler clones and pins the one managed checkout
+     on first use, and `PTO_ISA_ROOT` cannot redirect it.
 5. For a device environment, source the selected CANN `set_env.sh` and run
    `npu-smi info` before installing simpler. Simpler detects `ccec` and the
    cross-compiler during installation and only prebuilds the platforms whose
@@ -54,7 +54,8 @@ this skill.
      `backend/_ptoas_locate.py` does, because a v0.55+ release runs only
      through its own `ptoas.sh`;
    - the simpler submodule revision belongs to the selected PyPTO checkout;
-   - any PTO ISA checkout in use is at `runtime/pto_isa.pin`;
+   - the commit at the checkout `pypto.runtime.ensure_pto_isa_root()` returns
+     matches the full hash in `runtime/pto_isa.pin`;
    - `PTOAS_ROOT` and the repository `PYTHONPATH` are usable in the shell that
      will run the case.
 10. When the requested platform is available, run

--- a/.github/actions/setup-ci-job/action.yml
+++ b/.github/actions/setup-ci-job/action.yml
@@ -4,16 +4,19 @@ description: >-
   `sim`, daily_ci.yml `model-tests-sim`) and the on-device ones (ci.yml `a2a3` /
   `serving`, daily_ci.yml `model-tests-a2a3`). All of them run directly on the
   host, as the same user, through this one action: resilient checkout into a
-  per-job dir, toolchain resolution from the cached pypto source, ptoas + pto-isa
-  install, a per-job conda venv + activate.sh, and a from-source build/install of
-  pypto + simpler. The device jobs differ only in that they additionally check the
+  per-job dir, toolchain resolution from the cached pypto source, a ptoas install,
+  a per-job conda venv + activate.sh, and a from-source build/install of
+  pypto + simpler. Simpler's own installer resolves the pinned pto-isa checkout
+  (pypto's runtime/pto_isa.pin is the single source of truth), so this action
+  never clones it. The device jobs differ only in that they additionally check the
   NPU and source CANN's set_env.sh — see the needs-device input.
 
   Unlike pypto (which builds itself), pypto-lib builds against a separate pypto
   clone kept in a per-job ci-cache/pypto-src-<build-namespace> dir (concurrent
   jobs must not share one build tree — see the build-namespace input); the
   toolchain pins (ptoas version/sha, pto-isa commit) are read from that same clone
-  so the installed pypto and the pins always match.
+  so the installed pypto and the pins always match. The pto-isa commit only
+  namespaces ccache here; it does not select a checkout.
 
   Each host describes its own layout in the runner's `.env` (the file in the
   runner application's root dir, which the runner service loads into every job it
@@ -40,7 +43,7 @@ description: >-
   into an isolated venv at PTOAS_ROOT, which keeps the PTOAS_ROOT/bin/ptoas
   layout pypto's discovery already accepts.
 
-  The calling job must define the PTOAS_ROOT, PTO_ISA_ROOT, CMAKE_* and the
+  The calling job must define the PTOAS_ROOT, CMAKE_* and the
   non-path CCACHE_* (MAXSIZE / UMASK) environment variables; they are read from
   the job environment here. PTOAS_VERSION, PTOAS_SHA256, PTO_ISA_COMMIT and
   CCACHE_NAMESPACE are resolved and exported by this action, as is every cache
@@ -268,7 +271,8 @@ runs:
       # Sync the cached pypto checkout ONCE here; the Build step below reuses it,
       # so the toolchain pins and the installed pypto are always the same
       # revision. pypto owns ptoas (toolchain/versions.env) and pins pto-isa via
-      # its runtime submodule (runtime/pto_isa.pin); read both.
+      # its runtime submodule (runtime/pto_isa.pin); read both — the pto-isa pin
+      # only keys ccache, since simpler resolves the checkout from it itself.
       shell: bash
       run: |
         # $PYPTO_SRC is the per-job build tree exported by the loader step:
@@ -384,29 +388,6 @@ runs:
     - name: Scope ccache to pto-isa version
       shell: bash
       run: echo "CCACHE_NAMESPACE=pto-isa-${PTO_ISA_COMMIT}" >> "$GITHUB_ENV"
-
-    - name: Clone pto-isa repository (pinned)
-      shell: bash
-      run: |
-        # Each composite step is a fresh shell, so re-declare the retry helper
-        # here to wrap the clone in the same transient-TLS backoff as the sync
-        # step above (a single network blip must not fail the whole job).
-        retry() {
-          local attempt=0
-          until "$@"; do
-            attempt=$((attempt + 1))
-            if [ "$attempt" -ge 4 ]; then
-              echo "'$*' failed after $attempt attempts"; return 1
-            fi
-            echo "'$*' attempt $attempt failed; retrying in $((attempt * 10))s"
-            sleep $((attempt * 10))
-          done
-        }
-        rm -rf "$PTO_ISA_ROOT"
-        retry timeout 60 git clone https://github.com/hw-native-sys/pto-isa.git "$PTO_ISA_ROOT" \
-          || { rm -rf "$PTO_ISA_ROOT"; retry timeout 300 git clone https://gitcode.com/luohuan40/pto-isa.git "$PTO_ISA_ROOT"; }
-        cd "$PTO_ISA_ROOT"
-        git checkout "$PTO_ISA_COMMIT"
 
     - name: Bootstrap conda + per-job venv + write activate.sh
       if: ${{ inputs.toolchain == 'conda' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,7 +153,6 @@ jobs:
         working-directory: checkout
     env:
       PTOAS_ROOT: ${{ github.workspace }}/checkout/ptoas-bin
-      PTO_ISA_ROOT: ${{ github.workspace }}/checkout/pto-isa
       CMAKE_BUILD_PARALLEL_LEVEL: 16
       CMAKE_C_COMPILER_LAUNCHER: ccache
       CMAKE_CXX_COMPILER_LAUNCHER: ccache
@@ -255,7 +254,6 @@ jobs:
         working-directory: checkout
     env:
       PTOAS_ROOT: ${{ github.workspace }}/checkout/ptoas-bin
-      PTO_ISA_ROOT: ${{ github.workspace }}/checkout/pto-isa
       CMAKE_BUILD_PARALLEL_LEVEL: 16
       CMAKE_C_COMPILER_LAUNCHER: ccache
       CMAKE_CXX_COMPILER_LAUNCHER: ccache
@@ -358,7 +356,6 @@ jobs:
     timeout-minutes: 120
     env:
       PTOAS_ROOT: ${{ github.workspace }}/checkout/ptoas-bin
-      PTO_ISA_ROOT: ${{ github.workspace }}/checkout/pto-isa
       CMAKE_BUILD_PARALLEL_LEVEL: 16
       CMAKE_C_COMPILER_LAUNCHER: ccache
       CMAKE_CXX_COMPILER_LAUNCHER: ccache
@@ -419,7 +416,6 @@ jobs:
     timeout-minutes: 120
     env:
       PTOAS_ROOT: ${{ github.workspace }}/checkout/ptoas-bin
-      PTO_ISA_ROOT: ${{ github.workspace }}/checkout/pto-isa
       CMAKE_BUILD_PARALLEL_LEVEL: 16
       CMAKE_C_COMPILER_LAUNCHER: ccache
       CMAKE_CXX_COMPILER_LAUNCHER: ccache

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -29,7 +29,6 @@ jobs:
         working-directory: checkout
     env:
       PTOAS_ROOT: ${{ github.workspace }}/checkout/ptoas-bin
-      PTO_ISA_ROOT: ${{ github.workspace }}/checkout/pto-isa
       CMAKE_BUILD_PARALLEL_LEVEL: 16
       CMAKE_C_COMPILER_LAUNCHER: ccache
       CMAKE_CXX_COMPILER_LAUNCHER: ccache
@@ -165,7 +164,6 @@ jobs:
         working-directory: checkout
     env:
       PTOAS_ROOT: ${{ github.workspace }}/checkout/ptoas-bin
-      PTO_ISA_ROOT: ${{ github.workspace }}/checkout/pto-isa
       CMAKE_BUILD_PARALLEL_LEVEL: 16
       CMAKE_C_COMPILER_LAUNCHER: ccache
       CMAKE_CXX_COMPILER_LAUNCHER: ccache
@@ -332,7 +330,6 @@ jobs:
         working-directory: checkout
     env:
       PTOAS_ROOT: ${{ github.workspace }}/checkout/ptoas-bin
-      PTO_ISA_ROOT: ${{ github.workspace }}/checkout/pto-isa
       CMAKE_BUILD_PARALLEL_LEVEL: 16
       CMAKE_C_COMPILER_LAUNCHER: ccache
       CMAKE_CXX_COMPILER_LAUNCHER: ccache
@@ -513,7 +510,6 @@ jobs:
         working-directory: checkout
     env:
       PTOAS_ROOT: ${{ github.workspace }}/checkout/ptoas-bin
-      PTO_ISA_ROOT: ${{ github.workspace }}/checkout/pto-isa
       CMAKE_BUILD_PARALLEL_LEVEL: 16
       CMAKE_C_COMPILER_LAUNCHER: ccache
       CMAKE_CXX_COMPILER_LAUNCHER: ccache

--- a/docs/get-started/installation.md
+++ b/docs/get-started/installation.md
@@ -130,18 +130,19 @@ pinned one.
 
 ## PTO ISA
 
-Nothing to clone by hand — PyPTO and simpler each manage their own checkout at
-the commit in `$PYPTO_ROOT/runtime/pto_isa.pin`:
+Nothing to clone by hand, and nothing to point at. simpler owns the single
+managed checkout — `build/pto-isa` under the installed `simpler_setup` package
+— and `$PYPTO_ROOT/runtime/pto_isa.pin` is the only thing that selects its
+revision. PyPTO delegates to that resolver rather than keeping one of its own:
+`pypto.runtime.pto_isa_include_dir()` returns the include directory a kernel
+needs. `PTO_ISA_ROOT` is exported with the resolved path but never read back,
+so setting it cannot substitute a different tree.
 
-| Consumer | Managed checkout | Honours `PTO_ISA_ROOT` |
-|---|---|---|
-| PyPTO | `build_output/_deps/pto-isa` under the working directory | yes — set it and no clone happens |
-| simpler | `build/pto-isa` under the installed `simpler_setup` package | no — it always uses its own copy |
-
-Both clone on first use, so the first device build in a fresh environment
-pauses on a `git clone` — on a slow or blocked network that looks like a hang.
-Seeding either path with a symlink to an existing pto-isa at the pinned commit
-avoids the wait.
+The checkout is cloned on first use, so the first device build in a fresh
+environment pauses on a `git clone` — on a slow or blocked network that looks
+like a hang. Seeding that path with a symlink to an existing pto-isa at the
+pinned commit avoids the wait; a checkout that is dirty or off the pin is
+re-cloned rather than reused in place.
 
 ## Verify
 

--- a/models/qwen3_14b/paged_attention_cce.py
+++ b/models/qwen3_14b/paged_attention_cce.py
@@ -12,6 +12,7 @@ import os
 from pathlib import Path
 
 import pypto.language as pl
+from pypto.runtime import pto_isa_include_dir
 
 
 _KERNEL_DIR = Path(__file__).parent / "kernels" / "paged_attention_cce"
@@ -52,10 +53,9 @@ _CANN_INCLUDE_DIRS = _cann_include_dirs()
 
 # The fused rope+attention extern embeds the pypto-generated rope_qkv kernel,
 # which includes <pto/pto-inst.hpp>; add the pto-isa include root for it.
-_PTO_ISA_INCLUDE = Path(os.environ.get("PTO_ISA_ROOT", "")) / "include"
-_ROPE_INCLUDE_DIRS = _CANN_INCLUDE_DIRS + (
-    (_PTO_ISA_INCLUDE,) if _PTO_ISA_INCLUDE.is_dir() else ()
-)
+# pto_isa_include_dir() resolves runtime/pto_isa.pin -- an ambient PTO_ISA_ROOT
+# is not the pin and pypto no longer reads it.
+_ROPE_INCLUDE_DIRS = _CANN_INCLUDE_DIRS + (pto_isa_include_dir(),)
 
 SUPPORTED_PLATFORMS = ("a2a3", "a2a3sim")
 # METADATA_BATCH_SLOTS is the PHYSICAL slot count of the metadata length arrays.


### PR DESCRIPTION
PyPTO deleted its own PTO-ISA resolver and now delegates to simpler,
for which runtime/pto_isa.pin is the single source of truth. It still
exports PTO_ISA_ROOT with the resolved path but never reads one back,
so every consumer here that treated the variable as an input is now
reading something nothing sets.

- Build the fused rope+attention extern's include list from
  pypto.runtime.pto_isa_include_dir() instead of $PTO_ISA_ROOT/include,
  which degraded to a relative path and silently dropped the include
  when the variable was unset
- Resolve incore_profile.py's --pto-isa-root default from that same pin
  in validate_toolchain() rather than at parse time, so --help and the
  filesystem-only --list-funcs --build-dir path still import no pypto
  and clone nothing; an explicit --pto-isa-root still wins
- Drop the CI pto-isa clone step and the eight PTO_ISA_ROOT job-env
  entries -- simpler's installer resolves the pin itself, and
  PTO_ISA_COMMIT now only namespaces ccache
- Describe the single simpler-managed checkout, and how to resolve it,
  in installation.md, problem-handling.md, and the setup-env /
  create-issue skills