### PR TITLE
Refactor: rename enable_l2_swimlane to enable_chip_swimlane

### DIFF
--- a/.claude/rules/benchmarking.md
+++ b/.claude/rules/benchmarking.md
@@ -24,7 +24,7 @@ Where the numbers come from — see
 | Metric | Source | Quote |
 | --- | --- | --- |
 | Wall time | `PYPTO_BENCH=1` → `[RUN] effective_us (N rounds) …` | `mean=` (daily CI's per-case number is exactly this field) |
-| Core busy time | L2 swimlane per-task durations; PMU `*_busy_cycles` vs `pmu_total_cycles` | The bottleneck pipe's ratio |
+| Core busy time | chip swimlane per-task durations; PMU `*_busy_cycles` vs `pmu_total_cycles` | The bottleneck pipe's ratio |
 
 A `*sim` platform prints `effective_us unavailable: no device-domain spans`. A
 simulator run can confirm compile and correctness; it **cannot rank two
@@ -97,7 +97,7 @@ When the per-rank breakdown is not enough:
 
 - `PYPTO_BENCH_RAW=1` prints every dispatch's sample per rank in order — use it
   to spot start-up drift, a bimodal rank, or one card lagging.
-- Capture a per-rank L2 swimlane and measure from the first real compute task
+- Capture a per-rank chip swimlane and measure from the first real compute task
   instead of the window start, subtracting the leading wait explicitly.
 - `host_union_mean_us` is the opposite convention — it *includes* start skew and
   host dispatch overhead by construction. Never use it as the kernel number.

--- a/.claude/skills/add-dummy/SKILL.md
+++ b/.claude/skills/add-dummy/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: add-dummy
-description: Protect an Observed-critical-path PyPTO operator by stopping a named early-dispatched noncritical sibling from consuming the same speculative dispatch opportunity. Add an unflagged pl.system.task_dummy(deps=[]) only to that sibling's direct deps, then use before/after level-4 L2 swimlanes to prove the protected sibling was early-dispatched and compare shared-producer-end to protected-operator-end latency. Use for `/add-dummy operator-name`, sibling early-dispatch contention, or dependency-only dummy scheduling experiments.
+description: Protect an Observed-critical-path PyPTO operator by stopping a named early-dispatched noncritical sibling from consuming the same speculative dispatch opportunity. Add an unflagged pl.system.task_dummy(deps=[]) only to that sibling's direct deps, then use before/after level-4 chip swimlanes to prove the protected sibling was early-dispatched and compare shared-producer-end to protected-operator-end latency. Use for `/add-dummy operator-name`, sibling early-dispatch contention, or dependency-only dummy scheduling experiments.
 ---
 
 # Add Dummy
@@ -41,10 +41,10 @@ SKILL_PTOAS_VERSION=${PTOAS_VERSION#v}
 
 Inspect the executable's `argparse` definition before adding the swimlane flag:
 
-- `action="store_true"`: pass bare `--enable-l2-swimlane`; runtime `True` maps
+- `action="store_true"`: pass bare `--enable-chip-swimlane`; runtime `True` maps
   to level 4.
 - An integer/optional-value argument accepting `4`: pass
-  `--enable-l2-swimlane 4`.
+  `--enable-chip-swimlane 4`.
 - If the CLI excludes level 4, stop. Do not substitute level 1 or 2.
 
 Submit the real NPU run through the device queue; do not infer device health
@@ -64,8 +64,8 @@ task-submit --device auto --ptoas "$SKILL_PTOAS_VERSION" \
    else echo "invalid PTOAS install: $SKILL_PTOAS_INSTALL" >&2; exit 2; fi && \
    export PATH="$PTOAS_ROOT:$PATH" && \
    python <operator.py> <normal arguments> --device "$TASK_DEVICE" \
-     --enable-l2-swimlane 4'
-find build_output -type f -name l2_swimlane_records.json -newer "$CAPTURE_MARKER" -print
+     --enable-chip-swimlane 4'
+find build_output -type f -name chip_swimlane_records.json -newer "$CAPTURE_MARKER" -print
 rm -f "$CAPTURE_MARKER"
 ```
 
@@ -86,13 +86,13 @@ newer than it. Current onboard PyPTO automatically performs separate graph and
 timing passes; analyze the timing pass. Require each selected dispatch to have:
 
 ```text
-l2_swimlane_records.json
+chip_swimlane_records.json
 deps.json
 name_map*.json
 dispatch_program.json       # mandatory when multiple programs/dispatches exist
 ```
 
-Require `l2_swimlane_level == 4`, a complete AICore/AICPU clock join, and the
+Require `chip_swimlane_level == 4`, a complete AICore/AICPU clock join, and the
 same value-routed task topology in the deps and timing passes. Device-resident
 control tensors are zero-filled in the graph-only child; stop if that can alter
 task routing and no equivalent capture with real control values exists.

--- a/.claude/skills/add-dummy/scripts/report.py
+++ b/.claude/skills/add-dummy/scripts/report.py
@@ -36,7 +36,7 @@ except ImportError as exc:  # pragma: no cover - environment preflight
     ) from exc
 
 
-RECORD_NAMES = ("l2_swimlane_records.json", "l2_perf_records.json")
+RECORD_NAMES = ("chip_swimlane_records.json", "l2_swimlane_records.json", "l2_perf_records.json")
 RANK_RE = re.compile(r"rank\d+$")
 SNAPSHOT_VERSION = 1
 
@@ -247,9 +247,9 @@ def _build_run(directory: Path, graph_root: Path, tol_ticks: int) -> Run:
     if records is None:
         raise ValueError(f"{directory}: missing swimlane records")
     raw = _read_json(records)
-    level = raw.get("l2_swimlane_level") if isinstance(raw, dict) else None
+    level = raw.get("chip_swimlane_level", raw.get("l2_swimlane_level")) if isinstance(raw, dict) else None
     if level != 4:
-        raise ValueError(f"{records}: expected l2_swimlane_level=4, got {level!r}")
+        raise ValueError(f"{records}: expected chip_swimlane_level=4, got {level!r}")
     frequency = int((raw.get("metadata") or {}).get("clock_freq_hz") or 0)
     if frequency <= 0:
         raise ValueError(f"{records}: invalid clock frequency {frequency}")
@@ -1197,7 +1197,7 @@ def _render_comparison(before: dict[str, Any], after: dict[str, Any]) -> str:
 
 def parse_args(argv: list[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Analyze an add-dummy sibling-suppression experiment from level-4 L2 swimlanes."
+        description="Analyze an add-dummy sibling-suppression experiment from level-4 chip swimlanes."
     )
     parser.add_argument("build_dir", type=Path, help="Build/run directory containing fresh dfx_outputs")
     parser.add_argument("--suppressed", required=True, help="Exact name of sibling b that receives the dummy")

--- a/.claude/skills/critical-path/SKILL.md
+++ b/.claude/skills/critical-path/SKILL.md
@@ -1,18 +1,18 @@
 ---
 name: critical-path
-description: Find the execution critical path of a PyPTO operator from a level-4 L2 swimlane, report every path task and its preceding gap, mark gaps over 1 µs and tasks actually dispatched early, and identify defensible dispatch or core blockers. Use for `/critical-path operator`, operator latency investigations, multi-card fast-rank analysis, scheduler gaps, and early-dispatch verification.
+description: Find the execution critical path of a PyPTO operator from a level-4 chip swimlane, report every path task and its preceding gap, mark gaps over 1 µs and tasks actually dispatched early, and identify defensible dispatch or core blockers. Use for `/critical-path operator`, operator latency investigations, multi-card fast-rank analysis, scheduler gaps, and early-dispatch verification.
 ---
 
 # Critical Path
 
 Analyze one operator run in two stages:
 
-1. Capture a level-4 L2 swimlane and reconstruct the official Observed critical
+1. Capture a level-4 chip swimlane and reconstruct the official Observed critical
    path with `simpler_setup.tools.critical_path`.
 2. Investigate every path gap over 1 µs using task dependencies, AICPU
    dispatch/finish timestamps, and physical-core occupancy.
 
-Call this profiling tier **"L2 swimlane perf level 4"**. Do not confuse it with
+Call this profiling tier **"chip swimlane perf level 4"**. Do not confuse it with
 the runtime hierarchy's L4 worker level.
 
 ## 1. Resolve the operator and capture command
@@ -28,10 +28,10 @@ program name.
    list. A smaller or synthetic case answers a different performance question.
 4. Inspect the operator's `argparse` definition before choosing the swimlane
    flag:
-   - `action="store_true"`: pass bare `--enable-l2-swimlane`; `True` maps to
+   - `action="store_true"`: pass bare `--enable-chip-swimlane`; `True` maps to
      level 4 in the runtime binding.
    - An integer / optional-value argument accepting 4: pass
-     `--enable-l2-swimlane 4` explicitly. A bare flag often means level 1.
+     `--enable-chip-swimlane 4` explicitly. A bare flag often means level 1.
    - An argument whose choices exclude 4: stop and explain that this CLI cannot
      produce the required capture. Do not analyze level 1/2 as level 4 or
      silently edit the operator.
@@ -61,8 +61,8 @@ task-submit --device auto --ptoas "$SKILL_PTOAS_VERSION" \
    else echo "invalid PTOAS install: $SKILL_PTOAS_INSTALL" >&2; exit 2; fi && \
    export PATH="$PTOAS_ROOT:$PATH" && \
    python <operator.py> <normal operator arguments> --device "$TASK_DEVICE" \
-     --enable-l2-swimlane 4'
-find build_output -type f -name l2_swimlane_records.json -newer "$CAPTURE_MARKER" -print
+     --enable-chip-swimlane 4'
+find build_output -type f -name chip_swimlane_records.json -newer "$CAPTURE_MARKER" -print
 rm -f "$CAPTURE_MARKER"
 ```
 
@@ -92,7 +92,7 @@ join it with the timing artifacts offline.
 For every selected single-card or distributed dispatch directory, require:
 
 ```text
-l2_swimlane_records.json   # legacy l2_perf_records.json is also readable
+chip_swimlane_records.json   # legacy l2_swimlane_records.json / l2_perf_records.json also readable
 deps.json
 name_map*.json
 merged_swimlane*.json      # optional for analysis; useful in Perfetto
@@ -111,7 +111,7 @@ same `func_id`.
 Verify every records file is truly level 4:
 
 ```bash
-jq -e '.l2_swimlane_level == 4' <records>
+jq -e '.chip_swimlane_level == 4' <records>
 ```
 
 Reject the comparison if any candidate rank is missing dependencies, names, or

--- a/.claude/skills/critical-path/scripts/report.py
+++ b/.claude/skills/critical-path/scripts/report.py
@@ -7,7 +7,7 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
 
-"""Render an operator-focused report from level-4 L2 swimlane artifacts.
+"""Render an operator-focused report from level-4 chip swimlane artifacts.
 
 The observed path itself comes from ``simpler_setup.tools.critical_path``.
 This companion adds:
@@ -41,7 +41,7 @@ except ImportError as exc:  # pragma: no cover - exercised by the environment pr
     ) from exc
 
 
-RECORD_NAMES = ("l2_swimlane_records.json", "l2_perf_records.json")
+RECORD_NAMES = ("chip_swimlane_records.json", "l2_swimlane_records.json", "l2_perf_records.json")
 RANK_RE = re.compile(r"rank\d+$")
 
 
@@ -155,9 +155,9 @@ def _build_analysis(directory: Path, root: Path, tol: int) -> RunAnalysis:
     if records is None:
         raise ValueError(f"missing swimlane records in {directory}")
     raw = _read_json(records)
-    level = raw.get("l2_swimlane_level") if isinstance(raw, dict) else None
+    level = raw.get("chip_swimlane_level", raw.get("l2_swimlane_level")) if isinstance(raw, dict) else None
     if level != 4:
-        raise ValueError(f"{records}: expected l2_swimlane_level=4, got {level!r}")
+        raise ValueError(f"{records}: expected chip_swimlane_level=4, got {level!r}")
     metadata = raw.get("metadata") or {}
     frequency = int(metadata.get("clock_freq_hz") or 0)
     if frequency <= 0:
@@ -690,7 +690,7 @@ def _render(
 
 def parse_args(argv: list[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Render a gap/early-dispatch/blocker report from a level-4 L2 swimlane run."
+        description="Render a gap/early-dispatch/blocker report from a level-4 chip swimlane run."
     )
     parser.add_argument("build_dir", type=Path, help="Build/run directory containing dfx_outputs artifacts")
     parser.add_argument("--operator", help="Filter distributed dispatch_program.json values")

--- a/.claude/skills/early-dispatch/SKILL.md
+++ b/.claude/skills/early-dispatch/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: early-dispatch
-description: Enable and verify speculative early dispatch for a named small PyPTO operator by marking every direct producer with allow_early_resolve=True, using before/after level-4 L2 swimlanes to measure its start gap and prove actual scheduler staging. Use for `/early-dispatch operator-name`, reducing gaps before short operators, adding producer-side early-resolve hints, or diagnosing why an eligible task was not early-dispatched.
+description: Enable and verify speculative early dispatch for a named small PyPTO operator by marking every direct producer with allow_early_resolve=True, using before/after level-4 chip swimlanes to measure its start gap and prove actual scheduler staging. Use for `/early-dispatch operator-name`, reducing gaps before short operators, adding producer-side early-resolve hints, or diagnosing why an eligible task was not early-dispatched.
 ---
 
 # Early Dispatch
 
 Make one named small operator start sooner by opting in every direct producer,
-then prove the result with fresh before/after **L2 swimlane perf level 4**
+then prove the result with fresh before/after **chip swimlane perf level 4**
 captures.
 
 Keep these invariants:
@@ -36,10 +36,10 @@ names in the report.
    instance, not a source identifier.
 4. Inspect the executable's `argparse` definition before selecting the swimlane
    flag:
-   - For `action="store_true"`, pass bare `--enable-l2-swimlane`; runtime `True`
+   - For `action="store_true"`, pass bare `--enable-chip-swimlane`; runtime `True`
      maps to level 4.
    - For an integer/optional-value argument accepting `4`, pass
-     `--enable-l2-swimlane 4`.
+     `--enable-chip-swimlane 4`.
    - If the argument rejects level 4, stop. Do not analyze level 1/2 or silently
      change the CLI.
 
@@ -70,8 +70,8 @@ task-submit --device auto --ptoas "$SKILL_PTOAS_VERSION" \
    else echo "invalid PTOAS install: $SKILL_PTOAS_INSTALL" >&2; exit 2; fi && \
    export PATH="$PTOAS_ROOT:$PATH" && \
    python <operator.py> <normal arguments> --device "$TASK_DEVICE" \
-     --enable-l2-swimlane 4'
-find build_output -type f -name l2_swimlane_records.json -newer "$CAPTURE_MARKER" -print
+     --enable-chip-swimlane 4'
+find build_output -type f -name chip_swimlane_records.json -newer "$CAPTURE_MARKER" -print
 rm -f "$CAPTURE_MARKER"
 ```
 
@@ -101,13 +101,13 @@ value-routed graphs have identical callable identities.
 Require, for every selected rank/dispatch:
 
 ```text
-l2_swimlane_records.json
+chip_swimlane_records.json
 deps.json
 name_map*.json
 dispatch_program.json     # required when multiple programs/dispatches must be distinguished
 ```
 
-Read the raw records and require `l2_swimlane_level == 4`. Use
+Read the raw records and require `chip_swimlane_level == 4`. Use
 `swimlane_converter.read_perf_data()` for the AICore/AICPU clock join; never
 join raw cycle streams by hand. Reject a capture unless raw AICore rows, raw
 AICPU rows, and joined rows have equal counts. For every timed logical task,

--- a/.claude/skills/early-dispatch/scripts/report.py
+++ b/.claude/skills/early-dispatch/scripts/report.py
@@ -7,7 +7,7 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
 
-"""Inspect and compare actual early dispatch in level-4 L2 swimlane artifacts.
+"""Inspect and compare actual early dispatch in level-4 chip swimlane artifacts.
 
 The source-side ``allow_early_resolve`` flag belongs to a producer. A consumer
 is considered actually early-dispatched only when every direct producer is
@@ -36,7 +36,7 @@ except ImportError as exc:  # pragma: no cover - environment preflight
     ) from exc
 
 
-RECORD_NAMES = ("l2_swimlane_records.json", "l2_perf_records.json")
+RECORD_NAMES = ("chip_swimlane_records.json", "l2_swimlane_records.json", "l2_perf_records.json")
 RANK_RE = re.compile(r"rank\d+$")
 BASELINE_VERSION = 2
 
@@ -216,9 +216,9 @@ def _build_run(directory: Path) -> Run:
     if records is None:
         raise ValueError(f"{directory}: missing swimlane records")
     raw = _read_json(records)
-    level = raw.get("l2_swimlane_level") if isinstance(raw, dict) else None
+    level = raw.get("chip_swimlane_level", raw.get("l2_swimlane_level")) if isinstance(raw, dict) else None
     if level != 4:
-        raise ValueError(f"{records}: expected l2_swimlane_level=4, got {level!r}")
+        raise ValueError(f"{records}: expected chip_swimlane_level=4, got {level!r}")
     frequency = int((raw.get("metadata") or {}).get("clock_freq_hz") or 0)
     if frequency <= 0:
         raise ValueError(f"{records}: invalid clock frequency {frequency}")
@@ -1001,7 +1001,7 @@ def _render_comparison(before: dict[str, Any], after: dict[str, Any]) -> str:
 
 def parse_args(argv: list[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Inspect actual early dispatch for a named task in level-4 L2 swimlane artifacts."
+        description="Inspect actual early dispatch for a named task in level-4 chip swimlane artifacts."
     )
     parser.add_argument("build_dir", type=Path, help="Build/run directory containing fresh dfx_outputs")
     parser.add_argument("--target", required=True, help="Exact task/operator name from name_map")

--- a/.claude/skills/fmt-coding-style/SKILL.md
+++ b/.claude/skills/fmt-coding-style/SKILL.md
@@ -147,7 +147,7 @@ return mtp_projection(
 ```python
 # before
 parser.add_argument(
-    "--enable-l2-swimlane",
+    "--enable-chip-swimlane",
     type=int,
     nargs="?",
     const=1,
@@ -156,7 +156,7 @@ parser.add_argument(
 )
 
 # after
-parser.add_argument("--enable-l2-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2, 4))
+parser.add_argument("--enable-chip-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2, 4))
 ```
 
 Structures that stay one-item-per-line:

--- a/.claude/skills/incore-profiling/incore_profile.py
+++ b/.claude/skills/incore-profiling/incore_profile.py
@@ -20,7 +20,7 @@ Typical usage:
     --run-env PTO2_RING_TASK_WINDOW=131072 \
     --run-env PTO2_RING_DEP_POOL=131072 \
     --run-env PTO2_RING_HEAP=536870912 \
-    -- --enable-l2-swimlane
+    -- --enable-chip-swimlane
 
 CANN, the camodel SoC, and the compile arch are auto-resolved from --target;
 override with --cann-set-env / --soc-version / --aicore-arch when needed.

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ the args-dump / dep-gen DFX flags.
 ## Performance tuning
 
 See [docs/debug-and-tune/performance-tuning.md](docs/debug-and-tune/performance-tuning.md) for the L2
-(inter-kernel) and L1/L0 (intra-kernel) tuning workflow — L2 swimlane in
+(inter-kernel) and L1/L0 (intra-kernel) tuning workflow — chip swimlane in
 Perfetto, PMU counters, and the per-kernel insight swimlane.
 
 ## Precision tuning

--- a/docs/debug-and-tune/cce-incore-profiling.md
+++ b/docs/debug-and-tune/cce-incore-profiling.md
@@ -1,6 +1,6 @@
 # CCE In-Core Profiling
 
-Use on-device timestamps when an L2 swimlane identifies a slow fused task but
+Use on-device timestamps when a chip swimlane identifies a slow fused task but
 cannot show which phase inside the task is responsible. This technique is most
 useful for mixed AIC/AIV extern kernels, cross-core barriers, and producer to
 consumer fusion on real inputs.
@@ -12,7 +12,7 @@ kernel unless permanent telemetry is an explicit requirement.
 
 For single-core instruction and pipe analysis, use
 [In-Core Simulator Profiling](incore-simulator-profiling.md).
-For task-level scheduling, start with the L2 swimlane described in
+For task-level scheduling, start with the chip swimlane described in
 [`performance-tuning.md`](performance-tuning.md).
 
 ## Define event semantics before adding probes

--- a/docs/debug-and-tune/cube-tile-tuning.md
+++ b/docs/debug-and-tune/cube-tile-tuning.md
@@ -165,7 +165,7 @@ improve the running best beyond the noise band.
 - Use identical, seeded inputs for every candidate.
 - Revalidate numerical output for every shape; tiling must not change results.
 - Measure at least three times and compare medians, not the minimum.
-- Use the L2 swimlane and PMU data to confirm that the expected pipe changed.
+- Use the chip swimlane and PMU data to confirm that the expected pipe changed.
 - Record compile failures as evidence: a `Mat buffer usage ... exceeds` error
   identifies L1, while a UB allocation error usually belongs to the vector
   fragment.

--- a/docs/debug-and-tune/dependency-and-scheduling.md
+++ b/docs/debug-and-tune/dependency-and-scheduling.md
@@ -248,7 +248,7 @@ waiting for — is settled by two artifacts and their join.
 | File | Produced by | Carries |
 |------|------------|---------|
 | `deps.json` | `--enable-dep-gen` | The task graph: tasks, `kernel_ids`, `block_num`, `early_dispatch`, annotated edges |
-| `l2_swimlane_records.json` | `--enable-l2-swimlane` | Per-task timing and scheduler/orchestrator phases; **no** edges |
+| `chip_swimlane_records.json` | `--enable-chip-swimlane` | Per-task timing and scheduler/orchestrator phases; **no** edges |
 | `name_map*.json` | Compile | Callable id → source name |
 | `dispatch_program.json` | Compile | Which program a dispatch directory belongs to |
 | `merged_swimlane*.json` | `swimlane_converter` | The two joined, for Perfetto |
@@ -268,7 +268,7 @@ timing runs of the same topology.
 | 4 | + orchestrator phase records |
 
 Anything that reasons about dispatch — gap attribution, early-dispatch proof —
-needs level 4. Note this is the L2 swimlane's *perf level*; it is unrelated to
+needs level 4. Note this is the chip swimlane's *perf level*; it is unrelated to
 the runtime hierarchy's L4 worker level.
 
 **Check the entry's `argparse` before assuming a flag shape.** Across
@@ -302,7 +302,7 @@ shared `name_hint`, so one source site may own several runtime occurrences.
 Join the streams with `swimlane_converter.read_perf_data()`; the raw file holds
 separate cycle-domain streams that must not be joined by hand. Then require:
 
-- `l2_swimlane_level == 4` in the records file;
+- `chip_swimlane_level == 4` in the records file;
 - raw AICore rows, raw AICPU rows and joined rows have **equal counts**;
 - for every timed task, `joined physical rows == deps.block_num × active kernel_ids slots`.
 
@@ -576,7 +576,7 @@ Upstream references:
 - [Managing dependencies](https://www.pypto.ai/pypto/user/performance/03-dependencies/)
   and [Runtime overhead](https://www.pypto.ai/pypto/user/performance/02-runtime-overhead/)
   — false serialization and per-task cost, upstream.
-- [L2 swimlane profiling](https://www.pypto.ai/simpler/dfx/l2-swimlane-profiling/)
+- [chip swimlane profiling](https://www.pypto.ai/simpler/dfx/chip-swimlane-profiling/)
   and [dep_gen](https://www.pypto.ai/simpler/dfx/dep-gen/) — artifact schemas.
 - [Orchestrator](https://www.pypto.ai/simpler/orchestrator/) and
   [WAR anti-dependencies](https://www.pypto.ai/simpler/war-anti-dependency/) —

--- a/docs/debug-and-tune/incore-simulator-profiling.md
+++ b/docs/debug-and-tune/incore-simulator-profiling.md
@@ -2,13 +2,13 @@
 
 Use the Ascend `msprof op simulator` workflow to inspect the instruction and
 pipeline behavior of one generated PTOAS kernel on a single AI Core. It
-produces cycle-level traces that can explain a low-utilization kernel after an
-L2 swimlane or PMU report has identified the task worth investigating.
+produces cycle-level traces that can explain a low-utilization kernel after a
+chip swimlane or PMU report has identified the task worth investigating.
 
 This workflow is different from:
 
 - `report/perf_hints.log`, which contains compile-time recommendations;
-- the L2 swimlane in [Performance Tuning](performance-tuning.md), which
+- the chip swimlane in [Performance Tuning](performance-tuning.md), which
   shows the multi-kernel device schedule; and
 - [CCE In-Core Profiling](cce-incore-profiling.md),
   which instruments phases of a multi-core extern kernel on real inputs.

--- a/docs/debug-and-tune/index.md
+++ b/docs/debug-and-tune/index.md
@@ -27,7 +27,7 @@ then move from the broadest evidence to the narrowest:
 Prefer evidence that changes the program least:
 
 1. Existing compile reports and validation output.
-2. Repeated device benchmarks and L2 swimlanes.
+2. Repeated device benchmarks and chip swimlanes.
 3. PMU counters and simulator traces for one kernel.
 4. On-device instrumentation added to an extern kernel.
 

--- a/docs/debug-and-tune/performance-tuning.md
+++ b/docs/debug-and-tune/performance-tuning.md
@@ -2,7 +2,7 @@
 
 A practical guide for tuning pypto-lib kernels on Ascend NPU (A3 / 910C).
 The flow is two-tiered: first balance the inter-kernel schedule on the
-AICPU side (L2 swimlane), then optimize each kernel's internal pipeline
+AICPU side (chip swimlane), then optimize each kernel's internal pipeline
 (L1/L0 swimlane + PMU).
 
 For the underlying levels see simpler's
@@ -115,17 +115,17 @@ of every later run. See
 
 ### Capture
 
-Run the case with `--enable-l2-swimlane`. The runtime writes raw per-task L2
-records under the build directory and, on a real-device platform, converts
-them to a merged swimlane:
+Run the case with `--enable-chip-swimlane`. The runtime writes raw per-task
+chip swimlane records under the build directory and, on a real-device platform,
+converts them to a merged swimlane:
 
 ```bash
-python models/qwen3_14b/decode_fwd.py -p a2a3 -d 0 --enable-l2-swimlane
+python models/qwen3_14b/decode_fwd.py -p a2a3 -d 0 --enable-chip-swimlane
 ```
 
 ```
 build_output/<ProgramName>_<ts>/dfx_outputs/
-├── l2_swimlane_records.json
+├── chip_swimlane_records.json
 ├── deps.json                    # real-device graph pass
 └── merged_swimlane_<ts>.json   # real device only; open this
 ```
@@ -133,10 +133,10 @@ build_output/<ProgramName>_<ts>/dfx_outputs/
 Two viewers work:
 
 - Open `merged_swimlane_<ts>.json` in <https://ui.perfetto.dev/>.
-- Or open `l2_swimlane_records.json` directly with the
+- Or open `chip_swimlane_records.json` directly with the
   [pypto-toolkit VSCode extension](https://marketplace.visualstudio.com/items?itemName=CANN-PUB.pypto-toolkit).
 
-Simulator platforms emit `l2_swimlane_records.json` but intentionally skip
+Simulator platforms emit `chip_swimlane_records.json` but intentionally skip
 the merged conversion because their records do not yet include the task
 metadata the converter requires. Use a real-device capture when you need the
 merged Perfetto view and dependency arrows.

--- a/docs/debug-and-tune/ring-heap-and-scope-stats.md
+++ b/docs/debug-and-tune/ring-heap-and-scope-stats.md
@@ -189,7 +189,7 @@ to a **scope site**, not just a resource.
 ### Enable it
 
 `enable_scope_stats` is one of the five DFX flags the golden harness
-forwards (`enable_l2_swimlane`, `enable_dump_args`, `enable_pmu`,
+forwards (`enable_chip_swimlane`, `enable_dump_args`, `enable_pmu`,
 `enable_dep_gen`, `enable_scope_stats`). Add the flag to the entry's argparse
 and pass it through:
 
@@ -315,7 +315,7 @@ with an `rtMalloc 207001` OOM before it ever reaches the kernel.
 - [Dependencies and scheduling](dependency-and-scheduling.md) — the task
   graph and scheduler behind the rings: what a task is, how edges are formed,
   and what fills a window.
-- [Performance tuning](performance-tuning.md) — L2 swimlane and PMU; scope
+- [Performance tuning](performance-tuning.md) — chip swimlane and PMU; scope
   placement changes the schedule too, so re-measure wall time after it.
 - [PyPTO coding style](../pypto-coding/pypto-coding-style.md) — `pl.at`
   scopes (InCore), which are a different thing from the runtime scopes here.

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -53,9 +53,9 @@ Use a real A2/A3 device by selecting its device ID:
 python examples/intermediate/softmax.py -p a2a3 -d 0
 ```
 
-The single-device examples also accept `--enable-l2-swimlane` for an L2
-timeline capture. The distributed all-reduce instead takes a comma-separated
-device list and requires exactly two ranks:
+The single-device examples also accept `--enable-chip-swimlane` for a chip
+swimlane timeline capture. The distributed all-reduce instead takes a
+comma-separated device list and requires exactly two ranks:
 
 ```bash
 python examples/advanced/allreduce.py -p a2a3 -d 0,1

--- a/docs/run-and-validate/compile-runtime-workflow.md
+++ b/docs/run-and-validate/compile-runtime-workflow.md
@@ -15,7 +15,7 @@ the harness:
 ```python
 parser.add_argument("-p", "--platform", choices=["a2a3", "a2a3sim", "a5", "a5sim"])
 parser.add_argument("-d", "--device", type=int, default=0)
-parser.add_argument("--enable-l2-swimlane", action="store_true")
+parser.add_argument("--enable-chip-swimlane", action="store_true")
 args = parser.parse_args()
 
 result = run(
@@ -24,7 +24,7 @@ result = run(
     golden_fn=golden_qwen3_decode,            # PyTorch reference
     compile_cfg=dict(dump_passes=True),
     runtime_cfg=dict(platform=args.platform, device_id=args.device,
-                     enable_l2_swimlane=args.enable_l2_swimlane),
+                     enable_chip_swimlane=args.enable_chip_swimlane),
     rtol=3e-3, atol=3e-3,
 )
 ```
@@ -39,7 +39,7 @@ their `compile_cfg` fields and defaults differ; see
 |------|---------|
 | `-p` / `--platform` | Target backend. `a2a3` is Ascend 910B/C; `a5` is Ascend 950 — both run on real NPU. `a2a3sim` / `a5sim` are the matching simulators. |
 | `-d` / `--device` | Device ID for multi-card hosts. |
-| `--enable-l2-swimlane` | Forwarded to the runtime; collects per-task L2 perf records into the build_output (see [Runtime DFX flags](#runtime-dfx-flags)). |
+| `--enable-chip-swimlane` | Forwarded to the runtime; collects per-task chip swimlane records into the build_output (see [Runtime DFX flags](#runtime-dfx-flags)). |
 
 `a2a3*` maps to `BackendType.Ascend910B`; `a5*` maps to
 `BackendType.Ascend950`.
@@ -268,7 +268,7 @@ entry-specific; the table lists the common spelling when a script exposes it.
 
 | Kwarg | CLI flag | Artefact under `dfx_outputs/` |
 |-------|----------|-------------------------------|
-| `enable_l2_swimlane=True` (or a supported level) | `--enable-l2-swimlane [N]` | `l2_swimlane_records.json`; onboard runs also attempt `merged_swimlane_*.json` |
+| `enable_chip_swimlane=True` (or a supported level) | `--enable-chip-swimlane [N]` | `chip_swimlane_records.json`; onboard runs also attempt `merged_swimlane_*.json` |
 | `enable_dump_args=<N>` (int, `0`=off) | `--dump-args [N]` (bare = `1`) | `args_dump/{args_dump.json,args.bin}` |
 | `enable_pmu=<N>` (int, `0`=off) | `--enable-pmu [N]` (bare = `2`) | `pmu.csv` |
 | `enable_dep_gen=True` | `--enable-dep-gen` | `deps.json` |
@@ -279,14 +279,14 @@ Args-dump level `1` captures only arguments selected with `pl.dump_tag` or a
 values. Level `3` captures the same argument metadata without writing tensor
 payloads or `args.bin`.
 
-For an onboard L2 swimlane run, PyPTO first attempts a dependency-graph
+For an onboard chip swimlane run, PyPTO first attempts a dependency-graph
 capture and then a clean timing capture so the converter can add dependency
 arrows without perturbing the timing pass. Open the generated
 `merged_swimlane_*.json` at
 [ui.perfetto.dev](https://ui.perfetto.dev/) to visualize per-task
 execution on each AICPU / AIC / AIV lane and inspect kernel duration,
 gaps, and dependency stalls. Simulator runs retain
-`l2_swimlane_records.json` but do not generate the merged trace because the
+`chip_swimlane_records.json` but do not generate the merged trace because the
 required task metadata is unavailable.
 
 The raw dependency and scope-stat files can also be rendered offline:
@@ -305,10 +305,10 @@ end-to-end. It writes the export root below
 `build_output/<ProgramName>_<ts>/kernel_insight_all_funcs_<ts>/`.
 
 See pypto's `docs/en/dev/03-runtime-dfx.md` and the simpler reference at
-`runtime/docs/dfx/{l2-swimlane-profiling,args-dump,pmu-profiling,dep_gen,scope-stats}.md`
+`runtime/docs/dfx/{chip-swimlane-profiling,args-dump,pmu-profiling,dep_gen,scope-stats}.md`
 for full per-flag details. There is no `runtime_profiling` /
 `--runtime-profiling` compatibility alias in the current Python API; use
-`enable_l2_swimlane` or the entry's `--enable-l2-swimlane` flag.
+`enable_chip_swimlane` or the entry's `--enable-chip-swimlane` flag.
 
 ### 4b. Benchmark (opt-in, before validation)
 

--- a/examples/advanced/gemm_eltwise.py
+++ b/examples/advanced/gemm_eltwise.py
@@ -77,7 +77,7 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument("--enable-chip-swimlane", action="store_true", default=False)
     args = parser.parse_args()
 
     result = run_jit(
@@ -87,7 +87,7 @@ if __name__ == "__main__":
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
         ),
         rtol=1e-3,
         atol=1e-3,

--- a/examples/advanced/multi_proj.py
+++ b/examples/advanced/multi_proj.py
@@ -97,7 +97,7 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument("--enable-chip-swimlane", action="store_true", default=False)
     args = parser.parse_args()
 
     result = run_jit(
@@ -107,7 +107,7 @@ if __name__ == "__main__":
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
         ),
         rtol=1e-3,
         atol=1e-3,

--- a/examples/advanced/topk.py
+++ b/examples/advanced/topk.py
@@ -74,7 +74,7 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument("--enable-chip-swimlane", action="store_true", default=False)
     args = parser.parse_args()
 
     result = run_jit(
@@ -84,7 +84,7 @@ if __name__ == "__main__":
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
         ),
         rtol=1e-5,
         atol=1e-5,

--- a/examples/beginner/hello_world.py
+++ b/examples/beginner/hello_world.py
@@ -63,7 +63,7 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument("--enable-chip-swimlane", action="store_true", default=False)
     args = parser.parse_args()
 
     result = run_jit(
@@ -73,7 +73,7 @@ if __name__ == "__main__":
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
         ),
         rtol=1e-5,
         atol=1e-5,

--- a/examples/beginner/matmul.py
+++ b/examples/beginner/matmul.py
@@ -64,7 +64,7 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument("--enable-chip-swimlane", action="store_true", default=False)
     args = parser.parse_args()
 
     result = run_jit(
@@ -74,7 +74,7 @@ if __name__ == "__main__":
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
         ),
         rtol=1e-3,
         atol=1e-3,

--- a/examples/intermediate/gemm.py
+++ b/examples/intermediate/gemm.py
@@ -72,7 +72,7 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument("--enable-chip-swimlane", action="store_true", default=False)
     args = parser.parse_args()
 
     result = run_jit(
@@ -82,7 +82,7 @@ if __name__ == "__main__":
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
         ),
         rtol=1e-3,
         atol=1e-3,

--- a/examples/intermediate/layer_norm.py
+++ b/examples/intermediate/layer_norm.py
@@ -90,7 +90,7 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument("--enable-chip-swimlane", action="store_true", default=False)
     args = parser.parse_args()
 
     result = run_jit(
@@ -100,7 +100,7 @@ if __name__ == "__main__":
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
         ),
         rtol=1e-2,
         atol=1e-2,

--- a/examples/intermediate/rms_norm.py
+++ b/examples/intermediate/rms_norm.py
@@ -89,7 +89,7 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument("--enable-chip-swimlane", action="store_true", default=False)
     args = parser.parse_args()
 
     result = run_jit(
@@ -99,7 +99,7 @@ if __name__ == "__main__":
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
         ),
         rtol=1e-2,
         atol=1e-2,

--- a/examples/intermediate/rope.py
+++ b/examples/intermediate/rope.py
@@ -98,7 +98,7 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument("--enable-chip-swimlane", action="store_true", default=False)
     args = parser.parse_args()
 
     result = run_jit(
@@ -108,7 +108,7 @@ if __name__ == "__main__":
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
         ),
         rtol=1e-2,
         atol=1e-2,

--- a/examples/intermediate/softmax.py
+++ b/examples/intermediate/softmax.py
@@ -65,7 +65,7 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument("--enable-chip-swimlane", action="store_true", default=False)
     args = parser.parse_args()
 
     result = run_jit(
@@ -75,7 +75,7 @@ if __name__ == "__main__":
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
         ),
         rtol=1e-5,
         atol=1e-5,

--- a/golden/runner.py
+++ b/golden/runner.py
@@ -116,7 +116,7 @@ def _backend_for_platform(platform: str) -> Any:
 
 
 _DFX_FLAG_KEYS = (
-    "enable_l2_swimlane",
+    "enable_chip_swimlane",
     "enable_dump_args",
     "enable_pmu",
     "enable_dep_gen",
@@ -1241,7 +1241,7 @@ def run(
             keys raise there.
         runtime_cfg: Kwargs forwarded to
             :func:`pypto.runtime.execute_compiled` (``platform``, ``device_id``,
-            ``enable_l2_swimlane``, ...). Unknown keys raise there, except
+            ``enable_chip_swimlane``, ...). Unknown keys raise there, except
             the harness-only key ``log_level``, which is consumed up-front
             to configure the PyPTO runtime logger via
             :func:`pypto.runtime.log_config.configure_log`.
@@ -1436,7 +1436,7 @@ def run_jit(
             ``RunConfig`` is built.
         runtime_cfg: Kwargs forwarded to
             :func:`pypto.runtime.execute_compiled` (``platform``, ``device_id``,
-            ``enable_l2_swimlane``, ...). Unknown keys raise there, except
+            ``enable_chip_swimlane``, ...). Unknown keys raise there, except
             the harness-only key ``log_level``, which is consumed up-front
             to configure the PyPTO runtime logger via
             :func:`pypto.runtime.log_config.configure_log`.

--- a/models/deepseek_v3_2/decode_back.py
+++ b/models/deepseek_v3_2/decode_back.py
@@ -286,7 +286,7 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument("--enable-chip-swimlane", action="store_true", default=False)
     args = parser.parse_args()
 
     result = run(
@@ -297,7 +297,7 @@ if __name__ == "__main__":
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
         ),
         rtol=3e-3,
         atol=3e-3,

--- a/models/deepseek_v3_2/decode_front.py
+++ b/models/deepseek_v3_2/decode_front.py
@@ -866,7 +866,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3", choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument("--enable-chip-swimlane", action="store_true", default=False)
     args = parser.parse_args()
 
     result = run(
@@ -877,7 +877,7 @@ if __name__ == "__main__":
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
         ),
         rtol=4e-3,
         atol=4e-3,

--- a/models/deepseek_v3_2/prefill_back.py
+++ b/models/deepseek_v3_2/prefill_back.py
@@ -324,7 +324,7 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument("--enable-chip-swimlane", action="store_true", default=False)
     args = parser.parse_args()
 
     result = run(
@@ -335,7 +335,7 @@ if __name__ == "__main__":
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
         ),
         rtol=3e-3,
         atol=3e-3,

--- a/models/deepseek_v4_flash_dspark/decode_compressor_ratio128.py
+++ b/models/deepseek_v4_flash_dspark/decode_compressor_ratio128.py
@@ -583,7 +583,7 @@ if __name__ == "__main__":
     parser.add_argument("--start-pos", type=int, default=None,
                         help="Uniform fixture-only start_pos override for all batches; "
                              "default (unset) uses the canonical per-batch HCA set that includes the 8k point.")
-    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument("--enable-chip-swimlane", action="store_true", default=False)
     parser.add_argument("--dump-passes", action="store_true", default=False)
     args = parser.parse_args()
     if args.batch < 4 or args.batch > B or args.batch % 4 != 0:
@@ -597,7 +597,7 @@ if __name__ == "__main__":
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
         ),
         rtol=1e-3,
         atol=1e-3,

--- a/models/deepseek_v4_flash_dspark/decode_compressor_ratio4.py
+++ b/models/deepseek_v4_flash_dspark/decode_compressor_ratio4.py
@@ -581,7 +581,7 @@ if __name__ == "__main__":
     parser.add_argument("--start-pos", type=int, default=None,
                         help="Uniform fixture-only start_pos override for all batches; "
                              "default (unset) uses the canonical per-batch CSA set that includes the 8k point.")
-    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument("--enable-chip-swimlane", action="store_true", default=False)
     parser.add_argument("--runtime-dir", type=str, default=None)
     parser.add_argument("--golden-data", type=str, default=None)
     parser.add_argument("--dump-passes", action="store_true", default=False)
@@ -599,7 +599,7 @@ if __name__ == "__main__":
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
         ),
         rtol=1e-3,
         atol=1e-3,

--- a/models/deepseek_v4_flash_dspark/decode_hca.py
+++ b/models/deepseek_v4_flash_dspark/decode_hca.py
@@ -1266,7 +1266,7 @@ if __name__ == "__main__":
         help="absolute decode start position; a scalar sets batch=1, "
              "and a comma-separated list sets batch to its length",
     )
-    parser.add_argument("--enable-l2-swimlane", type=int, choices=(0, 1, 2, 4), default=0)
+    parser.add_argument("--enable-chip-swimlane", type=int, choices=(0, 1, 2, 4), default=0)
     parser.add_argument("--compile-only", action="store_true", default=False)
     parser.add_argument("--dump-passes", action="store_true", default=False)
     args = parser.parse_args()
@@ -1315,7 +1315,7 @@ if __name__ == "__main__":
                 runtime_cfg=dict(
                     platform=args.platform,
                     device_id=device_ids[0],
-                    enable_l2_swimlane=args.enable_l2_swimlane,
+                    enable_chip_swimlane=args.enable_chip_swimlane,
                 ),
                 rtol=1e-3,
                 atol=1e-3,
@@ -1354,7 +1354,7 @@ if __name__ == "__main__":
                 ),
                 runtime_cfg=dict(
                     platform=args.platform,
-                    enable_chip_swimlane=args.enable_l2_swimlane,
+                    enable_chip_swimlane=args.enable_chip_swimlane,
                 ),
                 rtol=1e-3,
                 atol=1e-3,

--- a/models/deepseek_v4_flash_dspark/decode_indexer.py
+++ b/models/deepseek_v4_flash_dspark/decode_indexer.py
@@ -752,8 +752,8 @@ if __name__ == "__main__":
                         help=f"runtime request count; a multiple of 4 up to {B} (the compile-time "
                              "upper bound). The batch axes are pl.dynamic, so one compiled program "
                              "serves every value.")
-    parser.add_argument("--enable-l2-swimlane", type=int, default=0, choices=[0, 1, 2],
-                        help="L2 swimlane level: 0=off, 1=AICore timing, 2=+AICPU timing.")
+    parser.add_argument("--enable-chip-swimlane", type=int, default=0, choices=[0, 1, 2],
+                        help="chip swimlane level: 0=off, 1=AICore timing, 2=+AICPU timing.")
     parser.add_argument("--runtime-dir", type=str, default=None)
     parser.add_argument("--start-pos", type=int, default=None,
                         help="Uniform fixture-only start_pos override for all batches; "
@@ -807,7 +807,7 @@ if __name__ == "__main__":
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
         ),
         rtol=1e-3,
         atol=1e-3,

--- a/models/deepseek_v4_flash_dspark/decode_indexer_compressor.py
+++ b/models/deepseek_v4_flash_dspark/decode_indexer_compressor.py
@@ -645,7 +645,7 @@ if __name__ == "__main__":
     parser.add_argument("--start-pos", type=int, default=None,
                         help="Uniform fixture-only start_pos override for all batches; "
                              "default (unset) uses the canonical per-batch CSA set that includes the 8k point.")
-    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument("--enable-chip-swimlane", action="store_true", default=False)
     parser.add_argument("--runtime-dir", type=str, default=None)
     parser.add_argument("--save-data", action="store_true", default=False,
                         help="Persist this run's data/{in,out} for offline inspection.")
@@ -664,7 +664,7 @@ if __name__ == "__main__":
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
         ),
         rtol=1e-3,
         atol=1e-3,

--- a/models/deepseek_v4_flash_dspark/decode_sparse_attn_csa.py
+++ b/models/deepseek_v4_flash_dspark/decode_sparse_attn_csa.py
@@ -685,7 +685,7 @@ if __name__ == "__main__":
     parser.add_argument("--cache-window-replacement-fixture", action="store_true", default=False,
                         help="Place a sentinel row inside the cache window prefix.")
     parser.add_argument("--golden-data", type=str, default=None)
-    parser.add_argument("--enable-l2-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2))
+    parser.add_argument("--enable-chip-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2))
     parser.add_argument("--enable-dep-gen", action="store_true", default=False,
                         help="Capture PTO2 dependency edges (deps.json) for the swimlane converter.")
     parser.add_argument("--enable-pmu", nargs="?", const=2, default=0, type=int, choices=[0, 1, 2, 4])
@@ -711,7 +711,7 @@ if __name__ == "__main__":
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
             enable_dep_gen=args.enable_dep_gen,
             enable_pmu=args.enable_pmu,
         ),

--- a/models/deepseek_v4_flash_dspark/decode_sparse_attn_hca.py
+++ b/models/deepseek_v4_flash_dspark/decode_sparse_attn_hca.py
@@ -1097,7 +1097,7 @@ if __name__ == "__main__":
     parser.add_argument("--cache-window-replacement-fixture", action="store_true", default=False,
                         help="Place a sentinel row inside the cache window prefix.")
     parser.add_argument("--golden-data", type=str, default=None)
-    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument("--enable-chip-swimlane", action="store_true", default=False)
     parser.add_argument("--enable-dep-gen", action="store_true", default=False,
                         help="Capture PTO2 dependency edges (deps.json); the swimlane "
                              "converter draws fanout/fanin arrows from the sibling file.")
@@ -1132,7 +1132,7 @@ if __name__ == "__main__":
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
             enable_dep_gen=args.enable_dep_gen,
             enable_pmu=args.enable_pmu,
         ),

--- a/models/deepseek_v4_flash_dspark/decode_sparse_attn_swa.py
+++ b/models/deepseek_v4_flash_dspark/decode_sparse_attn_swa.py
@@ -496,7 +496,7 @@ if __name__ == "__main__":
     parser.add_argument("--short-window-fixture", action="store_true", default=False,
                         help="Use a short-window topk row with valid prefix + -1 padding.")
     parser.add_argument("--golden-data", type=str, default=None)
-    parser.add_argument("--enable-l2-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2, 4))
+    parser.add_argument("--enable-chip-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2, 4))
     parser.add_argument("--enable-dep-gen", action="store_true", default=False,
                         help="Capture PTO2 dependency edges (deps.json); the swimlane "
                              "converter draws fanout/fanin arrows from the sibling file.")
@@ -521,7 +521,7 @@ if __name__ == "__main__":
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
             enable_dep_gen=args.enable_dep_gen,
             enable_pmu=args.enable_pmu,
         ),

--- a/models/deepseek_v4_flash_dspark/decode_swa.py
+++ b/models/deepseek_v4_flash_dspark/decode_swa.py
@@ -912,7 +912,7 @@ if __name__ == "__main__":
         help="absolute decode start position; a scalar sets batch=1, "
              "and a comma-separated list sets batch to its length",
     )
-    parser.add_argument("--enable-l2-swimlane", type=int, choices=(0, 1, 2, 4), default=0)
+    parser.add_argument("--enable-chip-swimlane", type=int, choices=(0, 1, 2, 4), default=0)
     parser.add_argument("--compile-only", action="store_true", default=False)
     parser.add_argument("--dump-passes", action="store_true", default=False)
     args = parser.parse_args()
@@ -960,7 +960,7 @@ if __name__ == "__main__":
                 runtime_cfg=dict(
                     platform=args.platform,
                     device_id=device_ids[0],
-                    enable_l2_swimlane=args.enable_l2_swimlane,
+                    enable_chip_swimlane=args.enable_chip_swimlane,
                 ),
                 rtol=1e-2,
                 atol=1e-2,
@@ -989,7 +989,7 @@ if __name__ == "__main__":
                 ),
                 runtime_cfg=dict(
                     platform=args.platform,
-                    enable_l2_swimlane=args.enable_l2_swimlane,
+                    enable_chip_swimlane=args.enable_chip_swimlane,
                 ),
                 rtol=1e-2,
                 atol=1e-2,

--- a/models/deepseek_v4_flash_dspark/dspark_attention.py
+++ b/models/deepseek_v4_flash_dspark/dspark_attention.py
@@ -526,7 +526,7 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3", choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
     parser.add_argument("--start-pos", type=int, default=None)
-    parser.add_argument("--enable-l2-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2, 4))
+    parser.add_argument("--enable-chip-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2, 4))
     parser.add_argument("--dump-passes", action="store_true", default=False)
     args = parser.parse_args()
 
@@ -538,7 +538,7 @@ if __name__ == "__main__":
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
         ),
         rtol=1e-2,
         atol=1e-2,

--- a/models/deepseek_v4_flash_dspark/dspark_proj.py
+++ b/models/deepseek_v4_flash_dspark/dspark_proj.py
@@ -114,7 +114,7 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3", choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
     parser.add_argument("--mode", choices=["decode", "prefill", "all"], default="all")
-    parser.add_argument("--enable-l2-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2, 4))
+    parser.add_argument("--enable-chip-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2, 4))
     parser.add_argument("--dump-passes", action="store_true", default=False)
     args = parser.parse_args()
 
@@ -133,7 +133,7 @@ if __name__ == "__main__":
             runtime_cfg=dict(
                 platform=args.platform,
                 device_id=args.device,
-                enable_l2_swimlane=args.enable_l2_swimlane,
+                enable_chip_swimlane=args.enable_chip_swimlane,
             ),
             rtol=5e-3,
             atol=5e-3,

--- a/models/deepseek_v4_flash_dspark/expert_routed.py
+++ b/models/deepseek_v4_flash_dspark/expert_routed.py
@@ -460,7 +460,7 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--enable-l2-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2))
+    parser.add_argument("--enable-chip-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2))
     parser.add_argument("--dump-passes", action="store_true", default=False)
     args = parser.parse_args()
 
@@ -472,7 +472,7 @@ if __name__ == "__main__":
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
         ),
         rtol=1e-3,
         atol=1e-3,

--- a/models/deepseek_v4_flash_dspark/expert_shared.py
+++ b/models/deepseek_v4_flash_dspark/expert_shared.py
@@ -396,7 +396,7 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument("--enable-chip-swimlane", action="store_true", default=False)
     parser.add_argument("--dump-passes", action="store_true", default=False)
     args = parser.parse_args()
 
@@ -408,7 +408,7 @@ if __name__ == "__main__":
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
         ),
         rtol=1e-3,
         atol=1e-3,

--- a/models/deepseek_v4_flash_dspark/gate.py
+++ b/models/deepseek_v4_flash_dspark/gate.py
@@ -417,7 +417,7 @@ if __name__ == "__main__":
     parser.add_argument("-d", "--device", type=int, default=0)
     parser.add_argument("--layer-id", type=int, default=10)
     parser.add_argument("--num-tokens", type=int, default=T)
-    parser.add_argument("--enable-l2-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2))
+    parser.add_argument("--enable-chip-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2))
     parser.add_argument("--dump-passes", action="store_true", default=False)
     args = parser.parse_args()
 
@@ -429,7 +429,7 @@ if __name__ == "__main__":
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
         ),
         rtol=1e-3,
         atol=1e-3,

--- a/models/deepseek_v4_flash_dspark/hc_head.py
+++ b/models/deepseek_v4_flash_dspark/hc_head.py
@@ -332,8 +332,8 @@ if __name__ == "__main__":
     parser.add_argument("--token-count", type=int, default=T, help="Physical token rows, up to 8192.")
     parser.add_argument("--compile-only", action="store_true", default=False)
     # Int mode (0=off; 1=timing only, most accurate; 2=timing + dep graph, two runs).
-    # `nargs="?"` so a bare `--enable-l2-swimlane` -> mode 1 (int, not bool True).
-    parser.add_argument("--enable-l2-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2))
+    # `nargs="?"` so a bare `--enable-chip-swimlane` -> mode 1 (int, not bool True).
+    parser.add_argument("--enable-chip-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2))
     parser.add_argument("--dump-passes", action="store_true", default=False)
     args = parser.parse_args()
     torch.manual_seed(args.seed)
@@ -348,7 +348,7 @@ if __name__ == "__main__":
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
         ),
         rtol=1e-3,
         atol=1e-3,

--- a/models/deepseek_v4_flash_dspark/hc_post.py
+++ b/models/deepseek_v4_flash_dspark/hc_post.py
@@ -209,7 +209,7 @@ if __name__ == "__main__":
     parser.add_argument("-d", "--device", type=int, default=0)
     parser.add_argument("--mode", choices=["decode", "prefill", "all"], default="decode",
                         help="Use decode or prefill batch sizes, or 'all' to test both.")
-    parser.add_argument("--enable-l2-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2))
+    parser.add_argument("--enable-chip-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2))
     parser.add_argument("--compile-only", action="store_true", default=False)
     parser.add_argument("--dump-passes", action="store_true", default=False)
     args = parser.parse_args()
@@ -227,7 +227,7 @@ if __name__ == "__main__":
             runtime_cfg=dict(
                 platform=args.platform,
                 device_id=args.device,
-                enable_l2_swimlane=args.enable_l2_swimlane,
+                enable_chip_swimlane=args.enable_chip_swimlane,
             ),
             rtol=1e-3,
             atol=1e-3,

--- a/models/deepseek_v4_flash_dspark/hc_pre.py
+++ b/models/deepseek_v4_flash_dspark/hc_pre.py
@@ -46,7 +46,7 @@ FOLDED into Phase D: since the C->D handoff was cross-core (different grid-strid
 it needed a barrier -- but each D task can just recompute the ONE gate it consumes from the
 published mixes_raw + sq_sum_acc on its OWN core (rsqrt+sigmoid is nearly free on
 this latency-bound kernel). That deletes a whole hard FFTS barrier (-8% decode / -11% prefill
-on the device L2 swimlane, latency-bound so barrier removal > byte removal). comb_logits /
+on the device chip swimlane, latency-bound so barrier removal > byte removal). comb_logits /
 post_pad_store survive only as SAME-CORE scratch (assemble then load-back, no barrier) because
 their downstream pl.load->pl.store needs an HC_PAD-wide 32B-aligned tile; the pre gate is
 consumed in tensor-world so it needs no buffer.
@@ -1006,7 +1006,7 @@ if __name__ == "__main__":
     parser.add_argument("-d", "--device", type=int, default=0)
     parser.add_argument("--mode", choices=["decode", "prefill", "all"], default="all",
                         help="Use decode or prefill batch sizes, or 'all' to test both.")
-    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument("--enable-chip-swimlane", action="store_true", default=False)
     parser.add_argument("--runtime-dir", type=str, default=None)
     parser.add_argument("--golden-data", type=str, default=None)
     parser.add_argument("--compile-only", action="store_true", default=False)
@@ -1057,7 +1057,7 @@ if __name__ == "__main__":
             runtime_cfg=dict(
                 platform=args.platform,
                 device_id=args.device,
-                enable_l2_swimlane=args.enable_l2_swimlane,
+                enable_chip_swimlane=args.enable_chip_swimlane,
                 # dep_gen: the "syncall" version's full-occupancy pl.system.syncall is
                 # incompatible with dep_gen -- the DFX instrumentation perturbs core
                 # occupancy and trips AICore timeout 507018 (pypto#1931) -- so it runs with

--- a/models/deepseek_v4_flash_dspark/lm_head.py
+++ b/models/deepseek_v4_flash_dspark/lm_head.py
@@ -493,7 +493,7 @@ if __name__ == "__main__":
     parser.add_argument("--num-tokens", type=int, default=TEST_TOKENS, help="Active hidden rows each owner projects")
     device_default = ",".join(str(i) for i in range(WORLD_SIZE))
     parser.add_argument("-d", "--device", type=str, default=device_default, help=f"comma-separated device ids; need at least {WORLD_SIZE}")
-    parser.add_argument("--enable-l2-swimlane", type=int, nargs="?", const=1, default=0,
+    parser.add_argument("--enable-chip-swimlane", type=int, nargs="?", const=1, default=0,
                         choices=(0, 1, 2, 4))
     parser.add_argument("--enable-scope-stats", action="store_true", default=False)
     parser.add_argument("--compile-only", action="store_true", default=False)
@@ -526,7 +526,7 @@ if __name__ == "__main__":
         ),
         runtime_cfg=dict(
             platform=args.platform,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
             enable_scope_stats=args.enable_scope_stats,
         ),
         rtol=1e-3,

--- a/models/deepseek_v4_flash_dspark/markov_head.py
+++ b/models/deepseek_v4_flash_dspark/markov_head.py
@@ -123,7 +123,7 @@ if __name__ == "__main__":
     parser.add_argument("-d", "--device", type=int, default=0)
     parser.add_argument("--token-count", type=int, default=DECODE_BATCH // TP)
     parser.add_argument("--vocab-size", type=int, default=TEST_VOCAB_SIZE)
-    parser.add_argument("--enable-l2-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2, 4))
+    parser.add_argument("--enable-chip-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2, 4))
     parser.add_argument("--dump-passes", action="store_true", default=False)
     args = parser.parse_args()
 
@@ -135,7 +135,7 @@ if __name__ == "__main__":
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
         ),
         rtol=2e-3,
         atol=2e-3,

--- a/models/deepseek_v4_flash_dspark/moe.py
+++ b/models/deepseek_v4_flash_dspark/moe.py
@@ -991,7 +991,7 @@ if __name__ == "__main__":
                         help=f"active token count for MoE dispatch/combine (0..{T})")
     parser.add_argument("--balanced-routing", action="store_true", default=False,
                         help="use deterministic hash routes balanced evenly across all experts")
-    parser.add_argument("--enable-l2-swimlane", type=int, nargs="?", const=1, default=0, choices=range(5))
+    parser.add_argument("--enable-chip-swimlane", type=int, nargs="?", const=1, default=0, choices=range(5))
     parser.add_argument("--compile-only", action="store_true", default=False)
     parser.add_argument("--runtime-dir", type=str, default=None)
     parser.add_argument("--save-data", action="store_true", default=False)
@@ -1029,7 +1029,7 @@ if __name__ == "__main__":
         ),
         runtime_cfg=dict(
             platform=args.platform,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
             log_level=args.log_level,
         ),
         rtol=1e-3,

--- a/models/deepseek_v4_flash_dspark/prefill_compressor_ratio128.py
+++ b/models/deepseek_v4_flash_dspark/prefill_compressor_ratio128.py
@@ -726,7 +726,7 @@ if __name__ == "__main__":
         default=PREFILL_SEQ,
         help="Physical token rows, up to 8192.",
     )
-    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument("--enable-chip-swimlane", action="store_true", default=False)
     parser.add_argument("--dump-passes", action="store_true", default=False)
     args = parser.parse_args()
 
@@ -736,7 +736,7 @@ if __name__ == "__main__":
         golden_fn=golden_prefill_compressor_ratio128,
         compile_cfg=dict(dump_passes=args.dump_passes),
         runtime_cfg=dict(
-            platform=args.platform, device_id=args.device, enable_l2_swimlane=args.enable_l2_swimlane
+            platform=args.platform, device_id=args.device, enable_chip_swimlane=args.enable_chip_swimlane
         ),
         rtol=1e-3,
         atol=1e-3,

--- a/models/deepseek_v4_flash_dspark/prefill_compressor_ratio4.py
+++ b/models/deepseek_v4_flash_dspark/prefill_compressor_ratio4.py
@@ -849,7 +849,7 @@ if __name__ == "__main__":
         default=PREFILL_SEQ,
         help="Physical token rows, up to 8192.",
     )
-    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument("--enable-chip-swimlane", action="store_true", default=False)
     parser.add_argument("--dump-passes", action="store_true", default=False)
     args = parser.parse_args()
 
@@ -861,7 +861,7 @@ if __name__ == "__main__":
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
         ),
         compile_only=args.compile_only,
         compare_fn={

--- a/models/deepseek_v4_flash_dspark/prefill_csa.py
+++ b/models/deepseek_v4_flash_dspark/prefill_csa.py
@@ -1186,7 +1186,7 @@ if __name__ == "__main__":
         default=PREFILL_SEQ,
         help="Physical query-token extent, up to 8192.",
     )
-    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument("--enable-chip-swimlane", action="store_true", default=False)
     parser.add_argument("--enable-dep-gen", action="store_true", default=False)
     parser.add_argument("--dump-passes", action="store_true", default=False)
     args = parser.parse_args()
@@ -1210,7 +1210,7 @@ if __name__ == "__main__":
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
             enable_dep_gen=args.enable_dep_gen,
         ),
         rtol=1e-2,

--- a/models/deepseek_v4_flash_dspark/prefill_hca.py
+++ b/models/deepseek_v4_flash_dspark/prefill_hca.py
@@ -787,7 +787,7 @@ if __name__ == "__main__":
         default=PREFILL_SEQ,
         help="Physical query-token extent, up to 8192.",
     )
-    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument("--enable-chip-swimlane", action="store_true", default=False)
     parser.add_argument("--enable-dep-gen", action="store_true", default=False)
     parser.add_argument("--dump-passes", action="store_true", default=False)
     args = parser.parse_args()
@@ -799,7 +799,7 @@ if __name__ == "__main__":
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
             enable_dep_gen=args.enable_dep_gen,
         ),
         rtol=1e-2,

--- a/models/deepseek_v4_flash_dspark/prefill_indexer.py
+++ b/models/deepseek_v4_flash_dspark/prefill_indexer.py
@@ -1444,7 +1444,7 @@ if __name__ == "__main__":
         default=PREFILL_SEQ,
         help=f"Physical token length in [1, {PREFILL_MAX_TOKENS}].",
     )
-    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument("--enable-chip-swimlane", action="store_true", default=False)
     parser.add_argument("--dump-passes", action="store_true", default=False)
     args = parser.parse_args()
 
@@ -1517,7 +1517,7 @@ if __name__ == "__main__":
         golden_fn=golden_prefill_indexer,
         compile_cfg=dict(dump_passes=args.dump_passes),
         runtime_cfg=dict(
-            platform=args.platform, device_id=args.device, enable_l2_swimlane=args.enable_l2_swimlane
+            platform=args.platform, device_id=args.device, enable_chip_swimlane=args.enable_chip_swimlane
         ),
         rtol=1e-3,
         atol=1e-3,

--- a/models/deepseek_v4_flash_dspark/prefill_indexer_compressor.py
+++ b/models/deepseek_v4_flash_dspark/prefill_indexer_compressor.py
@@ -1051,7 +1051,7 @@ if __name__ == "__main__":
         default=PREFILL_SEQ,
         help="Physical token rows, up to 8192.",
     )
-    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument("--enable-chip-swimlane", action="store_true", default=False)
     parser.add_argument("--dump-passes", action="store_true", default=False)
     args = parser.parse_args()
 
@@ -1061,7 +1061,7 @@ if __name__ == "__main__":
         golden_fn=golden_prefill_indexer_compressor,
         compile_cfg=dict(dump_passes=args.dump_passes),
         runtime_cfg=dict(
-            platform=args.platform, device_id=args.device, enable_l2_swimlane=args.enable_l2_swimlane
+            platform=args.platform, device_id=args.device, enable_chip_swimlane=args.enable_chip_swimlane
         ),
         compile_only=args.compile_only,
         compare_fn={

--- a/models/deepseek_v4_flash_dspark/prefill_sparse_attn.py
+++ b/models/deepseek_v4_flash_dspark/prefill_sparse_attn.py
@@ -1175,7 +1175,7 @@ if __name__ == "__main__":
     )
     parser.add_argument("--ori-block-num", type=int, default=ORI_BLOCK_NUM)
     parser.add_argument("--cmp-block-num", type=int, default=CMP_BLOCK_NUM)
-    parser.add_argument("--enable-l2-swimlane", nargs="?", const=4, default=0, type=int)
+    parser.add_argument("--enable-chip-swimlane", nargs="?", const=4, default=0, type=int)
     parser.add_argument("--enable-pmu", nargs="?", const=2, default=0, type=int, choices=[0, 1, 2, 4])
     parser.add_argument("--enable-scope-stats", action="store_true", default=False)
     parser.add_argument("--dump-passes", action="store_true", default=False)
@@ -1189,7 +1189,7 @@ if __name__ == "__main__":
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
             enable_pmu=args.enable_pmu,
             enable_scope_stats=args.enable_scope_stats,
         ),

--- a/models/deepseek_v4_flash_dspark/prefill_swa.py
+++ b/models/deepseek_v4_flash_dspark/prefill_swa.py
@@ -452,7 +452,7 @@ if __name__ == "__main__":
                         help="Absolute position of the first physical query token.")
     parser.add_argument("--token-count", "--num-tokens", dest="token_count", type=int, default=PREFILL_SEQ,
                         help="Physical query-token extent; --num-tokens is a compatibility alias.")
-    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument("--enable-chip-swimlane", action="store_true", default=False)
     parser.add_argument("--enable-dep-gen", action="store_true", default=False)
     parser.add_argument("--dump-passes", action="store_true", default=False)
     args = parser.parse_args()
@@ -465,7 +465,7 @@ if __name__ == "__main__":
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
             enable_dep_gen=args.enable_dep_gen,
         ),
         compile_only=args.compile_only,

--- a/models/deepseek_v4_flash_dspark/qkv_proj_rope.py
+++ b/models/deepseek_v4_flash_dspark/qkv_proj_rope.py
@@ -1192,11 +1192,11 @@ if __name__ == "__main__":
         help="decode / prefill batch sizes, 'split' for mismatched q and kv rows, or 'all'.",
     )
     parser.add_argument(
-        "--enable-l2-swimlane",
+        "--enable-chip-swimlane",
         type=int,
         choices=[0, 1, 2, 4],
         default=0,
-        help="L2 swimlane level: 0=off, 1=per-kernel AICore timing "
+        help="chip swimlane level: 0=off, 1=per-kernel AICore timing "
         "(prints the per-function Task Statistics table), 2=+AICPU timing.",
     )
     parser.add_argument("--runtime-dir", type=str, default=None)
@@ -1236,7 +1236,7 @@ if __name__ == "__main__":
             runtime_cfg=dict(
                 platform=args.platform,
                 device_id=args.device,
-                enable_l2_swimlane=args.enable_l2_swimlane,
+                enable_chip_swimlane=args.enable_chip_swimlane,
             ),
             compile_only=args.compile_only,
         )

--- a/models/deepseek_v4_flash_dspark/rmsnorm.py
+++ b/models/deepseek_v4_flash_dspark/rmsnorm.py
@@ -196,7 +196,7 @@ if __name__ == "__main__":
     parser.add_argument("-d", "--device", type=int, default=0)
     parser.add_argument("--mode", choices=["decode", "prefill", "all"], default="all",
                         help="Use decode or prefill batch sizes, or 'all' to test both.")
-    parser.add_argument("--enable-l2-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2, 4))
+    parser.add_argument("--enable-chip-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2, 4))
     parser.add_argument("--runtime-dir", type=str, default=None)
     parser.add_argument("--golden-data", type=str, default=None)
     parser.add_argument("--compile-only", action="store_true", default=False)
@@ -218,7 +218,7 @@ if __name__ == "__main__":
             runtime_cfg=dict(
                 platform=args.platform,
                 device_id=args.device,
-                enable_l2_swimlane=args.enable_l2_swimlane,
+                enable_chip_swimlane=args.enable_chip_swimlane,
             ),
             rtol=5e-3,
             atol=5e-3,

--- a/models/deepseek_v4_flash_mtp/decode_compressor_ratio128.py
+++ b/models/deepseek_v4_flash_mtp/decode_compressor_ratio128.py
@@ -571,7 +571,7 @@ if __name__ == "__main__":
     parser.add_argument("--start-pos", type=int, default=None,
                         help="Uniform fixture-only start_pos override for all batches; "
                              "default (unset) uses the canonical per-batch HCA set that includes the 8k point.")
-    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument("--enable-chip-swimlane", action="store_true", default=False)
     parser.add_argument("--dump-passes", action="store_true", default=False)
     args = parser.parse_args()
 
@@ -583,7 +583,7 @@ if __name__ == "__main__":
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
         ),
         rtol=1e-3,
         atol=1e-3,

--- a/models/deepseek_v4_flash_mtp/decode_compressor_ratio4.py
+++ b/models/deepseek_v4_flash_mtp/decode_compressor_ratio4.py
@@ -553,7 +553,7 @@ if __name__ == "__main__":
     parser.add_argument("--start-pos", type=int, default=None,
                         help="Uniform fixture-only start_pos override for all batches; "
                              "default (unset) uses the canonical per-batch CSA set that includes the 8k point.")
-    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument("--enable-chip-swimlane", action="store_true", default=False)
     parser.add_argument("--runtime-dir", type=str, default=None)
     parser.add_argument("--golden-data", type=str, default=None)
     parser.add_argument("--dump-passes", action="store_true", default=False)
@@ -569,7 +569,7 @@ if __name__ == "__main__":
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
         ),
         rtol=1e-3,
         atol=1e-3,

--- a/models/deepseek_v4_flash_mtp/decode_csa.py
+++ b/models/deepseek_v4_flash_mtp/decode_csa.py
@@ -933,7 +933,7 @@ if __name__ == "__main__":
     parser.add_argument("--start-pos", type=int, default=None,
                         help="Uniform fixture-only start_pos override for all batches; "
                              "default (unset) uses the canonical per-batch CSA set that includes the 8k point.")
-    parser.add_argument("--enable-l2-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2, 4))
+    parser.add_argument("--enable-chip-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2, 4))
     parser.add_argument("--runtime-dir", type=str, default=None)
     parser.add_argument("--golden-data", type=str, default=None,
                         help="Reuse a prior run's data/{in,out} (skips golden recompute); "
@@ -951,7 +951,7 @@ if __name__ == "__main__":
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
         ),
         rtol=1e-2,
         atol=1e-2,

--- a/models/deepseek_v4_flash_mtp/decode_fwd.py
+++ b/models/deepseek_v4_flash_mtp/decode_fwd.py
@@ -1836,7 +1836,7 @@ def main():
     parser.add_argument("--hca-state-block-num", type=int, default=HCA_COMPRESS_STATE_BLOCK_NUM, help="Per-layer physical HCA state cache blocks.")
     parser.add_argument("--csa-state-block-num", type=int, default=CSA_MAIN_STATE_BLOCK_NUM, help="Per-layer physical CSA state cache blocks.")
     parser.add_argument("--inner-state-block-num", type=int, default=CSA_INNER_STATE_BLOCK_NUM, help="Per-layer physical inner-state cache blocks.")
-    parser.add_argument("--enable-l2-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2))
+    parser.add_argument("--enable-chip-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2))
     parser.add_argument("--enable-scope-stats", action="store_true", default=False)
     parser.add_argument("--compile-only", action="store_true", default=False)
     parser.add_argument("--dump-passes", action="store_true", default=False)
@@ -1878,7 +1878,7 @@ def main():
         ),
         runtime_cfg=dict(
             platform=args.platform,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
             enable_scope_stats=args.enable_scope_stats,
         ),
     )

--- a/models/deepseek_v4_flash_mtp/decode_fwd_mtp.py
+++ b/models/deepseek_v4_flash_mtp/decode_fwd_mtp.py
@@ -1142,7 +1142,7 @@ def main():
     parser.add_argument("--csa-state-block-num", type=int, default=CSA_MAIN_STATE_BLOCK_NUM)
     parser.add_argument("--inner-state-block-num", type=int, default=CSA_INNER_STATE_BLOCK_NUM)
     parser.add_argument(
-        "--enable-l2-swimlane",
+        "--enable-chip-swimlane",
         type=int,
         nargs="?",
         const=1,
@@ -1193,7 +1193,7 @@ def main():
         ),
         runtime_cfg=dict(
             platform=args.platform,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
             enable_scope_stats=args.enable_scope_stats,
         ),
     )

--- a/models/deepseek_v4_flash_mtp/decode_hca.py
+++ b/models/deepseek_v4_flash_mtp/decode_hca.py
@@ -687,7 +687,7 @@ if __name__ == "__main__":
     parser.add_argument("--start-pos", type=int, default=None,
                         help="Uniform fixture-only start_pos override for all batches; "
                              "default (unset) uses the canonical per-batch HCA set that includes the 8k point.")
-    parser.add_argument("--enable-l2-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2))
+    parser.add_argument("--enable-chip-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2))
     parser.add_argument("--runtime-dir", type=str, default=None)
     parser.add_argument("--golden-data", type=str, default=None)
     parser.add_argument("--dump-passes", action="store_true", default=False)
@@ -703,7 +703,7 @@ if __name__ == "__main__":
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
         ),
         atol=1e-2,
         compare_fn={

--- a/models/deepseek_v4_flash_mtp/decode_indexer.py
+++ b/models/deepseek_v4_flash_mtp/decode_indexer.py
@@ -708,8 +708,8 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--enable-l2-swimlane", type=int, default=0, choices=[0, 1, 2],
-                        help="L2 swimlane level: 0=off, 1=AICore timing, 2=+AICPU timing.")
+    parser.add_argument("--enable-chip-swimlane", type=int, default=0, choices=[0, 1, 2],
+                        help="chip swimlane level: 0=off, 1=AICore timing, 2=+AICPU timing.")
     parser.add_argument("--runtime-dir", type=str, default=None)
     parser.add_argument("--start-pos", type=int, default=None,
                         help="Uniform fixture-only start_pos override for all batches; "
@@ -761,7 +761,7 @@ if __name__ == "__main__":
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
         ),
         rtol=1e-3,
         atol=1e-3,

--- a/models/deepseek_v4_flash_mtp/decode_indexer_compressor.py
+++ b/models/deepseek_v4_flash_mtp/decode_indexer_compressor.py
@@ -615,7 +615,7 @@ if __name__ == "__main__":
     parser.add_argument("--start-pos", type=int, default=None,
                         help="Uniform fixture-only start_pos override for all batches; "
                              "default (unset) uses the canonical per-batch CSA set that includes the 8k point.")
-    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument("--enable-chip-swimlane", action="store_true", default=False)
     parser.add_argument("--runtime-dir", type=str, default=None)
     parser.add_argument("--dump-passes", action="store_true", default=False)
     args = parser.parse_args()
@@ -629,7 +629,7 @@ if __name__ == "__main__":
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
         ),
         rtol=1e-3,
         atol=1e-3,

--- a/models/deepseek_v4_flash_mtp/decode_layer.py
+++ b/models/deepseek_v4_flash_mtp/decode_layer.py
@@ -889,7 +889,7 @@ if __name__ == "__main__":
     parser.add_argument("--start-pos", type=int, default=DECODE_START_POS,
                         help="Fixture-only start_pos for all batches; default is the 8k target position.")
     parser.add_argument("--layer-id", type=int, default=10)
-    parser.add_argument("--enable-l2-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2))
+    parser.add_argument("--enable-chip-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2))
     parser.add_argument("--compile-only", action="store_true", default=False)
     parser.add_argument("--runtime-dir", type=str, default=None)
     parser.add_argument("--dump-passes", action="store_true", default=False)
@@ -918,7 +918,7 @@ if __name__ == "__main__":
         ),
         runtime_cfg=dict(
             platform=args.platform,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
         ),
         rtol=1e-3,
         atol=1e-3,

--- a/models/deepseek_v4_flash_mtp/decode_mtp.py
+++ b/models/deepseek_v4_flash_mtp/decode_mtp.py
@@ -913,7 +913,7 @@ def main():
     parser.add_argument("--start-pos", type=int, default=DECODE_START_POS)
     parser.add_argument("--num-tokens", type=int, default=T)
     parser.add_argument("--ori-block-num", type=int, default=ORI_BLOCK_NUM)
-    parser.add_argument("--enable-l2-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2))
+    parser.add_argument("--enable-chip-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2))
     parser.add_argument("--compile-only", action="store_true", default=False)
     parser.add_argument("--runtime-dir", type=str, default=None)
     parser.add_argument("--dump-passes", action="store_true", default=False)
@@ -945,7 +945,7 @@ def main():
         ),
         runtime_cfg=dict(
             platform=args.platform,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
         ),
         rtol=1e-3,
         atol=1e-3,

--- a/models/deepseek_v4_flash_mtp/decode_sparse_attn_csa.py
+++ b/models/deepseek_v4_flash_mtp/decode_sparse_attn_csa.py
@@ -797,7 +797,7 @@ if __name__ == "__main__":
     parser.add_argument("--cache-window-replacement-fixture", action="store_true", default=False,
                         help="Place a sentinel row inside the cache window prefix.")
     parser.add_argument("--golden-data", type=str, default=None)
-    parser.add_argument("--enable-l2-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2))
+    parser.add_argument("--enable-chip-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2))
     parser.add_argument("--enable-dep-gen", action="store_true", default=False,
                         help="Capture PTO2 dependency edges (deps.json) for the swimlane converter.")
     parser.add_argument("--enable-pmu", nargs="?", const=2, default=0, type=int, choices=[0, 1, 2, 4])
@@ -820,7 +820,7 @@ if __name__ == "__main__":
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
             enable_dep_gen=args.enable_dep_gen,
             enable_pmu=args.enable_pmu,
         ),

--- a/models/deepseek_v4_flash_mtp/decode_sparse_attn_hca.py
+++ b/models/deepseek_v4_flash_mtp/decode_sparse_attn_hca.py
@@ -775,7 +775,7 @@ if __name__ == "__main__":
     parser.add_argument("--cache-window-replacement-fixture", action="store_true", default=False,
                         help="Place a sentinel row inside the cache window prefix.")
     parser.add_argument("--golden-data", type=str, default=None)
-    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument("--enable-chip-swimlane", action="store_true", default=False)
     parser.add_argument("--enable-dep-gen", action="store_true", default=False,
                         help="Capture PTO2 dependency edges (deps.json); the swimlane "
                              "converter draws fanout/fanin arrows from the sibling file.")
@@ -799,7 +799,7 @@ if __name__ == "__main__":
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
             enable_dep_gen=args.enable_dep_gen,
             enable_pmu=args.enable_pmu,
         ),

--- a/models/deepseek_v4_flash_mtp/decode_sparse_attn_swa.py
+++ b/models/deepseek_v4_flash_mtp/decode_sparse_attn_swa.py
@@ -649,7 +649,7 @@ if __name__ == "__main__":
     parser.add_argument("--short-window-fixture", action="store_true", default=False,
                         help="Use a short-window topk row with valid prefix + -1 padding.")
     parser.add_argument("--golden-data", type=str, default=None)
-    parser.add_argument("--enable-l2-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2, 4))
+    parser.add_argument("--enable-chip-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2, 4))
     parser.add_argument("--enable-dep-gen", action="store_true", default=False,
                         help="Capture PTO2 dependency edges (deps.json); the swimlane "
                              "converter draws fanout/fanin arrows from the sibling file.")
@@ -671,7 +671,7 @@ if __name__ == "__main__":
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
             enable_dep_gen=args.enable_dep_gen,
             enable_pmu=args.enable_pmu,
         ),

--- a/models/deepseek_v4_flash_mtp/decode_swa.py
+++ b/models/deepseek_v4_flash_mtp/decode_swa.py
@@ -486,7 +486,7 @@ if __name__ == "__main__":
     parser.add_argument("--start-pos", type=int, default=None,
                         help="Uniform fixture-only start_pos override for all batches; "
                              "default (unset) uses the canonical per-batch SWA set that includes the 8k point.")
-    parser.add_argument("--enable-l2-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2, 4))
+    parser.add_argument("--enable-chip-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2, 4))
     parser.add_argument("--runtime-dir", type=str, default=None)
     parser.add_argument("--golden-data", type=str, default=None)
     parser.add_argument("--dump-passes", action="store_true", default=False)
@@ -502,7 +502,7 @@ if __name__ == "__main__":
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
         ),
         rtol=1e-2,
         atol=1e-2,

--- a/models/deepseek_v4_flash_mtp/expert_routed.py
+++ b/models/deepseek_v4_flash_mtp/expert_routed.py
@@ -460,7 +460,7 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--enable-l2-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2))
+    parser.add_argument("--enable-chip-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2))
     parser.add_argument("--dump-passes", action="store_true", default=False)
     args = parser.parse_args()
 
@@ -472,7 +472,7 @@ if __name__ == "__main__":
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
         ),
         rtol=1e-3,
         atol=1e-3,

--- a/models/deepseek_v4_flash_mtp/expert_shared.py
+++ b/models/deepseek_v4_flash_mtp/expert_shared.py
@@ -396,7 +396,7 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument("--enable-chip-swimlane", action="store_true", default=False)
     parser.add_argument("--dump-passes", action="store_true", default=False)
     args = parser.parse_args()
 
@@ -408,7 +408,7 @@ if __name__ == "__main__":
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
         ),
         rtol=1e-3,
         atol=1e-3,

--- a/models/deepseek_v4_flash_mtp/gate.py
+++ b/models/deepseek_v4_flash_mtp/gate.py
@@ -417,7 +417,7 @@ if __name__ == "__main__":
     parser.add_argument("-d", "--device", type=int, default=0)
     parser.add_argument("--layer-id", type=int, default=10)
     parser.add_argument("--num-tokens", type=int, default=T)
-    parser.add_argument("--enable-l2-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2))
+    parser.add_argument("--enable-chip-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2))
     parser.add_argument("--dump-passes", action="store_true", default=False)
     args = parser.parse_args()
 
@@ -429,7 +429,7 @@ if __name__ == "__main__":
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
         ),
         rtol=1e-3,
         atol=1e-3,

--- a/models/deepseek_v4_flash_mtp/hc_head.py
+++ b/models/deepseek_v4_flash_mtp/hc_head.py
@@ -210,8 +210,8 @@ if __name__ == "__main__":
     parser.add_argument("-d", "--device", type=int, default=0)
     parser.add_argument("--seed", type=int, default=0)
     # Int mode (0=off; 1=timing only, most accurate; 2=timing + dep graph, two runs).
-    # `nargs="?"` so a bare `--enable-l2-swimlane` -> mode 1 (int, not bool True).
-    parser.add_argument("--enable-l2-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2))
+    # `nargs="?"` so a bare `--enable-chip-swimlane` -> mode 1 (int, not bool True).
+    parser.add_argument("--enable-chip-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2))
     parser.add_argument("--dump-passes", action="store_true", default=False)
     args = parser.parse_args()
     torch.manual_seed(args.seed)
@@ -226,7 +226,7 @@ if __name__ == "__main__":
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
         ),
         rtol=1e-3,
         atol=1e-3,

--- a/models/deepseek_v4_flash_mtp/hc_post.py
+++ b/models/deepseek_v4_flash_mtp/hc_post.py
@@ -207,7 +207,7 @@ if __name__ == "__main__":
     parser.add_argument("-d", "--device", type=int, default=0)
     parser.add_argument("--mode", choices=["decode", "prefill", "all"], default="decode",
                         help="Use decode or prefill batch sizes, or 'all' to test both.")
-    parser.add_argument("--enable-l2-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2))
+    parser.add_argument("--enable-chip-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2))
     parser.add_argument("--compile-only", action="store_true", default=False)
     parser.add_argument("--dump-passes", action="store_true", default=False)
     args = parser.parse_args()
@@ -225,7 +225,7 @@ if __name__ == "__main__":
             runtime_cfg=dict(
                 platform=args.platform,
                 device_id=args.device,
-                enable_l2_swimlane=args.enable_l2_swimlane,
+                enable_chip_swimlane=args.enable_chip_swimlane,
             ),
             rtol=1e-3,
             atol=1e-3,

--- a/models/deepseek_v4_flash_mtp/hc_pre.py
+++ b/models/deepseek_v4_flash_mtp/hc_pre.py
@@ -45,7 +45,7 @@ FOLDED into Phase D: since the C->D handoff was cross-core (different grid-strid
 it needed a barrier -- but each D task can just recompute the ONE gate it consumes from the
 barrier-2-published mixes_raw + sq_sum_acc on its OWN core (rsqrt+sigmoid is nearly free on
 this latency-bound kernel). That deletes a whole hard FFTS barrier (-8% decode / -11% prefill
-on the device L2 swimlane, latency-bound so barrier removal > byte removal). comb_logits /
+on the device chip swimlane, latency-bound so barrier removal > byte removal). comb_logits /
 post_pad_store survive only as SAME-CORE scratch (assemble then load-back, no barrier) because
 their downstream pl.load->pl.store needs an HC_PAD-wide 32B-aligned tile; the pre gate is
 consumed in tensor-world so it needs no buffer.
@@ -834,7 +834,7 @@ if __name__ == "__main__":
     parser.add_argument("-d", "--device", type=int, default=0)
     parser.add_argument("--mode", choices=["decode", "prefill", "all"], default="all",
                         help="Use decode or prefill batch sizes, or 'all' to test both.")
-    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument("--enable-chip-swimlane", action="store_true", default=False)
     parser.add_argument("--runtime-dir", type=str, default=None)
     parser.add_argument("--golden-data", type=str, default=None)
     parser.add_argument("--compile-only", action="store_true", default=False)
@@ -885,7 +885,7 @@ if __name__ == "__main__":
             runtime_cfg=dict(
                 platform=args.platform,
                 device_id=args.device,
-                enable_l2_swimlane=args.enable_l2_swimlane,
+                enable_chip_swimlane=args.enable_chip_swimlane,
                 # dep_gen: the "syncall" version's full-occupancy pl.system.syncall is
                 # incompatible with dep_gen -- the DFX instrumentation perturbs core
                 # occupancy and trips AICore timeout 507018 (pypto#1931) -- so it runs with

--- a/models/deepseek_v4_flash_mtp/lm_head.py
+++ b/models/deepseek_v4_flash_mtp/lm_head.py
@@ -636,7 +636,7 @@ if __name__ == "__main__":
                         help="Active hidden rows each owner projects")
     parser.add_argument("-d", "--device", type=str, default=",".join(str(i) for i in range(WORLD_SIZE)),
                         help=f"comma-separated device ids; need at least {WORLD_SIZE}")
-    parser.add_argument("--enable-l2-swimlane", type=int, nargs="?", const=1, default=0,
+    parser.add_argument("--enable-chip-swimlane", type=int, nargs="?", const=1, default=0,
                         choices=(0, 1, 2, 4))
     parser.add_argument("--compile-only", action="store_true", default=False)
     parser.add_argument("--runtime-dir", type=str, default=None)
@@ -675,7 +675,7 @@ if __name__ == "__main__":
         ),
         runtime_cfg=dict(
             platform=args.platform,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
         ),
         rtol=1e-3,
         atol=1e-3,

--- a/models/deepseek_v4_flash_mtp/moe.py
+++ b/models/deepseek_v4_flash_mtp/moe.py
@@ -991,7 +991,7 @@ if __name__ == "__main__":
                         help=f"active token count for MoE dispatch/combine (0..{T})")
     parser.add_argument("--balanced-routing", action="store_true", default=False,
                         help="use deterministic hash routes balanced evenly across all experts")
-    parser.add_argument("--enable-l2-swimlane", type=int, nargs="?", const=1, default=0, choices=range(5))
+    parser.add_argument("--enable-chip-swimlane", type=int, nargs="?", const=1, default=0, choices=range(5))
     parser.add_argument("--compile-only", action="store_true", default=False)
     parser.add_argument("--runtime-dir", type=str, default=None)
     parser.add_argument("--save-data", action="store_true", default=False)
@@ -1029,7 +1029,7 @@ if __name__ == "__main__":
         ),
         runtime_cfg=dict(
             platform=args.platform,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
             log_level=args.log_level,
         ),
         rtol=1e-3,

--- a/models/deepseek_v4_flash_mtp/mtp_projection.py
+++ b/models/deepseek_v4_flash_mtp/mtp_projection.py
@@ -345,7 +345,7 @@ if __name__ == "__main__":
     parser.add_argument("-d", "--device", type=int, default=0)
     parser.add_argument("--mode", choices=["decode", "prefill", "all"], default="all")
     parser.add_argument(
-        "--enable-l2-swimlane", type=int, nargs="?", const=1, default=0,
+        "--enable-chip-swimlane", type=int, nargs="?", const=1, default=0,
         choices=(0, 1, 2, 4),
     )
     parser.add_argument("--dump-passes", action="store_true", default=False)
@@ -365,7 +365,7 @@ if __name__ == "__main__":
             runtime_cfg=dict(
                 platform=args.platform,
                 device_id=args.device,
-                enable_l2_swimlane=args.enable_l2_swimlane,
+                enable_chip_swimlane=args.enable_chip_swimlane,
             ),
             rtol=1e-3,
             atol=1e-3,

--- a/models/deepseek_v4_flash_mtp/prefill_compressor_ratio128.py
+++ b/models/deepseek_v4_flash_mtp/prefill_compressor_ratio128.py
@@ -466,7 +466,7 @@ if __name__ == "__main__":
             "slot mapping; it is not a JIT kernel parameter."
         ),
     )
-    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument("--enable-chip-swimlane", action="store_true", default=False)
     parser.add_argument("--dump-passes", action="store_true", default=False)
     args = parser.parse_args()
 
@@ -475,7 +475,7 @@ if __name__ == "__main__":
         specs=build_tensor_specs(args.start_pos),
         golden_fn=golden_prefill_compressor_ratio128,
         compile_cfg=dict(dump_passes=args.dump_passes),
-        runtime_cfg=dict(platform=args.platform, device_id=args.device, enable_l2_swimlane=args.enable_l2_swimlane),
+        runtime_cfg=dict(platform=args.platform, device_id=args.device, enable_chip_swimlane=args.enable_chip_swimlane),
         rtol=1e-3,
         atol=1e-3,
         compile_only=args.compile_only,

--- a/models/deepseek_v4_flash_mtp/prefill_compressor_ratio4.py
+++ b/models/deepseek_v4_flash_mtp/prefill_compressor_ratio4.py
@@ -577,7 +577,7 @@ if __name__ == "__main__":
                         help="Compile/codegen only; also the implicit behavior on *sim platforms used by CI.")
     parser.add_argument("--start-pos", type=int, default=START_POS,
                         help="Fixture-only absolute position for token 0, lowered into position_ids and cmp_slot_mapping.")
-    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument("--enable-chip-swimlane", action="store_true", default=False)
     parser.add_argument("--dump-passes", action="store_true", default=False)
     args = parser.parse_args()
 
@@ -586,7 +586,7 @@ if __name__ == "__main__":
         specs=build_tensor_specs(args.start_pos),
         golden_fn=golden_prefill_compressor_ratio4,
         compile_cfg=dict(dump_passes=args.dump_passes),
-        runtime_cfg=dict(platform=args.platform, device_id=args.device, enable_l2_swimlane=args.enable_l2_swimlane),
+        runtime_cfg=dict(platform=args.platform, device_id=args.device, enable_chip_swimlane=args.enable_chip_swimlane),
         compile_only=args.compile_only,
         compare_fn={
             "compress_state": ratio_allclose(atol=1e-3, rtol=1e-3, max_error_ratio=0.0),

--- a/models/deepseek_v4_flash_mtp/prefill_cp_csa.py
+++ b/models/deepseek_v4_flash_mtp/prefill_cp_csa.py
@@ -3286,7 +3286,7 @@ if __name__ == "__main__":
     parser.add_argument("--cp", type=int, default=CP_SIZE, choices=CP_CHOICES)
     parser.add_argument("--compile-only", action="store_true")
     parser.add_argument("--dump-passes", action="store_true")
-    parser.add_argument("--enable-l2-swimlane", action="store_true")
+    parser.add_argument("--enable-chip-swimlane", action="store_true")
     args = parser.parse_args()
     from golden import ratio_allclose, ratio_reldiff, run_jit
 
@@ -3308,7 +3308,7 @@ if __name__ == "__main__":
         ),
         runtime_cfg=dict(
             platform=args.platform,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
         ),
         rtol=1e-2,
         atol=1e-2,

--- a/models/deepseek_v4_flash_mtp/prefill_cp_fwd_draft.py
+++ b/models/deepseek_v4_flash_mtp/prefill_cp_fwd_draft.py
@@ -3022,7 +3022,7 @@ if __name__ == "__main__":
         choices=list(FWD_LAYER_CHOICES),
         help=f"number of FWD layers (parsed at import; choices {FWD_LAYER_CHOICES}; 43 is the production schedule)",
     )
-    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument("--enable-chip-swimlane", action="store_true", default=False)
     parser.add_argument("--compile-only", action="store_true", default=False)
     parser.add_argument("--dump-passes", action="store_true", default=False)
     parser.add_argument(
@@ -3113,7 +3113,7 @@ if __name__ == "__main__":
         ),
         runtime_cfg=dict(
             platform=args.platform,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
             enable_scope_stats=args.enable_scope_stats,
         ),
     )

--- a/models/deepseek_v4_flash_mtp/prefill_cp_hca.py
+++ b/models/deepseek_v4_flash_mtp/prefill_cp_hca.py
@@ -2126,7 +2126,7 @@ if __name__ == "__main__":
     parser.add_argument("--cp", type=int, default=CP_SIZE, choices=list(CP_CHOICES))
     parser.add_argument("--compile-only", action="store_true")
     parser.add_argument("--dump-passes", action="store_true")
-    parser.add_argument("--enable-l2-swimlane", action="store_true")
+    parser.add_argument("--enable-chip-swimlane", action="store_true")
     args = parser.parse_args()
 
     from golden import ratio_allclose, ratio_reldiff, run_jit
@@ -2147,7 +2147,7 @@ if __name__ == "__main__":
         ),
         runtime_cfg=dict(
             platform=args.platform,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
         ),
         rtol=1e-2,
         atol=1e-2,

--- a/models/deepseek_v4_flash_mtp/prefill_cp_layer.py
+++ b/models/deepseek_v4_flash_mtp/prefill_cp_layer.py
@@ -2231,7 +2231,7 @@ if __name__ == "__main__":
         "--layer-id", type=int, default=SWA_LAYER_ID,
         help="layer 0 = SWA, layer 2 = CSA, layer 3 = HCA",
     )
-    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument("--enable-chip-swimlane", action="store_true", default=False)
     parser.add_argument("--enable-dep-gen", action="store_true", default=False)
     parser.add_argument("--no-golden", action="store_true", default=False)
     parser.add_argument("--compile-only", action="store_true", default=False)
@@ -2305,7 +2305,7 @@ if __name__ == "__main__":
         ),
         runtime_cfg=dict(
             platform=args.platform,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
             enable_dep_gen=args.enable_dep_gen,
         ),
         rtol=1e-2,

--- a/models/deepseek_v4_flash_mtp/prefill_cp_swa.py
+++ b/models/deepseek_v4_flash_mtp/prefill_cp_swa.py
@@ -961,7 +961,7 @@ if __name__ == "__main__":
     parser.add_argument("--compile-only", action="store_true", default=False)
     parser.add_argument("--cp", type=int, default=CP_SIZE, choices=list(CP_CHOICES))
     parser.add_argument("--dump-passes", action="store_true", default=False)
-    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument("--enable-chip-swimlane", action="store_true", default=False)
     args = parser.parse_args()
 
     from golden import ratio_allclose, ratio_reldiff, run_jit
@@ -983,7 +983,7 @@ if __name__ == "__main__":
         ),
         runtime_cfg=dict(
             platform=args.platform,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
         ),
         rtol=1e-2,
         atol=1e-2,

--- a/models/deepseek_v4_flash_mtp/prefill_csa.py
+++ b/models/deepseek_v4_flash_mtp/prefill_csa.py
@@ -963,7 +963,7 @@ if __name__ == "__main__":
                         help="context_len (multiple of S=WIN); fixture-only, lowered into token metadata.")
     parser.add_argument("--num-tokens", type=int, default=T,
                         help="Active token count (q_len), capped by T; passed to the kernel as num_tokens.")
-    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument("--enable-chip-swimlane", action="store_true", default=False)
     parser.add_argument("--enable-dep-gen", action="store_true", default=False)
     parser.add_argument("--dump-passes", action="store_true", default=False)
     args = parser.parse_args()
@@ -988,7 +988,7 @@ if __name__ == "__main__":
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
             enable_dep_gen=args.enable_dep_gen,
         ),
         rtol=1e-2,

--- a/models/deepseek_v4_flash_mtp/prefill_fwd.py
+++ b/models/deepseek_v4_flash_mtp/prefill_fwd.py
@@ -1632,7 +1632,7 @@ def main():
     parser.add_argument("--hca-state-block-num", type=int, default=HCA_STATE_BLOCK_NUM)
     parser.add_argument("--csa-state-block-num", type=int, default=CSA_STATE_BLOCK_NUM)
     parser.add_argument("--inner-state-block-num", type=int, default=INNER_STATE_BLOCK_NUM)
-    parser.add_argument("--enable-l2-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2))
+    parser.add_argument("--enable-chip-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2))
     parser.add_argument("--enable-scope-stats", action="store_true", default=False)
 
     parser.add_argument("--num-tiles", type=int, default=1,
@@ -1679,7 +1679,7 @@ def main():
         ),
         runtime_cfg=dict(
             platform=args.platform,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
             enable_scope_stats=args.enable_scope_stats,
             ring_heap=PREFILL_RING_HEAP,
         ),

--- a/models/deepseek_v4_flash_mtp/prefill_hca.py
+++ b/models/deepseek_v4_flash_mtp/prefill_hca.py
@@ -695,7 +695,7 @@ if __name__ == "__main__":
                         help="context_len (multiple of S=WIN); fixture-only, lowered into token metadata.")
     parser.add_argument("--num-tokens", type=int, default=T,
                         help="Active token count (q_len), capped by T; passed to the kernel as num_tokens.")
-    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument("--enable-chip-swimlane", action="store_true", default=False)
     parser.add_argument("--enable-dep-gen", action="store_true", default=False)
     parser.add_argument("--dump-passes", action="store_true", default=False)
     args = parser.parse_args()
@@ -712,7 +712,7 @@ if __name__ == "__main__":
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
             enable_dep_gen=args.enable_dep_gen,
         ),
         rtol=1e-2,

--- a/models/deepseek_v4_flash_mtp/prefill_indexer.py
+++ b/models/deepseek_v4_flash_mtp/prefill_indexer.py
@@ -1001,7 +1001,7 @@ if __name__ == "__main__":
                         help="Fixture-only absolute position for token 0; lowered into position_ids and dense idx_slot_mapping.")
     parser.add_argument("--num-tokens", type=int, default=T,
                         help="Active token prefix; inactive top-k rows must remain all -1.")
-    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument("--enable-chip-swimlane", action="store_true", default=False)
     parser.add_argument("--dump-passes", action="store_true", default=False)
     args = parser.parse_args()
 
@@ -1035,7 +1035,7 @@ if __name__ == "__main__":
         specs=build_tensor_specs(args.start_pos, args.num_tokens),
         golden_fn=golden_prefill_indexer,
         compile_cfg=dict(dump_passes=args.dump_passes),
-        runtime_cfg=dict(platform=args.platform, device_id=args.device, enable_l2_swimlane=args.enable_l2_swimlane),
+        runtime_cfg=dict(platform=args.platform, device_id=args.device, enable_chip_swimlane=args.enable_chip_swimlane),
         rtol=1e-3,
         atol=1e-3,
         compile_only=args.compile_only,

--- a/models/deepseek_v4_flash_mtp/prefill_indexer_compressor.py
+++ b/models/deepseek_v4_flash_mtp/prefill_indexer_compressor.py
@@ -779,7 +779,7 @@ if __name__ == "__main__":
     )
     parser.add_argument("--start-pos", type=int, default=START_POS,
                         help="Fixture-only absolute position for token 0; lowered into position_ids and dense idx_slot_mapping.")
-    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument("--enable-chip-swimlane", action="store_true", default=False)
     parser.add_argument("--dump-passes", action="store_true", default=False)
     args = parser.parse_args()
 
@@ -788,7 +788,7 @@ if __name__ == "__main__":
         specs=build_tensor_specs(args.start_pos),
         golden_fn=golden_prefill_indexer_compressor,
         compile_cfg=dict(dump_passes=args.dump_passes),
-        runtime_cfg=dict(platform=args.platform, device_id=args.device, enable_l2_swimlane=args.enable_l2_swimlane),
+        runtime_cfg=dict(platform=args.platform, device_id=args.device, enable_chip_swimlane=args.enable_chip_swimlane),
         compile_only=args.compile_only,
         compare_fn={
             # C8: raw INT8 compressed rows (+/-1 LSB on the boundary rows the compressor rewrote).

--- a/models/deepseek_v4_flash_mtp/prefill_layer.py
+++ b/models/deepseek_v4_flash_mtp/prefill_layer.py
@@ -1012,7 +1012,7 @@ if __name__ == "__main__":
                         help=f"comma-separated device ids; need at least {N_RANKS}")
     parser.add_argument("--layer-id", type=int, default=2,
                         help="Layer id selects attention by MODEL_CONFIG.compress_ratios[layer_id].")
-    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument("--enable-chip-swimlane", action="store_true", default=False)
     parser.add_argument("--compile-only", action="store_true", default=False)
     parser.add_argument("--dump-passes", action="store_true", default=False)
     args = parser.parse_args()
@@ -1034,7 +1034,7 @@ if __name__ == "__main__":
         ),
         runtime_cfg=dict(
             platform=args.platform,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
         ),
         rtol=1e-3,
         atol=1e-3,

--- a/models/deepseek_v4_flash_mtp/prefill_mtp.py
+++ b/models/deepseek_v4_flash_mtp/prefill_mtp.py
@@ -750,7 +750,7 @@ def main():
             "device-resident: keep hidden/pre-HC/logits on device and skip golden/readback"
         ),
     )
-    parser.add_argument("--enable-l2-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2))
+    parser.add_argument("--enable-chip-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2))
     parser.add_argument("--enable-scope-stats", action="store_true", default=False)
     parser.add_argument("--compile-only", action="store_true", default=False)
     parser.add_argument("--dump-passes", action="store_true", default=False)
@@ -780,7 +780,7 @@ def main():
         ),
         runtime_cfg=dict(
             platform=args.platform,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
             enable_scope_stats=args.enable_scope_stats,
         ),
         rtol=1e-3,

--- a/models/deepseek_v4_flash_mtp/prefill_sparse_attn.py
+++ b/models/deepseek_v4_flash_mtp/prefill_sparse_attn.py
@@ -746,7 +746,7 @@ if __name__ == "__main__":
     parser.add_argument("--num-tokens", type=int, default=T, help="Active prefix; inactive output rows stay zero.")
     parser.add_argument("--ori-block-num", type=int, default=ORI_BLOCK_NUM)
     parser.add_argument("--cmp-block-num", type=int, default=CMP_BLOCK_NUM)
-    parser.add_argument("--enable-l2-swimlane", nargs="?", const=4, default=0, type=int)
+    parser.add_argument("--enable-chip-swimlane", nargs="?", const=4, default=0, type=int)
     parser.add_argument("--enable-pmu", nargs="?", const=2, default=0, type=int, choices=[0, 1, 2, 4])
     parser.add_argument("--dump-passes", action="store_true", default=False)
     args = parser.parse_args()
@@ -760,7 +760,7 @@ if __name__ == "__main__":
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
             enable_pmu=args.enable_pmu,
         ),
         rtol=1e-3,

--- a/models/deepseek_v4_flash_mtp/prefill_swa.py
+++ b/models/deepseek_v4_flash_mtp/prefill_swa.py
@@ -499,7 +499,7 @@ if __name__ == "__main__":
                         help="context_len (multiple of S=WIN); fixture-only, lowered into token metadata.")
     parser.add_argument("--num-tokens", type=int, default=T,
                         help="Active token count (q_len), capped by T; passed to the kernel as num_tokens.")
-    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument("--enable-chip-swimlane", action="store_true", default=False)
     parser.add_argument("--enable-dep-gen", action="store_true", default=False)
     parser.add_argument("--dump-passes", action="store_true", default=False)
     args = parser.parse_args()
@@ -516,7 +516,7 @@ if __name__ == "__main__":
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
             enable_dep_gen=args.enable_dep_gen,
         ),
         compile_only=args.compile_only,

--- a/models/deepseek_v4_flash_mtp/qkv_proj_rope.py
+++ b/models/deepseek_v4_flash_mtp/qkv_proj_rope.py
@@ -559,8 +559,8 @@ if __name__ == "__main__":
     parser.add_argument("-d", "--device", type=int, default=0)
     parser.add_argument("--mode", choices=["decode", "prefill", "all"], default="all",
                         help="Use decode or prefill batch sizes, or 'all' to test both.")
-    parser.add_argument("--enable-l2-swimlane", type=int, choices=[0, 1, 2, 4], default=0,
-                        help="L2 swimlane level: 0=off, 1=per-kernel AICore timing "
+    parser.add_argument("--enable-chip-swimlane", type=int, choices=[0, 1, 2, 4], default=0,
+                        help="chip swimlane level: 0=off, 1=per-kernel AICore timing "
                              "(prints the per-function Task Statistics table), 2=+AICPU timing.")
     parser.add_argument("--runtime-dir", type=str, default=None)
     parser.add_argument("--golden-data", type=str, default=None)
@@ -594,7 +594,7 @@ if __name__ == "__main__":
             runtime_cfg=dict(
                 platform=args.platform,
                 device_id=args.device,
-                enable_l2_swimlane=args.enable_l2_swimlane,
+                enable_chip_swimlane=args.enable_chip_swimlane,
             ),
             compile_only=args.compile_only,
         )

--- a/models/deepseek_v4_flash_mtp/rmsnorm.py
+++ b/models/deepseek_v4_flash_mtp/rmsnorm.py
@@ -122,7 +122,7 @@ if __name__ == "__main__":
     parser.add_argument("-d", "--device", type=int, default=0)
     parser.add_argument("--mode", choices=["decode", "prefill", "all"], default="all",
                         help="Use decode or prefill batch sizes, or 'all' to test both.")
-    parser.add_argument("--enable-l2-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2, 4))
+    parser.add_argument("--enable-chip-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2, 4))
     parser.add_argument("--runtime-dir", type=str, default=None)
     parser.add_argument("--golden-data", type=str, default=None)
     parser.add_argument("--compile-only", action="store_true", default=False)
@@ -144,7 +144,7 @@ if __name__ == "__main__":
             runtime_cfg=dict(
                 platform=args.platform,
                 device_id=args.device,
-                enable_l2_swimlane=args.enable_l2_swimlane,
+                enable_chip_swimlane=args.enable_chip_swimlane,
             ),
             rtol=5e-3,
             atol=5e-3,

--- a/models/deepseek_v4_pro/decode_attention_csa.py
+++ b/models/deepseek_v4_pro/decode_attention_csa.py
@@ -888,7 +888,7 @@ if __name__ == "__main__":
     parser.add_argument("--start-pos", type=int, default=None,
                         help="Uniform fixture-only start_pos override for all batches; "
                              "default (unset) uses the canonical per-batch CSA set that includes the 8k point.")
-    parser.add_argument("--enable-l2-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2, 4))
+    parser.add_argument("--enable-chip-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2, 4))
     parser.add_argument("--runtime-dir", type=str, default=None)
     parser.add_argument("--golden-data", type=str, default=None,
                         help="Reuse a prior run's data/{in,out} (skips golden recompute); "
@@ -906,7 +906,7 @@ if __name__ == "__main__":
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
         ),
         rtol=1e-2,
         atol=1e-2,

--- a/models/deepseek_v4_pro/decode_attention_hca.py
+++ b/models/deepseek_v4_pro/decode_attention_hca.py
@@ -658,7 +658,7 @@ if __name__ == "__main__":
     parser.add_argument("--start-pos", type=int, default=None,
                         help="Uniform fixture-only start_pos override for all batches; "
                              "default (unset) uses the canonical per-batch HCA set that includes the 8k point.")
-    parser.add_argument("--enable-l2-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2))
+    parser.add_argument("--enable-chip-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2))
     parser.add_argument("--runtime-dir", type=str, default=None)
     parser.add_argument("--golden-data", type=str, default=None)
     parser.add_argument("--dump-passes", action="store_true", default=False)
@@ -674,7 +674,7 @@ if __name__ == "__main__":
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
         ),
         atol=1e-2,
         compare_fn={

--- a/models/deepseek_v4_pro/decode_attention_swa.py
+++ b/models/deepseek_v4_pro/decode_attention_swa.py
@@ -473,7 +473,7 @@ if __name__ == "__main__":
     parser.add_argument("--start-pos", type=int, default=None,
                         help="Uniform fixture-only start_pos override for all batches; "
                              "default (unset) uses the canonical per-batch SWA set that includes the 8k point.")
-    parser.add_argument("--enable-l2-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2, 4))
+    parser.add_argument("--enable-chip-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2, 4))
     parser.add_argument("--runtime-dir", type=str, default=None)
     parser.add_argument("--golden-data", type=str, default=None)
     parser.add_argument("--dump-passes", action="store_true", default=False)
@@ -489,7 +489,7 @@ if __name__ == "__main__":
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
         ),
         rtol=1e-2,
         atol=1e-2,

--- a/models/deepseek_v4_pro/decode_compressor_ratio128.py
+++ b/models/deepseek_v4_pro/decode_compressor_ratio128.py
@@ -564,7 +564,7 @@ if __name__ == "__main__":
     parser.add_argument("--start-pos", type=int, default=None,
                         help="Uniform fixture-only start_pos override for all batches; "
                              "default (unset) uses the canonical per-batch HCA set that includes the 8k point.")
-    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument("--enable-chip-swimlane", action="store_true", default=False)
     parser.add_argument("--dump-passes", action="store_true", default=False)
     args = parser.parse_args()
 
@@ -576,7 +576,7 @@ if __name__ == "__main__":
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
         ),
         rtol=1e-3,
         atol=1e-3,

--- a/models/deepseek_v4_pro/decode_compressor_ratio4.py
+++ b/models/deepseek_v4_pro/decode_compressor_ratio4.py
@@ -545,7 +545,7 @@ if __name__ == "__main__":
     parser.add_argument("--start-pos", type=int, default=None,
                         help="Uniform fixture-only start_pos override for all batches; "
                              "default (unset) uses the canonical per-batch CSA set that includes the 8k point.")
-    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument("--enable-chip-swimlane", action="store_true", default=False)
     parser.add_argument("--runtime-dir", type=str, default=None)
     parser.add_argument("--golden-data", type=str, default=None)
     parser.add_argument("--dump-passes", action="store_true", default=False)
@@ -561,7 +561,7 @@ if __name__ == "__main__":
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
         ),
         rtol=1e-3,
         atol=1e-3,

--- a/models/deepseek_v4_pro/decode_fwd.py
+++ b/models/deepseek_v4_pro/decode_fwd.py
@@ -1705,7 +1705,7 @@ def main():
         help="Fixture-only start_pos for all batches; default is the 8k target position.",
     )
     parser.add_argument("--num-tokens", type=int, default=T, help=f"Active token rows for MoE routing/combine; default is T={T}.")
-    parser.add_argument("--enable-l2-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2))
+    parser.add_argument("--enable-chip-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2))
     parser.add_argument("--enable-scope-stats", action="store_true", default=False)
     parser.add_argument("--compile-only", action="store_true", default=False)
     parser.add_argument("--dump-passes", action="store_true", default=False)
@@ -1739,7 +1739,7 @@ def main():
         ),
         runtime_cfg=dict(
             platform=args.platform,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
             enable_scope_stats=args.enable_scope_stats,
         ),
     )

--- a/models/deepseek_v4_pro/decode_indexer.py
+++ b/models/deepseek_v4_pro/decode_indexer.py
@@ -1164,8 +1164,8 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--enable-l2-swimlane", type=int, default=0, choices=[0, 1, 2],
-                        help="L2 swimlane level: 0=off, 1=AICore timing, 2=+AICPU timing.")
+    parser.add_argument("--enable-chip-swimlane", type=int, default=0, choices=[0, 1, 2],
+                        help="chip swimlane level: 0=off, 1=AICore timing, 2=+AICPU timing.")
     parser.add_argument("--runtime-dir", type=str, default=None)
     parser.add_argument("--start-pos", type=int, default=None,
                         help="Uniform fixture-only start_pos override for all batches; "
@@ -1182,7 +1182,7 @@ if __name__ == "__main__":
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
         ),
         rtol=1e-3,
         atol=1e-3,

--- a/models/deepseek_v4_pro/decode_indexer_compressor.py
+++ b/models/deepseek_v4_pro/decode_indexer_compressor.py
@@ -677,7 +677,7 @@ if __name__ == "__main__":
     parser.add_argument("--start-pos", type=int, default=None,
                         help="Uniform fixture-only start_pos override for all batches; "
                              "default (unset) uses the canonical per-batch CSA set that includes the 8k point.")
-    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument("--enable-chip-swimlane", action="store_true", default=False)
     parser.add_argument("--runtime-dir", type=str, default=None)
     parser.add_argument("--dump-passes", action="store_true", default=False)
     args = parser.parse_args()
@@ -691,7 +691,7 @@ if __name__ == "__main__":
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
         ),
         rtol=1e-3,
         atol=1e-3,

--- a/models/deepseek_v4_pro/decode_layer.py
+++ b/models/deepseek_v4_pro/decode_layer.py
@@ -964,7 +964,7 @@ if __name__ == "__main__":
     parser.add_argument("--start-pos", type=int, default=DECODE_START_POS,
                         help="Fixture-only start_pos for all batches; default is the 8k target position.")
     parser.add_argument("--layer-id", type=int, default=10)
-    parser.add_argument("--enable-l2-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2))
+    parser.add_argument("--enable-chip-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2))
     parser.add_argument("--compile-only", action="store_true", default=False)
     parser.add_argument("--runtime-dir", type=str, default=None)
     parser.add_argument("--save-data", action="store_true", default=False,
@@ -1109,7 +1109,7 @@ if __name__ == "__main__":
         ),
         runtime_cfg=dict(
             platform=args.platform,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
         ),
         rtol=1e-3,
         atol=1e-3,

--- a/models/deepseek_v4_pro/decode_mtp.py
+++ b/models/deepseek_v4_pro/decode_mtp.py
@@ -843,7 +843,7 @@ def main():
                         help=f"comma-separated device ids; need at least {N_RANKS}")
     parser.add_argument("--start-pos", type=int, default=DECODE_START_POS)
     parser.add_argument("--num-tokens", type=int, default=T)
-    parser.add_argument("--enable-l2-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2))
+    parser.add_argument("--enable-chip-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2))
     parser.add_argument("--compile-only", action="store_true", default=False)
     parser.add_argument("--runtime-dir", type=str, default=None)
     parser.add_argument("--seed", type=int, default=0,
@@ -868,7 +868,7 @@ def main():
         ),
         runtime_cfg=dict(
             platform=args.platform,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
         ),
         rtol=1e-3,
         atol=1e-3,

--- a/models/deepseek_v4_pro/decode_sparse_attn.py
+++ b/models/deepseek_v4_pro/decode_sparse_attn.py
@@ -988,7 +988,7 @@ if __name__ == "__main__":
     parser.add_argument("--cache-window-replacement-fixture", action="store_true", default=False,
                         help="Place a sentinel row inside the cache window prefix.")
     parser.add_argument("--golden-data", type=str, default=None)
-    parser.add_argument("--enable-l2-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2))
+    parser.add_argument("--enable-chip-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2))
     parser.add_argument("--enable-dep-gen", action="store_true", default=False,
                         help="Capture PTO2 dependency edges (deps.json); the swimlane "
                              "converter draws fanout/fanin arrows from the sibling file.")
@@ -1015,7 +1015,7 @@ if __name__ == "__main__":
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
             enable_dep_gen=args.enable_dep_gen,
             enable_pmu=args.enable_pmu,
         ),

--- a/models/deepseek_v4_pro/decode_sparse_attn_hca.py
+++ b/models/deepseek_v4_pro/decode_sparse_attn_hca.py
@@ -883,7 +883,7 @@ if __name__ == "__main__":
     parser.add_argument("--cache-window-replacement-fixture", action="store_true", default=False,
                         help="Place a sentinel row inside the cache window prefix.")
     parser.add_argument("--golden-data", type=str, default=None)
-    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument("--enable-chip-swimlane", action="store_true", default=False)
     parser.add_argument("--enable-dep-gen", action="store_true", default=False,
                         help="Capture PTO2 dependency edges (deps.json); the swimlane "
                              "converter draws fanout/fanin arrows from the sibling file.")
@@ -910,7 +910,7 @@ if __name__ == "__main__":
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
             enable_dep_gen=args.enable_dep_gen,
             enable_pmu=args.enable_pmu,
         ),

--- a/models/deepseek_v4_pro/decode_sparse_attn_swa.py
+++ b/models/deepseek_v4_pro/decode_sparse_attn_swa.py
@@ -746,7 +746,7 @@ if __name__ == "__main__":
     parser.add_argument("--short-window-fixture", action="store_true", default=False,
                         help="Use a short-window topk row with valid prefix + -1 padding.")
     parser.add_argument("--golden-data", type=str, default=None)
-    parser.add_argument("--enable-l2-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2, 4))
+    parser.add_argument("--enable-chip-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2, 4))
     parser.add_argument("--enable-dep-gen", action="store_true", default=False,
                         help="Capture PTO2 dependency edges (deps.json); the swimlane "
                              "converter draws fanout/fanin arrows from the sibling file.")
@@ -768,7 +768,7 @@ if __name__ == "__main__":
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
             enable_dep_gen=args.enable_dep_gen,
             enable_pmu=args.enable_pmu,
         ),

--- a/models/deepseek_v4_pro/expert_routed.py
+++ b/models/deepseek_v4_pro/expert_routed.py
@@ -562,7 +562,7 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--enable-l2-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2))
+    parser.add_argument("--enable-chip-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2))
     parser.add_argument("--dump-passes", action="store_true", default=False)
     args = parser.parse_args()
 
@@ -574,7 +574,7 @@ if __name__ == "__main__":
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
         ),
         rtol=1e-3,
         atol=1e-3,

--- a/models/deepseek_v4_pro/expert_shared.py
+++ b/models/deepseek_v4_pro/expert_shared.py
@@ -426,7 +426,7 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument("--enable-chip-swimlane", action="store_true", default=False)
     parser.add_argument("--dump-passes", action="store_true", default=False)
     args = parser.parse_args()
 
@@ -438,7 +438,7 @@ if __name__ == "__main__":
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
         ),
         rtol=1e-3,
         atol=1e-3,

--- a/models/deepseek_v4_pro/gate.py
+++ b/models/deepseek_v4_pro/gate.py
@@ -764,7 +764,7 @@ if __name__ == "__main__":
     parser.add_argument("--layer-id", type=int, default=10)
     parser.add_argument("--num-tokens", type=int, default=T)
     parser.add_argument("--seed", type=int, default=0)
-    parser.add_argument("--enable-l2-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2))
+    parser.add_argument("--enable-chip-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2))
     parser.add_argument("--dump-passes", action="store_true", default=False)
     args = parser.parse_args()
     torch.manual_seed(args.seed)
@@ -777,7 +777,7 @@ if __name__ == "__main__":
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
         ),
         rtol=1e-3,
         atol=1e-3,

--- a/models/deepseek_v4_pro/hc_head.py
+++ b/models/deepseek_v4_pro/hc_head.py
@@ -289,8 +289,8 @@ if __name__ == "__main__":
     parser.add_argument("-d", "--device", type=int, default=0)
     parser.add_argument("--seed", type=int, default=0)
     # Int mode (0=off; 1=timing only, most accurate; 2=timing + dep graph, two runs).
-    # `nargs="?"` so a bare `--enable-l2-swimlane` -> mode 1 (int, not bool True).
-    parser.add_argument("--enable-l2-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2))
+    # `nargs="?"` so a bare `--enable-chip-swimlane` -> mode 1 (int, not bool True).
+    parser.add_argument("--enable-chip-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2))
     parser.add_argument("--dump-passes", action="store_true", default=False)
     args = parser.parse_args()
     torch.manual_seed(args.seed)
@@ -305,7 +305,7 @@ if __name__ == "__main__":
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
         ),
         rtol=1e-3,
         atol=1e-3,

--- a/models/deepseek_v4_pro/hc_post.py
+++ b/models/deepseek_v4_pro/hc_post.py
@@ -207,7 +207,7 @@ if __name__ == "__main__":
     parser.add_argument("-d", "--device", type=int, default=0)
     parser.add_argument("--mode", choices=["decode", "prefill", "all"], default="decode",
                         help="Use decode or prefill batch sizes, or 'all' to test both.")
-    parser.add_argument("--enable-l2-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2))
+    parser.add_argument("--enable-chip-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2))
     parser.add_argument("--compile-only", action="store_true", default=False)
     parser.add_argument("--dump-passes", action="store_true", default=False)
     args = parser.parse_args()
@@ -225,7 +225,7 @@ if __name__ == "__main__":
             runtime_cfg=dict(
                 platform=args.platform,
                 device_id=args.device,
-                enable_l2_swimlane=args.enable_l2_swimlane,
+                enable_chip_swimlane=args.enable_chip_swimlane,
             ),
             rtol=1e-3,
             atol=1e-3,

--- a/models/deepseek_v4_pro/hc_pre.py
+++ b/models/deepseek_v4_pro/hc_pre.py
@@ -48,7 +48,7 @@ FOLDED into Phase D: since the C->D handoff was cross-core (different grid-strid
 it needed a barrier -- but each D task can just recompute the ONE gate it consumes from the
 barrier-2-published mixes_raw + sq_sum_acc on its OWN core (rsqrt+sigmoid is nearly free on
 this latency-bound kernel). That deletes a whole hard FFTS barrier (-8% decode / -11% prefill
-on the device L2 swimlane, latency-bound so barrier removal > byte removal). comb_logits /
+on the device chip swimlane, latency-bound so barrier removal > byte removal). comb_logits /
 post_pad_store survive only as SAME-CORE scratch (assemble then load-back, no barrier) because
 their downstream pl.load->pl.store needs an HC_PAD-wide 32B-aligned tile; the pre gate is
 consumed in tensor-world so it needs no buffer.
@@ -1091,7 +1091,7 @@ if __name__ == "__main__":
     parser.add_argument("-d", "--device", type=int, default=0)
     parser.add_argument("--mode", choices=["decode", "prefill", "all"], default="all",
                         help="Use decode or prefill batch sizes, or 'all' to test both.")
-    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument("--enable-chip-swimlane", action="store_true", default=False)
     parser.add_argument("--runtime-dir", type=str, default=None)
     parser.add_argument("--golden-data", type=str, default=None)
     parser.add_argument("--compile-only", action="store_true", default=False)
@@ -1142,7 +1142,7 @@ if __name__ == "__main__":
             runtime_cfg=dict(
                 platform=args.platform,
                 device_id=args.device,
-                enable_l2_swimlane=args.enable_l2_swimlane,
+                enable_chip_swimlane=args.enable_chip_swimlane,
                 # dep_gen: the "syncall" version's full-occupancy pl.system.syncall is
                 # incompatible with dep_gen -- the DFX instrumentation perturbs core
                 # occupancy and trips AICore timeout 507018 (pypto#1931) -- so it runs with

--- a/models/deepseek_v4_pro/lm_head.py
+++ b/models/deepseek_v4_pro/lm_head.py
@@ -634,7 +634,7 @@ if __name__ == "__main__":
                         help="Active hidden rows each owner projects")
     parser.add_argument("-d", "--device", type=str, default=",".join(str(i) for i in range(DP_SIZE)),
                         help=f"comma-separated device ids; need at least {DP_SIZE}")
-    parser.add_argument("--enable-l2-swimlane", type=int, nargs="?", const=1, default=0,
+    parser.add_argument("--enable-chip-swimlane", type=int, nargs="?", const=1, default=0,
                         choices=(0, 1, 2, 4))
     parser.add_argument("--compile-only", action="store_true", default=False)
     parser.add_argument("--runtime-dir", type=str, default=None)
@@ -673,7 +673,7 @@ if __name__ == "__main__":
         ),
         runtime_cfg=dict(
             platform=args.platform,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
         ),
         rtol=1e-3,
         atol=1e-3,

--- a/models/deepseek_v4_pro/moe.py
+++ b/models/deepseek_v4_pro/moe.py
@@ -1114,7 +1114,7 @@ if __name__ == "__main__":
                         help=f"active token count for MoE dispatch/combine (0..{T})")
     parser.add_argument("--balanced-routing", action="store_true", default=False,
                         help="use deterministic hash routes balanced evenly across all experts")
-    parser.add_argument("--enable-l2-swimlane", type=int, nargs="?", const=1, default=0, choices=range(5))
+    parser.add_argument("--enable-chip-swimlane", type=int, nargs="?", const=1, default=0, choices=range(5))
     parser.add_argument("--compile-only", action="store_true", default=False)
     parser.add_argument("--runtime-dir", type=str, default=None)
     parser.add_argument("--save-data", action="store_true", default=False)
@@ -1169,7 +1169,7 @@ if __name__ == "__main__":
         ),
         runtime_cfg=dict(
             platform=args.platform,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
             log_level=args.log_level,
         ),
         rtol=1e-3,

--- a/models/deepseek_v4_pro/mtp_projection.py
+++ b/models/deepseek_v4_pro/mtp_projection.py
@@ -357,7 +357,7 @@ if __name__ == "__main__":
     parser.add_argument("-d", "--device", type=int, default=0)
     parser.add_argument("--mode", choices=["decode", "prefill", "all"], default="all")
     parser.add_argument("--seed", type=int, default=0)
-    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument("--enable-chip-swimlane", action="store_true", default=False)
     parser.add_argument("--dump-passes", action="store_true", default=False)
     args = parser.parse_args()
     torch.manual_seed(args.seed)
@@ -376,7 +376,7 @@ if __name__ == "__main__":
             runtime_cfg=dict(
                 platform=args.platform,
                 device_id=args.device,
-                enable_l2_swimlane=args.enable_l2_swimlane,
+                enable_chip_swimlane=args.enable_chip_swimlane,
             ),
             rtol=1e-3,
             atol=1e-3,

--- a/models/deepseek_v4_pro/prefill_attention_csa.py
+++ b/models/deepseek_v4_pro/prefill_attention_csa.py
@@ -964,7 +964,7 @@ if __name__ == "__main__":
                         help="context_len (multiple of S=WIN); fixture-only, lowered into token metadata.")
     parser.add_argument("--num-tokens", type=int, default=T,
                         help="Active token count (q_len), capped by T; passed to the kernel as num_tokens.")
-    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument("--enable-chip-swimlane", action="store_true", default=False)
     parser.add_argument("--enable-dep-gen", action="store_true", default=False)
     parser.add_argument("--dump-passes", action="store_true", default=False)
     args = parser.parse_args()
@@ -989,7 +989,7 @@ if __name__ == "__main__":
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
             enable_dep_gen=args.enable_dep_gen,
         ),
         rtol=1e-2,

--- a/models/deepseek_v4_pro/prefill_attention_hca.py
+++ b/models/deepseek_v4_pro/prefill_attention_hca.py
@@ -709,7 +709,7 @@ if __name__ == "__main__":
                         help="context_len (multiple of S=WIN); fixture-only, lowered into token metadata.")
     parser.add_argument("--num-tokens", type=int, default=T,
                         help="Active token count (q_len), capped by T; passed to the kernel as num_tokens.")
-    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument("--enable-chip-swimlane", action="store_true", default=False)
     parser.add_argument("--enable-dep-gen", action="store_true", default=False)
     parser.add_argument("--dump-passes", action="store_true", default=False)
     args = parser.parse_args()
@@ -726,7 +726,7 @@ if __name__ == "__main__":
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
             enable_dep_gen=args.enable_dep_gen,
         ),
         rtol=1e-2,

--- a/models/deepseek_v4_pro/prefill_attention_swa.py
+++ b/models/deepseek_v4_pro/prefill_attention_swa.py
@@ -686,7 +686,7 @@ if __name__ == "__main__":
                         help="context_len (multiple of S=WIN); fixture-only, lowered into token metadata.")
     parser.add_argument("--num-tokens", type=int, default=T,
                         help="Active token count (q_len), capped by T; passed to the kernel as num_tokens.")
-    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument("--enable-chip-swimlane", action="store_true", default=False)
     parser.add_argument("--enable-dep-gen", action="store_true", default=False)
     parser.add_argument("--dump-passes", action="store_true", default=False)
     args = parser.parse_args()
@@ -703,7 +703,7 @@ if __name__ == "__main__":
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
             enable_dep_gen=args.enable_dep_gen,
         ),
         compile_only=args.compile_only,

--- a/models/deepseek_v4_pro/prefill_compressor_ratio128.py
+++ b/models/deepseek_v4_pro/prefill_compressor_ratio128.py
@@ -483,7 +483,7 @@ if __name__ == "__main__":
             "slot mapping; it is not a JIT kernel parameter."
         ),
     )
-    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument("--enable-chip-swimlane", action="store_true", default=False)
     parser.add_argument("--dump-passes", action="store_true", default=False)
     args = parser.parse_args()
 
@@ -492,7 +492,7 @@ if __name__ == "__main__":
         specs=build_tensor_specs(args.start_pos),
         golden_fn=golden_prefill_compressor_ratio128,
         compile_cfg=dict(dump_passes=args.dump_passes),
-        runtime_cfg=dict(platform=args.platform, device_id=args.device, enable_l2_swimlane=args.enable_l2_swimlane),
+        runtime_cfg=dict(platform=args.platform, device_id=args.device, enable_chip_swimlane=args.enable_chip_swimlane),
         rtol=1e-3,
         atol=1e-3,
         compile_only=args.compile_only,

--- a/models/deepseek_v4_pro/prefill_compressor_ratio4.py
+++ b/models/deepseek_v4_pro/prefill_compressor_ratio4.py
@@ -601,7 +601,7 @@ if __name__ == "__main__":
     )
     parser.add_argument("--start-pos", type=int, default=START_POS,
                         help="Fixture-only absolute position for token 0; lowered into position_ids and dense cmp_slot_mapping.")
-    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument("--enable-chip-swimlane", action="store_true", default=False)
     parser.add_argument("--dump-passes", action="store_true", default=False)
     args = parser.parse_args()
 
@@ -610,7 +610,7 @@ if __name__ == "__main__":
         specs=build_tensor_specs(args.start_pos),
         golden_fn=golden_prefill_compressor_ratio4,
         compile_cfg=dict(dump_passes=args.dump_passes),
-        runtime_cfg=dict(platform=args.platform, device_id=args.device, enable_l2_swimlane=args.enable_l2_swimlane),
+        runtime_cfg=dict(platform=args.platform, device_id=args.device, enable_chip_swimlane=args.enable_chip_swimlane),
         compile_only=args.compile_only,
         compare_fn={
             "compress_state": ratio_allclose(atol=1e-3, rtol=1e-3, max_error_ratio=0.0),

--- a/models/deepseek_v4_pro/prefill_fwd.py
+++ b/models/deepseek_v4_pro/prefill_fwd.py
@@ -1685,7 +1685,7 @@ def main():
     parser.add_argument("--start-pos", type=int, default=0)
     parser.add_argument("--num-tokens", type=int, default=T // 2,
                         help=f"Active token rows for MoE routing/combine; default is T // 2={T // 2}.")
-    parser.add_argument("--enable-l2-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2))
+    parser.add_argument("--enable-chip-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2))
     parser.add_argument("--enable-scope-stats", action="store_true", default=False)
     parser.add_argument(
         "--disable-resident-caches",
@@ -1791,7 +1791,7 @@ def main():
         ),
         runtime_cfg=dict(
             platform=args.platform,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
             enable_scope_stats=args.enable_scope_stats,
             enable_dep_gen=args.enable_dep_gen,
             enable_dump_args=args.dump_args,

--- a/models/deepseek_v4_pro/prefill_indexer.py
+++ b/models/deepseek_v4_pro/prefill_indexer.py
@@ -1077,7 +1077,7 @@ if __name__ == "__main__":
                         help="Fixture-only absolute position for token 0; lowered into position_ids and dense idx_slot_mapping.")
     parser.add_argument("--num-tokens", type=int, default=T,
                         help="Active token prefix; inactive top-k rows and slot mappings remain -1.")
-    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument("--enable-chip-swimlane", action="store_true", default=False)
     parser.add_argument("--dump-passes", action="store_true", default=False)
     args = parser.parse_args()
 
@@ -1086,7 +1086,7 @@ if __name__ == "__main__":
         specs=build_tensor_specs(args.start_pos, args.num_tokens),
         golden_fn=golden_prefill_indexer,
         compile_cfg=dict(dump_passes=args.dump_passes),
-        runtime_cfg=dict(platform=args.platform, device_id=args.device, enable_l2_swimlane=args.enable_l2_swimlane),
+        runtime_cfg=dict(platform=args.platform, device_id=args.device, enable_chip_swimlane=args.enable_chip_swimlane),
         rtol=1e-3,
         atol=1e-3,
         compile_only=args.compile_only,

--- a/models/deepseek_v4_pro/prefill_indexer_compressor.py
+++ b/models/deepseek_v4_pro/prefill_indexer_compressor.py
@@ -1117,7 +1117,7 @@ if __name__ == "__main__":
                         help="Fixture-only absolute position for token 0; lowered into position_ids and dense idx_slot_mapping.")
     parser.add_argument("--num-tokens", type=int, default=T,
                         help="Active token prefix; inactive slot mappings remain -1.")
-    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument("--enable-chip-swimlane", action="store_true", default=False)
     parser.add_argument("--dump-passes", action="store_true", default=False)
     args = parser.parse_args()
 
@@ -1126,7 +1126,7 @@ if __name__ == "__main__":
         specs=build_tensor_specs(args.start_pos, args.num_tokens),
         golden_fn=golden_prefill_indexer_compressor,
         compile_cfg=dict(dump_passes=args.dump_passes),
-        runtime_cfg=dict(platform=args.platform, device_id=args.device, enable_l2_swimlane=args.enable_l2_swimlane),
+        runtime_cfg=dict(platform=args.platform, device_id=args.device, enable_chip_swimlane=args.enable_chip_swimlane),
         compile_only=args.compile_only,
         compare_fn={
             # C8: raw INT8 compressed rows (+/-1 LSB on the boundary rows the compressor rewrote).

--- a/models/deepseek_v4_pro/prefill_layer.py
+++ b/models/deepseek_v4_pro/prefill_layer.py
@@ -1648,7 +1648,7 @@ if __name__ == "__main__":
                         help="Comma-separated per-request logical chunk lengths.")
     parser.add_argument("--start-positions", type=str, default=None,
                         help="Comma-separated per-request prior context lengths; defaults to all zeros.")
-    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument("--enable-chip-swimlane", action="store_true", default=False)
     parser.add_argument("--compile-only", action="store_true", default=False)
     parser.add_argument("--save-data", action="store_true", default=False,
                         help="persist inputs and golden outputs for replay")
@@ -1750,7 +1750,7 @@ if __name__ == "__main__":
         ),
         runtime_cfg=dict(
             platform=args.platform,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
         ),
         rtol=1e-3,
         atol=1e-3,

--- a/models/deepseek_v4_pro/prefill_mtp.py
+++ b/models/deepseek_v4_pro/prefill_mtp.py
@@ -596,7 +596,7 @@ def main():
                         help=f"comma-separated device ids; need at least {N_RANKS}")
     parser.add_argument("--start-pos", type=int, default=0)
     parser.add_argument("--num-tokens", type=int, default=T)
-    parser.add_argument("--enable-l2-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2))
+    parser.add_argument("--enable-chip-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2))
     parser.add_argument("--enable-scope-stats", action="store_true", default=False)
     parser.add_argument("--compile-only", action="store_true", default=False)
     parser.add_argument("--dump-passes", action="store_true", default=False)
@@ -619,7 +619,7 @@ def main():
         ),
         runtime_cfg=dict(
             platform=args.platform,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
             enable_scope_stats=args.enable_scope_stats,
         ),
         rtol=1e-3,

--- a/models/deepseek_v4_pro/prefill_sparse_attn.py
+++ b/models/deepseek_v4_pro/prefill_sparse_attn.py
@@ -744,7 +744,7 @@ if __name__ == "__main__":
     parser.add_argument("--compile-only", action="store_true", default=False)
     parser.add_argument("--compress-ratio", type=int, default=DEFAULT_COMPRESS_RATIO,
                         choices=list(SUPPORTED_COMPRESS_RATIOS))
-    parser.add_argument("--enable-l2-swimlane", nargs="?", const=4, default=0, type=int)
+    parser.add_argument("--enable-chip-swimlane", nargs="?", const=4, default=0, type=int)
     parser.add_argument("--enable-pmu", nargs="?", const=2, default=0, type=int, choices=[0, 1, 2, 4])
     parser.add_argument("--dump-passes", action="store_true", default=False)
     args = parser.parse_args()
@@ -757,7 +757,7 @@ if __name__ == "__main__":
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
             enable_pmu=args.enable_pmu,
         ),
         rtol=1e-3,

--- a/models/deepseek_v4_pro/qkv_proj_rope.py
+++ b/models/deepseek_v4_pro/qkv_proj_rope.py
@@ -1079,8 +1079,8 @@ if __name__ == "__main__":
     parser.add_argument("-d", "--device", type=int, default=0)
     parser.add_argument("--mode", choices=["decode", "prefill", "all"], default="all",
                         help="Use decode or prefill batch sizes, or 'all' to test both.")
-    parser.add_argument("--enable-l2-swimlane", type=int, choices=[0, 1, 2, 4], default=0,
-                        help="L2 swimlane level: 0=off, 1=per-kernel AICore timing "
+    parser.add_argument("--enable-chip-swimlane", type=int, choices=[0, 1, 2, 4], default=0,
+                        help="chip swimlane level: 0=off, 1=per-kernel AICore timing "
                              "(prints the per-function Task Statistics table), 2=+AICPU timing.")
     parser.add_argument("--runtime-dir", type=str, default=None)
     parser.add_argument("--golden-data", type=str, default=None)
@@ -1118,7 +1118,7 @@ if __name__ == "__main__":
             runtime_cfg=dict(
                 platform=args.platform,
                 device_id=args.device,
-                enable_l2_swimlane=args.enable_l2_swimlane,
+                enable_chip_swimlane=args.enable_chip_swimlane,
             ),
             compile_only=args.compile_only,
         )

--- a/models/deepseek_v4_pro/rmsnorm.py
+++ b/models/deepseek_v4_pro/rmsnorm.py
@@ -151,7 +151,7 @@ if __name__ == "__main__":
     parser.add_argument("-d", "--device", type=int, default=0)
     parser.add_argument("--mode", choices=["decode", "prefill", "all"], default="all",
                         help="Use decode or prefill batch sizes, or 'all' to test both.")
-    parser.add_argument("--enable-l2-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2, 4))
+    parser.add_argument("--enable-chip-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2, 4))
     parser.add_argument("--runtime-dir", type=str, default=None)
     parser.add_argument("--golden-data", type=str, default=None)
     parser.add_argument("--compile-only", action="store_true", default=False)
@@ -173,7 +173,7 @@ if __name__ == "__main__":
             runtime_cfg=dict(
                 platform=args.platform,
                 device_id=args.device,
-                enable_l2_swimlane=args.enable_l2_swimlane,
+                enable_chip_swimlane=args.enable_chip_swimlane,
             ),
             rtol=5e-3,
             atol=5e-3,

--- a/models/deepseek_v4_pro/synthetic_token_loop.py
+++ b/models/deepseek_v4_pro/synthetic_token_loop.py
@@ -648,14 +648,14 @@ def _run_session(args, prefill_dir, decode_dir, model_dir):
             platform=args.platform,
             device_id=0,
             backend_type=BackendType.Ascend950,
-            enable_l2_swimlane=False,
+            enable_chip_swimlane=False,
             ring_heap=PREFILL_RING_HEAP,
         )
         decode_config = RunConfig(
             platform=args.platform,
             device_id=0,
             backend_type=BackendType.Ascend950,
-            enable_l2_swimlane=False,
+            enable_chip_swimlane=False,
         )
 
         inherited = _unique_storage_tensors(resident_hosts)

--- a/models/qwen3_14b/decode_fwd.py
+++ b/models/qwen3_14b/decode_fwd.py
@@ -1592,13 +1592,13 @@ if __name__ == "__main__":
     )
     parser.add_argument("-d", "--device", type=int, default=0)
     parser.add_argument(
-        "--enable-l2-swimlane",
+        "--enable-chip-swimlane",
         nargs="?",
         const=4,
         default=0,
         type=int,
         metavar="PERF_LEVEL",
-        help="Enable L2 swimlane perf capture at the given granularity level. Bare flag "
+        help="Enable chip swimlane perf capture at the given granularity level. Bare flag "
              "= level 4 (full). Levels: 1=AICore timing, 2=+dispatch/fanout, 3=+sched "
              "phases, 4=+orch phases; 0 (default) disables.",
     )
@@ -1684,7 +1684,7 @@ if __name__ == "__main__":
             runtime_cfg=dict(
                 platform=args.platform,
                 device_id=args.device,
-                enable_l2_swimlane=args.enable_l2_swimlane,
+                enable_chip_swimlane=args.enable_chip_swimlane,
                 enable_dep_gen=args.enable_dep_gen,
 
             ),
@@ -1720,7 +1720,7 @@ if __name__ == "__main__":
         platform=args.platform,
         device_id=args.device,
         backend_type=_backend_type(args.platform),
-        enable_l2_swimlane=args.enable_l2_swimlane,
+        enable_chip_swimlane=args.enable_chip_swimlane,
         enable_dep_gen=args.enable_dep_gen,
         dump_passes=False,
     )
@@ -1841,13 +1841,13 @@ if __name__ == "__main__":
             print(f"[stacked-fwd {N}L+LMhead] {_n_steps}-step autoregressive decode complete "
                   f"(host-ref argmax check skipped for --decode-steps > 1)")
             raise SystemExit(0)
-        # Perf-only mode: the L2 swimlane collector cannot register host buffers for a
+        # Perf-only mode: the chip swimlane collector cannot register host buffers for a
         # second on-device program in the same process (the host-ref call below would
-        # `init_l2_swimlane failed: 8`). decode_fwd already emitted the swimlane table,
+        # `init_chip_swimlane failed: 8`). decode_fwd already emitted the swimlane table,
         # so skip the reference comparison and exit cleanly.
-        if args.enable_l2_swimlane:
+        if args.enable_chip_swimlane:
             print(f"[stacked-fwd {N}L+LMhead] swimlane perf run complete "
-                  f"(host-ref argmax check skipped under --enable-l2-swimlane)")
+                  f"(host-ref argmax check skipped under --enable-chip-swimlane)")
             raise SystemExit(0)
         # host ref: run one N-layer decode_fwd_layers chunk -> final RMSNorm -> lm_head.
         # _CHUNK_NLAYERS = N keeps the inter-layer residual FP32 (chunk casts BF16 only at

--- a/models/qwen3_14b/decode_tq_draft.py
+++ b/models/qwen3_14b/decode_tq_draft.py
@@ -1263,7 +1263,7 @@ if __name__ == "__main__":
     parser.add_argument("--max-seq", type=int, default=128)
     parser.add_argument("--num-layers", type=int, default=NUM_LAYERS)
     parser.add_argument("--compile-only", action="store_true", default=False)
-    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument("--enable-chip-swimlane", action="store_true", default=False)
     parser.add_argument("--pass-rate", type=float, default=0.98,
                         help="Fraction of `out` elements that must satisfy atol/rtol. "
                              "Default 0.98 tolerates the BF16 ULP long-tail.")
@@ -1291,7 +1291,7 @@ if __name__ == "__main__":
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
         ),
         rtol=5e-3,
         atol=5e-3,

--- a/models/qwen3_14b/greedy_sample.py
+++ b/models/qwen3_14b/greedy_sample.py
@@ -154,7 +154,7 @@ if __name__ == "__main__":
     parser.add_argument("-p", "--platform", type=str, default="a2a3",
                         choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument("--enable-chip-swimlane", action="store_true", default=False)
     args = parser.parse_args()
 
     result = run_jit(
@@ -164,7 +164,7 @@ if __name__ == "__main__":
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
         ),
         rtol=0,
         atol=0,

--- a/models/qwen3_14b/prefill_fwd.py
+++ b/models/qwen3_14b/prefill_fwd.py
@@ -1950,14 +1950,14 @@ if __name__ == "__main__":
                               "program serves any batch <= host KV-cache "
                               "capacity. Default: %(default)s"))
     parser.add_argument(
-        "--enable-l2-swimlane",
+        "--enable-chip-swimlane",
         nargs="?",
         const=4,
         default=0,
         type=int,
         metavar="PERF_LEVEL",
         choices=[0, 1, 2, 3, 4],
-        help="Enable L2 swimlane perf capture at the given granularity level. Bare flag "
+        help="Enable chip swimlane perf capture at the given granularity level. Bare flag "
              "= level 4 (full). Levels: 1=AICore timing, 2=+dispatch/fanout, 3=+sched "
              "phases, 4=+orch phases; 0 (default) disables.",
     )
@@ -1998,7 +1998,7 @@ if __name__ == "__main__":
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
             enable_scope_stats=args.enable_scope_stats,
             enable_dep_gen=args.enable_dep_gen,
         ),

--- a/models/qwen3_14b/prefill_tq_draft.py
+++ b/models/qwen3_14b/prefill_tq_draft.py
@@ -1336,7 +1336,7 @@ if __name__ == "__main__":
               "program serves any batch <= host KV-cache "
               "capacity. Default: %(default)s"),
     )
-    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument("--enable-chip-swimlane", action="store_true", default=False)
     parser.add_argument("--max-seq", action="store_true", default=False,
                         help="set all seq_lens to MAX_SEQ")
     parser.add_argument("--num-layers", type=int, default=2)
@@ -1357,7 +1357,7 @@ if __name__ == "__main__":
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
         ),
         rtol=5e-3,
         atol=5e-3,

--- a/models/qwen3_14b/test_paged_attention_cce.py
+++ b/models/qwen3_14b/test_paged_attention_cce.py
@@ -126,7 +126,7 @@ def main() -> None:
     parser.add_argument("--ragged", action="store_true")
     parser.add_argument("--cache-offset-test", action="store_true")
     parser.add_argument("--compile-only", action="store_true")
-    parser.add_argument("--enable-l2-swimlane", action="store_true")
+    parser.add_argument("--enable-chip-swimlane", action="store_true")
     args = parser.parse_args()
     if not 0 < args.context_len <= args.capacity:
         raise ValueError("context length must be in (0, capacity]")
@@ -167,7 +167,7 @@ def main() -> None:
         runtime_cfg={
             "platform": args.platform,
             "device_id": args.device,
-            "enable_l2_swimlane": args.enable_l2_swimlane,
+            "enable_chip_swimlane": args.enable_chip_swimlane,
         },
         compile_only=args.compile_only or args.platform.endswith("sim"),
         rtol=5e-3,

--- a/models/qwen3_14b/topk_select.py
+++ b/models/qwen3_14b/topk_select.py
@@ -353,7 +353,7 @@ if __name__ == "__main__":
     )
     parser.add_argument("-d", "--device", type=int, default=0)
     parser.add_argument("--selection-k", type=int, choices=[1, TOPK], default=TOPK)
-    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument("--enable-chip-swimlane", action="store_true", default=False)
     args = parser.parse_args()
 
     result = run_jit(
@@ -363,7 +363,7 @@ if __name__ == "__main__":
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
         ),
         rtol=1e-5,
         atol=1e-5,

--- a/models/qwen3_32b/decode.py
+++ b/models/qwen3_32b/decode.py
@@ -637,7 +637,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3", choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument("--enable-chip-swimlane", action="store_true", default=False)
     parser.add_argument("--max-seq", action="store_true", default=False)
     args = parser.parse_args()
 
@@ -649,7 +649,7 @@ if __name__ == "__main__":
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
         ),
         rtol=3e-3,
         atol=3e-3,

--- a/models/qwen3_32b/decode_4d.py
+++ b/models/qwen3_32b/decode_4d.py
@@ -708,7 +708,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("-p", "--platform", type=str, default="a2a3", choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument("--enable-chip-swimlane", action="store_true", default=False)
     parser.add_argument("--max-seq", action="store_true", default=False)
     args = parser.parse_args()
 
@@ -722,7 +722,7 @@ if __name__ == "__main__":
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
         ),
         rtol=3e-3,
         atol=3e-3,

--- a/models/qwen3_32b/prefill_draft.py
+++ b/models/qwen3_32b/prefill_draft.py
@@ -750,7 +750,7 @@ if __name__ == "__main__":
         "-p", "--platform", type=str, default="a2a3", choices=["a2a3", "a5"]
     )
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument("--enable-chip-swimlane", action="store_true", default=False)
     parser.add_argument("--max-seq", action="store_true", default=False, help="set all seq_lens to MAX_SEQ")
     args = parser.parse_args()
 
@@ -762,7 +762,7 @@ if __name__ == "__main__":
         runtime_cfg=dict(
             platform=args.platform,
             device_id=args.device,
-            enable_l2_swimlane=args.enable_l2_swimlane,
+            enable_chip_swimlane=args.enable_chip_swimlane,
         ),
         rtol=3e-3,
         atol=3e-3,


### PR DESCRIPTION
PyPTO followed Simpler's Worker/Chip/Core naming migration and renamed
the L2 swimlane layer to "chip". `RunConfig` keeps a deprecated alias,
but the `_DfxOpts` the golden harness builds does not, so every entry
passing `enable_l2_swimlane` through `runtime_cfg` now raises
`TypeError: execute_compiled() got an unexpected keyword argument`.

- Rename the `runtime_cfg` DFX key and every entry's
  `--enable-l2-swimlane` CLI flag to `--enable-chip-swimlane`, matching
  the canonical upstream spelling
- Point docs and skills at `chip_swimlane_records.json` and the
  `chip_swimlane_level` record field, which are what the runtime writes
  now
- Keep the critical-path / early-dispatch / add-dummy report scripts able
  to read `l2_swimlane_records.json` captures taken before the rename