### PR TITLE
Perf: accelerate DeepSeek-V4 Flash token generation

### DIFF
--- a/models/deepseek_v4_pro/decode_attention_swa.py
+++ b/models/deepseek_v4_pro/decode_attention_swa.py
@@ -117,7 +117,8 @@ def attention_swa(
         for b in pl.range(B):
             for s_idx in pl.range(S):
                 t = b * S + s_idx
-                pos_b = pl.cast(pl.read(position_ids, [t]), pl.INDEX)
+                pos_raw = pl.read(position_ids, [t])
+                pos_b = pl.cast(pos_raw, pl.INDEX)
                 cos_row = pl.cast(freqs_cos[pos_b : pos_b + 1, 0 : ROPE_HEAD_DIM], target_type=pl.FP32)
                 sin_row = pl.cast(freqs_sin[pos_b : pos_b + 1, 0 : ROPE_HEAD_DIM], target_type=pl.FP32)
                 rope_cos_t[t : t + 1, 0 : ROPE_HEAD_DIM] = pl.cast(cos_row, target_type=pl.BF16, mode="rint")
@@ -148,14 +149,23 @@ def attention_swa(
             if write_row_i64 >= 0:
                 write_row = pl.cast(write_row_i64, pl.INDEX)
                 kv_cache_flat[write_row : write_row + 1, 0 : HEAD_DIM] = kv[write_t : write_t + 1, 0 : HEAD_DIM]
-        v_col = pl.cast(pl.arange(0, [1, WIN], dtype=pl.INT32), target_type=pl.FP32)
-        v_col_m = pl.col_expand(pl.full([T, WIN], dtype=pl.FP32, value=0.0), v_col)
-        v_lens = pl.cast(pl.reshape(swa_lens[0:T], [T, 1]), target_type=pl.FP32)
-        v_valid = pl.minimum(
-            pl.maximum(pl.neg(pl.row_expand_sub(v_col_m, v_lens)), 0.0),
-            1.0,
-        )
-        sparse_bias[0:T, 0:WIN] = pl.mul(pl.sub(v_valid, 1.0), -NEG_INF)
+        v_col_i32 = pl.arange(0, [1, WIN], dtype=pl.INT32)
+        v_col = pl.cast(v_col_i32, target_type=pl.FP32)
+        v_col_base = pl.full([T, WIN], dtype=pl.FP32, value=0.0)
+        v_col_m = pl.col_expand(v_col_base, v_col)
+        v_lens_row = pl.reshape(swa_lens[0:T], [T, 1])
+        v_lens = pl.cast(v_lens_row, target_type=pl.FP32)
+        v_delta = pl.row_expand_sub(v_col_m, v_lens)
+        v_inside = pl.neg(v_delta)
+        v_floor = pl.maximum(v_inside, 0.0)
+        v_len_valid = pl.minimum(v_floor, 1.0)
+        v_idx_f = pl.cast(swa_indices[0:T, 0:WIN], target_type=pl.FP32)
+        v_idx_one = pl.add(v_idx_f, 1.0)
+        v_idx_floor = pl.maximum(v_idx_one, 0.0)
+        v_idx_valid = pl.minimum(v_idx_floor, 1.0)
+        v_valid = pl.mul(v_len_valid, v_idx_valid)
+        v_mask = pl.sub(v_valid, 1.0)
+        sparse_bias[0:T, 0:WIN] = pl.mul(v_mask, -NEG_INF)
     attn_out = pl.create_tensor([T, D], dtype=pl.BF16)
     sparse_attn_swa(
         q, kv_cache_flat, swa_indices, sparse_bias,
@@ -240,8 +250,6 @@ def golden_attention_swa(tensors):
 
     # ===== Attention.forward (model.py:484-543), ratio==0 branch =====
     position_ids = tensors["position_ids"].to(torch.int64)
-    bsz, seqlen = B, S
-    win = WIN
     rd = ROPE_HEAD_DIM
 
     freqs_cos = tensors["freqs_cos"]
@@ -315,8 +323,8 @@ def golden_attention_swa(tensors):
     tensors["x_out"][:] = y
 
 
-def build_tensor_specs(start_pos=None):
-    import torch  # type: ignore[import]
+def build_tensor_specs(start_pos=None, unmapped_visible_page_fixture=False):
+    import torch
     from decode_metadata import (
         block_table,
         paged_slot_mapping,
@@ -327,6 +335,9 @@ def build_tensor_specs(start_pos=None):
     )
     from golden import TensorSpec
     from rope_tables import build_deepseek_v4_rope_tables
+
+    if start_pos is not None and unmapped_visible_page_fixture:
+        raise ValueError("start-pos and unmapped-page fixtures are mutually exclusive")
 
     shared_freqs_cos, shared_freqs_sin = build_deepseek_v4_rope_tables(M, 0, dtype=torch.bfloat16)
 
@@ -391,7 +402,10 @@ def build_tensor_specs(start_pos=None):
         return init_normalized_cache((ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM))
 
     def init_block_table():
-        return block_table(batch=B, table_blocks=ORI_TABLE_MAX_BLOCKS, physical_blocks=ORI_MAX_BLOCKS)
+        table = block_table(batch=B, table_blocks=ORI_TABLE_MAX_BLOCKS, physical_blocks=ORI_MAX_BLOCKS)
+        if unmapped_visible_page_fixture:
+            table[:, 0] = -1
+        return table
 
     def init_attn_sink():
         return torch.zeros(H)
@@ -399,6 +413,14 @@ def build_tensor_specs(start_pos=None):
         # Canonical SWA start-position set (sliding-window regimes + 8k long-context).
         return swa_decode_start_set(batch=B, window=WIN)
     def init_start_pos():
+        if unmapped_visible_page_fixture:
+            fixture_start = BLOCK_SIZE + BLOCK_SIZE // 2 - 1
+            return resolve_start_positions(
+                fixture_start,
+                batch=B,
+                seq=S,
+                max_seq_len=MAX_SEQ_LEN,
+            )
         return resolve_start_positions(
             start_pos,
             batch=B,
@@ -473,6 +495,13 @@ if __name__ == "__main__":
     parser.add_argument("--start-pos", type=int, default=None,
                         help="Uniform fixture-only start_pos override for all batches; "
                              "default (unset) uses the canonical per-batch SWA set that includes the 8k point.")
+    unmapped_help = "Use a visible window whose older cache page is unmapped."
+    parser.add_argument(
+        "--unmapped-visible-page-fixture",
+        action="store_true",
+        default=False,
+        help=unmapped_help,
+    )
     parser.add_argument("--enable-chip-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2, 4))
     parser.add_argument("--runtime-dir", type=str, default=None)
     parser.add_argument("--golden-data", type=str, default=None)
@@ -481,7 +510,7 @@ if __name__ == "__main__":
 
     result = run_jit(
         fn=attention_swa_test,
-        specs=build_tensor_specs(args.start_pos),
+        specs=build_tensor_specs(args.start_pos, args.unmapped_visible_page_fixture),
         golden_fn=golden_attention_swa,
         runtime_dir=args.runtime_dir,
         golden_data=args.golden_data,

--- a/models/deepseek_v4_pro/decode_compressor_ratio128.py
+++ b/models/deepseek_v4_pro/decode_compressor_ratio128.py
@@ -6,10 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-"""DeepSeek-V4 KV Compressor (decode incremental, ratio=128 non-overlap).
-
-Uses non-overlapping state layout with 128 slots.
-Softmax+pool over all slots. No state shift needed."""
+"""DeepSeek-V4 non-overlapping ratio-128 decode KV compressor."""
 
 import pypto.language as pl
 
@@ -41,24 +38,16 @@ HEAD_DIM_INV = 1.0 / HEAD_DIM
 ROPE_HEAD_DIM = M.qk_rope_head_dim
 NOPE_HEAD_DIM = M.nope_head_dim
 MAX_SEQ_LEN = M.max_position_embeddings
+ROPE_HEAD_DIM_F = float(ROPE_HEAD_DIM)
+ROPE_HALF_F = float(ROPE_HEAD_DIM // 2)
 
-# kernel-local (ratio-128 non-overlap compressor)
+# compressor config
 COMPRESS_RATIO = 128
 IDX_KV_LEN = MAX_SEQ_LEN // COMPRESS_RATIO
 COFF = 1
 OUT_DIM = COFF * HEAD_DIM
 STATE_LEN = COFF * COMPRESS_RATIO
-# Paged read contract:
-# - compress_state_block_table is still used to read the historical ratio window
-#   by absolute token position.
-# - Persistent writes are explicit token-major contracts:
-#     state_slot_mapping[b, s] -> flattened compressor-state row, -1 means no-write
-#     cmp_slot_mapping[b, s]   -> flattened compressed-KV row, -1 means no-write
-# - APE remains ratio-local:
-#     ape_row = position_ids[b, s] % COMPRESS_RATIO
 COMPRESS_STATE_BLOCK_SIZE = C128_COMPRESSOR_BLOCK_SIZE
-# Logical state block tables cover MAX_SEQ_LEN while the physical state pool
-# remains bounded to the per-request rolling state capacity.
 COMPRESS_STATE_PHYSICAL_BLOCKS = 64
 COMPRESS_STATE_MAX_BLOCKS = (MAX_SEQ_LEN + COMPRESS_STATE_BLOCK_SIZE - 1) // COMPRESS_STATE_BLOCK_SIZE
 COMPRESS_STATE_BLOCK_NUM = COMPRESS_STATE_PHYSICAL_BLOCKS
@@ -69,19 +58,14 @@ if IDX_KV_LEN > CMP_MAX_BLOCKS * BLOCK_SIZE:
     raise ValueError("ratio128 compressed KV cache capacity is smaller than max compressed sequence length")
 
 # tiling
-ROPE_TILE = 32
 K_TILE = 512
 OUT_TILE = 64
 HEAD_TILE = 64
-B_TILE = 8
 MM_B_TILE = 16
 BS_PAD = ((B * S + MM_B_TILE - 1) // MM_B_TILE) * MM_B_TILE
 RMS_PAD_TILE = 16
-RMS_PAD_ROWS = RMS_PAD_TILE
-assert B <= RMS_PAD_TILE
-# softmax_pool reduces over the state axis with column reductions (no transpose), so it can
-# afford a wider head tile than HEAD_TILE: each wider tile loads each state block fewer times
-# (HEAD_DIM/POOL_HEAD_TILE tiles/batch instead of HEAD_DIM/HEAD_TILE), cutting load redundancy.
+ROPE_FLAT_LEN = RMS_PAD_TILE * ROPE_HEAD_DIM
+ROPE_HALF_FLAT_LEN = RMS_PAD_TILE * (ROPE_HEAD_DIM // 2)
 POOL_HEAD_TILE = 128
 
 
@@ -106,17 +90,14 @@ def compressor_ratio128(
     b_dim = pl.tensor.dim(x, 0)
     s_dim = pl.tensor.dim(x, 1)
     bs = b_dim * s_dim
-    compress_state_block_num = pl.tensor.dim(compress_state, 0)
-    cmp_block_num = pl.tensor.dim(cmp_kv_cache, 0)
 
     x_flat = pl.reshape(x, [bs, D])
     t_matmul = pl.max(bs, MM_B_TILE)
     kv_proj_pad = pl.create_tensor([BS_PAD, OUT_DIM], dtype=pl.FP32)
     score_proj_pad = pl.create_tensor([BS_PAD, OUT_DIM], dtype=pl.FP32)
-
     with pl.spmd(
         t_matmul * OUT_DIM // (MM_B_TILE * OUT_TILE), name_hint="kv_score_proj", deps=[late_dep]
-    ) as _kv_score_tid:
+    ) as kv_score_tid:
         idx = pl.tile.get_block_idx()
         global_row0 = (idx // (OUT_DIM // OUT_TILE)) * MM_B_TILE
         o0 = (idx % (OUT_DIM // OUT_TILE)) * OUT_TILE
@@ -126,10 +107,6 @@ def compressor_ratio128(
             k0 = kb * K_TILE
             x_rows = pl.min(MM_B_TILE, bs - global_row0)
             x_tile = pl.slice(x_flat, [MM_B_TILE, K_TILE], [global_row0, k0], valid_shape=[x_rows, K_TILE])
-            # Weights stored transposed [OUT_DIM, D] and consumed via b_trans=True so the
-            # GM->L1 load is a DN2ZN (each [OUT_TILE, K_TILE] row is K-contiguous = long
-            # bursts) instead of ND2NZ on [K_TILE, OUT_TILE] (K strided = many short
-            # bursts). Cuts the transaction-bound MTE2 cost. Matches ratio4/CSA layout.
             wkv_tile = wkv[o0 : o0 + OUT_TILE, k0 : k0 + K_TILE]
             wgate_tile = wgate[o0 : o0 + OUT_TILE, k0 : k0 + K_TILE]
             if k0 == 0:
@@ -142,156 +119,170 @@ def compressor_ratio128(
         kv_proj_pad[global_row0 : global_row0 + MM_B_TILE, o0 : o0 + OUT_TILE] = kv_acc
         score_proj_pad[global_row0 : global_row0 + MM_B_TILE, o0 : o0 + OUT_TILE] = score_acc
 
+    compress_state_block_num = pl.tensor.dim(compress_state, 0)
     compress_state_rows_num = compress_state_block_num * COMPRESS_STATE_BLOCK_SIZE
     compress_state_rows = pl.reshape(compress_state, [compress_state_rows_num, COMPRESS_STATE_DIM])
-    pooled_kv = pl.create_tensor([RMS_PAD_ROWS, HEAD_DIM], dtype=pl.FP32)
-    # The target decode point is start_pos=8192, where the ratio-128 boundary branch
-    # is inactive. Keep scatter and all pool gates in one task to minimize dispatches.
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="scatter_softmax_pool") as pool_tid:
-        for global_c_idx in pl.range(b_dim):
-            for s_sc in pl.pipeline(s_dim, stage=2):
-                proj_row = global_c_idx * s_dim + s_sc
-                token_pos = pl.read(position_ids, [global_c_idx, s_sc])
-                token_ape_row = pl.cast(token_pos % COMPRESS_RATIO, target_type=pl.INDEX)
-                state_row_i64 = pl.read(state_slot_mapping, [global_c_idx, s_sc])
-                if state_row_i64 >= 0:
-                    state_row = pl.cast(state_row_i64, target_type=pl.INDEX)
-                    kv_row = kv_proj_pad[proj_row : proj_row + 1, 0 : OUT_DIM]
-                    score_row = score_proj_pad[proj_row : proj_row + 1, 0 : OUT_DIM]
-                    ape_row = ape[token_ape_row : token_ape_row + 1, 0 : OUT_DIM]
-                    compress_state_rows[state_row : state_row + 1, 0 : OUT_DIM] = kv_row
-                    compress_state_rows[
-                        state_row : state_row + 1, OUT_DIM : COMPRESS_STATE_DIM
-                    ] = pl.add(score_row, ape_row)
+    with pl.spmd(bs, name_hint="state_scatter", deps=[kv_score_tid]) as scatter_tid:
+        sc_row = pl.tile.get_block_idx()
+        sc_c_idx = sc_row // s_dim
+        sc_s = sc_row - sc_c_idx * s_dim
+        token_pos = pl.read(position_ids, [sc_c_idx, sc_s])
+        token_ape_row = pl.cast(token_pos % COMPRESS_RATIO, target_type=pl.INDEX)
+        state_row_i64 = pl.read(state_slot_mapping, [sc_c_idx, sc_s])
+        if state_row_i64 >= 0:
+            state_row = pl.cast(state_row_i64, target_type=pl.INDEX)
+            proj_kv_row = kv_proj_pad[sc_row : sc_row + 1, 0:OUT_DIM]
+            score_row = score_proj_pad[sc_row : sc_row + 1, 0:OUT_DIM]
+            ape_row = ape[token_ape_row : token_ape_row + 1, 0:OUT_DIM]
+            compress_state_rows[state_row : state_row + 1, 0:OUT_DIM] = proj_kv_row
+            score_ape = pl.add(score_row, ape_row)
+            compress_state_rows[state_row : state_row + 1, OUT_DIM:COMPRESS_STATE_DIM] = score_ape
 
-            first_pos_gate = pl.read(position_ids, [global_c_idx, 0])
-            pos_gate = first_pos_gate % COMPRESS_RATIO
-            if pos_gate + s_dim >= COMPRESS_RATIO:
-                compress_pos = first_pos_gate + (COMPRESS_RATIO - 1 - pos_gate)
-                state_pos0 = compress_pos - (COMPRESS_RATIO - 1)
-                base_logical_blk = state_pos0 // COMPRESS_STATE_BLOCK_SIZE
-                for h0 in pl.range(0, HEAD_DIM, POOL_HEAD_TILE):
-                    softmax_score_state = pl.create_tensor(
-                        [STATE_LEN, POOL_HEAD_TILE], dtype=pl.FP32
+    pooled_kv = pl.create_tensor([RMS_PAD_TILE, HEAD_DIM], dtype=pl.FP32)
+    with pl.spmd(b_dim * (HEAD_DIM // POOL_HEAD_TILE), name_hint="softmax_pool", deps=[scatter_tid]) as pool_tid:
+        pool_blk = pl.tile.get_block_idx()
+        pool_c_idx = pool_blk // (HEAD_DIM // POOL_HEAD_TILE)
+        h0 = (pool_blk % (HEAD_DIM // POOL_HEAD_TILE)) * POOL_HEAD_TILE
+        first_pos_gate = pl.read(position_ids, [pool_c_idx, 0])
+        pos_gate = first_pos_gate % COMPRESS_RATIO
+        if pos_gate + s_dim >= COMPRESS_RATIO:
+            compress_pos = first_pos_gate + (COMPRESS_RATIO - 1 - pos_gate)
+            state_pos0 = compress_pos - (COMPRESS_RATIO - 1)
+            base_logical_blk = state_pos0 // COMPRESS_STATE_BLOCK_SIZE
+            softmax_score_state = pl.create_tensor([STATE_LEN, POOL_HEAD_TILE], dtype=pl.FP32)
+            softmax_kv_state = pl.create_tensor([STATE_LEN, POOL_HEAD_TILE], dtype=pl.FP32)
+            for blk_i in pl.pipeline(STATE_LEN // COMPRESS_STATE_BLOCK_SIZE, stage=2):
+                s0 = blk_i * COMPRESS_STATE_BLOCK_SIZE
+                state_blk_raw = pl.read(compress_state_block_table, [pool_c_idx, base_logical_blk + blk_i])
+                if state_blk_raw >= 0:
+                    state_blk_id = pl.cast(state_blk_raw, target_type=pl.INDEX)
+                    row0 = state_blk_id * COMPRESS_STATE_BLOCK_SIZE
+                    score_state_block = compress_state_rows[
+                        row0 : row0 + COMPRESS_STATE_BLOCK_SIZE,
+                        OUT_DIM + h0 : OUT_DIM + h0 + POOL_HEAD_TILE,
+                    ]
+                    kv_state_block = compress_state_rows[
+                        row0 : row0 + COMPRESS_STATE_BLOCK_SIZE, h0 : h0 + POOL_HEAD_TILE
+                    ]
+                    softmax_score_state[s0 : s0 + COMPRESS_STATE_BLOCK_SIZE, :] = score_state_block
+                    softmax_kv_state[s0 : s0 + COMPRESS_STATE_BLOCK_SIZE, :] = kv_state_block
+                else:
+                    score_pad_block = pl.full(
+                        [COMPRESS_STATE_BLOCK_SIZE, POOL_HEAD_TILE], dtype=pl.FP32, value=FP32_NEG_INF
                     )
-                    softmax_kv_state = pl.create_tensor(
-                        [STATE_LEN, POOL_HEAD_TILE], dtype=pl.FP32
-                    )
-                    for blk_i in pl.pipeline(STATE_LEN // COMPRESS_STATE_BLOCK_SIZE, stage=2):
-                        s0 = blk_i * COMPRESS_STATE_BLOCK_SIZE
-                        slot_score = pl.full(
-                            [COMPRESS_STATE_BLOCK_SIZE, POOL_HEAD_TILE],
-                            dtype=pl.FP32,
-                            value=FP32_NEG_INF,
-                        )
-                        slot_kv = pl.full(
-                            [COMPRESS_STATE_BLOCK_SIZE, POOL_HEAD_TILE],
-                            dtype=pl.FP32,
-                            value=0.0,
-                        )
-                        state_blk_raw = pl.read(
-                            compress_state_block_table,
-                            [global_c_idx, base_logical_blk + blk_i],
-                        )
-                        if state_blk_raw >= 0:
-                            state_blk_id = pl.cast(state_blk_raw, target_type=pl.INDEX)
-                            row0 = state_blk_id * COMPRESS_STATE_BLOCK_SIZE
-                            slot_score = compress_state_rows[
-                                row0 : row0 + COMPRESS_STATE_BLOCK_SIZE,
-                                OUT_DIM + h0 : OUT_DIM + h0 + POOL_HEAD_TILE,
-                            ]
-                            slot_kv = compress_state_rows[
-                                row0 : row0 + COMPRESS_STATE_BLOCK_SIZE,
-                                h0 : h0 + POOL_HEAD_TILE,
-                            ]
-                        softmax_score_state[
-                            s0 : s0 + COMPRESS_STATE_BLOCK_SIZE, :
-                        ] = slot_score
-                        softmax_kv_state[
-                            s0 : s0 + COMPRESS_STATE_BLOCK_SIZE, :
-                        ] = slot_kv
+                    kv_pad_block = pl.full([COMPRESS_STATE_BLOCK_SIZE, POOL_HEAD_TILE], dtype=pl.FP32, value=0.0)
+                    softmax_score_state[s0 : s0 + COMPRESS_STATE_BLOCK_SIZE, :] = score_pad_block
+                    softmax_kv_state[s0 : s0 + COMPRESS_STATE_BLOCK_SIZE, :] = kv_pad_block
 
-                    score_max = pl.col_max(softmax_score_state)
-                    score_exp = pl.col_expand_expdif(softmax_score_state, score_max)
-                    score_sum = pl.col_sum(score_exp)
-                    score_prob = pl.col_expand_mul(score_exp, pl.recip(score_sum))
-                    pooled_chunk = pl.col_sum(pl.mul(softmax_kv_state, score_prob))
-                    pooled_kv[
-                        global_c_idx : global_c_idx + 1, h0 : h0 + POOL_HEAD_TILE
-                    ] = pooled_chunk
+            score_max = pl.col_max(softmax_score_state)
+            score_exp = pl.col_expand_expdif(softmax_score_state, score_max)
+            score_sum = pl.col_sum(score_exp)
+            score_sum_inv = pl.recip(score_sum)
+            score_prob = pl.col_expand_mul(score_exp, score_sum_inv)
+            weighted_kv = pl.mul(softmax_kv_state, score_prob)
+            pooled_chunk = pl.col_sum(weighted_kv)
+            pooled_kv[pool_c_idx : pool_c_idx + 1, h0 : h0 + POOL_HEAD_TILE] = pooled_chunk
 
     norm_w_2d = pl.reshape(norm_w, [1, HEAD_DIM])
-    normed_kv = pl.create_tensor([RMS_PAD_ROWS, HEAD_DIM], dtype=pl.FP32)
+    normed_kv = pl.create_tensor([RMS_PAD_TILE, HEAD_DIM], dtype=pl.FP32)
     kv_flat = pl.reshape(kv, [bs, HEAD_DIM])
+    cmp_block_num = pl.tensor.dim(cmp_kv_cache, 0)
     cmp_flat_rows = cmp_block_num * BLOCK_SIZE
     cmp_kv_cache_flat = pl.reshape(cmp_kv_cache, [cmp_flat_rows, HEAD_DIM])
 
-    with pl.at(
-        level=pl.Level.CORE_GROUP, name_hint="rmsnorm_rope_cache_write", deps=[pool_tid]
-    ):
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="rmsnorm_rope_cache_write", deps=[pool_tid]):
         cos_b = pl.full([RMS_PAD_TILE, ROPE_HEAD_DIM // 2], dtype=pl.FP32, value=0.0)
         sin_b = pl.full([RMS_PAD_TILE, ROPE_HEAD_DIM // 2], dtype=pl.FP32, value=0.0)
-        for global_c_idx in pl.range(b_dim):
-            cos_b[global_c_idx : global_c_idx + 1, 0 : ROPE_HEAD_DIM // 2] = cos[
-                global_c_idx : global_c_idx + 1, 0 : ROPE_HEAD_DIM // 2
-            ]
-            sin_b[global_c_idx : global_c_idx + 1, 0 : ROPE_HEAD_DIM // 2] = sin[
-                global_c_idx : global_c_idx + 1, 0 : ROPE_HEAD_DIM // 2
-            ]
+        for rope_c_idx in pl.range(b_dim):
+            cos_row = cos[rope_c_idx : rope_c_idx + 1, 0 : ROPE_HEAD_DIM // 2]
+            cos_b[rope_c_idx : rope_c_idx + 1, 0 : ROPE_HEAD_DIM // 2] = cos_row
+            sin_row = sin[rope_c_idx : rope_c_idx + 1, 0 : ROPE_HEAD_DIM // 2]
+            sin_b[rope_c_idx : rope_c_idx + 1, 0 : ROPE_HEAD_DIM // 2] = sin_row
         partial_sq = pl.full([1, RMS_PAD_TILE], dtype=pl.FP32, value=0.0)
         for rms_kb in pl.pipeline(HEAD_DIM // HEAD_TILE, stage=2):
             rms_h0 = rms_kb * HEAD_TILE
             kv_rms_chunk = pooled_kv[0:RMS_PAD_TILE, rms_h0 : rms_h0 + HEAD_TILE]
             kv_rms_sq = pl.mul(kv_rms_chunk, kv_rms_chunk)
-            kv_rms_rowsum = pl.reshape(pl.row_sum(kv_rms_sq), [1, RMS_PAD_TILE])
+            kv_rms_sum = pl.row_sum(kv_rms_sq)
+            kv_rms_rowsum = pl.reshape(kv_rms_sum, [1, RMS_PAD_TILE])
             partial_sq = pl.add(partial_sq, kv_rms_rowsum)
 
-        variance = pl.reshape(pl.add(pl.mul(partial_sq, HEAD_DIM_INV), EPS), [RMS_PAD_TILE, 1])
-        inv_rms = pl.recip(pl.sqrt(variance))
+        partial_mean = pl.mul(partial_sq, HEAD_DIM_INV)
+        variance_row = pl.add(partial_mean, EPS)
+        variance = pl.reshape(variance_row, [RMS_PAD_TILE, 1])
+        rms = pl.sqrt(variance)
+        inv_rms = pl.recip(rms)
         for rms_kb in pl.pipeline(NOPE_HEAD_DIM // HEAD_TILE, stage=2):
             norm_h0 = rms_kb * HEAD_TILE
             kv_norm_chunk = pooled_kv[0:RMS_PAD_TILE, norm_h0 : norm_h0 + HEAD_TILE]
-            gamma = pl.cast(norm_w_2d[:, norm_h0 : norm_h0 + HEAD_TILE], pl.FP32)
-            normed_chunk = pl.col_expand_mul(pl.row_expand_mul(kv_norm_chunk, inv_rms), gamma)
+            gamma_bf16 = norm_w_2d[:, norm_h0 : norm_h0 + HEAD_TILE]
+            gamma = pl.cast(gamma_bf16, pl.FP32)
+            kv_rms_scaled = pl.row_expand_mul(kv_norm_chunk, inv_rms)
+            normed_chunk = pl.col_expand_mul(kv_rms_scaled, gamma)
             normed_kv[0:RMS_PAD_TILE, norm_h0 : norm_h0 + HEAD_TILE] = normed_chunk
 
         kv_rope_norm = pooled_kv[0:RMS_PAD_TILE, NOPE_HEAD_DIM : HEAD_DIM]
-        gamma_rope = pl.cast(norm_w_2d[:, NOPE_HEAD_DIM : HEAD_DIM], pl.FP32)
-        # A3 interleaved swap-gather (same form as kv_rope_fused in qkv_proj_rope),
-        # replacing the de-interleave gather + rotate + re-interleave scatter. gamma+inv_rms
-        # are folded into rope_normed BEFORE the swap, so the swapped lane n[j^1] correctly
-        # carries gamma[j^1]; inv_rms is per-row so it commutes. swap_idx (j^1), sign
-        # ([-1,+1,...]) and dup_idx (j>>1) are built IN-KERNEL from pl.arange; cos_il/sin_il
-        # are dup-gathered from the per-batch cos/sin rows. normed_kv is FP32 -> write directly.
-        #   out[j] = n[j]*cos_il[j] + n[j^1]*sign[j]*sin_il[j]
-        rope_normed = pl.col_expand_mul(pl.row_expand_mul(kv_rope_norm, inv_rms), gamma_rope)
+        gamma_rope_bf16 = norm_w_2d[:, NOPE_HEAD_DIM : HEAD_DIM]
+        gamma_rope = pl.cast(gamma_rope_bf16, pl.FP32)
+        # out[j] = n[j] * cos[j] + n[j ^ 1] * sign[j] * sin[j]
+        rope_rms_scaled = pl.row_expand_mul(kv_rope_norm, inv_rms)
+        rope_normed = pl.col_expand_mul(rope_rms_scaled, gamma_rope)
         rope_ones = pl.full([RMS_PAD_TILE, ROPE_HEAD_DIM], dtype=pl.FP32, value=1.0)
-        rope_col = pl.col_expand_mul(rope_ones, pl.cast(pl.arange(0, [1, ROPE_HEAD_DIM], dtype=pl.INT32), target_type=pl.FP32))
-        rope_dup_f = pl.cast(pl.cast(pl.mul(rope_col, 0.5), target_type=pl.INT32, mode="trunc"), target_type=pl.FP32)
-        rope_dup_idx = pl.cast(rope_dup_f, target_type=pl.INT32)                                       # j>>1
-        rope_lane = pl.sub(rope_col, pl.mul(rope_dup_f, 2.0))                                          # j%2
-        rope_swap_idx = pl.cast(pl.sub(pl.add(rope_col, 1.0), pl.mul(rope_lane, 2.0)), target_type=pl.INT32)  # j^1
-        rope_sign = pl.sub(pl.mul(rope_lane, 2.0), 1.0)                                                # [-1,+1,...]
-        cos_il = pl.gather(cos_b, dim=-1, index=rope_dup_idx)
-        sin_il = pl.gather(sin_b, dim=-1, index=rope_dup_idx)
-        swapped = pl.gather(rope_normed, dim=-1, index=rope_swap_idx)
-        rope_rot = pl.add(pl.mul(rope_normed, cos_il), pl.mul(pl.mul(swapped, rope_sign), sin_il))
+        rope_col_idx = pl.arange(0, [1, ROPE_HEAD_DIM], dtype=pl.INT32)
+        rope_col_f32 = pl.cast(rope_col_idx, target_type=pl.FP32)
+        rope_col = pl.col_expand_mul(rope_ones, rope_col_f32)
+        rope_row_idx = pl.arange(0, [1, RMS_PAD_TILE], dtype=pl.INT32)
+        rope_row_f32 = pl.cast(rope_row_idx, target_type=pl.FP32)
+        rope_row_col = pl.reshape(rope_row_f32, [RMS_PAD_TILE, 1])
+        rope_row = pl.row_expand_mul(rope_ones, rope_row_col)
+        rope_half = pl.mul(rope_col, 0.5)
+        rope_dup_i32 = pl.cast(rope_half, target_type=pl.INT32, mode="trunc")
+        rope_dup_f = pl.cast(rope_dup_i32, target_type=pl.FP32)
+        rope_dup_twice = pl.mul(rope_dup_f, 2.0)
+        rope_lane = pl.sub(rope_col, rope_dup_twice)  # j % 2
+        rope_col_next = pl.add(rope_col, 1.0)
+        rope_jx_lane = pl.mul(rope_lane, 2.0)
+        rope_jx = pl.sub(rope_col_next, rope_jx_lane)  # j ^ 1
+        rope_sign_lane = pl.mul(rope_lane, 2.0)
+        rope_sign = pl.sub(rope_sign_lane, 1.0)  # [-1, +1, ...]
+        rope_dup_row = pl.mul(rope_row, ROPE_HALF_F)
+        rope_dup_sum = pl.add(rope_dup_row, rope_dup_f)
+        rope_dup_idx = pl.cast(rope_dup_sum, target_type=pl.INT32)
+        rope_dup_flat = pl.reshape(rope_dup_idx, [1, ROPE_FLAT_LEN])
+        rope_swap_row = pl.mul(rope_row, ROPE_HEAD_DIM_F)
+        rope_swap_sum = pl.add(rope_swap_row, rope_jx)
+        rope_swap_idx = pl.cast(rope_swap_sum, target_type=pl.INT32)
+        rope_swap_flat = pl.reshape(rope_swap_idx, [1, ROPE_FLAT_LEN])
+        cos_flat = pl.reshape(cos_b, [1, ROPE_HALF_FLAT_LEN])
+        cos_gathered = pl.gather(cos_flat, dim=-1, index=rope_dup_flat)
+        cos_il = pl.reshape(cos_gathered, [RMS_PAD_TILE, ROPE_HEAD_DIM])
+        sin_flat = pl.reshape(sin_b, [1, ROPE_HALF_FLAT_LEN])
+        sin_gathered = pl.gather(sin_flat, dim=-1, index=rope_dup_flat)
+        sin_il = pl.reshape(sin_gathered, [RMS_PAD_TILE, ROPE_HEAD_DIM])
+        rope_normed_flat = pl.reshape(rope_normed, [1, ROPE_FLAT_LEN])
+        swapped_flat = pl.gather(rope_normed_flat, dim=-1, index=rope_swap_flat)
+        swapped = pl.reshape(swapped_flat, [RMS_PAD_TILE, ROPE_HEAD_DIM])
+        rope_cos = pl.mul(rope_normed, cos_il)
+        swapped_signed = pl.mul(swapped, rope_sign)
+        rope_sin = pl.mul(swapped_signed, sin_il)
+        rope_rot = pl.add(rope_cos, rope_sin)
         normed_kv[0:RMS_PAD_TILE, NOPE_HEAD_DIM : HEAD_DIM] = rope_rot
 
-        for global_c_idx in pl.range(b_dim):
-            first_pos_b = pl.read(position_ids, [global_c_idx, 0])
+        for write_c_idx in pl.range(b_dim):
+            first_pos_b = pl.read(position_ids, [write_c_idx, 0])
             pos_b = first_pos_b % COMPRESS_RATIO
             if pos_b + s_dim >= COMPRESS_RATIO:
                 boundary_s = COMPRESS_RATIO - 1 - pos_b
-                kv_row = normed_kv[global_c_idx : global_c_idx + 1, 0 : HEAD_DIM]
-                cmp_row_i64 = pl.read(cmp_slot_mapping, [global_c_idx, boundary_s])
+                pooled_kv_row = normed_kv[write_c_idx : write_c_idx + 1, 0 : HEAD_DIM]
+                cmp_row_i64 = pl.read(cmp_slot_mapping, [write_c_idx, boundary_s])
                 if cmp_row_i64 >= 0:
                     cmp_row = pl.cast(cmp_row_i64, target_type=pl.INDEX)
-                    kv_flat[global_c_idx * s_dim : global_c_idx * s_dim + 1, :] = kv_row
-                    cmp_kv_cache_flat[cmp_row : cmp_row + 1, :] = pl.cast(kv_row, target_type=pl.BF16, mode="rint")
+                    kv_flat[write_c_idx * s_dim : write_c_idx * s_dim + 1, :] = pooled_kv_row
+                    kv_row_bf16 = pl.cast(pooled_kv_row, target_type=pl.BF16, mode="rint")
+                    cmp_kv_cache_flat[cmp_row : cmp_row + 1, :] = kv_row_bf16
 
-    kv = pl.reshape(kv_flat, [b_dim, s_dim, HEAD_DIM])
-    return kv
+    kv_out = pl.reshape(kv_flat, [b_dim, s_dim, HEAD_DIM])
+    return kv_out
 
 
 @pl.jit
@@ -337,11 +328,7 @@ def compressor_test(
 
 
 def golden_compressor(tensors):
-    """Torch reference for Compressor.forward (decode branch, ratio=128 non-overlap).
-
-    Operates on paged caches: compress_state (kv + score channels merged) and cmp_kv_cache,
-    each addressed via the corresponding block_table.
-    """
+    """Torch reference for ratio-128 decode compression with paged caches."""
     import torch
 
     x = tensors["x"].float()
@@ -349,8 +336,6 @@ def golden_compressor(tensors):
     position_ids = tensors["position_ids"].to(torch.int64)
     cmp_slot_mapping = tensors["cmp_slot_mapping"].to(torch.int64)
     state_slot_mapping = tensors["state_slot_mapping"].to(torch.int64)
-    # Historical state reads still use absolute-position block-table addressing.
-    # Persistent writes use token-major slot mappings. APE remains modulo ratio.
     compress_state = tensors["compress_state"]
 
     def read_state_row(b, pos):
@@ -385,8 +370,8 @@ def golden_compressor(tensors):
     bsz, _, _ = x.shape
     ratio, rd = COMPRESS_RATIO, ROPE_HEAD_DIM
 
-    kv = x @ wkv.t()                    # [B, S, OUT_DIM]  (wkv stored [OUT_DIM, D] for b_trans)
-    score = x @ wgate.t()               # [B, S, OUT_DIM]
+    kv = x @ wkv.t()
+    score = x @ wgate.t()
     pooled = torch.zeros(bsz, 1, HEAD_DIM, dtype=torch.float32, device=x.device)
     should_compress_rows = torch.zeros(bsz, dtype=torch.bool, device=x.device)
 
@@ -442,8 +427,6 @@ def golden_compressor(tensors):
         boundary_s = int(boundary_positions[0].item())
         cmp_row = int(cmp_slot_mapping[b, boundary_s].item())
         if cmp_row >= 0:
-            # Kernel writes committed pooled result only to kv[:, 0, :]; leave
-            # speculative-boundary rows and kv[:, 1:, :] zero-initialized.
             tensors["kv"][b : b + 1, 0:1, :] = kv_b
             cblk = cmp_row // BLOCK_SIZE
             intra_offset = cmp_row % BLOCK_SIZE
@@ -453,7 +436,7 @@ def golden_compressor(tensors):
 
 
 def build_tensor_specs(start_pos=None):
-    import torch  # type: ignore[import]
+    import torch
     from decode_metadata import (
         block_table,
         compressed_slot_mapping,
@@ -471,10 +454,6 @@ def build_tensor_specs(start_pos=None):
         return torch.rand(B, S, D)
     def init_compress_state():
         return torch.zeros(COMPRESS_STATE_BLOCK_NUM, COMPRESS_STATE_BLOCK_SIZE, COMPRESS_STATE_DIM)
-    # Calibrated to the real DeepSeek-V4-Flash 150
-    #  (ratio-128) main compressor (mean l7/l9 of
-    # extract_weights_flash): zero-mean Gaussian BF16 weights at the measured std; the RMSNorm
-    # gamma centers near the measured mean (not ones / not uniform).
     def init_wkv():
         return torch.randn(OUT_DIM, D) * 0.0246
     def init_wgate():
@@ -508,7 +487,6 @@ def build_tensor_specs(start_pos=None):
             permuted=True,
         )
     def init_default_start_pos():
-        # Canonical HCA start-position set (ratio-128 compressor branches + 8k long-context).
         return hca_decode_start_set(
             batch=B, compress_ratio=COMPRESS_RATIO, state_block_size=COMPRESS_STATE_BLOCK_SIZE)
     def init_start_pos():
@@ -580,8 +558,6 @@ if __name__ == "__main__":
         ),
         rtol=1e-3,
         atol=1e-3,
-        # Precision reference: AscendC torch.ops.custom.compressor —
-        # ops-transformer/experimental/attention/compressor/tests/pytest/compressor_golden.py
         compare_fn={
             "kv":            ratio_allclose(atol=1e-4, rtol=1.0 / 128, max_error_ratio=0.0),
             "compress_state": ratio_allclose(atol=1e-3, rtol=1e-3, max_error_ratio=0.0),

--- a/models/deepseek_v4_pro/decode_compressor_ratio4.py
+++ b/models/deepseek_v4_pro/decode_compressor_ratio4.py
@@ -6,26 +6,20 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-"""DeepSeek-V4 KV Compressor (decode incremental, ratio=4 overlap).
-
-Uses overlapping state layout with 8 slots.
-Front slots 0-3 at columns [0:HEAD_DIM], back slots 4-7 at columns [HEAD_DIM:OUT_DIM].
-Tree reduction for softmax+pool. State shift after compression."""
-
+"""DeepSeek-V4 overlapping ratio-4 decode KV compressor."""
 
 import pypto.language as pl
 
 from config import (
     ACTIVE as M,
-    DECODE_BATCH,
-    DECODE_SEQ,
     BLOCK_SIZE,
     C4A_COMPRESSOR_BLOCK_SIZE,
+    DECODE_BATCH,
     DECODE_CMP_BLOCK_NUM,
-    KV_CMP_MAX_BLOCKS,
+    DECODE_SEQ,
     FP32_NEG_INF,
+    KV_CMP_MAX_BLOCKS,
 )
-
 
 # model config
 B = DECODE_BATCH
@@ -37,14 +31,14 @@ HEAD_DIM_INV = 1.0 / HEAD_DIM
 ROPE_HEAD_DIM = M.qk_rope_head_dim
 NOPE_HEAD_DIM = M.nope_head_dim
 MAX_SEQ_LEN = M.max_position_embeddings
+ROPE_HEAD_DIM_F = float(ROPE_HEAD_DIM)
+ROPE_HALF_F = float(ROPE_HEAD_DIM // 2)
 
-# kernel-local (ratio-4 overlapping compressor)
+# compressor config
 COMPRESS_RATIO = 4
 OVERLAP = COMPRESS_RATIO == 4
 COFF = 1 + int(OVERLAP)
 OUT_DIM = COFF * HEAD_DIM
-STATE_LEN = COFF * COMPRESS_RATIO
-IDX_KV_LEN = MAX_SEQ_LEN // COMPRESS_RATIO
 COMPRESS_STATE_BLOCK_SIZE = C4A_COMPRESSOR_BLOCK_SIZE
 COMPRESS_STATE_PHYSICAL_BLOCKS = 65
 COMPRESS_STATE_MAX_BLOCKS = (MAX_SEQ_LEN + COMPRESS_STATE_BLOCK_SIZE - 1) // COMPRESS_STATE_BLOCK_SIZE
@@ -54,17 +48,14 @@ CMP_MAX_BLOCKS = KV_CMP_MAX_BLOCKS
 CMP_BLOCK_NUM = DECODE_CMP_BLOCK_NUM
 
 # tiling
-ROPE_TILE = 32
 K_TILE = 512
 OUT_TILE = 64
-B_TILE = 8
 MM_B_TILE = 16
 BS_PAD = ((B * S + MM_B_TILE - 1) // MM_B_TILE) * MM_B_TILE
 HEAD_TILE = 64
-HEAD_DIM_TILE = 128
-RMS_PAD_TILE = 16  # pad B rows up to one 16-row block (min M for FP32 vec ops)
-RMS_PAD_ROWS = RMS_PAD_TILE  # single block; requires B <= RMS_PAD_TILE
-assert B <= RMS_PAD_TILE
+RMS_PAD_TILE = 16
+ROPE_FLAT_LEN = RMS_PAD_TILE * ROPE_HEAD_DIM
+ROPE_HALF_FLAT_LEN = RMS_PAD_TILE * (ROPE_HEAD_DIM // 2)
 
 
 @pl.jit.inline
@@ -88,12 +79,7 @@ def compressor_ratio4(
     x_flat = pl.reshape(x, [B * S, D])
     cmp4_kv_proj_pad = pl.create_tensor([BS_PAD, OUT_DIM], dtype=pl.FP32)
     cmp4_score_proj_pad = pl.create_tensor([BS_PAD, OUT_DIM], dtype=pl.FP32)
-    compress_state_flat = pl.reshape(compress_state, [COMPRESS_STATE_BLOCK_NUM * COMPRESS_STATE_BLOCK_SIZE, COMPRESS_STATE_DIM])
-    kv_flat = pl.reshape(kv, [B * S, HEAD_DIM])
-    cmp_kv_cache_flat = pl.reshape(cmp_kv_cache, [CMP_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
 
-    # Deferred behind the caller's rms_norm dummy barrier: qkv's qr_proj_matmul is the
-    # critical path and must win the cores when rms_norm retires.
     with pl.spmd(
         BS_PAD * OUT_DIM // (MM_B_TILE * OUT_TILE), name_hint="kv_score_proj", deps=[late_dep]
     ) as _kv_score_tid:
@@ -106,10 +92,6 @@ def compressor_ratio4(
             k0 = kb * K_TILE
             x_rows = pl.min(MM_B_TILE, B * S - global_row0)
             x_tile = pl.slice(x_flat, [MM_B_TILE, K_TILE], [global_row0, k0], valid_shape=[x_rows, K_TILE])
-            # Weights stored transposed [OUT_DIM, D] and consumed via b_trans=True so the
-            # GM->L1 load is a DN2ZN (each [OUT_TILE, K_TILE] row is K-contiguous = long
-            # bursts) instead of ND2NZ on [K_TILE, OUT_TILE] (K strided = many short
-            # bursts). Cuts the transaction-bound MTE2 cost ~14% busy / ~7% compressor wall.
             wkv_tile = wkv[o0 : o0 + OUT_TILE, k0 : k0 + K_TILE]
             wgate_tile = wgate[o0 : o0 + OUT_TILE, k0 : k0 + K_TILE]
             if k0 == 0:
@@ -122,10 +104,10 @@ def compressor_ratio4(
         cmp4_kv_proj_pad[global_row0 : global_row0 + MM_B_TILE, o0 : o0 + OUT_TILE] = kv_acc
         cmp4_score_proj_pad[global_row0 : global_row0 + MM_B_TILE, o0 : o0 + OUT_TILE] = score_acc
 
-    # scatter_softmax_pool: per batch, scatter the padded proj rows into compress_state, then
-    # online-softmax pool that batch's window into pooled_kv. One region -- each batch's pool
-    # reads only its own just-scattered state (per-batch block table), so no cross-task barrier.
-    pooled_kv = pl.create_tensor([RMS_PAD_ROWS, HEAD_DIM], dtype=pl.FP32)
+    compress_state_flat = pl.reshape(
+        compress_state, [COMPRESS_STATE_BLOCK_NUM * COMPRESS_STATE_BLOCK_SIZE, COMPRESS_STATE_DIM]
+    )
+    pooled_kv = pl.create_tensor([RMS_PAD_TILE, HEAD_DIM], dtype=pl.FP32)
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="scatter_softmax_pool"):
         for c_idx in pl.range(B):
             for s_sc in pl.pipeline(S, stage=2):
@@ -138,9 +120,9 @@ def compressor_ratio4(
                     kv_tile = cmp4_kv_proj_pad[proj_row : proj_row + 1, 0 : OUT_DIM]
                     score_tile = cmp4_score_proj_pad[proj_row : proj_row + 1, 0 : OUT_DIM]
                     ape_tile = ape[token_ape_row : token_ape_row + 1, 0 : OUT_DIM]
-                    score_tile = pl.add(score_tile, ape_tile)
+                    score_ape_tile = pl.add(score_tile, ape_tile)
                     compress_state_flat[state_row : state_row + 1, 0 : OUT_DIM] = kv_tile
-                    compress_state_flat[state_row : state_row + 1, OUT_DIM : 2 * OUT_DIM] = score_tile
+                    compress_state_flat[state_row : state_row + 1, OUT_DIM : 2 * OUT_DIM] = score_ape_tile
 
             pad_idx = c_idx
             first_pos_b = pl.read(position_ids, [c_idx, 0])
@@ -154,10 +136,12 @@ def compressor_ratio4(
                 last_abs = cur_window_start_b + COMPRESS_RATIO - 1
                 last_blk_off = last_abs // COMPRESS_STATE_BLOCK_SIZE
                 last_intra = last_abs % COMPRESS_STATE_BLOCK_SIZE
-                last_blk_id = pl.cast(pl.read(compress_state_block_table, [c_idx, last_blk_off]), pl.INDEX)
+                last_blk_raw = pl.read(compress_state_block_table, [c_idx, last_blk_off])
+                last_blk_id = pl.cast(last_blk_raw, pl.INDEX)
                 last_row = last_blk_id * COMPRESS_STATE_BLOCK_SIZE + last_intra
                 mi = compress_state_flat[last_row : last_row + 1, OUT_DIM + HEAD_DIM : COMPRESS_STATE_DIM]
-                li = pl.exp(pl.sub(mi, mi))
+                li_diff = pl.sub(mi, mi)
+                li = pl.exp(li_diff)
                 oi = compress_state_flat[last_row : last_row + 1, HEAD_DIM : OUT_DIM]
 
                 for s in pl.range(0, COMPRESS_RATIO):
@@ -167,39 +151,52 @@ def compressor_ratio4(
                     if first_pos_b >= COMPRESS_RATIO:
                         prev_blk_off = prev_abs // COMPRESS_STATE_BLOCK_SIZE
                         prev_intra = prev_abs % COMPRESS_STATE_BLOCK_SIZE
-                        prev_blk_id = pl.cast(pl.read(compress_state_block_table, [c_idx, prev_blk_off]), pl.INDEX)
+                        prev_blk_raw = pl.read(compress_state_block_table, [c_idx, prev_blk_off])
+                        prev_blk_id = pl.cast(prev_blk_raw, pl.INDEX)
                         prev_row = prev_blk_id * COMPRESS_STATE_BLOCK_SIZE + prev_intra
                         front_score = compress_state_flat[prev_row : prev_row + 1, OUT_DIM : OUT_DIM + HEAD_DIM]
                         front_kv = compress_state_flat[prev_row : prev_row + 1, 0 : HEAD_DIM]
                     mi_next_front = pl.maximum(mi, front_score)
-                    alpha_front = pl.exp(pl.sub(mi, mi_next_front))
-                    beta_front = pl.exp(pl.sub(front_score, mi_next_front))
-                    li = pl.add(pl.mul(alpha_front, li), beta_front)
-                    oi = pl.add(pl.mul(oi, alpha_front), pl.mul(front_kv, beta_front))
+                    alpha_front_diff = pl.sub(mi, mi_next_front)
+                    alpha_front = pl.exp(alpha_front_diff)
+                    beta_front_diff = pl.sub(front_score, mi_next_front)
+                    beta_front = pl.exp(beta_front_diff)
+                    li_front = pl.mul(alpha_front, li)
+                    li = pl.add(li_front, beta_front)
+                    oi_front = pl.mul(oi, alpha_front)
+                    kv_front = pl.mul(front_kv, beta_front)
+                    oi = pl.add(oi_front, kv_front)
                     mi = mi_next_front
 
                 for s in pl.range(0, COMPRESS_RATIO - 1):
                     cur_abs = cur_window_start_b + s
                     cur_blk_off = cur_abs // COMPRESS_STATE_BLOCK_SIZE
                     cur_intra = cur_abs % COMPRESS_STATE_BLOCK_SIZE
-                    cur_blk_id = pl.cast(pl.read(compress_state_block_table, [c_idx, cur_blk_off]), pl.INDEX)
+                    cur_blk_raw = pl.read(compress_state_block_table, [c_idx, cur_blk_off])
+                    cur_blk_id = pl.cast(cur_blk_raw, pl.INDEX)
                     cur_row = cur_blk_id * COMPRESS_STATE_BLOCK_SIZE + cur_intra
                     back_score = compress_state_flat[cur_row : cur_row + 1, OUT_DIM + HEAD_DIM : COMPRESS_STATE_DIM]
                     back_kv = compress_state_flat[cur_row : cur_row + 1, HEAD_DIM : OUT_DIM]
                     mi_next_back = pl.maximum(mi, back_score)
-                    alpha_back = pl.exp(pl.sub(mi, mi_next_back))
-                    beta_back = pl.exp(pl.sub(back_score, mi_next_back))
-                    li = pl.add(pl.mul(alpha_back, li), beta_back)
-                    oi = pl.add(pl.mul(oi, alpha_back), pl.mul(back_kv, beta_back))
+                    alpha_back_diff = pl.sub(mi, mi_next_back)
+                    alpha_back = pl.exp(alpha_back_diff)
+                    beta_back_diff = pl.sub(back_score, mi_next_back)
+                    beta_back = pl.exp(beta_back_diff)
+                    li_back = pl.mul(alpha_back, li)
+                    li = pl.add(li_back, beta_back)
+                    oi_back = pl.mul(oi, alpha_back)
+                    kv_back = pl.mul(back_kv, beta_back)
+                    oi = pl.add(oi_back, kv_back)
                     mi = mi_next_back
 
                 pooled_chunk = pl.div(oi, li)
                 pooled_kv[pad_idx : pad_idx + 1, 0 : HEAD_DIM] = pooled_chunk
 
-    normed_kv = pl.create_tensor([RMS_PAD_ROWS, HEAD_DIM], dtype=pl.FP32)
+    kv_flat = pl.reshape(kv, [B * S, HEAD_DIM])
+    cmp_kv_cache_flat = pl.reshape(cmp_kv_cache, [CMP_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
+    normed_kv = pl.create_tensor([RMS_PAD_TILE, HEAD_DIM], dtype=pl.FP32)
     norm_w_2d = pl.reshape(norm_w, [1, HEAD_DIM])
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="rmsnorm_rope_cache_write"):
-        # single 16-row block: B real rows at rows 0..B-1, rows B..15 are pad
         cos_b = pl.full([RMS_PAD_TILE, ROPE_HEAD_DIM // 2], dtype=pl.FP32, value=0.0)
         sin_b = pl.full([RMS_PAD_TILE, ROPE_HEAD_DIM // 2], dtype=pl.FP32, value=0.0)
         cos_b[0:B, 0 : ROPE_HEAD_DIM // 2] = cos[0:B, 0 : ROPE_HEAD_DIM // 2]
@@ -208,57 +205,86 @@ def compressor_ratio4(
         for k0 in pl.range(0, HEAD_DIM, HEAD_TILE):
             kv_rms_chunk = pooled_kv[0 : RMS_PAD_TILE, k0 : k0 + HEAD_TILE]
             kv_rms_sq = pl.mul(kv_rms_chunk, kv_rms_chunk)
-            kv_rms_rowsum = pl.reshape(pl.row_sum(kv_rms_sq), [1, RMS_PAD_TILE])
+            kv_rms_sum = pl.row_sum(kv_rms_sq)
+            kv_rms_rowsum = pl.reshape(kv_rms_sum, [1, RMS_PAD_TILE])
             partial_sq = pl.add(partial_sq, kv_rms_rowsum)
 
-        variance = pl.reshape(pl.add(pl.mul(partial_sq, HEAD_DIM_INV), EPS), [RMS_PAD_TILE, 1])
-        inv_rms = pl.recip(pl.sqrt(variance))
+        partial_mean = pl.mul(partial_sq, HEAD_DIM_INV)
+        variance_row = pl.add(partial_mean, EPS)
+        variance = pl.reshape(variance_row, [RMS_PAD_TILE, 1])
+        rms = pl.sqrt(variance)
+        inv_rms = pl.recip(rms)
         for k0 in pl.range(0, NOPE_HEAD_DIM, HEAD_TILE):
             kv_norm_chunk = pooled_kv[0 : RMS_PAD_TILE, k0 : k0 + HEAD_TILE]
-            gamma = pl.cast(norm_w_2d[:, k0 : k0 + HEAD_TILE], pl.FP32)
-            normed_chunk = pl.col_expand_mul(pl.row_expand_mul(kv_norm_chunk, inv_rms), gamma)
+            gamma_bf16 = norm_w_2d[:, k0 : k0 + HEAD_TILE]
+            gamma = pl.cast(gamma_bf16, pl.FP32)
+            kv_rms_scaled = pl.row_expand_mul(kv_norm_chunk, inv_rms)
+            normed_chunk = pl.col_expand_mul(kv_rms_scaled, gamma)
             normed_kv[0 : RMS_PAD_TILE, k0 : k0 + HEAD_TILE] = normed_chunk
 
         kv_rope_norm = pooled_kv[0 : RMS_PAD_TILE, NOPE_HEAD_DIM : HEAD_DIM]
-        gamma_rope = pl.cast(norm_w_2d[:, NOPE_HEAD_DIM : HEAD_DIM], pl.FP32)
-        # A3 interleaved swap-gather (same form as kv_rope_fused in qkv_proj_rope),
-        # replacing the de-interleave gather + rotate + re-interleave scatter. gamma+inv_rms
-        # are folded into rope_normed BEFORE the swap, so the swapped lane n[j^1] correctly
-        # carries gamma[j^1]; inv_rms is per-row so it commutes. swap_idx (j^1), sign
-        # ([-1,+1,...]) and dup_idx (j>>1) are built IN-KERNEL from pl.arange; cos_il/sin_il
-        # are dup-gathered from the per-batch cos/sin rows. normed_kv is FP32 -> write directly.
-        #   out[j] = n[j]*cos_il[j] + n[j^1]*sign[j]*sin_il[j]
-        rope_normed = pl.col_expand_mul(pl.row_expand_mul(kv_rope_norm, inv_rms), gamma_rope)
+        gamma_rope_bf16 = norm_w_2d[:, NOPE_HEAD_DIM : HEAD_DIM]
+        gamma_rope = pl.cast(gamma_rope_bf16, pl.FP32)
+        # out[j] = n[j] * cos[j] + n[j ^ 1] * sign[j] * sin[j]
+        rope_rms_scaled = pl.row_expand_mul(kv_rope_norm, inv_rms)
+        rope_normed = pl.col_expand_mul(rope_rms_scaled, gamma_rope)
         rope_ones = pl.full([RMS_PAD_TILE, ROPE_HEAD_DIM], dtype=pl.FP32, value=1.0)
-        rope_col = pl.col_expand_mul(rope_ones, pl.cast(pl.arange(0, [1, ROPE_HEAD_DIM], dtype=pl.INT32), target_type=pl.FP32))
-        rope_dup_f = pl.cast(pl.cast(pl.mul(rope_col, 0.5), target_type=pl.INT32, mode="trunc"), target_type=pl.FP32)
-        rope_dup_idx = pl.cast(rope_dup_f, target_type=pl.INT32)                                       # j>>1
-        rope_lane = pl.sub(rope_col, pl.mul(rope_dup_f, 2.0))                                          # j%2
-        rope_swap_idx = pl.cast(pl.sub(pl.add(rope_col, 1.0), pl.mul(rope_lane, 2.0)), target_type=pl.INT32)  # j^1
-        rope_sign = pl.sub(pl.mul(rope_lane, 2.0), 1.0)                                                # [-1,+1,...]
-        cos_il = pl.gather(cos_b, dim=-1, index=rope_dup_idx)
-        sin_il = pl.gather(sin_b, dim=-1, index=rope_dup_idx)
-        swapped = pl.gather(rope_normed, dim=-1, index=rope_swap_idx)
-        rope_rot = pl.add(pl.mul(rope_normed, cos_il), pl.mul(pl.mul(swapped, rope_sign), sin_il))
+        rope_col_idx = pl.arange(0, [1, ROPE_HEAD_DIM], dtype=pl.INT32)
+        rope_col_f32 = pl.cast(rope_col_idx, target_type=pl.FP32)
+        rope_col = pl.col_expand_mul(rope_ones, rope_col_f32)
+        rope_row_idx = pl.arange(0, [1, RMS_PAD_TILE], dtype=pl.INT32)
+        rope_row_f32 = pl.cast(rope_row_idx, target_type=pl.FP32)
+        rope_row_col = pl.reshape(rope_row_f32, [RMS_PAD_TILE, 1])
+        rope_row = pl.row_expand_mul(rope_ones, rope_row_col)
+        rope_half = pl.mul(rope_col, 0.5)
+        rope_dup_i32 = pl.cast(rope_half, target_type=pl.INT32, mode="trunc")
+        rope_dup_f = pl.cast(rope_dup_i32, target_type=pl.FP32)
+        rope_dup_twice = pl.mul(rope_dup_f, 2.0)
+        rope_lane = pl.sub(rope_col, rope_dup_twice)  # j % 2
+        rope_col_next = pl.add(rope_col, 1.0)
+        rope_jx_lane = pl.mul(rope_lane, 2.0)
+        rope_jx = pl.sub(rope_col_next, rope_jx_lane)  # j ^ 1
+        rope_sign_lane = pl.mul(rope_lane, 2.0)
+        rope_sign = pl.sub(rope_sign_lane, 1.0)  # [-1, +1, ...]
+        rope_dup_row = pl.mul(rope_row, ROPE_HALF_F)
+        rope_dup_sum = pl.add(rope_dup_row, rope_dup_f)
+        rope_dup_idx = pl.cast(rope_dup_sum, target_type=pl.INT32)
+        rope_dup_flat = pl.reshape(rope_dup_idx, [1, ROPE_FLAT_LEN])
+        rope_swap_row = pl.mul(rope_row, ROPE_HEAD_DIM_F)
+        rope_swap_sum = pl.add(rope_swap_row, rope_jx)
+        rope_swap_idx = pl.cast(rope_swap_sum, target_type=pl.INT32)
+        rope_swap_flat = pl.reshape(rope_swap_idx, [1, ROPE_FLAT_LEN])
+        cos_flat = pl.reshape(cos_b, [1, ROPE_HALF_FLAT_LEN])
+        cos_gathered = pl.gather(cos_flat, dim=-1, index=rope_dup_flat)
+        cos_il = pl.reshape(cos_gathered, [RMS_PAD_TILE, ROPE_HEAD_DIM])
+        sin_flat = pl.reshape(sin_b, [1, ROPE_HALF_FLAT_LEN])
+        sin_gathered = pl.gather(sin_flat, dim=-1, index=rope_dup_flat)
+        sin_il = pl.reshape(sin_gathered, [RMS_PAD_TILE, ROPE_HEAD_DIM])
+        rope_normed_flat = pl.reshape(rope_normed, [1, ROPE_FLAT_LEN])
+        swapped_flat = pl.gather(rope_normed_flat, dim=-1, index=rope_swap_flat)
+        swapped = pl.reshape(swapped_flat, [RMS_PAD_TILE, ROPE_HEAD_DIM])
+        rope_cos = pl.mul(rope_normed, cos_il)
+        swapped_signed = pl.mul(swapped, rope_sign)
+        rope_sin = pl.mul(swapped_signed, sin_il)
+        rope_rot = pl.add(rope_cos, rope_sin)
         normed_kv[0 : RMS_PAD_TILE, NOPE_HEAD_DIM : HEAD_DIM] = rope_rot
 
-        # cache write: reads back only this block's own normed_kv rows, so the normed_kv
-        # RAW is intra-block -- no separate scope / cross-task barrier needed.
         for inner in pl.range(B):
-            c_idx = inner
-            first_pos_b = pl.read(position_ids, [c_idx, 0])
-            pos_b = first_pos_b % COMPRESS_RATIO
-            if pos_b + S >= COMPRESS_RATIO:
-                boundary_s = COMPRESS_RATIO - 1 - pos_b
+            write_c_idx = inner
+            write_first_pos = pl.read(position_ids, [write_c_idx, 0])
+            write_pos = write_first_pos % COMPRESS_RATIO
+            if write_pos + S >= COMPRESS_RATIO:
+                boundary_s = COMPRESS_RATIO - 1 - write_pos
                 kv_row_fp32 = normed_kv[inner : inner + 1, 0 : HEAD_DIM]
-                cache_row_i64 = pl.read(cmp_slot_mapping, [c_idx, boundary_s])
+                cache_row_i64 = pl.read(cmp_slot_mapping, [write_c_idx, boundary_s])
                 if cache_row_i64 >= 0:
                     cache_row = pl.cast(cache_row_i64, pl.INDEX)
-                    kv_flat[c_idx * S : c_idx * S + 1, :] = kv_row_fp32
-                    cmp_kv_cache_flat[cache_row : cache_row + 1, :] = pl.cast(kv_row_fp32, target_type=pl.BF16, mode="rint")
+                    kv_flat[write_c_idx * S : write_c_idx * S + 1, :] = kv_row_fp32
+                    kv_row_bf16 = pl.cast(kv_row_fp32, target_type=pl.BF16, mode="rint")
+                    cmp_kv_cache_flat[cache_row : cache_row + 1, :] = kv_row_bf16
 
-    kv = pl.reshape(kv_flat, [B, S, HEAD_DIM])
-    return kv
+    kv_out = pl.reshape(kv_flat, [B, S, HEAD_DIM])
+    return kv_out
 
 
 @pl.jit
@@ -278,23 +304,11 @@ def compressor_test(
     cmp_slot_mapping: pl.Tensor[[B, S], pl.INT64],
     state_slot_mapping: pl.Tensor[[B, S], pl.INT64],
 ):
-    # Standalone: no rms_norm producer, so the barrier fences nothing (ready on submit).
     late_dep = pl.system.task_dummy(deps=[])
     compressor_ratio4(
-        x,
-        kv,
-        compress_state,
-        compress_state_block_table,
-        wkv,
-        wgate,
-        ape,
-        norm_w,
-        cos,
-        sin,
-        cmp_kv_cache,
-        position_ids,
-        cmp_slot_mapping,
-        state_slot_mapping,
+        x, kv, compress_state, compress_state_block_table,
+        wkv, wgate, ape, norm_w, cos, sin,
+        cmp_kv_cache, position_ids, cmp_slot_mapping, state_slot_mapping,
         late_dep,
     )
     return kv, compress_state, cmp_kv_cache
@@ -320,8 +334,8 @@ def golden_compressor(tensors):
     bsz, _, _ = x.shape
     ratio, rd = COMPRESS_RATIO, ROPE_HEAD_DIM
 
-    kv = x @ wkv.t()                    # [B, S, OUT_DIM]  (wkv stored [OUT_DIM, D] for b_trans)
-    score = x @ wgate.t()               # [B, S, OUT_DIM]
+    kv = x @ wkv.t()
+    score = x @ wgate.t()
 
     pooled = torch.zeros(bsz, 1, HEAD_DIM, dtype=torch.float32, device=x.device)
     should_compress_rows = torch.zeros(bsz, dtype=torch.bool, device=x.device)
@@ -361,7 +375,6 @@ def golden_compressor(tensors):
         cur_window_start = boundary_end - ratio + 1
         prev_window_start = cur_window_start - ratio
 
-        # Per-token ape add + state scatter through explicit token-major slots.
         for s in range(S):
             pos = int(position_ids[b, s].item())
             token_ape_row = pos % ratio
@@ -423,8 +436,6 @@ def golden_compressor(tensors):
 
         cmp_row = int(cmp_slot_mapping[b, boundary_s].item())
         if cmp_row >= 0:
-            # Kernel writes committed pooled result only to kv[:, 0, :]; leave
-            # speculative-boundary rows and kv[:, 1:, :] zero-initialized.
             tensors["kv"][b : b + 1, 0:1, :] = kv_b
             blk_id = cmp_row // BLOCK_SIZE
             cmp_kv_cache[blk_id, cmp_row % BLOCK_SIZE, 0] = kv_b[0, 0]
@@ -433,7 +444,7 @@ def golden_compressor(tensors):
 
 
 def build_tensor_specs(start_pos=None):
-    import torch  # type: ignore[import]
+    import torch
     from decode_metadata import (
         block_table,
         compressed_slot_mapping,
@@ -459,9 +470,6 @@ def build_tensor_specs(start_pos=None):
             table_blocks=COMPRESS_STATE_MAX_BLOCKS,
             physical_blocks=COMPRESS_STATE_PHYSICAL_BLOCKS,
         )
-    # Calibrated to the real DeepSeek-V4-Flash CSA (ratio-4) main compressor (mean l8/l32 of
-    # extract_weights_flash): zero-mean Gaussian BF16 weights at the measured std; the RMSNorm
-    # gamma centers near the measured mean (not ones / not uniform).
     def init_wkv():
         return torch.randn(OUT_DIM, D) * 0.0245
     def init_wgate():
@@ -487,7 +495,6 @@ def build_tensor_specs(start_pos=None):
             physical_blocks=CMP_BLOCK_NUM,
         )
     def init_default_start_pos():
-        # Canonical CSA start-position set (ratio-4 compressor + indexer + sliding-window + 8k).
         return csa_decode_start_set(
             batch=B, seq=S, compress_ratio=COMPRESS_RATIO,
             state_block_size=COMPRESS_STATE_BLOCK_SIZE)

--- a/models/deepseek_v4_pro/decode_indexer.py
+++ b/models/deepseek_v4_pro/decode_indexer.py
@@ -6,24 +6,21 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-"""DeepSeek-V4 Indexer (decode). Mirrors model.py Indexer (line 380-433);
-golden is a port of forward's decode branch (prefill `start_pos == 0` path is omitted).
-The inner Compressor is invoked via golden_compressor (placeholder)."""
-
+"""DeepSeek-V4 decode indexer with compressed-cache scoring and top-k selection."""
 
 import pypto.language as pl
 
 from config import (
     ACTIVE as M,
-    DECODE_BATCH,
-    DECODE_SEQ,
     BLOCK_SIZE,
     C4A_COMPRESSOR_BLOCK_SIZE,
+    DECODE_BATCH,
     DECODE_IDX_BLOCK_NUM,
-    IDX_CACHE_MAX_BLOCKS,
+    DECODE_SEQ,
     FP32_NEG_INF,
-    INT8_SCALE_MAX,
+    IDX_CACHE_MAX_BLOCKS,
     INT8_AMAX_EPS,
+    INT8_SCALE_MAX,
 )
 from decode_indexer_compressor import indexer_compressor
 
@@ -40,9 +37,13 @@ IDX_NOPE_HEAD_DIM = M.index_nope_head_dim
 WEIGHTS_SCALE = M.index_weights_scale
 MAX_SEQ_LEN = M.max_position_embeddings
 OFFSET = M.sliding_window
+ROPE_HEAD_DIM_F = float(ROPE_HEAD_DIM)
+ROPE_HEAD_DIM_INV = 1.0 / ROPE_HEAD_DIM
+ROPE_HALF_F = float(ROPE_HEAD_DIM // 2)
+IDX_HEAD_DIM_F = float(IDX_HEAD_DIM)
 
-# kernel-local
-COMPRESS_RATIO = 4   # the indexer only runs on ratio-4 layers
+# indexer config
+COMPRESS_RATIO = 4
 IDX_TOPK = M.index_topk
 INNER_OVERLAP = COMPRESS_RATIO == 4
 INNER_COFF = 1 + int(INNER_OVERLAP)
@@ -64,56 +65,22 @@ SCORE_HARD_ATOL = 5e-3
 
 # tiling
 CACHE_TILE = 64
-assert BLOCK_SIZE % CACHE_TILE == 0, "CACHE_TILE must not cross a paged idx_kv_cache block"
-# matmul/reduce tile over contiguous GM scratch, not the paged KV cache
-MAT_TILE = 512
-REDUCE_TILE = 128
-# score_kv_quant / score_reduce fan the cache-tile loop across NSPLIT extra lanes: T * NSPLIT.
-QUANT_NSPLIT = 4
-REDUCE_NSPLIT = 4
 Q_TILE = 256
-# Q_OUT_TILE is the per-task N granularity (sets idx_qr_proj task count); MM_N_TILE
-# is the Mat-safe cube N-tile. Q_OUT_TILE fans Q_OUT_TILE // MM_N_TILE cube ops per
-# task so task count halves without growing the [Q_TILE, MM_N_TILE] L1 wq load.
 Q_OUT_TILE = 1024
 MM_N_TILE = 512
 MM_ROW_TILE = 16
 T_PAD = ((T + MM_ROW_TILE - 1) // MM_ROW_TILE) * MM_ROW_TILE
-# weights_proj is one 16-row boxed matmul per task; decode T fits in one row tile.
-# Fail loudly if a config makes T exceed it (would drop rows).
-assert T_PAD == MM_ROW_TILE, "weights_proj single-row-tile scope assumes decode T <= MM_ROW_TILE"
-HEAD_DIM_TILE = 32
 D_TILE = 512
-# weights_proj splits K, not N: a [D_TILE, IDX_N_HEADS] row block reads contiguous GM,
-# while an N slice would take 32B out of every 128B row. Each task writes its own
-# partial row block, summed by a separate reduce scope -- a zero-seed + atomic-add
-# assemble races here, since T_PAD == MM_ROW_TILE makes the seed a full-extent write.
-# WEIGHTS_K_SLICE // D_TILE == 2, so the inner loop is a pl.range: a degenerate
-# 2-iteration pl.pipeline(stage=2) miscompiles over matmul.
-# The projection split must divide D / D_TILE exactly. Flash has 8 D tiles;
-# Pro has 14, and these choices preserve each deployment's existing tuning.
-WEIGHTS_OK = 4 if M.name == "flash" else 7
-WEIGHTS_K_SLICE = D // WEIGHTS_OK
-assert WEIGHTS_K_SLICE % D_TILE == 0
-QH_QUANT_TILE = 64
-# cube tile for q @ hadamard; L0C caps it at QH_MM_TILE * IDX_HEAD_DIM * 4B <= 64KiB.
-QH_MM_TILE = 64
-QH_HEAD_DIM_TILE = 64
-ROPE_ROW_BLOCK = S * IDX_N_HEADS
-# qr_rope SPMD tile == row block: one ROPE_ROW_TILE-row block per SPMD tile.
-ROPE_ROW_TILE = 32
-# qr_rope gathers with a single-row flat index so the a5 lowering's per-block
-# row-base chain is skipped (see the qr_rope_tables scope).
-ROPE_SWAP_FLAT_LEN = ROPE_ROW_TILE * ROPE_HEAD_DIM
-# float forms: the tracer does not accept float()/int() calls inside a kernel body.
-ROPE_HEAD_DIM_F = float(ROPE_HEAD_DIM)
-ROPE_HEAD_DIM_INV = 1.0 / ROPE_HEAD_DIM
+WEIGHTS_K_TILE = D // (4 if M.name == "flash" else 7)
+Q_HEAD_TILE = 32
+Q_HEAD_FLAT_LEN = Q_HEAD_TILE * IDX_HEAD_DIM
+assert IDX_N_HEADS % Q_HEAD_TILE == 0
+ROPE_IL_FLAT_LEN = B * ROPE_HEAD_DIM
+ROPE_IL_SRC_LEN = B * (ROPE_HEAD_DIM // 2)
+SCORE_LANE_TILE = 8
 TOPK_HALF_LEN = SCORE_LEN // 2
 TOPK_HALF_PAIR_OFFSET = 2 * TOPK_HALF_LEN
 TOPK_PAIR_WIDTH = 2 * IDX_TOPK
-assert SCORE_LEN == 2 * TOPK_HALF_LEN, "decode indexer topk expects an even score length"
-assert TOPK_HALF_LEN == 2048, "decode indexer 4096-value topk uses two 2048-value halves"
-assert IDX_TOPK <= TOPK_HALF_LEN, "per-half candidate list must cover the final topk width"
 
 
 @pl.jit.inline
@@ -126,7 +93,7 @@ def indexer(
     weights_proj: pl.Tensor[[D, IDX_N_HEADS], pl.BF16],
     cos: pl.Tensor[[B, ROPE_HEAD_DIM // 2], pl.FP32],
     sin: pl.Tensor[[B, ROPE_HEAD_DIM // 2], pl.FP32],
-    hadamard: pl.Tensor[[IDX_HEAD_DIM, IDX_HEAD_DIM], pl.BF16],  # shared by q rotation and inner Compressor
+    hadamard: pl.Tensor[[IDX_HEAD_DIM, IDX_HEAD_DIM], pl.BF16],
     inner_kv: pl.Tensor[[B, S, INNER_HEAD_DIM], pl.FP32],
     inner_compress_state: pl.InOut[
         pl.Tensor[
@@ -139,7 +106,7 @@ def indexer(
     inner_wgate: pl.Tensor[[INNER_OUT_DIM, D], pl.BF16],
     inner_ape: pl.Tensor[[COMPRESS_RATIO, INNER_OUT_DIM], pl.FP32],
     inner_norm_w: pl.Tensor[[INNER_HEAD_DIM], pl.BF16],
-    # C8 indexer cache: INT8 KV (quant-on-write) + per-position FP32 dequant scale; no bf16 cache.
+    # INT8 index cache and per-position FP32 dequantization scale.
     idx_kv_cache: pl.InOut[pl.Tensor[[IDX_CACHE_BLOCK_NUM, BLOCK_SIZE, 1, IDX_HEAD_DIM], pl.INT8]],
     idx_kv_scale: pl.InOut[pl.Tensor[[IDX_CACHE_BLOCK_NUM, BLOCK_SIZE, 1, 1], pl.FP32]],
     idx_block_table: pl.Tensor[[B, IDX_CACHE_MAX_BLOCKS], pl.INT32],
@@ -153,7 +120,7 @@ def indexer(
     late_dep: pl.Scalar[pl.TASK_ID],
 ):
     qr_acc_pad = pl.create_tensor([T_PAD, IDX_N_HEADS * IDX_HEAD_DIM], dtype=pl.INT32)
-    for ot in pl.spmd(IDX_N_HEADS * IDX_HEAD_DIM // Q_OUT_TILE, name_hint="idx_qr_proj_matmul", allow_early_resolve=True):
+    for ot in pl.spmd(IDX_N_HEADS * IDX_HEAD_DIM // Q_OUT_TILE, name_hint="idx_qr_proj_matmul"):
         o_base = ot * Q_OUT_TILE
         for ns in pl.range(0, Q_OUT_TILE, MM_N_TILE):
             qr_acc = pl.create_tensor([MM_ROW_TILE, MM_N_TILE], dtype=pl.INT32)
@@ -166,136 +133,123 @@ def indexer(
                 else:
                     qr_acc = pl.matmul_acc(qr_acc, qr_tile, wq_tile)
             qr_acc_pad[0:T_PAD, o_base + ns : o_base + ns + MM_N_TILE] = qr_acc
-    qr_proj = pl.create_tensor([T, IDX_N_HEADS * IDX_HEAD_DIM], dtype=pl.FP32)
-    for ot in pl.spmd(IDX_N_HEADS * IDX_HEAD_DIM // Q_OUT_TILE, name_hint="idx_qr_proj_dequant", allow_early_resolve=True):
-        o_base = ot * Q_OUT_TILE
-        wq_scale = pl.reshape(wq_b_scale[o_base : o_base + Q_OUT_TILE], [1, Q_OUT_TILE])
-        acc_fp32 = pl.cast(qr_acc_pad[0:T, o_base : o_base + Q_OUT_TILE], target_type=pl.FP32, mode="none")
-        qr_dequant = pl.col_expand_mul(pl.row_expand_mul(acc_fp32, qr_scale[0:T, :]), wq_scale)
-        qr_proj[0:T, o_base : o_base + Q_OUT_TILE] = qr_dequant
 
-    qr_proj_flat = pl.reshape(qr_proj, [T * IDX_N_HEADS, IDX_HEAD_DIM])
-    # BF16 q for the Hadamard matmul: nope half rounded from the FP32 dequant, rope
-    # half rotated then rounded.
-    qr_bf16 = pl.create_tensor([T * IDX_N_HEADS, IDX_HEAD_DIM], dtype=pl.BF16)
-    # The interleave tables are block-invariant: cos_il[j] = cos[b, j>>1], the sign
-    # pattern, and the j^1 lane-swap index do not depend on the spmd block. pl.gather
-    # lowers to a per-row TGATHER loop, so rebuilding them inside the grid cost
-    # 16 blocks x ROPE_ROW_TILE rows x 2 tables of row-gathers per layer. Build them
-    # once here and read them as plain loads per block.
-    #   out[j] = x[j]*cos_il[j] + x[j^1]*sin_il_signed[j]  (sign folded into sin)
-    # Folding the sign into sin is exact: multiplying by +/-1 only flips the sign bit,
-    # so (x*sign)*sin and x*(sin*sign) are bit-identical.
-    cos_il_t = pl.create_tensor([B, ROPE_HEAD_DIM], dtype=pl.FP32)
-    sin_signed_t = pl.create_tensor([B, ROPE_HEAD_DIM], dtype=pl.FP32)
-    rope_swap_idx_t = pl.create_tensor([1, ROPE_SWAP_FLAT_LEN], dtype=pl.INT32)
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="qr_rope_tables", allow_early_resolve=True):
-        il_col = pl.col_expand_mul(
-            pl.full([B, ROPE_HEAD_DIM], dtype=pl.FP32, value=1.0),
-            pl.cast(pl.arange(0, [1, ROPE_HEAD_DIM], dtype=pl.INT32), target_type=pl.FP32))
-        il_dup_f = pl.cast(pl.cast(pl.mul(il_col, 0.5), target_type=pl.INT32, mode="trunc"), target_type=pl.FP32)
-        il_dup_idx = pl.cast(il_dup_f, target_type=pl.INT32)                                    # j>>1
-        il_lane = pl.sub(il_col, pl.mul(il_dup_f, 2.0))                                         # j%2
-        il_sign = pl.sub(pl.mul(il_lane, 2.0), 1.0)                                             # [-1,+1,...]
-        cos_il_t[0:B, 0:ROPE_HEAD_DIM] = pl.gather(
-            cos[0:B, 0 : ROPE_HEAD_DIM // 2], dim=-1, index=il_dup_idx)
-        sin_signed_t[0:B, 0:ROPE_HEAD_DIM] = pl.mul(
-            pl.gather(sin[0:B, 0 : ROPE_HEAD_DIM // 2], dim=-1, index=il_dup_idx), il_sign)
-        # The j^1 lane swap permutes data, so it stays an index tensor; it is block
-        # invariant all the same. Store it as a SINGLE-ROW *flat* index over the
-        # [ROPE_ROW_TILE, ROPE_HEAD_DIM] block: flat[r*RHD + j] = r*RHD + (j^1).
-        #
-        # Why flat and single-row: on a5 the gather lowering (op_conversion_registry
-        # emit_a5_flat_idx) rebuilds a row-base chain -- tile.ci over rows*cols, reshape,
-        # divs, muls, add -- inside EVERY spmd block whenever the index has more than one
-        # row, and returns the index untouched when rows == 1. The row base is a compile-
-        # time constant here, so folding it into this once-per-layer table removes four
-        # full-tile INT32 passes per block.
-        sw_col = pl.cast(
-            pl.arange(0, [1, ROPE_SWAP_FLAT_LEN], dtype=pl.INT32), target_type=pl.FP32)
-        sw_rowbase = pl.mul(
-            pl.cast(pl.cast(pl.mul(sw_col, ROPE_HEAD_DIM_INV), target_type=pl.INT32, mode="trunc"),
-                    target_type=pl.FP32),
-            ROPE_HEAD_DIM_F)                                                               # r*RHD
-        sw_j = pl.sub(sw_col, sw_rowbase)                                                       # j
-        sw_dup_f = pl.cast(pl.cast(pl.mul(sw_j, 0.5), target_type=pl.INT32, mode="trunc"), target_type=pl.FP32)
-        sw_lane = pl.sub(sw_j, pl.mul(sw_dup_f, 2.0))                                           # j%2
-        sw_jx = pl.sub(pl.add(sw_j, 1.0), pl.mul(sw_lane, 2.0))                                 # j^1
-        rope_swap_idx_t[0:1, 0:ROPE_SWAP_FLAT_LEN] = pl.cast(
-            pl.add(sw_rowbase, sw_jx), target_type=pl.INT32)
+    # out[j] = x[j] * cos[j] + x[j ^ 1] * sin_signed[j]
+    cos_full_t = pl.create_tensor([B, IDX_HEAD_DIM], dtype=pl.FP32)
+    sin_full_t = pl.create_tensor([B, IDX_HEAD_DIM], dtype=pl.FP32)
+    q_swap_idx_t = pl.create_tensor([1, Q_HEAD_FLAT_LEN], dtype=pl.INT32)
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="qr_rope_tables"):
+        il_col_idx = pl.arange(0, [1, ROPE_IL_FLAT_LEN], dtype=pl.INT32)
+        il_col = pl.cast(il_col_idx, target_type=pl.FP32)
+        il_row_scaled = pl.mul(il_col, ROPE_HEAD_DIM_INV)
+        il_row_i32 = pl.cast(il_row_scaled, target_type=pl.INT32, mode="trunc")
+        il_row = pl.cast(il_row_i32, target_type=pl.FP32)
+        il_row_base = pl.mul(il_row, ROPE_HEAD_DIM_F)
+        il_j = pl.sub(il_col, il_row_base)
+        il_half = pl.mul(il_j, 0.5)
+        il_dup_i32 = pl.cast(il_half, target_type=pl.INT32, mode="trunc")
+        il_dup_f = pl.cast(il_dup_i32, target_type=pl.FP32)
+        il_dup_twice = pl.mul(il_dup_f, 2.0)
+        il_lane = pl.sub(il_j, il_dup_twice)  # j % 2
+        il_lane_twice = pl.mul(il_lane, 2.0)
+        il_sign_row = pl.sub(il_lane_twice, 1.0)
+        il_sign = pl.reshape(il_sign_row, [B, ROPE_HEAD_DIM])
+        il_dup_row = pl.mul(il_row, ROPE_HALF_F)
+        il_dup_sum = pl.add(il_dup_row, il_dup_f)
+        il_dup_flat = pl.cast(il_dup_sum, target_type=pl.INT32)
+        cos_flat = pl.reshape(cos, [1, ROPE_IL_SRC_LEN])
+        cos_gathered = pl.gather(cos_flat, dim=-1, index=il_dup_flat)
+        cos_il = pl.reshape(cos_gathered, [B, ROPE_HEAD_DIM])
+        sin_flat = pl.reshape(sin, [1, ROPE_IL_SRC_LEN])
+        sin_gathered = pl.gather(sin_flat, dim=-1, index=il_dup_flat)
+        sin_il = pl.reshape(sin_gathered, [B, ROPE_HEAD_DIM])
+        sin_signed = pl.mul(sin_il, il_sign)
+        nope_cos = pl.full([B, IDX_NOPE_HEAD_DIM], dtype=pl.FP32, value=1.0)
+        cos_full = pl.concat(nope_cos, cos_il)
+        cos_full_t[0:B, 0:IDX_HEAD_DIM] = cos_full
+        nope_sin = pl.full([B, IDX_NOPE_HEAD_DIM], dtype=pl.FP32, value=0.0)
+        sin_full = pl.concat(nope_sin, sin_signed)
+        sin_full_t[0:B, 0:IDX_HEAD_DIM] = sin_full
+        sw_ones = pl.full([Q_HEAD_TILE, IDX_HEAD_DIM], dtype=pl.FP32, value=1.0)
+        sw_col_idx = pl.arange(0, [1, IDX_HEAD_DIM], dtype=pl.INT32)
+        sw_col_f32 = pl.cast(sw_col_idx, target_type=pl.FP32)
+        sw_col = pl.col_expand_mul(sw_ones, sw_col_f32)
+        sw_row_idx = pl.arange(0, [1, Q_HEAD_TILE], dtype=pl.INT32)
+        sw_row_f32 = pl.cast(sw_row_idx, target_type=pl.FP32)
+        sw_row_col = pl.reshape(sw_row_f32, [Q_HEAD_TILE, 1])
+        sw_row = pl.row_expand_mul(sw_ones, sw_row_col)
+        sw_rowbase = pl.mul(sw_row, IDX_HEAD_DIM_F)
+        sw_half = pl.mul(sw_col, 0.5)
+        sw_dup_i32 = pl.cast(sw_half, target_type=pl.INT32, mode="trunc")
+        sw_dup_f = pl.cast(sw_dup_i32, target_type=pl.FP32)
+        sw_dup_twice = pl.mul(sw_dup_f, 2.0)
+        sw_lane = pl.sub(sw_col, sw_dup_twice)  # j % 2
+        sw_col_next = pl.add(sw_col, 1.0)
+        sw_lane_twice = pl.mul(sw_lane, 2.0)
+        sw_jx = pl.sub(sw_col_next, sw_lane_twice)  # j ^ 1
+        sw_swap_sum = pl.add(sw_rowbase, sw_jx)
+        sw_swap_idx = pl.cast(sw_swap_sum, target_type=pl.INT32)
+        sw_swap_flat = pl.reshape(sw_swap_idx, [1, Q_HEAD_FLAT_LEN])
+        q_swap_idx_t[0:1, 0:Q_HEAD_FLAT_LEN] = sw_swap_flat
 
-    # spmd over ROPE_ROW_TILE-row blocks; batch_idx = block base // ROPE_ROW_BLOCK
-    # picks the per-batch cos/sin row. col_expand_mul folds the [1, ROPE_HEAD_DIM]
-    # row broadcast into the rotation multiply, so no cos_il/sin_il tile is
-    # materialized per block.
-    for idx in pl.spmd(T * IDX_N_HEADS // ROPE_ROW_TILE, name_hint="qr_rope", allow_early_resolve=True):
-        o0 = idx * ROPE_ROW_TILE
-        batch_idx = o0 // ROPE_ROW_BLOCK
-        rope_swap_flat = rope_swap_idx_t[0:1, 0:ROPE_SWAP_FLAT_LEN]
-        cos_row = cos_il_t[batch_idx : batch_idx + 1, 0:ROPE_HEAD_DIM]
-        sin_row = sin_signed_t[batch_idx : batch_idx + 1, 0:ROPE_HEAD_DIM]
-        qr_nope_slice = qr_proj_flat[o0 : o0 + ROPE_ROW_TILE, 0 : IDX_NOPE_HEAD_DIM]
-        qr_rope_slice = qr_proj_flat[o0 : o0 + ROPE_ROW_TILE, IDX_NOPE_HEAD_DIM : IDX_HEAD_DIM]
-        # qr_proj_flat is a GM tensor, so this column window lowers to its own
-        # tile.load and lands as a dense [ROPE_ROW_TILE, ROPE_HEAD_DIM] tile in UB:
-        # the UB row stride is ROPE_HEAD_DIM, which is what the flat index assumes.
-        # Slicing a UB *tile* would instead inherit the parent's row stride -- see
-        # merge_norm in decode_sparse_attn.py, where the rope half is materialized as
-        # an elementwise result for exactly that reason.
-        # rows == 1 -> the a5 lowering uses this index as the flat index directly.
-        qr_rope_flat = pl.reshape(qr_rope_slice, [1, ROPE_SWAP_FLAT_LEN])
-        qr_swapped = pl.reshape(
-            pl.gather(qr_rope_flat, dim=-1, index=rope_swap_flat),
-            [ROPE_ROW_TILE, ROPE_HEAD_DIM])
-        rope_rot = pl.add(
-            pl.col_expand_mul(qr_rope_slice, cos_row), pl.col_expand_mul(qr_swapped, sin_row))
-        qr_vec = pl.concat(
-            pl.cast(qr_nope_slice, target_type=pl.BF16, mode="rint"),
-            pl.cast(rope_rot, target_type=pl.BF16, mode="rint"))
-        qr_bf16[o0 : o0 + ROPE_ROW_TILE, :] = qr_vec
-
-    # cube-only scope: q @ hadamard lands in GM, keeping the vector amax/quant below
-    # in its own scope so the two run as separate cube and vector tasks.
-    qh_acc_gm = pl.create_tensor([T * IDX_N_HEADS, IDX_HEAD_DIM], dtype=pl.FP32)
-    for idx in pl.spmd(T * IDX_N_HEADS // QH_MM_TILE, name_hint="qr_hadamard_matmul", allow_early_resolve=True):
-        o0 = idx * QH_MM_TILE
-        qh_acc = pl.matmul(qr_bf16[o0 : o0 + QH_MM_TILE, :], hadamard, out_dtype=pl.FP32)
-        qh_acc_gm[o0 : o0 + QH_MM_TILE, :] = qh_acc
+    topk_idx_init_t = pl.create_tensor([1, SCORE_LEN], dtype=pl.UINT32)
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="topk_idx_table"):
+        topk_idx_values = pl.arange(0, [1, SCORE_LEN], dtype=pl.UINT32)
+        topk_idx_init_t[0:1, 0:SCORE_LEN] = topk_idx_values
 
     qr_hadamard_i8 = pl.create_tensor([T * IDX_N_HEADS, IDX_HEAD_DIM], dtype=pl.INT8)
     qr_hadamard_scale_dq = pl.create_tensor([T * IDX_N_HEADS, 1], dtype=pl.FP32)
-    for idx in pl.spmd(T * IDX_N_HEADS // QH_QUANT_TILE, name_hint="qr_hadamard_quant", allow_early_resolve=True):
-        o0 = idx * QH_QUANT_TILE
-        qh_amax = pl.full([1, QH_QUANT_TILE], dtype=pl.FP32, value=INT8_AMAX_EPS)
-        for h0 in pl.range(0, IDX_HEAD_DIM, QH_HEAD_DIM_TILE):
-            qh_a_f32 = qh_acc_gm[o0 : o0 + QH_QUANT_TILE, h0 : h0 + QH_HEAD_DIM_TILE]
-            qh_a_abs = pl.maximum(qh_a_f32, pl.neg(qh_a_f32))
-            qh_a_max = pl.reshape(pl.row_max(qh_a_abs), [1, QH_QUANT_TILE])
-            qh_amax = pl.maximum(qh_amax, qh_a_max)
-        qh_scale_quant_row = pl.div(pl.full([1, QH_QUANT_TILE], dtype=pl.FP32, value=INT8_SCALE_MAX), qh_amax)
-        qh_scale_dq = pl.reshape(pl.recip(qh_scale_quant_row), [QH_QUANT_TILE, 1])
-        qr_hadamard_scale_dq[o0 : o0 + QH_QUANT_TILE, :] = qh_scale_dq
-        qh_scale_quant = pl.reshape(qh_scale_quant_row, [QH_QUANT_TILE, 1])
-        for h1 in pl.range(0, IDX_HEAD_DIM, QH_HEAD_DIM_TILE):
-            qh_q_f32 = qh_acc_gm[o0 : o0 + QH_QUANT_TILE, h1 : h1 + QH_HEAD_DIM_TILE]
-            qh_q_scaled = pl.row_expand_mul(qh_q_f32, qh_scale_quant)
-            qh_q_i32 = pl.cast(qh_q_scaled, target_type=pl.INT32, mode="rint")
-            qh_q_half = pl.cast(qh_q_i32, target_type=pl.FP16, mode="round")
-            qh_i8 = pl.cast(qh_q_half, target_type=pl.INT8, mode="trunc")
-            qr_hadamard_i8[o0 : o0 + QH_QUANT_TILE, h1 : h1 + QH_HEAD_DIM_TILE] = qh_i8
+    for idx in pl.spmd(T * IDX_N_HEADS // Q_HEAD_TILE, name_hint="qr_head"):
+        o0 = idx * Q_HEAD_TILE
+        tok = o0 // IDX_N_HEADS
+        c0 = (o0 - tok * IDX_N_HEADS) * IDX_HEAD_DIM
+        qr_batch_idx = tok // S
+        wq_scale_slice = wq_b_scale[c0 : c0 + Q_HEAD_FLAT_LEN]
+        wq_scale_flat = pl.reshape(wq_scale_slice, [1, Q_HEAD_FLAT_LEN])
+        acc_i32 = qr_acc_pad[tok : tok + 1, c0 : c0 + Q_HEAD_FLAT_LEN]
+        acc_flat = pl.cast(acc_i32, target_type=pl.FP32, mode="none")
+        qr_scale_scalar = pl.read(qr_scale, [tok, 0])
+        qr_dequant = pl.mul(acc_flat, qr_scale_scalar)
+        qr_dq_flat = pl.mul(qr_dequant, wq_scale_flat)
+        q_swap_idx = q_swap_idx_t[0:1, 0:Q_HEAD_FLAT_LEN]
+        qr_swapped_flat = pl.gather(qr_dq_flat, dim=-1, index=q_swap_idx)
+        qh_rows = pl.reshape(qr_dq_flat, [Q_HEAD_TILE, IDX_HEAD_DIM])
+        qh_swapped = pl.reshape(qr_swapped_flat, [Q_HEAD_TILE, IDX_HEAD_DIM])
+        cos_full_row = cos_full_t[qr_batch_idx : qr_batch_idx + 1, 0:IDX_HEAD_DIM]
+        qh_cos = pl.col_expand_mul(qh_rows, cos_full_row)
+        sin_full_row = sin_full_t[qr_batch_idx : qr_batch_idx + 1, 0:IDX_HEAD_DIM]
+        qh_sin = pl.col_expand_mul(qh_swapped, sin_full_row)
+        qh_rot = pl.add(qh_cos, qh_sin)
+        qh_rot_bf16 = pl.cast(qh_rot, target_type=pl.BF16, mode="rint")
+        qh_acc = pl.matmul(qh_rot_bf16, hadamard, out_dtype=pl.FP32)
+        qh_a_neg = pl.neg(qh_acc)
+        qh_a_abs = pl.maximum(qh_acc, qh_a_neg)
+        qh_row_max = pl.row_max(qh_a_abs)
+        qh_amax_row = pl.reshape(qh_row_max, [1, Q_HEAD_TILE])
+        qh_amax_floor = pl.full([1, Q_HEAD_TILE], dtype=pl.FP32, value=INT8_AMAX_EPS)
+        qh_amax = pl.maximum(qh_amax_row, qh_amax_floor)
+        qh_scale_max = pl.full([1, Q_HEAD_TILE], dtype=pl.FP32, value=INT8_SCALE_MAX)
+        qh_scale_quant_row = pl.div(qh_scale_max, qh_amax)
+        qh_scale_dq_row = pl.recip(qh_scale_quant_row)
+        qh_scale_dq = pl.reshape(qh_scale_dq_row, [Q_HEAD_TILE, 1])
+        qr_hadamard_scale_dq[o0 : o0 + Q_HEAD_TILE, :] = qh_scale_dq
+        qh_scale_quant = pl.reshape(qh_scale_quant_row, [Q_HEAD_TILE, 1])
+        qh_q_scaled = pl.row_expand_mul(qh_acc, qh_scale_quant)
+        qh_q_i32 = pl.cast(qh_q_scaled, target_type=pl.INT32, mode="rint")
+        qh_q_half = pl.cast(qh_q_i32, target_type=pl.FP16, mode="round")
+        qh_q_i8 = pl.cast(qh_q_half, target_type=pl.INT8, mode="trunc")
+        qr_hadamard_i8[o0 : o0 + Q_HEAD_TILE, :] = qh_q_i8
 
     x_flat = pl.reshape(x, [T, D])
-    weights = pl.create_tensor([T_PAD, IDX_N_HEADS], dtype=pl.FP32)
-    weights_partial = pl.create_tensor([WEIGHTS_OK * MM_ROW_TILE, IDX_N_HEADS], dtype=pl.FP32)
-    # Deferred behind the caller's rms_norm dummy barrier: qkv's qr_proj_matmul is the
-    # critical path and must win the cores when rms_norm retires.
-    with pl.spmd(WEIGHTS_OK, name_hint="weights_proj", deps=[late_dep]) as _weights_tid:
+    weights_partial = pl.create_tensor([(D // WEIGHTS_K_TILE) * MM_ROW_TILE, IDX_N_HEADS], dtype=pl.FP32)
+    with pl.spmd(D // WEIGHTS_K_TILE, name_hint="weights_proj", deps=[late_dep]) as _weights_tid:
         kb = pl.tile.get_block_idx()
-        k_base = kb * WEIGHTS_K_SLICE
+        k_base = kb * WEIGHTS_K_TILE
         weights_acc = pl.create_tensor([MM_ROW_TILE, IDX_N_HEADS], dtype=pl.FP32)
-        for db in pl.range(WEIGHTS_K_SLICE // D_TILE):
+        for db in pl.range(WEIGHTS_K_TILE // D_TILE):
             d0 = k_base + db * D_TILE
-            x_tile = pl.slice(x_flat, [MM_ROW_TILE, D_TILE], [0, d0], valid_shape=[pl.min(MM_ROW_TILE, T), D_TILE])
+            x_rows = pl.min(MM_ROW_TILE, T)
+            x_tile = pl.slice(x_flat, [MM_ROW_TILE, D_TILE], [0, d0], valid_shape=[x_rows, D_TILE])
             weights_proj_tile = weights_proj[d0 : d0 + D_TILE, :]
             if db == 0:
                 weights_acc = pl.matmul(x_tile, weights_proj_tile, out_dtype=pl.FP32)
@@ -303,11 +257,14 @@ def indexer(
                 weights_acc = pl.matmul_acc(weights_acc, x_tile, weights_proj_tile)
         weights_partial[kb * MM_ROW_TILE : kb * MM_ROW_TILE + MM_ROW_TILE, :] = weights_acc
 
+    weights = pl.create_tensor([T_PAD, IDX_N_HEADS], dtype=pl.FP32)
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="weights_proj_reduce"):
         w_sum = weights_partial[0:MM_ROW_TILE, :]
-        for kb in pl.unroll(1, WEIGHTS_OK):
-            w_sum = pl.add(w_sum, weights_partial[kb * MM_ROW_TILE : kb * MM_ROW_TILE + MM_ROW_TILE, :])
-        weights[0:MM_ROW_TILE, :] = pl.mul(w_sum, WEIGHTS_SCALE)
+        for kb in pl.unroll(1, D // WEIGHTS_K_TILE):
+            weights_partial_tile = weights_partial[kb * MM_ROW_TILE : kb * MM_ROW_TILE + MM_ROW_TILE, :]
+            w_sum = pl.add(w_sum, weights_partial_tile)
+        weights_scaled = pl.mul(w_sum, WEIGHTS_SCALE)
+        weights[0:MM_ROW_TILE, :] = weights_scaled
 
     indexer_compressor(
         x, inner_kv,
@@ -319,105 +276,110 @@ def indexer(
     )
 
     kv_cache_i8_flat = pl.reshape(idx_kv_cache, [IDX_CACHE_BLOCK_NUM * BLOCK_SIZE, IDX_HEAD_DIM])
-    kv_scale_flat = pl.reshape(idx_kv_scale, [IDX_CACHE_BLOCK_NUM * BLOCK_SIZE, 1])
     idx_block_table_flat = pl.reshape(idx_block_table, [B * IDX_CACHE_MAX_BLOCKS])
+    score_acc_gm = pl.create_tensor([T * IDX_N_HEADS, SCORE_LEN], dtype=pl.INT32)
+
+    with pl.spmd(SCORE_LANE_TILE, name_hint="score_mat") as score_mat_tid:
+        mat_lane = pl.tile.get_block_idx()
+        for mat_tg in pl.unroll(T):
+            mat_b = mat_tg // S
+            mat_s = mat_tg - mat_b * S
+            mat_cache_len = pl.read(kv_seq_lens, [mat_b]) // COMPRESS_RATIO
+            mat_score_pos = pl.read(position_ids, [mat_b, mat_s])
+            mat_visible_cache = pl.min(mat_cache_len, (mat_score_pos + 1) // COMPRESS_RATIO)
+            mat_visible_len = pl.min(mat_visible_cache, SCORE_LEN)
+            mat_cache_blocks = (mat_visible_len + BLOCK_SIZE - 1) // BLOCK_SIZE
+            mat_q0 = (mat_b * S + mat_s) * IDX_N_HEADS
+            mat_lane_rot = mat_lane + (SCORE_LANE_TILE - mat_tg % SCORE_LANE_TILE) % SCORE_LANE_TILE
+            mat_first_block = mat_lane_rot - SCORE_LANE_TILE * (mat_lane_rot // SCORE_LANE_TILE)
+            mat_lane_iters = (mat_cache_blocks - mat_first_block + SCORE_LANE_TILE - 1) // SCORE_LANE_TILE
+            if mat_lane_iters > 0:
+                mat_query = qr_hadamard_i8[mat_q0 : mat_q0 + IDX_N_HEADS, 0:IDX_HEAD_DIM]
+                for mat_local_block in pl.pipeline(0, mat_lane_iters, stage=2):
+                    mat_cache_block = mat_first_block + mat_local_block * SCORE_LANE_TILE
+                    mat_c0 = mat_cache_block * BLOCK_SIZE
+                    mat_block_raw = pl.read(idx_block_table_flat, [mat_b * IDX_CACHE_MAX_BLOCKS + mat_cache_block])
+                    mat_block_id = pl.cast(mat_block_raw, pl.INDEX)
+                    mat_kv0 = mat_block_id * BLOCK_SIZE
+                    mat_kv_tile = kv_cache_i8_flat[mat_kv0 : mat_kv0 + BLOCK_SIZE, :]
+                    mat_score_acc = pl.matmul(mat_query, mat_kv_tile, out_dtype=pl.INT32, b_trans=True)
+                    score_acc_gm[mat_q0 : mat_q0 + IDX_N_HEADS, mat_c0 : mat_c0 + BLOCK_SIZE] = mat_score_acc
+
+    kv_scale_rows = pl.reshape(idx_kv_scale, [IDX_CACHE_BLOCK_NUM, BLOCK_SIZE])
     score_flat = pl.reshape(score, [T, SCORE_LEN])
-
-    # No score_init: reduce writes the valid region; the tail is never read (topk re-masks).
-    # Two GM-handoff stages: matmul (cube, reads paged C8 directly) -> reduce (vec).
-    score_acc_gm = pl.create_tensor([T * IDX_KV_LEN, IDX_N_HEADS], dtype=pl.INT32)
-
-    # read paged C8 KV one page per tile, matmul with the per-step-quantized query
-    for tg in pl.spmd(T, name_hint="score_mat", allow_early_resolve=True):
-        b = tg // S
-        s = tg - b * S
-        clen_b = pl.read(kv_seq_lens, [b]) // COMPRESS_RATIO
-        cblk_b = (clen_b + BLOCK_SIZE - 1) // BLOCK_SIZE
-        qb = b * S * IDX_N_HEADS
-        qr_full = qr_hadamard_i8[qb + s * IDX_N_HEADS : qb + (s + 1) * IDX_N_HEADS, 0 : IDX_HEAD_DIM]
-        for cb in pl.pipeline(0, cblk_b, stage=2):
-            cache0 = cb * BLOCK_SIZE
-            idx_blk_id = pl.cast(
-                pl.read(idx_block_table_flat, [b * IDX_CACHE_MAX_BLOCKS + cb]),
-                pl.INDEX,
-            )
-            kv0 = idx_blk_id * BLOCK_SIZE
-            base = tg * IDX_KV_LEN + cache0
-            kv_i8_mat = kv_cache_i8_flat[kv0 : kv0 + BLOCK_SIZE, :]
-            score_acc_mat = pl.matmul(kv_i8_mat, qr_full, out_dtype=pl.INT32, b_trans=True)
-            score_acc_gm[base : base + BLOCK_SIZE, :] = score_acc_mat
-
-    for unit in pl.spmd(T * REDUCE_NSPLIT, name_hint="score_reduce", allow_early_resolve=True):
-        tg = unit // REDUCE_NSPLIT
-        split = unit - tg * REDUCE_NSPLIT
-        b = tg // S
-        s = tg - b * S
-        clen_b = pl.read(kv_seq_lens, [b]) // COMPRESS_RATIO
-        pos_t = pl.read(position_ids, [b, s])
-        visible_len_t = pl.min(pl.min(clen_b, (pos_t + 1) // COMPRESS_RATIO), SCORE_LEN)
-        cblk_t = (visible_len_t + REDUCE_TILE - 1) // REDUCE_TILE
-        tb = b * S
-        qb = b * S * IDX_N_HEADS
-        qh_scale_s = pl.reshape(qr_hadamard_scale_dq[qb + s * IDX_N_HEADS : qb + (s + 1) * IDX_N_HEADS, :], [1, IDX_N_HEADS])
-        weights_row_s = pl.reshape(weights[tb + s : tb + s + 1, :], [1, IDX_N_HEADS])
-        lane_iters = (cblk_t - split + REDUCE_NSPLIT - 1) // REDUCE_NSPLIT
-        for cb_local in pl.pipeline(0, lane_iters, stage=2):
-            cb = split + cb_local * REDUCE_NSPLIT
-            cache0 = cb * REDUCE_TILE
-            valid_len = pl.min(REDUCE_TILE, visible_len_t - cache0)
-            base = tg * IDX_KV_LEN + cache0
-            idx_blk_id = pl.cast(
-                pl.read(idx_block_table_flat, [b * IDX_CACHE_MAX_BLOCKS + cb]),
-                pl.INDEX,
-            )
-            kv0 = idx_blk_id * BLOCK_SIZE
-            score_acc_red = score_acc_gm[base : base + REDUCE_TILE, :]
-            kv_dq_red = kv_scale_flat[kv0 : kv0 + REDUCE_TILE, :]  # paged per-position dequant scale
-            score_tile_red = pl.cast(score_acc_red, target_type=pl.FP32, mode="none")
-            # per-position dequant kv_dq_red applied after the head-sum
-            score_tile_red = pl.col_expand_mul(score_tile_red, qh_scale_s)
-            relu_score_red = pl.maximum(score_tile_red, pl.full([REDUCE_TILE, IDX_N_HEADS], dtype=pl.FP32, value=0.0))
-            weighted_score_red = pl.col_expand_mul(relu_score_red, weights_row_s)
-            weighted_score_row = pl.mul(pl.row_sum(weighted_score_red), kv_dq_red)
-            weighted_score_s = pl.reshape(weighted_score_row, [1, REDUCE_TILE])
-            weighted_score_valid_s = pl.fillpad(pl.set_validshape(weighted_score_s, 1, valid_len), pad_value=pl.PadValue.min)
-            weighted_score_valid_s = pl.maximum(
-                weighted_score_valid_s,
-                pl.full([1, REDUCE_TILE], dtype=pl.FP32, value=FP32_NEG_INF),
-            )
-            score_flat[tb + s : tb + s + 1, cache0 : cache0 + REDUCE_TILE] = weighted_score_valid_s
+    with pl.spmd(SCORE_LANE_TILE, name_hint="score_reduce", deps=[score_mat_tid]) as score_reduce_tid:
+        reduce_lane = pl.tile.get_block_idx()
+        for reduce_tg in pl.unroll(T):
+            reduce_b = reduce_tg // S
+            reduce_s = reduce_tg - reduce_b * S
+            reduce_cache_len = pl.read(kv_seq_lens, [reduce_b]) // COMPRESS_RATIO
+            reduce_score_pos = pl.read(position_ids, [reduce_b, reduce_s])
+            reduce_visible_cache = pl.min(reduce_cache_len, (reduce_score_pos + 1) // COMPRESS_RATIO)
+            reduce_visible_len = pl.min(reduce_visible_cache, SCORE_LEN)
+            reduce_cache_blocks = (reduce_visible_len + BLOCK_SIZE - 1) // BLOCK_SIZE
+            reduce_t = reduce_b * S + reduce_s
+            reduce_q0 = reduce_t * IDX_N_HEADS
+            reduce_lane_rot = reduce_lane + (SCORE_LANE_TILE - reduce_tg % SCORE_LANE_TILE) % SCORE_LANE_TILE
+            reduce_first_block = reduce_lane_rot - SCORE_LANE_TILE * (reduce_lane_rot // SCORE_LANE_TILE)
+            reduce_lane_iters = (reduce_cache_blocks - reduce_first_block + SCORE_LANE_TILE - 1) // SCORE_LANE_TILE
+            if reduce_lane_iters > 0:
+                reduce_query_scale = qr_hadamard_scale_dq[reduce_q0 : reduce_q0 + IDX_N_HEADS, :]
+                reduce_weight_row = weights[reduce_t : reduce_t + 1, 0:IDX_N_HEADS]
+                reduce_weight_col = pl.reshape(reduce_weight_row, [IDX_N_HEADS, 1])
+                reduce_head_scale = pl.mul(reduce_query_scale, reduce_weight_col)
+                for reduce_local_block in pl.pipeline(0, reduce_lane_iters, stage=2):
+                    reduce_cache_block = reduce_first_block + reduce_local_block * SCORE_LANE_TILE
+                    reduce_c0 = reduce_cache_block * BLOCK_SIZE
+                    reduce_valid_len = pl.min(BLOCK_SIZE, reduce_visible_len - reduce_c0)
+                    reduce_block_index = reduce_b * IDX_CACHE_MAX_BLOCKS + reduce_cache_block
+                    reduce_block_raw = pl.read(idx_block_table_flat, [reduce_block_index])
+                    reduce_block_id = pl.cast(reduce_block_raw, pl.INDEX)
+                    reduce_acc = score_acc_gm[reduce_q0 : reduce_q0 + IDX_N_HEADS, reduce_c0 : reduce_c0 + BLOCK_SIZE]
+                    reduce_score_fp32 = pl.cast(reduce_acc, target_type=pl.FP32, mode="none")
+                    reduce_score_relu = pl.maximum(reduce_score_fp32, 0.0)
+                    reduce_score_weighted = pl.row_expand_mul(reduce_score_relu, reduce_head_scale)
+                    reduce_score_head_sum = pl.col_sum(reduce_score_weighted)
+                    reduce_kv_scale = kv_scale_rows[reduce_block_id : reduce_block_id + 1, 0:BLOCK_SIZE]
+                    reduce_score_dequant = pl.mul(reduce_score_head_sum, reduce_kv_scale)
+                    reduce_score_shape = pl.set_validshape(reduce_score_dequant, 1, reduce_valid_len)
+                    reduce_score_padded = pl.fillpad(reduce_score_shape, pad_value=pl.PadValue.min)
+                    reduce_score_valid = pl.maximum(reduce_score_padded, FP32_NEG_INF)
+                    score_flat[reduce_t : reduce_t + 1, reduce_c0 : reduce_c0 + BLOCK_SIZE] = reduce_score_valid
 
     topk_idxs_flat = pl.reshape(topk_idxs, [T, SCORE_LEN])
-    for t in pl.spmd(T, name_hint="topk", allow_early_resolve=True):
+    with pl.spmd(T, name_hint="topk", deps=[score_reduce_tid]) as _topk_tid:
+        t = pl.tile.get_block_idx()
         invalid_idxs = pl.full([1, SCORE_LEN], dtype=pl.INT32, value=-1)
         topk_idxs_flat[t : t + 1, :] = invalid_idxs
-        batch_idx = t // S
-        token_s = t - batch_idx * S
-        cache_len_b = pl.read(kv_seq_lens, [batch_idx]) // COMPRESS_RATIO
-        pos_t = pl.read(position_ids, [batch_idx, token_s])
-        visible_len_t = pl.min(pl.min(cache_len_b, (pos_t + 1) // COMPRESS_RATIO), SCORE_LEN)
-        if visible_len_t > 0:
+        topk_batch_idx = t // S
+        token_s = t - topk_batch_idx * S
+        cache_len_b = pl.read(kv_seq_lens, [topk_batch_idx]) // COMPRESS_RATIO
+        topk_pos = pl.read(position_ids, [topk_batch_idx, token_s])
+        topk_visible_cache = pl.min(cache_len_b, (topk_pos + 1) // COMPRESS_RATIO)
+        topk_visible_len = pl.min(topk_visible_cache, SCORE_LEN)
+        if topk_visible_len > 0:
             offset_i32 = pl.cast(offset, target_type=pl.INT32)
             score_full_raw = score_flat[t : t + 1, 0:SCORE_LEN]
-            score_full = pl.fillpad(pl.set_validshape(score_full_raw, 1, visible_len_t), pad_value=pl.PadValue.min)
-            score_full = pl.maximum(score_full, pl.full([1, SCORE_LEN], dtype=pl.FP32, value=FP32_NEG_INF))
-            idx_init = pl.arange(0, [1, SCORE_LEN], dtype=pl.UINT32)
-            sorted_full = pl.sort32(score_full, idx_init)
-            sorted_full = pl.mrgsort(sorted_full, block_len=64)
-            sorted_full = pl.mrgsort(sorted_full, block_len=256)
-            sorted_full = pl.mrgsort(sorted_full, block_len=1024)
+            score_full_shape = pl.set_validshape(score_full_raw, 1, topk_visible_len)
+            score_full_padded = pl.fillpad(score_full_shape, pad_value=pl.PadValue.min)
+            score_floor = pl.full([1, SCORE_LEN], dtype=pl.FP32, value=FP32_NEG_INF)
+            score_full = pl.maximum(score_full_padded, score_floor)
+            topk_index_row = topk_idx_init_t[0:1, 0:SCORE_LEN]
+            sorted_32 = pl.sort32(score_full, topk_index_row)
+            sorted_64 = pl.mrgsort(sorted_32, block_len=64)
+            sorted_256 = pl.mrgsort(sorted_64, block_len=256)
+            sorted_full = pl.mrgsort(sorted_256, block_len=1024)
 
-            # After the 1024 merge, the 4096-score row is two sorted 2048-score
-            # runs. sort32/mrgsort keeps score/index pairs interleaved, so the
-            # second 2048-score run starts at pair-lane offset 2 * 2048.
+            # Merge the two sorted 2048-score runs.
             half0_candidates = sorted_full[:, 0:TOPK_PAIR_WIDTH]
             half1_candidates = sorted_full[:, TOPK_HALF_PAIR_OFFSET : TOPK_HALF_PAIR_OFFSET + TOPK_PAIR_WIDTH]
             merged_candidates = pl.mrgsort(half0_candidates, half1_candidates)
             topk_pairs = merged_candidates[:, 0:TOPK_PAIR_WIDTH]
             topk_idxs_tile = pl.gather(topk_pairs, mask_pattern=pl.tile.MaskPattern.P1010, output_dtype=pl.INT32)
-            valid_topk = pl.min(IDX_TOPK, visible_len_t)
+            valid_topk = pl.min(IDX_TOPK, topk_visible_len)
             topk_idxs_valid = pl.set_validshape(topk_idxs_tile, 1, valid_topk)
-            topk_idxs_flat[t : t + 1, 0:IDX_TOPK] = pl.add(topk_idxs_valid, offset_i32)
+            topk_idxs_offset = pl.add(topk_idxs_valid, offset_i32)
+            topk_idxs_flat[t : t + 1, 0:IDX_TOPK] = topk_idxs_offset
 
     return idx_kv_cache, idx_kv_scale, inner_compress_state, score, topk_idxs
 
@@ -456,36 +418,16 @@ def indexer_test(
     kv_seq_lens: pl.Tensor[[B], pl.INT32],
     offset: pl.Scalar[pl.INT32],
 ):
-    # Standalone: no rms_norm producer, so the barrier fences nothing (ready on submit).
     late_dep = pl.system.task_dummy(deps=[])
     indexer(
-        x,
-        qr,
-        qr_scale,
-        wq_b,
-        wq_b_scale,
-        weights_proj,
-        cos,
-        sin,
-        hadamard,
-        inner_kv,
-        inner_compress_state,
-        inner_compress_state_block_table,
-        inner_wkv,
-        inner_wgate,
-        inner_ape,
-        inner_norm_w,
-        idx_kv_cache,
-        idx_kv_scale,
-        idx_block_table,
-        score,
-        topk_idxs,
-        position_ids,
-        idx_slot_mapping,
-        inner_state_slot_mapping,
-        kv_seq_lens,
-        offset,
-        late_dep,
+        x, qr, qr_scale, wq_b, wq_b_scale, weights_proj,
+        cos, sin, hadamard,
+        inner_kv, inner_compress_state, inner_compress_state_block_table,
+        inner_wkv, inner_wgate, inner_ape, inner_norm_w,
+        idx_kv_cache, idx_kv_scale, idx_block_table,
+        score, topk_idxs,
+        position_ids, idx_slot_mapping, inner_state_slot_mapping, kv_seq_lens,
+        offset, late_dep,
     )
     return score, inner_compress_state, idx_kv_cache, idx_kv_scale, topk_idxs
 
@@ -504,30 +446,19 @@ def _int8_quant_per_row(x):
 
 
 def gen_shared_weight(shape, dequant_std, chan_cv):
-    """Synthesize a per-output-channel-symmetric INT8 weight + FP32 scale by simulating the
-    real DeepSeek-V4-Flash MXFP8 quant grid (e4m3, 128x128-block E8M0 scale), then re-quantizing
-    per-output-channel. Used for the indexer ``idx wq_b`` (and shared by decode_attention_csa),
-    which follows the same FP8 grid as the shared experts: ~200 discrete levels, ~1.1% zero
-    spike, per-channel scale CV ~0.61. A plain randn INT8 misses that level/scale structure.
-    ``chan_cv`` (log-space source-gain std) injects the per-output-channel magnitude spread the
-    coarse 128-block scale leaves behind; per-channel INT8 is scale-invariant, so the grid sets
-    the level shape and ``dequant_std`` only sets the absolute scale magnitude.
-
-    ``shape`` last dim = reduction (in) dim; leading dims map to the per-output-channel scale
-    shape ([out, in] -> scale [out]).
-    """
+    """Generate per-output-channel INT8 weights from an MXFP8 E4M3/E8M0 grid."""
     import torch
 
     FP8_MAX, TINY = 448.0, 1e-20
 
-    def sim_fp8(W, block=128):   # e4m3 + 128x128-block E8M0 (round-up) scale on (out, in)
+    def sim_fp8(W, block=128):
         out, inn = W.shape
         Wb = W.reshape(out // block, block, inn // block, block)
         scale = torch.exp2(torch.ceil(torch.log2((Wb.abs().amax(dim=(1, 3), keepdim=True) / FP8_MAX).clamp_min(TINY))))
         q = (Wb / scale).to(torch.float8_e4m3fn).float() * scale
         return q.reshape(out, inn)
 
-    W = torch.randn(*shape) * torch.exp(chan_cv * torch.randn(*shape[:-1], 1))  # per-channel gain
+    W = torch.randn(*shape) * torch.exp(chan_cv * torch.randn(*shape[:-1], 1))
     Wq = sim_fp8(W)
     amax = Wq.abs().amax(dim=-1, keepdim=True).clamp_min(INT8_AMAX_EPS)
     scale = amax / INT8_SCALE_MAX
@@ -570,9 +501,7 @@ def golden_indexer(tensors):
     q = torch.cat([q[..., :-rd], torch.stack([y0, y1], dim=-1).flatten(-2)], dim=-1)
 
     q = q.to(torch.bfloat16).float() @ hadamard
-    # W8A8C16: q and Indexer Cache are quantized per row to INT8 for score matmul,
-    # then dequantized with q_scale * kv_scale.
-    # flash: fp4_act_quant on q (FP4 simulation).
+    # Per-row INT8 query values and scales feed the score matmul.
 
     inner_tensors = {
         "x": tensors["x"],
@@ -596,7 +525,7 @@ def golden_indexer(tensors):
 
     weights = (x @ weights_proj) * WEIGHTS_SCALE
 
-    # C8 cache: pre-quantized INT8 KV + per-position dequant scale (no score-time re-quant)
+    # The index cache stores INT8 KV rows and per-position dequantization scales.
     idx_kv_cache_i8 = tensors["idx_kv_cache"]
     idx_kv_scale = tensors["idx_kv_scale"].float()
     idx_block_table = tensors["idx_block_table"]
@@ -805,8 +734,7 @@ def decode_topk_compare(
             )
             candidate_error = (actual_row - expected_row).abs()
 
-            # A score outlier that fits the score tensor's global ratio budget
-            # must not justify a changed selection or order.
+            # Check pointwise score errors for displaced candidates.
             displaced = torch.unique(
                 torch.cat((actual_order[mismatch], expected_order[mismatch]))
             )
@@ -825,10 +753,7 @@ def decode_topk_compare(
                     f"expected={float(expected_row[candidate].item()):.6g})"
                 )
 
-            # Every earlier/later pair emitted by the kernel must remain
-            # descending under its own score uncertainty. A prefix minimum of
-            # the earlier upper bounds checks all pairs in O(k), without
-            # constructing a 1024-by-1024 rank-inversion matrix.
+            # Check selected candidates remain descending within score uncertainty.
             if k >= 2:
                 for label, row in (
                     ("expected", expected_row),
@@ -881,9 +806,7 @@ def decode_topk_compare(
                             f"joint_bound={joint_bound:.6g}"
                         )
 
-            # When visible > k, an internally sorted but wholly inferior set
-            # would pass an order-only check. Compare candidates crossing the
-            # top-k boundary using both the reference and emitted score grids.
+            # Check candidate changes across the top-k boundary.
             if visible > k:
                 missing_mask = ~torch.isin(expected_order, actual_order)
                 added_mask = ~torch.isin(actual_order, expected_order)
@@ -1018,7 +941,7 @@ score_valid_compare.__name__ = "score_valid_region_compare"
 
 
 def build_tensor_specs(start_pos=None):
-    import torch  # type: ignore[import]
+    import torch
     from decode_metadata import (
         block_table,
         compressed_slot_mapping,
@@ -1037,9 +960,6 @@ def build_tensor_specs(start_pos=None):
         return torch.rand(B, S, D)
     def init_qr():
         return torch.rand(T, Q_LORA)
-    # weights_proj / inner compressor calibrated to the real DeepSeek-V4-Flash CSA indexer
-    # (mean l8/l32 of extract_weights_flash): zero-mean Gaussian at the measured std, gamma
-    # near the measured mean. idx wq_b uses the MXFP8 grid below (not a benign randn INT8).
     def init_weights_proj():
         return torch.randn(D, IDX_N_HEADS) * 0.2313
     def init_rope_positions():
@@ -1075,7 +995,6 @@ def build_tensor_specs(start_pos=None):
             physical_blocks=IDX_CACHE_MAX_BLOCKS,
         )
     def init_default_start_pos():
-        # Canonical CSA start-position set (ratio-4 compressor + indexer + sliding-window + 8k).
         return csa_decode_start_set(
             batch=B, seq=S, compress_ratio=COMPRESS_RATIO,
             state_block_size=INNER_STATE_BLOCK_SIZE, cache_tile=CACHE_TILE)
@@ -1106,15 +1025,11 @@ def build_tensor_specs(start_pos=None):
             block_size=BLOCK_SIZE,
         )
 
-    # idx wq_b: simulate the real MXFP8 (e4m3 + 128x128-block E8M0) grid (~200 levels, scaleCV
-    # ~0.61, ~1.1% zero spike) instead of a benign randn INT8. gen_shared_weight reduces over
-    # the last (in) dim, so build [out, in] then transpose.
     wq_b_i8_T, wq_b_scale = gen_shared_weight(
         (IDX_N_HEADS * IDX_HEAD_DIM, Q_LORA), dequant_std=0.108, chan_cv=0.56)
     wq_b_i8 = wq_b_i8_T.t().contiguous()
     qr_i8, qr_scale = _int8_quant_per_row(init_qr())
 
-    # C8 indexer cache fixture: INT8 + scale from one bf16-rounded random draw
     idx_kv_cache_bf16 = torch.rand(IDX_CACHE_BLOCK_NUM, BLOCK_SIZE, 1, IDX_HEAD_DIM).to(torch.bfloat16)
     idx_kv_i8, idx_kv_sc = _int8_quant_per_row(
         idx_kv_cache_bf16.float().reshape(IDX_CACHE_BLOCK_NUM * BLOCK_SIZE, IDX_HEAD_DIM))
@@ -1141,7 +1056,7 @@ def build_tensor_specs(start_pos=None):
         TensorSpec("idx_kv_cache", [IDX_CACHE_BLOCK_NUM, BLOCK_SIZE, 1, IDX_HEAD_DIM], torch.int8, init_value=lambda: idx_kv_i8, is_output=True),
         TensorSpec("idx_kv_scale", [IDX_CACHE_BLOCK_NUM, BLOCK_SIZE, 1, 1], torch.float32, init_value=lambda: idx_kv_sc, is_output=True),
         TensorSpec("idx_block_table", [B, IDX_CACHE_MAX_BLOCKS], torch.int32, init_value=init_idx_block_table),
-        # Outputs are fixed to SCORE_LEN; positions past cache_len are -inf for score and -1 for topk_idxs.
+        # Output tails use -inf scores and -1 indices.
         TensorSpec("score", [B, S, SCORE_LEN], torch.float32, is_output=True),
         TensorSpec("topk_idxs", [B, S, SCORE_LEN], torch.int32, is_output=True),
         TensorSpec("position_ids", [B, S], torch.int32, init_value=init_position_ids),
@@ -1191,8 +1106,7 @@ if __name__ == "__main__":
             "topk_idxs":    decode_topk_compare,
             "inner_compress_state": mapped_inner_state_ratio_allclose(
                 atol=1e-3, rtol=1e-3, max_error_ratio=0.0),
-            # Ratio budgets apply only to rows written by the current slot mappings;
-            # every historical/unallocated physical row must remain bitwise exact.
+            # Compare rows selected by the current slot mappings.
             "idx_kv_cache": mapped_idx_cache_ratio_allclose(
                 atol=1, rtol=0, max_error_ratio=0.01),
             "idx_kv_scale": mapped_idx_cache_ratio_allclose(

--- a/models/deepseek_v4_pro/decode_indexer_compressor.py
+++ b/models/deepseek_v4_pro/decode_indexer_compressor.py
@@ -8,24 +8,21 @@
 # -----------------------------------------------------------------------------------------------------------
 """DeepSeek-V4 Indexer KV Compressor (decode incremental, ratio=4 overlap)."""
 
-
 import pypto.language as pl
-
-from golden import mapped_pool_ratio_allclose
 
 from config import (
     ACTIVE as M,
-    DECODE_BATCH,
-    DECODE_SEQ,
     BLOCK_SIZE,
     C4A_COMPRESSOR_BLOCK_SIZE,
+    DECODE_BATCH,
     DECODE_IDX_BLOCK_NUM,
-    IDX_CACHE_MAX_BLOCKS,
+    DECODE_SEQ,
     FP32_NEG_INF,
-    INT8_SCALE_MAX,
+    IDX_CACHE_MAX_BLOCKS,
     INT8_AMAX_EPS,
+    INT8_SCALE_MAX,
 )
-
+from golden import mapped_pool_ratio_allclose
 
 # model config
 B = DECODE_BATCH
@@ -37,14 +34,14 @@ HEAD_DIM_INV = 1.0 / HEAD_DIM
 ROPE_HEAD_DIM = M.qk_rope_head_dim
 NOPE_HEAD_DIM = M.index_nope_head_dim
 MAX_SEQ_LEN = M.max_position_embeddings
+ROPE_HEAD_DIM_F = float(ROPE_HEAD_DIM)
+ROPE_HALF_F = float(ROPE_HEAD_DIM // 2)
 
-# kernel-local (ratio-4 overlapping compressor)
+# compressor config
 COMPRESS_RATIO = 4
 OVERLAP = COMPRESS_RATIO == 4
 COFF = 1 + int(OVERLAP)
 OUT_DIM = COFF * HEAD_DIM
-STATE_LEN = COFF * COMPRESS_RATIO
-IDX_KV_LEN = MAX_SEQ_LEN // COMPRESS_RATIO
 COMPRESS_STATE_BLOCK_SIZE = C4A_COMPRESSOR_BLOCK_SIZE
 COMPRESS_STATE_PHYSICAL_BLOCKS = 65
 COMPRESS_STATE_MAX_BLOCKS = (MAX_SEQ_LEN + COMPRESS_STATE_BLOCK_SIZE - 1) // COMPRESS_STATE_BLOCK_SIZE
@@ -53,24 +50,16 @@ COMPRESS_STATE_DIM = 2 * OUT_DIM
 IDX_CACHE_BLOCK_NUM = DECODE_IDX_BLOCK_NUM
 
 # tiling
-ROPE_TILE = 32
 K_TILE = 512
 OUT_TILE = 64
-PROJ_OUT_TILE = 32  # kv_score_proj N-tile
+PROJ_OUT_TILE = 32  # Cube N tile.
 assert PROJ_OUT_TILE % 16 == 0, "cube tile cols must be a multiple of 16"
-B_TILE = 8
 MM_B_TILE = 16
 BS_PAD = ((B * S + MM_B_TILE - 1) // MM_B_TILE) * MM_B_TILE
 HEAD_TILE = 64
-HEAD_DIM_TILE = 128
-RMS_PAD_TILE = 16  # pad B rows up to one 16-row block (hadamard matmul M multiple of 16)
-# rmsnorm_rope gathers with a single-row flat index so the a5 gather lowering's
-# per-call row-base chain (tile.ci/divs/muls/add) hits its rows==1 early-out.
+RMS_PAD_TILE = 16
 CMP_SWAP_FLAT_LEN = RMS_PAD_TILE * ROPE_HEAD_DIM
-ROPE_HEAD_DIM_F = float(ROPE_HEAD_DIM)
-ROPE_HEAD_DIM_INV = 1.0 / ROPE_HEAD_DIM
-RMS_PAD_ROWS = RMS_PAD_TILE  # single block; requires B <= RMS_PAD_TILE
-assert B <= RMS_PAD_TILE
+CMP_DUP_SRC_LEN = RMS_PAD_TILE * (ROPE_HEAD_DIM // 2)
 
 
 @pl.jit.inline
@@ -105,13 +94,7 @@ def indexer_compressor(
     x_flat = pl.reshape(x, [B * S, D])
     kv_proj_pad = pl.create_tensor([BS_PAD, OUT_DIM], dtype=pl.FP32)
     score_proj_pad = pl.create_tensor([BS_PAD, OUT_DIM], dtype=pl.FP32)
-    compress_state_flat = pl.reshape(compress_state, [COMPRESS_STATE_BLOCK_NUM * COMPRESS_STATE_BLOCK_SIZE, COMPRESS_STATE_DIM])
-    kv_flat = pl.reshape(kv, [B * S, HEAD_DIM])
-    idx_kv_cache_flat = pl.reshape(idx_kv_cache, [IDX_CACHE_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
-    idx_kv_scale_flat = pl.reshape(idx_kv_scale, [IDX_CACHE_BLOCK_NUM * BLOCK_SIZE, 1])
 
-    # Deferred behind the caller's rms_norm dummy barrier: qkv's qr_proj_matmul is the
-    # critical path and must win the cores when rms_norm retires.
     with pl.spmd(
         BS_PAD * OUT_DIM // (MM_B_TILE * PROJ_OUT_TILE), name_hint="kv_score_proj", deps=[late_dep]
     ) as _kv_score_tid:
@@ -124,11 +107,6 @@ def indexer_compressor(
             k0 = kb * K_TILE
             x_rows = pl.min(MM_B_TILE, B * S - global_row0)
             x_tile = pl.slice(x_flat, [MM_B_TILE, K_TILE], [global_row0, k0], valid_shape=[x_rows, K_TILE])
-            # Weights stored transposed [OUT_DIM, D] and consumed via b_trans=True so the
-            # GM->L1 load is a DN2ZN (each [PROJ_OUT_TILE, K_TILE] row is K-contiguous = long
-            # bursts) instead of ND2NZ on [K_TILE, PROJ_OUT_TILE] (K strided = many short
-            # bursts). Mirrors the main compressor (decode_compressor_ratio4); the strided
-            # ND2NZ form here was ~2x slower on this matmul (43us -> ~20us per task).
             wkv_tile = wkv[o0 : o0 + PROJ_OUT_TILE, k0 : k0 + K_TILE]
             wgate_tile = wgate[o0 : o0 + PROJ_OUT_TILE, k0 : k0 + K_TILE]
             if k0 == 0:
@@ -141,10 +119,10 @@ def indexer_compressor(
         kv_proj_pad[global_row0 : global_row0 + MM_B_TILE, o0 : o0 + PROJ_OUT_TILE] = kv_acc
         score_proj_pad[global_row0 : global_row0 + MM_B_TILE, o0 : o0 + PROJ_OUT_TILE] = score_acc
 
-    # scatter_softmax_pool: per batch, scatter the padded proj rows into compress_state, then
-    # online-softmax pool that batch's window into pooled_kv. One region -- each batch's pool
-    # reads only its own just-scattered state (per-batch block table), so no cross-task barrier.
-    pooled_kv = pl.create_tensor([RMS_PAD_ROWS, HEAD_DIM], dtype=pl.FP32)
+    compress_state_flat = pl.reshape(
+        compress_state, [COMPRESS_STATE_BLOCK_NUM * COMPRESS_STATE_BLOCK_SIZE, COMPRESS_STATE_DIM]
+    )
+    pooled_kv = pl.create_tensor([RMS_PAD_TILE, HEAD_DIM], dtype=pl.FP32)
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="scatter_softmax_pool"):
         for c_idx in pl.range(B):
             for s_sc in pl.pipeline(S, stage=2):
@@ -157,9 +135,9 @@ def indexer_compressor(
                     kv_tile = kv_proj_pad[proj_row : proj_row + 1, 0 : OUT_DIM]
                     score_tile = score_proj_pad[proj_row : proj_row + 1, 0 : OUT_DIM]
                     ape_tile = ape[token_ape_row : token_ape_row + 1, 0 : OUT_DIM]
-                    score_tile = pl.add(score_tile, ape_tile)
+                    score_ape_tile = pl.add(score_tile, ape_tile)
                     compress_state_flat[state_row : state_row + 1, 0 : OUT_DIM] = kv_tile
-                    compress_state_flat[state_row : state_row + 1, OUT_DIM : 2 * OUT_DIM] = score_tile
+                    compress_state_flat[state_row : state_row + 1, OUT_DIM : 2 * OUT_DIM] = score_ape_tile
 
             pad_idx = c_idx
             first_pos_b = pl.read(position_ids, [c_idx, 0])
@@ -175,11 +153,13 @@ def indexer_compressor(
                     last_abs = cur_window_start_b + COMPRESS_RATIO - 1
                     last_blk_off = last_abs // COMPRESS_STATE_BLOCK_SIZE
                     last_intra = last_abs % COMPRESS_STATE_BLOCK_SIZE
-                    last_blk_id = pl.cast(pl.read(compress_state_block_table, [c_idx, last_blk_off]), pl.INDEX)
+                    last_blk_raw = pl.read(compress_state_block_table, [c_idx, last_blk_off])
+                    last_blk_id = pl.cast(last_blk_raw, pl.INDEX)
                     last_row = last_blk_id * COMPRESS_STATE_BLOCK_SIZE + last_intra
                     last_col0 = OUT_DIM + HEAD_DIM + h0
                     mi = compress_state_flat[last_row : last_row + 1, last_col0 : last_col0 + HEAD_TILE]
-                    li = pl.exp(pl.sub(mi, mi))
+                    li_diff = pl.sub(mi, mi)
+                    li = pl.exp(li_diff)
                     oi = compress_state_flat[last_row : last_row + 1, HEAD_DIM + h0 : HEAD_DIM + h0 + HEAD_TILE]
 
                     for s in pl.range(0, COMPRESS_RATIO):
@@ -189,121 +169,137 @@ def indexer_compressor(
                         if first_pos_b >= COMPRESS_RATIO:
                             prev_blk_off = prev_abs // COMPRESS_STATE_BLOCK_SIZE
                             prev_intra = prev_abs % COMPRESS_STATE_BLOCK_SIZE
-                            prev_blk_id = pl.cast(pl.read(compress_state_block_table, [c_idx, prev_blk_off]), pl.INDEX)
+                            prev_blk_raw = pl.read(compress_state_block_table, [c_idx, prev_blk_off])
+                            prev_blk_id = pl.cast(prev_blk_raw, pl.INDEX)
                             prev_row = prev_blk_id * COMPRESS_STATE_BLOCK_SIZE + prev_intra
                             front_score = compress_state_flat[prev_row : prev_row + 1, OUT_DIM + h0 : OUT_DIM + h0 + HEAD_TILE]
                             front_kv = compress_state_flat[prev_row : prev_row + 1, h0 : h0 + HEAD_TILE]
                         mi_next_front = pl.maximum(mi, front_score)
-                        alpha_front = pl.exp(pl.sub(mi, mi_next_front))
-                        beta_front = pl.exp(pl.sub(front_score, mi_next_front))
-                        li = pl.add(pl.mul(alpha_front, li), beta_front)
-                        oi = pl.add(pl.mul(oi, alpha_front), pl.mul(front_kv, beta_front))
+                        alpha_front_diff = pl.sub(mi, mi_next_front)
+                        alpha_front = pl.exp(alpha_front_diff)
+                        beta_front_diff = pl.sub(front_score, mi_next_front)
+                        beta_front = pl.exp(beta_front_diff)
+                        li_front = pl.mul(alpha_front, li)
+                        li = pl.add(li_front, beta_front)
+                        oi_front = pl.mul(oi, alpha_front)
+                        kv_front = pl.mul(front_kv, beta_front)
+                        oi = pl.add(oi_front, kv_front)
                         mi = mi_next_front
 
                     for s in pl.range(0, COMPRESS_RATIO - 1):
                         cur_abs = cur_window_start_b + s
                         cur_blk_off = cur_abs // COMPRESS_STATE_BLOCK_SIZE
                         cur_intra = cur_abs % COMPRESS_STATE_BLOCK_SIZE
-                        cur_blk_id = pl.cast(pl.read(compress_state_block_table, [c_idx, cur_blk_off]), pl.INDEX)
+                        cur_blk_raw = pl.read(compress_state_block_table, [c_idx, cur_blk_off])
+                        cur_blk_id = pl.cast(cur_blk_raw, pl.INDEX)
                         cur_row = cur_blk_id * COMPRESS_STATE_BLOCK_SIZE + cur_intra
                         back_col0 = OUT_DIM + HEAD_DIM + h0
                         back_score = compress_state_flat[cur_row : cur_row + 1, back_col0 : back_col0 + HEAD_TILE]
                         back_kv = compress_state_flat[cur_row : cur_row + 1, HEAD_DIM + h0 : HEAD_DIM + h0 + HEAD_TILE]
                         mi_next_back = pl.maximum(mi, back_score)
-                        alpha_back = pl.exp(pl.sub(mi, mi_next_back))
-                        beta_back = pl.exp(pl.sub(back_score, mi_next_back))
-                        li = pl.add(pl.mul(alpha_back, li), beta_back)
-                        oi = pl.add(pl.mul(oi, alpha_back), pl.mul(back_kv, beta_back))
+                        alpha_back_diff = pl.sub(mi, mi_next_back)
+                        alpha_back = pl.exp(alpha_back_diff)
+                        beta_back_diff = pl.sub(back_score, mi_next_back)
+                        beta_back = pl.exp(beta_back_diff)
+                        li_back = pl.mul(alpha_back, li)
+                        li = pl.add(li_back, beta_back)
+                        oi_back = pl.mul(oi, alpha_back)
+                        kv_back = pl.mul(back_kv, beta_back)
+                        oi = pl.add(oi_back, kv_back)
                         mi = mi_next_back
 
                     pooled_chunk = pl.div(oi, li)
                     pooled_kv[pad_idx : pad_idx + 1, h0 : h0 + HEAD_TILE] = pooled_chunk
 
-    normed_kv = pl.create_tensor([RMS_PAD_ROWS, HEAD_DIM], dtype=pl.BF16)
-    norm_w_2d = pl.reshape(norm_w, [1, HEAD_DIM])
-    # The interleave tables and the j^1 lane-swap index do not depend on the pooled KV,
-    # so they are built in their own scope instead of inside rmsnorm_rope. rmsnorm_rope is
-    # a single-block AIV task on the critical path; each pl.gather there also drags the a5
-    # row-base chain behind it, so moving two of the three gathers out and flattening the
-    # third takes that work off the path entirely.
     cmp_cos_il = pl.create_tensor([RMS_PAD_TILE, ROPE_HEAD_DIM], dtype=pl.FP32)
     cmp_sin_signed = pl.create_tensor([RMS_PAD_TILE, ROPE_HEAD_DIM], dtype=pl.FP32)
     cmp_swap_flat = pl.create_tensor([1, CMP_SWAP_FLAT_LEN], dtype=pl.INT32)
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="cmp_rope_tables", allow_early_resolve=True):
-        # single 16-row block: B real rows at rows 0..B-1, rows B..15 are pad
         cos_b = pl.full([RMS_PAD_TILE, ROPE_HEAD_DIM // 2], dtype=pl.FP32, value=0.0)
         sin_b = pl.full([RMS_PAD_TILE, ROPE_HEAD_DIM // 2], dtype=pl.FP32, value=0.0)
         cos_b[0:B, 0 : ROPE_HEAD_DIM // 2] = cos[0:B, 0 : ROPE_HEAD_DIM // 2]
         sin_b[0:B, 0 : ROPE_HEAD_DIM // 2] = sin[0:B, 0 : ROPE_HEAD_DIM // 2]
-        t_col = pl.col_expand_mul(
-            pl.full([RMS_PAD_TILE, ROPE_HEAD_DIM], dtype=pl.FP32, value=1.0),
-            pl.cast(pl.arange(0, [1, ROPE_HEAD_DIM], dtype=pl.INT32), target_type=pl.FP32))
-        t_dup_f = pl.cast(pl.cast(pl.mul(t_col, 0.5), target_type=pl.INT32, mode="trunc"), target_type=pl.FP32)
-        t_dup_idx = pl.cast(t_dup_f, target_type=pl.INT32)                                      # j>>1
-        t_lane = pl.sub(t_col, pl.mul(t_dup_f, 2.0))                                            # j%2
-        t_sign = pl.sub(pl.mul(t_lane, 2.0), 1.0)                                               # [-1,+1,...]
-        cmp_cos_il[0:RMS_PAD_TILE, 0:ROPE_HEAD_DIM] = pl.gather(cos_b, dim=-1, index=t_dup_idx)
-        # Folding the sign into sin is exact: it only flips a sign bit.
-        cmp_sin_signed[0:RMS_PAD_TILE, 0:ROPE_HEAD_DIM] = pl.mul(
-            pl.gather(sin_b, dim=-1, index=t_dup_idx), t_sign)
-        f_col = pl.cast(pl.arange(0, [1, CMP_SWAP_FLAT_LEN], dtype=pl.INT32), target_type=pl.FP32)
-        f_rowbase = pl.mul(
-            pl.cast(pl.cast(pl.mul(f_col, ROPE_HEAD_DIM_INV), target_type=pl.INT32, mode="trunc"),
-                    target_type=pl.FP32),
-            ROPE_HEAD_DIM_F)                                                                    # r*ROPE_HEAD_DIM
-        f_j = pl.sub(f_col, f_rowbase)
-        f_dup = pl.cast(pl.cast(pl.mul(f_j, 0.5), target_type=pl.INT32, mode="trunc"), target_type=pl.FP32)
-        f_lane = pl.sub(f_j, pl.mul(f_dup, 2.0))                                                # j%2
-        f_jx = pl.sub(pl.add(f_j, 1.0), pl.mul(f_lane, 2.0))                                    # j^1
-        cmp_swap_flat[0:1, 0:CMP_SWAP_FLAT_LEN] = pl.cast(
-            pl.add(f_rowbase, f_jx), target_type=pl.INT32)
+        t_ones = pl.full([RMS_PAD_TILE, ROPE_HEAD_DIM], dtype=pl.FP32, value=1.0)
+        t_col_idx = pl.arange(0, [1, ROPE_HEAD_DIM], dtype=pl.INT32)
+        t_col_f32 = pl.cast(t_col_idx, target_type=pl.FP32)
+        t_col = pl.col_expand_mul(t_ones, t_col_f32)
+        t_row_idx = pl.arange(0, [1, RMS_PAD_TILE], dtype=pl.INT32)
+        t_row_f32 = pl.cast(t_row_idx, target_type=pl.FP32)
+        t_row_col = pl.reshape(t_row_f32, [RMS_PAD_TILE, 1])
+        t_row = pl.row_expand_mul(t_ones, t_row_col)
+        t_half = pl.mul(t_col, 0.5)
+        t_dup_i32 = pl.cast(t_half, target_type=pl.INT32, mode="trunc")
+        t_dup_f = pl.cast(t_dup_i32, target_type=pl.FP32)
+        t_dup_twice = pl.mul(t_dup_f, 2.0)
+        t_lane = pl.sub(t_col, t_dup_twice)  # j % 2
+        t_sign_lane = pl.mul(t_lane, 2.0)
+        t_sign = pl.sub(t_sign_lane, 1.0)  # [-1, +1, ...]
+        t_col_next = pl.add(t_col, 1.0)
+        t_jx_lane = pl.mul(t_lane, 2.0)
+        t_jx = pl.sub(t_col_next, t_jx_lane)  # j ^ 1
+        t_dup_row = pl.mul(t_row, ROPE_HALF_F)
+        t_dup_sum = pl.add(t_dup_row, t_dup_f)
+        t_dup_idx = pl.cast(t_dup_sum, target_type=pl.INT32)
+        t_dup_flat = pl.reshape(t_dup_idx, [1, CMP_SWAP_FLAT_LEN])
+        cos_flat = pl.reshape(cos_b, [1, CMP_DUP_SRC_LEN])
+        cos_gathered = pl.gather(cos_flat, dim=-1, index=t_dup_flat)
+        cos_il = pl.reshape(cos_gathered, [RMS_PAD_TILE, ROPE_HEAD_DIM])
+        cmp_cos_il[0:RMS_PAD_TILE, 0:ROPE_HEAD_DIM] = cos_il
+        sin_flat = pl.reshape(sin_b, [1, CMP_DUP_SRC_LEN])
+        sin_gathered = pl.gather(sin_flat, dim=-1, index=t_dup_flat)
+        sin_il = pl.reshape(sin_gathered, [RMS_PAD_TILE, ROPE_HEAD_DIM])
+        sin_signed = pl.mul(sin_il, t_sign)
+        cmp_sin_signed[0:RMS_PAD_TILE, 0:ROPE_HEAD_DIM] = sin_signed
+        t_swap_row = pl.mul(t_row, ROPE_HEAD_DIM_F)
+        t_swap_sum = pl.add(t_swap_row, t_jx)
+        t_swap_idx = pl.cast(t_swap_sum, target_type=pl.INT32)
+        t_swap_flat = pl.reshape(t_swap_idx, [1, CMP_SWAP_FLAT_LEN])
+        cmp_swap_flat[0:1, 0:CMP_SWAP_FLAT_LEN] = t_swap_flat
 
+    normed_kv = pl.create_tensor([RMS_PAD_TILE, HEAD_DIM], dtype=pl.BF16)
+    norm_w_2d = pl.reshape(norm_w, [1, HEAD_DIM])
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="rmsnorm_rope"):
         partial_sq = pl.full([1, RMS_PAD_TILE], dtype=pl.FP32, value=0.0)
         for k0 in pl.range(0, HEAD_DIM, HEAD_TILE):
             kv_rms_chunk = pooled_kv[0 : RMS_PAD_TILE, k0 : k0 + HEAD_TILE]
             kv_rms_sq = pl.mul(kv_rms_chunk, kv_rms_chunk)
-            kv_rms_rowsum = pl.reshape(pl.row_sum(kv_rms_sq), [1, RMS_PAD_TILE])
+            kv_rms_sum = pl.row_sum(kv_rms_sq)
+            kv_rms_rowsum = pl.reshape(kv_rms_sum, [1, RMS_PAD_TILE])
             partial_sq = pl.add(partial_sq, kv_rms_rowsum)
 
-        variance = pl.reshape(pl.add(pl.mul(partial_sq, HEAD_DIM_INV), EPS), [RMS_PAD_TILE, 1])
-        inv_rms = pl.recip(pl.sqrt(variance))
+        partial_mean = pl.mul(partial_sq, HEAD_DIM_INV)
+        variance_row = pl.add(partial_mean, EPS)
+        variance = pl.reshape(variance_row, [RMS_PAD_TILE, 1])
+        rms = pl.sqrt(variance)
+        inv_rms = pl.recip(rms)
         for k0 in pl.range(0, NOPE_HEAD_DIM, HEAD_TILE):
             kv_norm_chunk = pooled_kv[0 : RMS_PAD_TILE, k0 : k0 + HEAD_TILE]
-            gamma = pl.cast(norm_w_2d[:, k0 : k0 + HEAD_TILE], pl.FP32)
-            normed_chunk = pl.col_expand_mul(pl.row_expand_mul(kv_norm_chunk, inv_rms), gamma)
-            normed_kv[0 : RMS_PAD_TILE, k0 : k0 + HEAD_TILE] = pl.cast(
-                normed_chunk,
-                target_type=pl.BF16,
-                mode="rint",
-            )
+            gamma_bf16 = norm_w_2d[:, k0 : k0 + HEAD_TILE]
+            gamma = pl.cast(gamma_bf16, pl.FP32)
+            kv_rms_scaled = pl.row_expand_mul(kv_norm_chunk, inv_rms)
+            normed_chunk = pl.col_expand_mul(kv_rms_scaled, gamma)
+            normed_bf16 = pl.cast(normed_chunk, target_type=pl.BF16, mode="rint")
+            normed_kv[0 : RMS_PAD_TILE, k0 : k0 + HEAD_TILE] = normed_bf16
 
         kv_rope_norm = pooled_kv[0 : RMS_PAD_TILE, NOPE_HEAD_DIM : HEAD_DIM]
-        gamma_rope = pl.cast(norm_w_2d[:, NOPE_HEAD_DIM : HEAD_DIM], pl.FP32)
-        # A3 interleaved swap-gather (same form as kv_rms_norm_rope in qkv_proj_rope),
-        # replacing the de-interleave gather + rotate + re-interleave scatter. gamma+inv_rms
-        # are folded into rope_normed BEFORE the swap, so the swapped lane n[j^1] correctly
-        # carries gamma[j^1]; inv_rms is per-row so it commutes. swap_idx (j^1), sign
-        # ([-1,+1,...]) and dup_idx (j>>1) are built IN-KERNEL from pl.arange; cos_il/sin_il
-        # are dup-gathered from the per-batch cos/sin rows. normed_kv is BF16 -> cast on write.
-        #   out[j] = n[j]*cos_il[j] + n[j^1]*sign[j]*sin_il[j]
-        rope_normed = pl.col_expand_mul(pl.row_expand_mul(kv_rope_norm, inv_rms), gamma_rope)
-        # rope_normed is a fresh elementwise result, hence contiguous: a single-row flat
-        # index addresses it correctly and rows == 1 skips the a5 row-base chain.
+        gamma_rope_bf16 = norm_w_2d[:, NOPE_HEAD_DIM : HEAD_DIM]
+        gamma_rope = pl.cast(gamma_rope_bf16, pl.FP32)
+        # out[j] = n[j] * cos[j] + n[j ^ 1] * sign[j] * sin[j]
+        rope_rms_scaled = pl.row_expand_mul(kv_rope_norm, inv_rms)
+        rope_normed = pl.col_expand_mul(rope_rms_scaled, gamma_rope)
         rope_flat = pl.reshape(rope_normed, [1, CMP_SWAP_FLAT_LEN])
-        swapped = pl.reshape(
-            pl.gather(rope_flat, dim=-1, index=cmp_swap_flat[0:1, 0:CMP_SWAP_FLAT_LEN]),
-            [RMS_PAD_TILE, ROPE_HEAD_DIM])
-        rope_rot = pl.add(
-            pl.mul(rope_normed, cmp_cos_il[0:RMS_PAD_TILE, 0:ROPE_HEAD_DIM]),
-            pl.mul(swapped, cmp_sin_signed[0:RMS_PAD_TILE, 0:ROPE_HEAD_DIM]))
-        normed_kv[0 : RMS_PAD_TILE, NOPE_HEAD_DIM : HEAD_DIM] = pl.cast(
-            rope_rot,
-            target_type=pl.BF16,
-            mode="rint",
-        )
+        swap_idx = cmp_swap_flat[0:1, 0:CMP_SWAP_FLAT_LEN]
+        swapped_flat = pl.gather(rope_flat, dim=-1, index=swap_idx)
+        swapped = pl.reshape(swapped_flat, [RMS_PAD_TILE, ROPE_HEAD_DIM])
+        cmp_cos = cmp_cos_il[0:RMS_PAD_TILE, 0:ROPE_HEAD_DIM]
+        rope_cos = pl.mul(rope_normed, cmp_cos)
+        cmp_sin = cmp_sin_signed[0:RMS_PAD_TILE, 0:ROPE_HEAD_DIM]
+        rope_sin = pl.mul(swapped, cmp_sin)
+        rope_rot = pl.add(rope_cos, rope_sin)
+        rope_bf16 = pl.cast(rope_rot, target_type=pl.BF16, mode="rint")
+        normed_kv[0 : RMS_PAD_TILE, NOPE_HEAD_DIM : HEAD_DIM] = rope_bf16
 
-    kv_final = pl.create_tensor([RMS_PAD_ROWS, HEAD_DIM], dtype=pl.FP32)
+    kv_final = pl.create_tensor([RMS_PAD_TILE, HEAD_DIM], dtype=pl.FP32)
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="kv_hadamard"):
         kv_proj_tile = normed_kv[0 : RMS_PAD_TILE, 0 : HEAD_DIM]
         for o0 in pl.range(0, HEAD_DIM, OUT_TILE):
@@ -311,39 +307,45 @@ def indexer_compressor(
             kv_hadamard_acc = pl.matmul(kv_proj_tile, hadamard_tile, out_dtype=pl.FP32)
             kv_final[0 : RMS_PAD_TILE, o0 : o0 + OUT_TILE] = kv_hadamard_acc
 
+    kv_flat = pl.reshape(kv, [B * S, HEAD_DIM])
+    idx_kv_cache_flat = pl.reshape(idx_kv_cache, [IDX_CACHE_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
+    idx_kv_scale_flat = pl.reshape(idx_kv_scale, [IDX_CACHE_BLOCK_NUM * BLOCK_SIZE, 1])
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="kv_and_cache_write"):
-        # C8 quant-on-write: per-row INT8 quant of the block (M=RMS_PAD_TILE keeps tiles 32B-aligned;
-        # quantize the bf16-rounded value to match golden)
-        kv_blk_f32 = pl.cast(
-            pl.cast(kv_final[0 : RMS_PAD_TILE, 0 : HEAD_DIM], target_type=pl.BF16, mode="rint"),
-            target_type=pl.FP32)
-        # amax = max(|x|); abs-based (max(row_max, -row_min) is wrong on signed KV)
-        kv_amax = pl.reshape(pl.row_max(pl.abs(kv_blk_f32)), [1, RMS_PAD_TILE])
-        kv_amax = pl.maximum(kv_amax, pl.full([1, RMS_PAD_TILE], dtype=pl.FP32, value=INT8_AMAX_EPS))
-        kv_scale_q_row = pl.div(pl.full([1, RMS_PAD_TILE], dtype=pl.FP32, value=INT8_SCALE_MAX), kv_amax)
-        kv_scale_dq_col = pl.reshape(pl.recip(kv_scale_q_row), [RMS_PAD_TILE, 1])
+        kv_final_tile = kv_final[0 : RMS_PAD_TILE, 0 : HEAD_DIM]
+        kv_blk_bf16 = pl.cast(kv_final_tile, target_type=pl.BF16, mode="rint")
+        kv_blk_f32 = pl.cast(kv_blk_bf16, target_type=pl.FP32)
+        kv_abs = pl.abs(kv_blk_f32)
+        kv_row_max = pl.row_max(kv_abs)
+        kv_amax_row = pl.reshape(kv_row_max, [1, RMS_PAD_TILE])
+        kv_amax_floor = pl.full([1, RMS_PAD_TILE], dtype=pl.FP32, value=INT8_AMAX_EPS)
+        kv_amax = pl.maximum(kv_amax_row, kv_amax_floor)
+        kv_scale_max = pl.full([1, RMS_PAD_TILE], dtype=pl.FP32, value=INT8_SCALE_MAX)
+        kv_scale_q_row = pl.div(kv_scale_max, kv_amax)
+        kv_scale_dq_row = pl.recip(kv_scale_q_row)
+        kv_scale_dq_col = pl.reshape(kv_scale_dq_row, [RMS_PAD_TILE, 1])
         kv_scale_q_col = pl.reshape(kv_scale_q_row, [RMS_PAD_TILE, 1])
         kv_scaled = pl.row_expand_mul(kv_blk_f32, kv_scale_q_col)
         kv_i32 = pl.cast(kv_scaled, target_type=pl.INT32, mode="rint")
         kv_half = pl.cast(kv_i32, target_type=pl.FP16, mode="round")
         kv_i8_blk = pl.cast(kv_half, target_type=pl.INT8, mode="trunc")
         for inner in pl.range(B):
-            c_idx = inner
-            first_pos_b = pl.read(position_ids, [c_idx, 0])
-            pos_b = first_pos_b % COMPRESS_RATIO
-            if pos_b + S >= COMPRESS_RATIO:
-                boundary_s = COMPRESS_RATIO - 1 - pos_b
+            write_c_idx = inner
+            write_first_pos = pl.read(position_ids, [write_c_idx, 0])
+            write_pos = write_first_pos % COMPRESS_RATIO
+            if write_pos + S >= COMPRESS_RATIO:
+                boundary_s = COMPRESS_RATIO - 1 - write_pos
                 kv_row_fp32 = kv_final[inner : inner + 1, 0 : HEAD_DIM]
-                cache_row_i64 = pl.read(idx_slot_mapping, [c_idx, boundary_s])
+                cache_row_i64 = pl.read(idx_slot_mapping, [write_c_idx, boundary_s])
                 if cache_row_i64 >= 0:
                     cache_row = pl.cast(cache_row_i64, pl.INDEX)
-                    kv_flat[c_idx * S : c_idx * S + 1, :] = kv_row_fp32
-                    idx_kv_cache_flat[cache_row : cache_row + 1, :] = kv_i8_blk[inner : inner + 1, :]
-                    # scale is one value per position; a [1,1] tile store is sub-32B, so scalar-write it
-                    pl.write(idx_kv_scale_flat, [cache_row, 0], pl.read(kv_scale_dq_col, [inner, 0]))
+                    kv_flat[write_c_idx * S : write_c_idx * S + 1, :] = kv_row_fp32
+                    kv_i8_row = kv_i8_blk[inner : inner + 1, :]
+                    idx_kv_cache_flat[cache_row : cache_row + 1, :] = kv_i8_row
+                    scale_dq = pl.read(kv_scale_dq_col, [inner, 0])
+                    pl.write(idx_kv_scale_flat, [cache_row, 0], scale_dq)
 
-    kv = pl.reshape(kv_flat, [B, S, HEAD_DIM])
-    return kv, compress_state, idx_kv_cache, idx_kv_scale
+    kv_out = pl.reshape(kv_flat, [B, S, HEAD_DIM])
+    return kv_out, compress_state, idx_kv_cache, idx_kv_scale
 
 
 @pl.jit
@@ -365,25 +367,12 @@ def compressor_test(
     idx_slot_mapping: pl.Tensor[[B, S], pl.INT64],
     inner_state_slot_mapping: pl.Tensor[[B, S], pl.INT64],
 ):
-    # Standalone: no rms_norm producer, so the barrier fences nothing (ready on submit).
     late_dep = pl.system.task_dummy(deps=[])
     indexer_compressor(
-        x,
-        kv,
-        compress_state,
-        compress_state_block_table,
-        wkv,
-        wgate,
-        ape,
-        norm_w,
-        cos,
-        sin,
-        hadamard,
-        idx_kv_cache,
-        idx_kv_scale,
-        position_ids,
-        idx_slot_mapping,
-        inner_state_slot_mapping,
+        x, kv, compress_state, compress_state_block_table,
+        wkv, wgate, ape, norm_w, cos, sin, hadamard,
+        idx_kv_cache, idx_kv_scale,
+        position_ids, idx_slot_mapping, inner_state_slot_mapping,
         late_dep,
     )
     return kv, compress_state, idx_kv_cache, idx_kv_scale
@@ -411,8 +400,8 @@ def golden_compressor(tensors):
     bsz, _, _ = x.shape
     ratio, rd = COMPRESS_RATIO, ROPE_HEAD_DIM
 
-    kv = x @ wkv.t()                    # [B, S, OUT_DIM]  (wkv stored [OUT_DIM, D] for b_trans)
-    score = x @ wgate.t()               # [B, S, OUT_DIM]
+    kv = x @ wkv.t()
+    score = x @ wgate.t()
 
     pooled = torch.zeros(bsz, 1, HEAD_DIM, dtype=torch.float32, device=x.device)
     should_compress_rows = torch.zeros(bsz, dtype=torch.bool, device=x.device)
@@ -452,7 +441,6 @@ def golden_compressor(tensors):
         cur_window_start = boundary_end - ratio + 1
         prev_window_start = cur_window_start - ratio
 
-        # Per-token ape add + state scatter through explicit token-major slots.
         for s in range(S):
             pos = int(position_ids[b, s].item())
             token_ape_row = pos % ratio
@@ -516,12 +504,10 @@ def golden_compressor(tensors):
 
         cache_row = int(idx_slot_mapping[b, boundary_s].item())
         if cache_row >= 0:
-            # Kernel writes committed pooled result only to kv[:, 0, :]; leave
-            # speculative-boundary rows and kv[:, 1:, :] zero-initialized.
             tensors["kv"][b : b + 1, 0:1, :] = kv_b
             blk_id = cache_row // BLOCK_SIZE
             intra = cache_row % BLOCK_SIZE
-            # C8 quant-on-write: quantize the bf16-rounded compressed row to int8 + per-position scale
+            # Quantize the BF16-rounded row to INT8 with a per-position scale.
             row_bf16 = kv_b[0, 0].to(torch.bfloat16).float()
             amax = row_bf16.abs().amax().clamp_min(INT8_AMAX_EPS)
             scale_q = INT8_SCALE_MAX / amax
@@ -559,7 +545,7 @@ def mapped_inner_state_ratio_allclose(*, atol, rtol, max_error_ratio):
 
 
 def build_tensor_specs(start_pos=None):
-    import torch  # type: ignore[import]
+    import torch
     from decode_metadata import (
         block_table,
         compressed_slot_mapping,
@@ -585,9 +571,6 @@ def build_tensor_specs(start_pos=None):
             table_blocks=COMPRESS_STATE_MAX_BLOCKS,
             physical_blocks=COMPRESS_STATE_PHYSICAL_BLOCKS,
         )
-    # Calibrated to the real DeepSeek-V4-Flash CSA inner (indexer) compressor (mean l8/l32 of
-    # extract_weights_flash): zero-mean Gaussian BF16 weights at the measured std; the RMSNorm
-    # gamma centers near the measured mean (not ones / not uniform).
     def init_wkv():
         return torch.randn(OUT_DIM, D) * 0.0293
     def init_wgate():
@@ -617,7 +600,6 @@ def build_tensor_specs(start_pos=None):
             physical_blocks=IDX_CACHE_MAX_BLOCKS,
         )
     def init_default_start_pos():
-        # Canonical CSA start-position set (ratio-4 compressor + indexer + sliding-window + 8k).
         return csa_decode_start_set(
             batch=B, seq=S, compress_ratio=COMPRESS_RATIO,
             state_block_size=COMPRESS_STATE_BLOCK_SIZE)
@@ -699,8 +681,7 @@ if __name__ == "__main__":
             "kv":          ratio_allclose(atol=1e-4, rtol=1.0 / 128, max_error_ratio=0.0),
             "compress_state": mapped_inner_state_ratio_allclose(
                 atol=1e-3, rtol=1e-3, max_error_ratio=0.0),
-            # Ratio budgets apply only to rows written by the current slot mappings;
-            # every historical/unallocated physical row must remain bitwise exact.
+            # Compare rows selected by the current slot mappings.
             "idx_kv_cache": mapped_idx_cache_ratio_allclose(
                 atol=1, rtol=0, max_error_ratio=0.01),
             "idx_kv_scale": mapped_idx_cache_ratio_allclose(

--- a/models/deepseek_v4_pro/decode_metadata.py
+++ b/models/deepseek_v4_pro/decode_metadata.py
@@ -212,9 +212,9 @@ def swa_indices_and_lens(
     Each visible absolute logical position is translated with the same paged-KV
     block table contract as vLLM:
     ``physical_slot = block_table[req, pos // block_size] * block_size + pos % block_size``.
-    Each row is ordered from the oldest visible token to the current token;
-    invalid tail columns are padded with -1 and ``lens`` records the valid
-    prefix length.
+    Each row is ordered from the oldest visible token to the current token.
+    ``lens`` records the logical visible length; an unmapped in-range page is a
+    ``-1`` hole inside that range, while columns beyond it are ``-1`` padding.
     """
     if positions.ndim != 2:
         raise ValueError("SWA indices expect positions with shape [B, S]")

--- a/models/deepseek_v4_pro/decode_sparse_attn.py
+++ b/models/deepseek_v4_pro/decode_sparse_attn.py
@@ -38,146 +38,58 @@ NOPE_DIM = M.nope_head_dim
 WIN = M.sliding_window
 MAX_SEQ_LEN = M.max_position_embeddings
 IDX_TOPK = M.index_topk
-TOPK_FULL = WIN + IDX_TOPK           # sparse-K columns: window block + indexer topk
 CMP_TOPK = IDX_TOPK
+TOPK = WIN + CMP_TOPK
 SOFTMAX_SCALE = M.softmax_scale
 O_LORA = M.o_lora_rank
 O_GROUPS = M.o_groups
 HEADS_PER_GROUP = H // O_GROUPS
 O_GROUP_IN = HEADS_PER_GROUP * HEAD_DIM
-O_GROUPS_PER_SPMD = 2
-
-# kernel-local
 SUPPORTED_COMPRESS_RATIOS = (0, 4, 128)
 DEFAULT_COMPRESS_RATIO = 4
-# CSA compressed-slot masking (folded in from the CSA orchestrator): raw indexer
-# topk -> per-token bound floor((pos + 1) / COMPRESS_RATIO).
-MAX_SEQ_LEN = M.max_position_embeddings
 INDEXER_SCORE_LEN = MAX_SEQ_LEN // 4
 COMPRESS_RATIO_INV = 1.0 / DEFAULT_COMPRESS_RATIO
-CSA_CMP_GE_BIAS = 1.0  # raw + 1, folded for the ge clamp
+CSA_CMP_GE_BIAS = 1.0
 ORI_MAX_BLOCKS = KV_ORI_MAX_BLOCKS
 ORI_BLOCK_NUM = DECODE_ORI_BLOCK_NUM
 CMP_MAX_BLOCKS = KV_CMP_MAX_BLOCKS
 CMP_BLOCK_NUM = DECODE_CMP_BLOCK_NUM
-
-# tiling
-ROPE_OUT_TOK_TILE = 8
-H_TILE = 16
-# merge_norm gathers with a single-row flat index so the a5 gather lowering's
-# per-block row-base chain (tile.ci/divs/muls/add) hits its rows==1 early-out.
-# The gather source must be CONTIGUOUS for a flat index to address it correctly,
-# so the rope half is produced as its own tile rather than sliced out of n_full.
-MERGE_SWAP_FLAT_LEN = H_TILE * ROPE_DIM
-ROPE_DIM_F = float(ROPE_DIM)
-ROPE_DIM_INV = 1.0 / ROPE_DIM
-# qk_pv cube-batch tile (M for the QK/PV matmuls). Batching QK_M_TILE head rows
-# per matmul extracts the shared KV tile L1->L0 once per QK_M_TILE/H_TILE
-# head-tiles (2x reuse at 32) instead of per H_TILE head-tile, then slices the
-# [QK_M_TILE, ...] result back into H_TILE-row stores so the sparse_blk_* layout
-# and merge_norm stay unchanged. 32 keeps the [32,128] softmax inside the 192KB
-# Vec budget without a cross-core split. 64 is infeasible without further work
-# (its [64,128] softmax and co-resident QK+PV L0C accumulators overflow Vec/L0C).
-QK_M_TILE = 32
-ATTN_K_TILE = 128
-# qk_pv dispatch width = the a2a3 AIC (MIX-cluster) count. A runtime pre-pass
-# (qk_plan, below) load-balances the T*SPARSE_BLOCKS work items across these lanes,
-# replacing the old fixed strided (token, block-lane) NSPLIT split whose imbalance
-# grew with per-token variance in the valid-block count. Platform-specific: this is
-# the 24-wide dispatch a2a3 targets; re-sweep NUM_QK_CORES for other AIC counts.
-NUM_QK_CORES = 24
-# proj_a cube K-frag. 256 (not 128) keeps the B-cache-line floor: B is K-contiguous
-# under b_trans, so K*2B(bf16) = 512B == the a2a3 L2 line (K=128 was 256B, half a
-# line -> wasted MTE2 DMA). At 256 the cube's L0A/L0B operand staging hits 100%
-# (the wall); 512 would spill it for no gain (swept: K=512 net-negative).
-A_K_TILE = 256
-# proj_a is a pure-cube matmul scope (proj_a_mm) writing the fp32 GM intermediate
-# o_r (cf. expert_routed w2 decouple), consumed directly by the fused amax+quant
-# scope below; the decouple frees the cube N-frag from any vector-side UB constraint.
-PROJ_A_MM_N_TILE = 128   # cube N frag; Mat/L0C have room but L0A/L0B are the wall at
-                         # K=256, and a wider N raised cube exec without a TTT win (swept).
-MM_T_TILE = 16
-T_PAD = ((T + MM_T_TILE - 1) // MM_T_TILE) * MM_T_TILE
-B_K_TILE = 256  # proj_b_mm cube K frag; the GEMM is not the proj_b bottleneck (see below),
-                # and a device sweep found growing it (512/1024) only re-streamed more weight
-                # for no TTT gain, so it stays at the cache-line-safe 256 (256 B per INT8 row).
-# proj_b is decoupled into a pure-cube GEMM scope (proj_b_mm) and a pure-vector dequant
-# scope (proj_b_act) meeting through grouped INT32 partials in GM, so each sizes its
-# own N-fragment to its own wall (cf. the expert_routed w2 decouple). A device tile sweep
-# showed the cube is NOT the bottleneck (proj_b_mm ~32us, ~78% Exec, with L0C/L1 headroom)
-# while the vector dequant dominated: growing PROJ_B_ACT_N_TILE 128->1024 cut the per-N-block
-# vector-setup count 4x and dropped standalone TTT ~835->~730us. The vector frag goes to
-# the UB wall; the cube frag sizes to its own L0C wall (below).
-PROJ_B_MM_N_TILE = 256    # cube N frag. A later device-bias-controlled sweep (paired
-                          # within-device, post vector-retune) found 128->256 worth ~1.5-2%
-                          # (fewer matmul setups: per-D-chunk inner N-frags 8->4; proj_b_mm
-                          # exec ~33->31us). Acc = M*N*4 = 128*256*4 = 128KB rides the L0C
-                          # wall exactly (fits a2a3); Mat ~192KB has room. proj_a N stayed
-                          # 128: growing it was TTT-neutral (64->32 task drop offset by 2x
-                          # per-task cube exec). B_K_TILE stayed 256: the K=512 cache-line
-                          # fix was ambiguous (raised proj_b dispatch-prop for no clear gain).
-PROJ_B_ACT_N_TILE = 512   # vector N frag for the decoupled per-group dequant+sum (proj_b_act
-                          # now sums O_GROUPS INT32 partials, each x its group act scale, then
-                          # x the per-channel weight scale -> BF16). 512 keeps the O_GROUPS-way
-                          # accumulate inside UB and avoids the extra dispatch wave seen at 256.
-# Fused amax+quant token tile. The fused scope streams o_r twice (amax pass + quant
-# pass) per token-tile rather than holding the whole row, so UB stays small; 8 keeps
-# the [1, QUANT_TOKEN_TILE] fp32 amax tile 32-byte aligned (8*4=32B, the alloc-tile
-# row floor that a [QUANT_TOKEN_TILE, 1] column accumulator would violate). The
-# full-row hold (read o_r once) needs QUANT_TOKEN_TILE<=4 for UB but >=8 for that
-# alignment -- mutually exclusive -- so we stream; the 2nd pass mostly hits L2.
-QUANT_TOKEN_TILE = 8
-# Per-group back-to-back o_proj (manual-scope, qwen3-style fine-grained deps):
-# proj_a[g] -> quant[g] (PER-GROUP amax, no global barrier) -> proj_b[g] pipeline.
-# Each proj_b group writes a disjoint INT32 partial; the final vector task combines
-# all group partials with their row scales, then applies the channel weight scale.
-PA_NFRAGS = O_LORA // PROJ_A_MM_N_TILE   # proj_a cube N-frags per group
-# proj_a N-frags per SPMD block. The cube tile stays PROJ_A_MM_N_TILE (L0A/L0B are
-# the wall, see above); this only folds several frags into one block so the grid
-# shrinks and the per-shard dispatch stagger amortises, exactly as the D-chunk loop
-# already does for proj_b below.
-PA_NF_PER_BLOCK = 2
-PA_BLOCKS = PA_NFRAGS // PA_NF_PER_BLOCK
-assert PA_NFRAGS % PA_NF_PER_BLOCK == 0, "proj_a N-frag loop must cover PA_NFRAGS"
-# proj_b is one task per (D-chunk, group): the D-chunk's N-frags loop INSIDE the task,
-# so the per-group split does not multiply the task count by N-frags. The block count
-# is O_GROUPS * PB_DCHUNKS; the cube tile is set by PROJ_B_MM_N_TILE, not by the chunk
-# width, so the chunk only picks the block granularity.
-#
-# 1792 (64 blocks), not the 3584 (32 blocks) that "one wave over a5's 28 cube cores"
-# suggests. The one-wave argument assumes the wave starts together, but proj_b bundle g
-# is gated by its own proj_a -> quant chain, so the 8 bundles enter the cube array
-# staggered over ~80us and the array DRAINS at the end of the tail (AIC occupancy falls
-# 86% -> 64% -> 27% over t=620..700 in the level-4 capture). Half-width chunks halve the
-# quantum a late bundle has to fit into that draining array. Device-measured on the
-# a5 CSA decode case, paired interleaved A/B, 5 reps x 100 rounds: 715.6 -> 709.5us
-# (-6.1). 1024 (112 blocks) gave back the win (+0.4us) -- past 64 blocks the extra
-# matmul setups outweigh the finer fit.
-PROJ_B_D_CHUNK = 512 if M.name == "flash" else 1792
-PB_DCHUNKS = D // PROJ_B_D_CHUNK
-# proj_b_act uses one block per 512-column output region, eight blocks in total.
-PROJ_B_ACT_T_TILE = 8    # inner token tile for the proj_b_act O_GROUPS-way INT32->FP32 accumulate
-PROJ_B_ACT_TBLK = 8      # proj_b_act token block per task
-PB_ACT_NREG = D // PROJ_B_ACT_N_TILE
-PB_ACT_TBLKS = T // PROJ_B_ACT_TBLK
 NEG_INF = -1.0e20
 
-assert T % 2 == 0
-assert T % ROPE_OUT_TOK_TILE == 0  # rope-pack loop tiles tokens by ROPE_OUT_TOK_TILE
-assert H % 4 == 0
-assert QK_M_TILE % H_TILE == 0
-assert H % QK_M_TILE == 0
-assert T % QUANT_TOKEN_TILE == 0
+# tiling
+H_TILE = 16
+MERGE_SWAP_FLAT_LEN = H_TILE * ROPE_DIM
+CS_DUP_FLAT_LEN = T * ROPE_DIM
+assert CS_DUP_FLAT_LEN <= MERGE_SWAP_FLAT_LEN
+ROPE_DIM_F = float(ROPE_DIM)
+ROPE_DIM_INV = 1.0 / ROPE_DIM
+QK_M_TILE = 32
+ATTN_K_TILE = 128
+QK_CORE_TILE = 28
+A_K_TILE = 256
+PROJ_A_MM_N_TILE = 128
+MM_T_TILE = 16
+T_PAD = ((T + MM_T_TILE - 1) // MM_T_TILE) * MM_T_TILE
+B_K_TILE = 256
+PROJ_B_MM_N_TILE = 256
+PROJ_B_ACT_N_TILE = 512
+QUANT_TOKEN_TILE = 8
+O_GROUP_TILE = 2
+assert H % H_TILE == 0
 assert H % O_GROUPS == 0
-assert O_GROUPS % O_GROUPS_PER_SPMD == 0
-assert O_GROUPS_PER_SPMD * HEADS_PER_GROUP == H_TILE
-assert (O_GROUPS * O_LORA) % B_K_TILE == 0
-assert D % PROJ_B_MM_N_TILE == 0, "proj_b_mm cube N-loop must cover D"
-assert D % PROJ_B_D_CHUNK == 0, "proj_b D-chunk loop must cover D"
-assert PROJ_B_D_CHUNK % PROJ_B_MM_N_TILE == 0, "proj_b inner N-frag loop must cover the D-chunk"
-assert T % PROJ_B_ACT_TBLK == 0 and PROJ_B_ACT_TBLK % PROJ_B_ACT_T_TILE == 0
-assert D % PROJ_B_ACT_N_TILE == 0, "proj_b_act vector N-loop must cover D"
-assert O_LORA % B_K_TILE == 0, "proj_b group K-loop covers O_LORA in B_K_TILE iters"
+assert O_GROUPS % O_GROUP_TILE == 0
+assert H // H_TILE == O_GROUPS // O_GROUP_TILE
+PA_NF_TILE = 2
+WARM_GROUP_TILE = min(12, O_GROUPS)
+WARM_BLOCK_TILE = 8
+WARM_ROW_TILE = (WARM_GROUP_TILE * O_LORA) // WARM_BLOCK_TILE
+assert WIN == ATTN_K_TILE
+PROJ_B_D_TILE = 512 if M.name == "flash" else 1792
+PROJ_B_ACT_T_TILE = 8
+PROJ_B_ACT_TASK_T_TILE = 8
+# CSA uses at least two sparse blocks.
+SPARSE_BLOCKS = max(2, (TOPK + ATTN_K_TILE - 1) // ATTN_K_TILE)
+PADDED_TOPK = SPARSE_BLOCKS * ATTN_K_TILE
 
 
 def get_standalone_cmp_valid(compress_ratio: int) -> int:
@@ -189,21 +101,6 @@ def get_standalone_cmp_valid(compress_ratio: int) -> int:
     if compress_ratio == 128:
         return MAX_SEQ_LEN // compress_ratio
     raise ValueError(f"Unsupported compress_ratio={compress_ratio}; expected one of {SUPPORTED_COMPRESS_RATIOS}")
-
-
-# CSA/full sparse-K width. SWA and HCA use explicit sibling modules so a
-# combined decode layer can import all three variants in one Python process
-# without relying on import-time config mutation and module-cache order.
-TOPK = WIN + CMP_TOPK
-# Floor to 2: a single sparse-K block miscompiles in pypto (S-stride cross-token
-# output mixup); a 2-block build with an all-invalid 2nd block is bit-exact.
-SPARSE_BLOCKS = max(2, (TOPK + ATTN_K_TILE - 1) // ATTN_K_TILE)
-PADDED_TOPK = SPARSE_BLOCKS * ATTN_K_TILE
-assert WIN <= TOPK <= TOPK_FULL, f"TOPK ({TOPK}) must be in [WIN={WIN}, TOPK_FULL={TOPK_FULL}]"
-# qk_pv work items: one per (token, sparse block), load-balanced across NUM_QK_CORES
-# lanes by the qk_plan pre-pass (non-empty tiles first, empty tiles appended).
-QK_ITEMS = T * SPARSE_BLOCKS
-
 
 @pl.jit.inline
 def sparse_attn(
@@ -223,111 +120,109 @@ def sparse_attn(
     attn_out: pl.Tensor[[T, D], pl.BF16],
 ):
     """Run sparse decode attention, inverse RoPE, and grouped output projection."""
-    # Gather the sliding-window + compressed-cache rows. Compressed index contract:
-    #   -1              invalid
-    #   [0, ...)        compressed KV slots
     ori_kv_flat = pl.reshape(ori_kv, [ORI_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
-    cmp_kv_flat = pl.reshape(cmp_kv, [CMP_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
-    sparse_bias = pl.create_tensor([T, PADDED_TOPK], dtype=pl.FP32)
 
-    # WAR marker (pypto-lib#481): the fused gather reads ori_kv inside qk_pv, but a
-    # scalar-driven gather_row does not by itself mark the param add_inout (and an
-    # in-qk_pv self-copy collides with the gather's tensor view). One no-op self-copy
-    # marks ori_kv add_inout before qk_pv, so the enclosing layer's in-place KV-cache
-    # writeback gets its WAR edge against the gather read. add_inout is a param-level
-    # property, so a single tile touch suffices -- no per-token fan-out.
+    # pypto-lib#481: Register the fused gather's ori_kv WAR dependency.
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="kv_touch"):
         ori_kv_flat[0:T, 0:HEAD_DIM] = ori_kv_flat[0:T, 0:HEAD_DIM]
 
-    # qk_pv gathers window/compressed rows into one L1 matmul operand. Invalid
-    # lanes gather a finite row and are zeroed out by the NEG_INF softmax bias.
     q_flat = pl.reshape(q, [T * H, HEAD_DIM])
-    o_packed = pl.create_tensor([O_GROUPS * T, O_GROUP_IN], dtype=pl.BF16)
-    sparse_blk_mi = pl.create_tensor([T * (H // H_TILE) * SPARSE_BLOCKS * H_TILE, 1], dtype=pl.FP32)
-    sparse_blk_li = pl.create_tensor([T * (H // H_TILE) * SPARSE_BLOCKS * H_TILE, 1], dtype=pl.FP32)
-    sparse_blk_oi = pl.create_tensor([T * (H // H_TILE) * SPARSE_BLOCKS * H_TILE, HEAD_DIM], dtype=pl.FP32)
 
-    # Load-balanced qk_pv planning (qk_plan): a single scalar task compacts the
-    # T*SPARSE_BLOCKS (token, sparse-block) work items into qk_order[] -- non-empty
-    # tiles (valid_block_mask > 0) first, empty tiles appended -- via one running
-    # write cursor. qk_pv then dispatches NUM_QK_CORES lanes; lane c walks its items
-    # strided by NUM_QK_CORES (qk_order[c], qk_order[c + NC], ...). Because the
-    # non-empty tiles occupy the front of qk_order, they spread one-per-lane before
-    # any lane takes a second -- the heavy tiles balance evenly across cores while the
-    # cheap empty tiles fill the tail slots. Replaces the fixed strided (token,
-    # block-lane) NSPLIT mapping, whose imbalance grew with per-token variance in the
-    # valid-block count. The T/SPARSE_BLOCKS scan loops are trace-time unrolled (small
-    # constants) so the cursor read-modify-write is an explicit sequential chain.
-    # cmp_sparse_indices holds compressed-cache slots (invalid = -1); valid_block_mask
-    # flags non-empty sparse blocks. Both feed qk_pv, so they stay GM scratch here.
+    wo_a_2d = pl.reshape(wo_a, [O_GROUPS * O_LORA, O_GROUP_IN])
+    # The unread sink materializes the shared-L2 wo_a cache-warm task.
+    warm_sink = pl.create_tensor([WARM_BLOCK_TILE * MM_T_TILE, PROJ_A_MM_N_TILE], dtype=pl.FP32)
+    with pl.spmd(WARM_BLOCK_TILE, name_hint="wo_a_warm", allow_early_resolve=True):
+        w_blk = pl.tile.get_block_idx()
+        w_r0 = w_blk * WARM_ROW_TILE
+        w_a = q_flat[0:MM_T_TILE, 0:A_K_TILE]
+        for wn in pl.range(WARM_ROW_TILE // PROJ_A_MM_N_TILE):
+            wn0 = w_r0 + wn * PROJ_A_MM_N_TILE
+            w_acc = pl.matmul(w_a, wo_a_2d[wn0 : wn0 + PROJ_A_MM_N_TILE, 0:A_K_TILE], b_trans=True, out_dtype=pl.FP32)
+            for wk in pl.pipeline(1, O_GROUP_IN // A_K_TILE, stage=2):
+                wk0 = wk * A_K_TILE
+                w_weight = wo_a_2d[wn0 : wn0 + PROJ_A_MM_N_TILE, wk0 : wk0 + A_K_TILE]
+                w_acc = pl.matmul_acc(w_acc, w_a, w_weight, b_trans=True)
+            warm_sink[w_blk * MM_T_TILE : (w_blk + 1) * MM_T_TILE, 0:PROJ_A_MM_N_TILE] = w_acc
+
+    sparse_bias = pl.create_tensor([T, PADDED_TOPK], dtype=pl.FP32)
     cmp_sparse_indices = pl.create_tensor([T, CMP_TOPK], dtype=pl.INT32)
     valid_block_mask = pl.create_tensor([T, SPARSE_BLOCKS], dtype=pl.INT32)
-    qk_order = pl.create_tensor([QK_ITEMS], dtype=pl.INT32)
+    qk_order = pl.create_tensor([T * SPARSE_BLOCKS], dtype=pl.INT32)
     qk_wcur = pl.create_tensor([1], dtype=pl.INT32)
+
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="csa_slots_build_valid_qk_plan", allow_early_resolve=True) as qk_plan_tid:
-        # Compressed slots [0, IDX_TOPK): vectorized masked copy over all T rows, keeping
-        # raw iff 0 <= raw < floor((pos + 1) / COMPRESS_RATIO), as out = mask*(raw + 1) - 1.
         c_raw = pl.cast(idx_topk[0:T, 0:IDX_TOPK], target_type=pl.FP32)
         c_pos = pl.cast(position_ids[0:T, 0:1], target_type=pl.FP32)
-        c_pos_q = pl.cast(pl.cast(pl.mul(pl.add(c_pos, 1.0), COMPRESS_RATIO_INV), target_type=pl.INT32, mode="trunc"), target_type=pl.FP32)
-        # Broadcast the per-token bound over IDX_TOPK cols.
-        c_upper_b = pl.row_expand_mul(pl.full([T, IDX_TOPK], dtype=pl.FP32, value=1.0), c_pos_q)
-        c_ge = pl.minimum(pl.maximum(pl.add(c_raw, CSA_CMP_GE_BIAS), 0.0), 1.0)
-        c_lt = pl.minimum(pl.maximum(pl.sub(c_upper_b, c_raw), 0.0), 1.0)
+        c_pos_one = pl.add(c_pos, 1.0)
+        c_pos_scaled = pl.mul(c_pos_one, COMPRESS_RATIO_INV)
+        c_pos_i32 = pl.cast(c_pos_scaled, target_type=pl.INT32, mode="trunc")
+        c_pos_q = pl.cast(c_pos_i32, target_type=pl.FP32)
+        c_upper_ones = pl.full([T, IDX_TOPK], dtype=pl.FP32, value=1.0)
+        c_upper_b = pl.row_expand_mul(c_upper_ones, c_pos_q)
+        c_raw_bias = pl.add(c_raw, CSA_CMP_GE_BIAS)
+        c_ge_floor = pl.maximum(c_raw_bias, 0.0)
+        c_ge = pl.minimum(c_ge_floor, 1.0)
+        c_upper_delta = pl.sub(c_upper_b, c_raw)
+        c_lt_floor = pl.maximum(c_upper_delta, 0.0)
+        c_lt = pl.minimum(c_lt_floor, 1.0)
         c_mask = pl.mul(c_ge, c_lt)
-        c_out = pl.sub(pl.mul(c_mask, pl.add(c_raw, 1.0)), 1.0)
+        c_raw_one = pl.add(c_raw, 1.0)
+        c_masked = pl.mul(c_mask, c_raw_one)
+        c_out = pl.sub(c_masked, 1.0)
         cmp_sparse_indices[0:T, 0:IDX_TOPK] = pl.cast(c_out, target_type=pl.INT32)
-        # Block 0 (sliding-window) is always live; blocks 1.. from the compressed mask.
         for c_t0 in pl.range(T):
-            pl.write(valid_block_mask, [c_t0, 0], pl.cast(1, pl.INT32))
+            c_valid_one = pl.cast(1, pl.INT32)
+            pl.write(valid_block_mask, [c_t0, 0], c_valid_one)
         for c_sb in pl.range(1, SPARSE_BLOCKS):
             c_s0 = (c_sb - 1) * ATTN_K_TILE
             c_blk_valid = pl.row_max(c_mask[:, c_s0 : c_s0 + ATTN_K_TILE])
             for c_dt in pl.range(T):
-                c_valid = pl.cast(pl.read(c_blk_valid, [c_dt, 0]), target_type=pl.INT32)
+                c_valid_f = pl.read(c_blk_valid, [c_dt, 0])
+                c_valid = pl.cast(c_valid_f, target_type=pl.INT32)
                 pl.write(valid_block_mask, [c_dt, c_sb], c_valid)
 
-        # Additive softmax bias (0 valid / NEG_INF invalid) that qk_pv adds onto the
-        # scaled scores, so invalid lanes exp to ~0 with no per-block mask multiply.
         v_win_f = pl.cast(window_swa_indices[0:T, 0:WIN], target_type=pl.FP32)
-        # Index contract (line 138): raw == -1 invalid, raw >= 0 valid. min(idx, 0)
-        # is -1 for invalid / 0 for valid; * -NEG_INF gives NEG_INF / 0. Bit-exact,
-        # 2 vector ops instead of the add/max/min/sub clamp chain. c_out is the just-
-        # computed post-mask compressed slots (integer-valued), reused directly.
-        v_win_valid = pl.minimum(pl.maximum(pl.add(v_win_f, 1.0), 0.0), 1.0)
-        sparse_bias[0:T, 0:WIN] = pl.mul(pl.sub(v_win_valid, 1.0), -NEG_INF)
-        sparse_bias[0:T, WIN:TOPK] = pl.mul(pl.minimum(c_out, 0.0), -NEG_INF)
+        v_win_one = pl.add(v_win_f, 1.0)
+        v_win_floor = pl.maximum(v_win_one, 0.0)
+        v_win_valid = pl.minimum(v_win_floor, 1.0)
+        v_win_mask = pl.sub(v_win_valid, 1.0)
+        sparse_bias[0:T, 0:WIN] = pl.mul(v_win_mask, -NEG_INF)
+        c_invalid = pl.minimum(c_out, 0.0)
+        sparse_bias[0:T, WIN:TOPK] = pl.mul(c_invalid, -NEG_INF)
         if PADDED_TOPK > TOPK:
             sparse_bias[0:T, TOPK:PADDED_TOPK] = pl.full([T, PADDED_TOPK - TOPK], dtype=pl.FP32, value=NEG_INF)
 
-        pl.write(qk_wcur, [0], pl.cast(0, pl.INT32))
-        # Pass 1: non-empty tiles to the front of qk_order.
+        qk_wcur_zero = pl.cast(0, pl.INT32)
+        pl.write(qk_wcur, [0], qk_wcur_zero)
         for plan_t in pl.unroll(T):
             for plan_sb in pl.unroll(SPARSE_BLOCKS):
                 if pl.read(valid_block_mask, [plan_t, plan_sb]) > 0:
                     plan_w = pl.read(qk_wcur, [0])
-                    pl.write(qk_order, [plan_w], pl.cast(plan_t * SPARSE_BLOCKS + plan_sb, pl.INT32))
-                    pl.write(qk_wcur, [0], pl.cast(plan_w + 1, pl.INT32))
-        # Pass 2: empty tiles appended to the tail.
+                    plan_valid_order = pl.cast(plan_t * SPARSE_BLOCKS + plan_sb, pl.INT32)
+                    pl.write(qk_order, [plan_w], plan_valid_order)
+                    plan_valid_next = pl.cast(plan_w + 1, pl.INT32)
+                    pl.write(qk_wcur, [0], plan_valid_next)
         for plan_t in pl.unroll(T):
             for plan_sb in pl.unroll(SPARSE_BLOCKS):
                 if pl.read(valid_block_mask, [plan_t, plan_sb]) <= 0:
                     plan_w = pl.read(qk_wcur, [0])
-                    pl.write(qk_order, [plan_w], pl.cast(plan_t * SPARSE_BLOCKS + plan_sb, pl.INT32))
-                    pl.write(qk_wcur, [0], pl.cast(plan_w + 1, pl.INT32))
+                    plan_invalid_order = pl.cast(plan_t * SPARSE_BLOCKS + plan_sb, pl.INT32)
+                    pl.write(qk_order, [plan_w], plan_invalid_order)
+                    plan_invalid_next = pl.cast(plan_w + 1, pl.INT32)
+                    pl.write(qk_wcur, [0], plan_invalid_next)
 
-    # One lane per core. Each lane walks its planned items -- the (token, block)
-    # work is derived per item, and qk_pv directly gathers window/compressed KV
-    # rows into the shared matmul operand.
-    with pl.spmd(NUM_QK_CORES, name_hint="qk_pv", deps=[qk_plan_tid], allow_early_resolve=True) as qk_tid:
+    cmp_kv_flat = pl.reshape(cmp_kv, [CMP_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
+    sparse_blk_mi = pl.create_tensor([T * (H // H_TILE) * SPARSE_BLOCKS * H_TILE, 1], dtype=pl.FP32)
+    sparse_blk_li = pl.create_tensor([T * (H // H_TILE) * SPARSE_BLOCKS * H_TILE, 1], dtype=pl.FP32)
+    sparse_blk_oi = pl.create_tensor([T * (H // H_TILE) * SPARSE_BLOCKS * H_TILE, HEAD_DIM], dtype=pl.FP32)
+
+    with pl.spmd(QK_CORE_TILE, name_hint="qk_pv", deps=[qk_plan_tid], allow_early_resolve=True) as _qk_tid:
         qk_core = pl.tile.get_block_idx()
-        # Items for this lane: qk_core, qk_core + NUM_QK_CORES, ...  The per-lane
-        # count is derived from the lane index (no stored per-core count); a lane
-        # with index >= QK_ITEMS runs zero iterations.
-        qk_lane_iters = (QK_ITEMS - qk_core + NUM_QK_CORES - 1) // NUM_QK_CORES
+        qk_lane_iters = (T * SPARSE_BLOCKS - qk_core + QK_CORE_TILE - 1) // QK_CORE_TILE
         for qk_it in pl.range(qk_lane_iters):
-            qk_flat = qk_core + qk_it * NUM_QK_CORES
-            qk_item = pl.cast(pl.read(qk_order, [qk_flat]), pl.INDEX)
+            qk_flat = qk_core + qk_it * QK_CORE_TILE
+            qk_item_i32 = pl.read(qk_order, [qk_flat])
+            qk_item = pl.cast(qk_item_i32, pl.INDEX)
             qk_t = qk_item // SPARSE_BLOCKS
             qk_sb = qk_item - qk_t * SPARSE_BLOCKS
             qk_b = qk_t // S
@@ -352,7 +247,8 @@ def sparse_attn(
                             qk_ridx = pl.read(cmp_sparse_indices, [qk_t, qk_cmp_k])
                             if qk_ridx >= 0:
                                 qk_slot = qk_ridx
-                                qk_cblk = pl.cast(pl.read(cmp_block_table, [qk_b, qk_slot // BLOCK_SIZE]), pl.INDEX)
+                                qk_cblk_i32 = pl.read(cmp_block_table, [qk_b, qk_slot // BLOCK_SIZE])
+                                qk_cblk = pl.cast(qk_cblk_i32, pl.INDEX)
                                 qk_csrc = qk_cblk * BLOCK_SIZE + qk_slot % BLOCK_SIZE
                                 qk_kv = pl.gather_row(qk_kv, cmp_kv_flat, [qk_r, 0], [qk_csrc, 0], [1, HEAD_DIM])
                             else:
@@ -360,26 +256,16 @@ def sparse_attn(
                         else:
                             qk_kv = pl.gather_row(qk_kv, ori_kv_flat, [qk_r, 0], [0, 0], [1, HEAD_DIM])
 
-                # Cube-batch QK_M_TILE head rows per QK/PV matmul so the shared KV
-                # tile is extracted L1->L0 once per QK_M_TILE/H_TILE head-tiles
-                # (2x reuse at QK_M_TILE=32) instead of per head-tile. The
-                # [QK_M_TILE, ...] softmax result is sliced back into H_TILE-row
-                # stores at the SAME offsets as the per-head-tile path
-                # (qk_h_idx == qk_hb * (QK_M_TILE // H_TILE) + qk_sub), so the
-                # sparse_blk_* layout and merge_norm are bit-identical.
                 for qk_hb in pl.pipeline(H // QK_M_TILE, stage=2):
                     qk_h0 = qk_hb * QK_M_TILE
                     qk_head_row = qk_t * H + qk_h0
                     qk_q_tile = q_flat[qk_head_row : qk_head_row + QK_M_TILE, 0 : HEAD_DIM]
                     qk_raw = pl.matmul(qk_q_tile, qk_kv, b_trans=True, out_dtype=pl.FP32)
                     qk_scaled = pl.mul(qk_raw, SOFTMAX_SCALE)
-                    # Broadcast-add the per-block bias directly (col_expand_add) instead
-                    # of col_expand into a dead pl.full(0) base + a separate add.
                     qk_scores = pl.col_expand_add(qk_scaled, qk_bias_row)
                     qk_mi = pl.row_max(qk_scores)
-                    # Invalid lanes (NEG_INF bias, zero kv rows) exp to ~0; all-invalid
-                    # blocks die in the merge alpha/beta -- no mask multiply needed.
-                    qk_exp = pl.exp(pl.row_expand_sub(qk_scores, qk_mi))
+                    qk_centered = pl.row_expand_sub(qk_scores, qk_mi)
+                    qk_exp = pl.exp(qk_centered)
                     qk_li = pl.row_sum(qk_exp)
                     qk_exp_bf16 = pl.cast(qk_exp, target_type=pl.BF16, mode="rint")
                     qk_oi = pl.matmul(qk_exp_bf16, qk_kv, out_dtype=pl.FP32)
@@ -390,7 +276,8 @@ def sparse_attn(
                         qk_row = qk_blk_base + qk_sb * H_TILE
                         sparse_blk_mi[qk_row : qk_row + H_TILE, 0 : 1] = qk_mi[qk_r0 : qk_r0 + H_TILE, 0 : 1]
                         sparse_blk_li[qk_row : qk_row + H_TILE, 0 : 1] = qk_li[qk_r0 : qk_r0 + H_TILE, 0 : 1]
-                        sparse_blk_oi[qk_row : qk_row + H_TILE, 0 : HEAD_DIM] = qk_oi[qk_r0 : qk_r0 + H_TILE, 0 : HEAD_DIM]
+                        qk_oi_tile = qk_oi[qk_r0 : qk_r0 + H_TILE, 0 : HEAD_DIM]
+                        sparse_blk_oi[qk_row : qk_row + H_TILE, 0 : HEAD_DIM] = qk_oi_tile
             else:
                 qk_oi_zero = pl.full([H_TILE, HEAD_DIM], dtype=pl.FP32, value=0.0)
                 for qk_h_idx in pl.range(H // H_TILE):
@@ -401,46 +288,50 @@ def sparse_attn(
                         pl.write(sparse_blk_li, [qk_row + qk_hr, 0], 0.0)
                     sparse_blk_oi[qk_row : qk_row + H_TILE, 0 : HEAD_DIM] = qk_oi_zero
 
-    # Precompute the head-invariant interleaved cos and sign*sin once: they depend
-    # only on (token, column), not head, so building them per head would repeat the
-    # same dup-gather H times on the bottleneck Vec engine. sign is folded into sin
-    # (multiply by +/-1). The conjugate (inverse) rotation is:
-    #   out[j] = x[j]*cos_il[j] + x[j^1]*sign[j]*sin_il[j]
-    # Hoisted ABOVE merge_norm (which now fuses the rotation): independent of qk_pv,
-    # so it overlaps it and is off merge_norm's critical path.
+    # Inverse RoPE: out[j] = x[j] * cos[j] + x[j ^ 1] * sign[j] * sin[j].
     rope_cos_il = pl.create_tensor([T, ROPE_DIM], dtype=pl.FP32)
     rope_sin_signed = pl.create_tensor([T, ROPE_DIM], dtype=pl.FP32)
-    # The j^1 lane-swap index is block-invariant too; merge_norm rebuilt the whole
-    # arange/trunc/lane chain on each of its T*(H//H_TILE) blocks. Build it here.
     rope_swap_idx_m = pl.create_tensor([1, MERGE_SWAP_FLAT_LEN], dtype=pl.INT32)
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="rope_cs", allow_early_resolve=True):
-        sw_col_m = pl.cast(
-            pl.arange(0, [1, MERGE_SWAP_FLAT_LEN], dtype=pl.INT32), target_type=pl.FP32)
-        sw_rowbase_m = pl.mul(
-            pl.cast(pl.cast(pl.mul(sw_col_m, ROPE_DIM_INV), target_type=pl.INT32, mode="trunc"),
-                    target_type=pl.FP32),
-            ROPE_DIM_F)                                                                           # r*ROPE_DIM
-        sw_j_m = pl.sub(sw_col_m, sw_rowbase_m)                                                   # j
-        sw_dup_f_m = pl.cast(pl.cast(pl.mul(sw_j_m, 0.5), target_type=pl.INT32, mode="trunc"), target_type=pl.FP32)
-        sw_lane_m = pl.sub(sw_j_m, pl.mul(sw_dup_f_m, 2.0))                                       # j%2
-        sw_jx_m = pl.sub(pl.add(sw_j_m, 1.0), pl.mul(sw_lane_m, 2.0))                              # j^1
-        rope_swap_idx_m[0:1, 0:MERGE_SWAP_FLAT_LEN] = pl.cast(
-            pl.add(sw_rowbase_m, sw_jx_m), target_type=pl.INT32)
-        cs_col = pl.col_expand_mul(
-            pl.full([T, ROPE_DIM], dtype=pl.FP32, value=1.0),
-            pl.cast(pl.arange(0, [1, ROPE_DIM], dtype=pl.INT32), target_type=pl.FP32))
-        cs_dup_f = pl.cast(pl.cast(pl.mul(cs_col, 0.5), target_type=pl.INT32, mode="trunc"), target_type=pl.FP32)
-        cs_dup_idx = pl.cast(cs_dup_f, target_type=pl.INT32)                                      # j>>1
-        cs_lane = pl.sub(cs_col, pl.mul(cs_dup_f, 2.0))                                           # j%2
-        cs_sign = pl.neg(pl.sub(pl.mul(cs_lane, 2.0), 1.0))                                       # [+1,-1,...] (conjugate)
-        cs_cos = pl.cast(freqs_cos[0:T, 0:HALF_ROPE], target_type=pl.FP32)
-        cs_sin = pl.cast(freqs_sin[0:T, 0:HALF_ROPE], target_type=pl.FP32)
-        rope_cos_il[0:T, 0:ROPE_DIM] = pl.gather(cs_cos, dim=-1, index=cs_dup_idx)
-        rope_sin_signed[0:T, 0:ROPE_DIM] = pl.mul(pl.gather(cs_sin, dim=-1, index=cs_dup_idx), cs_sign)
+        sw_col_i_m = pl.arange(0, [1, MERGE_SWAP_FLAT_LEN], dtype=pl.INT32)
+        sw_col_m = pl.cast(sw_col_i_m, target_type=pl.FP32)
+        sw_row_f_m = pl.mul(sw_col_m, ROPE_DIM_INV)
+        sw_row_i_m = pl.cast(sw_row_f_m, target_type=pl.INT32, mode="trunc")
+        sw_row_m = pl.cast(sw_row_i_m, target_type=pl.FP32)
+        sw_rowbase_m = pl.mul(sw_row_m, ROPE_DIM_F)
+        sw_j_m = pl.sub(sw_col_m, sw_rowbase_m)
+        sw_half_m = pl.mul(sw_j_m, 0.5)
+        sw_dup_i_m = pl.cast(sw_half_m, target_type=pl.INT32, mode="trunc")
+        sw_dup_f_m = pl.cast(sw_dup_i_m, target_type=pl.FP32)
+        sw_dup2_m = pl.mul(sw_dup_f_m, 2.0)
+        sw_lane_m = pl.sub(sw_j_m, sw_dup2_m)
+        sw_j_next_m = pl.add(sw_j_m, 1.0)
+        sw_lane2_m = pl.mul(sw_lane_m, 2.0)
+        sw_jx_m = pl.sub(sw_j_next_m, sw_lane2_m)
+        sw_swap_m = pl.add(sw_rowbase_m, sw_jx_m)
+        rope_swap_idx_m[0:1, 0:MERGE_SWAP_FLAT_LEN] = pl.cast(sw_swap_m, target_type=pl.INT32)
+        cs_rowbase = pl.mul(sw_rowbase_m[0:1, 0:CS_DUP_FLAT_LEN], 0.5)
+        cs_dup_f = sw_dup_f_m[0:1, 0:CS_DUP_FLAT_LEN]
+        cs_dup_idx_f = pl.add(cs_rowbase, cs_dup_f)
+        cs_dup_idx = pl.cast(cs_dup_idx_f, target_type=pl.INT32)
+        cs_lane2 = pl.mul(sw_lane_m[0:1, 0:ROPE_DIM], 2.0)
+        cs_sign_base = pl.sub(cs_lane2, 1.0)
+        cs_sign = pl.neg(cs_sign_base)
+        cs_cos_f32 = pl.cast(freqs_cos[0:T, 0:HALF_ROPE], target_type=pl.FP32)
+        cs_cos = pl.reshape(cs_cos_f32, [1, T * HALF_ROPE])
+        cs_sin_f32 = pl.cast(freqs_sin[0:T, 0:HALF_ROPE], target_type=pl.FP32)
+        cs_sin = pl.reshape(cs_sin_f32, [1, T * HALF_ROPE])
+        cs_cos_gather = pl.gather(cs_cos, dim=-1, index=cs_dup_idx)
+        cs_cos_il = pl.reshape(cs_cos_gather, [T, ROPE_DIM])
+        rope_cos_il[0:T, 0:ROPE_DIM] = cs_cos_il
+        cs_sin_gather = pl.gather(cs_sin, dim=-1, index=cs_dup_idx)
+        cs_sin_il = pl.reshape(cs_sin_gather, [T, ROPE_DIM])
+        rope_sin_signed[0:T, 0:ROPE_DIM] = pl.col_expand_mul(cs_sin_il, cs_sign)
 
-    # Online-softmax merge, sink-norm, and inverse RoPE in output-projection bundles.
-    merge_tids = pl.array.create(O_GROUPS // O_GROUPS_PER_SPMD, pl.TASK_ID)
-    for merge_group in pl.parallel(O_GROUPS // O_GROUPS_PER_SPMD):
+    o_packed = pl.create_tensor([O_GROUPS * T, O_GROUP_IN], dtype=pl.BF16)
+    merge_tids = pl.array.create(O_GROUPS // O_GROUP_TILE, pl.TASK_ID)
+
+    for merge_group in pl.parallel(O_GROUPS // O_GROUP_TILE):
         with pl.spmd(T, name_hint="merge_norm") as merge_tid:
             m_t = pl.tile.get_block_idx()
             m_h_idx = merge_group
@@ -458,15 +349,24 @@ def sparse_attn(
                     m_cur_li = sparse_blk_li[m_row : m_row + H_TILE, 0 : 1]
                     m_cur_oi = sparse_blk_oi[m_row : m_row + H_TILE, 0 : HEAD_DIM]
                     m_mi_new = pl.maximum(m_mi, m_cur_mi)
-                    m_alpha = pl.exp(pl.sub(m_mi, m_mi_new))
-                    m_beta = pl.exp(pl.sub(m_cur_mi, m_mi_new))
-                    m_li = pl.add(pl.mul(m_alpha, m_li), pl.mul(m_beta, m_cur_li))
-                    m_oi = pl.add(pl.row_expand_mul(m_oi, m_alpha), pl.row_expand_mul(m_cur_oi, m_beta))
+                    m_alpha_delta = pl.sub(m_mi, m_mi_new)
+                    m_alpha = pl.exp(m_alpha_delta)
+                    m_beta_delta = pl.sub(m_cur_mi, m_mi_new)
+                    m_beta = pl.exp(m_beta_delta)
+                    m_li_prev = pl.mul(m_alpha, m_li)
+                    m_li_cur = pl.mul(m_beta, m_cur_li)
+                    m_li = pl.add(m_li_prev, m_li_cur)
+                    m_oi_prev = pl.row_expand_mul(m_oi, m_alpha)
+                    m_oi_cur = pl.row_expand_mul(m_cur_oi, m_beta)
+                    m_oi = pl.add(m_oi_prev, m_oi_cur)
                     m_mi = m_mi_new
 
             n_sink_bias = pl.reshape(attn_sink[m_h0 : m_h0 + H_TILE], [H_TILE, 1])
-            n_sink_tile = pl.add(pl.sub(m_mi, m_mi), n_sink_bias)
-            n_denom = pl.add(m_li, pl.exp(pl.sub(n_sink_tile, m_mi)))
+            n_zero = pl.sub(m_mi, m_mi)
+            n_sink_tile = pl.add(n_zero, n_sink_bias)
+            n_sink_delta = pl.sub(n_sink_tile, m_mi)
+            n_sink_exp = pl.exp(n_sink_delta)
+            n_denom = pl.add(m_li, n_sink_exp)
             n_nope = pl.row_expand_div(m_oi[0 : H_TILE, 0 : NOPE_DIM], n_denom)
             n_nope_bf16 = pl.cast(n_nope, target_type=pl.BF16, mode="rint")
 
@@ -475,8 +375,11 @@ def sparse_attn(
             m_cos_il = rope_cos_il[m_t : m_t + 1, 0 : ROPE_DIM]
             m_sin_signed = rope_sin_signed[m_t : m_t + 1, 0 : ROPE_DIM]
             m_rope_flat = pl.reshape(m_rope, [1, MERGE_SWAP_FLAT_LEN])
-            m_swapped = pl.reshape(pl.gather(m_rope_flat, dim=-1, index=m_swap_flat), [H_TILE, ROPE_DIM])
-            m_rot = pl.add(pl.col_expand_mul(m_rope, m_cos_il), pl.col_expand_mul(m_swapped, m_sin_signed))
+            m_swapped_flat = pl.gather(m_rope_flat, dim=-1, index=m_swap_flat)
+            m_swapped = pl.reshape(m_swapped_flat, [H_TILE, ROPE_DIM])
+            m_rope_cos = pl.col_expand_mul(m_rope, m_cos_il)
+            m_rope_sin = pl.col_expand_mul(m_swapped, m_sin_signed)
+            m_rot = pl.add(m_rope_cos, m_rope_sin)
             n_rope_bf16 = pl.cast(m_rot, target_type=pl.BF16, mode="rint")
             n_full_bf16 = pl.concat(n_nope_bf16, n_rope_bf16)
 
@@ -486,49 +389,32 @@ def sparse_attn(
                 n_hh = n_gh - n_g * HEADS_PER_GROUP
                 n_pack_row = n_g * T + m_t
                 n_col = n_hh * HEAD_DIM
-                o_packed[n_pack_row : n_pack_row + 1, n_col : n_col + HEAD_DIM] = n_full_bf16[n_hi : n_hi + 1, 0 : HEAD_DIM]
+                n_head = n_full_bf16[n_hi : n_hi + 1, 0 : HEAD_DIM]
+                o_packed[n_pack_row : n_pack_row + 1, n_col : n_col + HEAD_DIM] = n_head
         merge_tids[merge_group] = merge_tid
 
-    # ========================================================================
-    # Back-to-back grouped output projection (manual scope, PER-GROUP INT8 quant).
-    #
-    # Per-GROUP amax localizes the quant reduction to each O_LORA group (vs the
-    # per-ROW-amax form, where a full-8192-row reduction is a hard barrier between
-    # proj_a and proj_b), so the three stages PIPELINE per group with qwen3-style
-    # fine-grained deps: proj_b[*, g] waits only on quant[g], which waits only on
-    # proj_a[g, *] -- so proj_b's cube for group g runs while proj_a/quant of later
-    # groups are still in flight (a genuine proj_a<->proj_b back-to-back GEMM).
-    #
-    # manual_scope suppresses auto-dep, so every edge is explicit: each proj_a grid
-    # waits on merge_norm; quant[g] waits on the group grid; proj_b[g] waits on
-    # quant[g] and writes a disjoint group partial. proj_b_act combines those partials
-    # with their group row scales and is the consolidated attn_out writer.
-    # ========================================================================
     o_r_pad = pl.create_tensor([T_PAD, O_GROUPS * O_LORA], dtype=pl.FP32)
     o_r_i8_pad = pl.create_tensor([T_PAD, O_GROUPS * O_LORA], dtype=pl.INT8)
     act_scale_dq = pl.create_tensor([O_GROUPS, T], dtype=pl.FP32)
-    # Per-group INT32 partials: proj_b_mm (pure cube) writes group g's contribution to
-    # output channel n at partials[:, g*D + n]; proj_b_act (pure vector) sums the
-    # O_GROUPS partials with their per-group act scales. No atomic-add -> no zero-seed.
     partials = pl.create_tensor([T_PAD, O_GROUPS * D], dtype=pl.INT32)
-    proj_b_tids = pl.array.create(O_GROUPS // O_GROUPS_PER_SPMD, pl.TASK_ID)
+    proj_b_tids = pl.array.create(O_GROUPS // O_GROUP_TILE, pl.TASK_ID)
 
     with pl.manual_scope():
-        for group_bundle in pl.parallel(O_GROUPS // O_GROUPS_PER_SPMD):
+        for group_bundle in pl.parallel(O_GROUPS // O_GROUP_TILE):
             with pl.spmd(
-                O_GROUPS_PER_SPMD * PA_BLOCKS,
+                O_GROUP_TILE * (O_LORA // PROJ_A_MM_N_TILE // PA_NF_TILE),
                 name_hint="proj_a_mm",
                 deps=[merge_tids[group_bundle]],
                 allow_early_resolve=True,
             ) as pa_tid:
                 pa_idx = pl.tile.get_block_idx()
-                pa_local_group = pa_idx // PA_BLOCKS
-                pa_blk = pa_idx - pa_local_group * PA_BLOCKS
-                g = group_bundle * O_GROUPS_PER_SPMD + pa_local_group
+                pa_local_group = pa_idx // (O_LORA // PROJ_A_MM_N_TILE // PA_NF_TILE)
+                pa_blk = pa_idx - pa_local_group * (O_LORA // PROJ_A_MM_N_TILE // PA_NF_TILE)
+                g = group_bundle * O_GROUP_TILE + pa_local_group
                 row_base_o = g * T
                 out_col_g = g * O_LORA
-                for anf in pl.range(PA_NF_PER_BLOCK):
-                    n0 = pa_blk * (PA_NF_PER_BLOCK * PROJ_A_MM_N_TILE) + anf * PROJ_A_MM_N_TILE
+                for anf in pl.range(PA_NF_TILE):
+                    n0 = pa_blk * (PA_NF_TILE * PROJ_A_MM_N_TILE) + anf * PROJ_A_MM_N_TILE
                     xa0_chunk = pl.slice(o_packed, [MM_T_TILE, A_K_TILE], [row_base_o, 0], valid_shape=[T, A_K_TILE])
                     wa0_chunk = wo_a[g : g + 1, n0 : n0 + PROJ_A_MM_N_TILE, 0:A_K_TILE]
                     acc_a = pl.matmul(xa0_chunk, wa0_chunk, b_trans=True, out_dtype=pl.FP32)
@@ -540,13 +426,13 @@ def sparse_attn(
                     o_r_pad = pl.assemble(o_r_pad, acc_a, [0, out_col_g + n0])
 
             with pl.spmd(
-                O_GROUPS_PER_SPMD,
+                O_GROUP_TILE,
                 name_hint="quant",
                 deps=[pa_tid],
                 allow_early_resolve=True,
             ) as q_tid:
                 q_local_group = pl.tile.get_block_idx()
-                g = group_bundle * O_GROUPS_PER_SPMD + q_local_group
+                g = group_bundle * O_GROUP_TILE + q_local_group
                 col_g = g * O_LORA
                 for qt in pl.pipeline(0, T, QUANT_TOKEN_TILE, stage=2):
                     oc_amax = o_r_pad[qt : qt + QUANT_TOKEN_TILE, col_g : col_g + O_LORA]
@@ -557,35 +443,28 @@ def sparse_attn(
                     g_amax = pl.maximum(g_amax_floor, g_row_max)
                     g_scale_num = pl.full([1, QUANT_TOKEN_TILE], dtype=pl.FP32, value=INT8_SCALE_MAX)
                     g_sq_row = pl.div(g_scale_num, g_amax)
-                    act_scale_dq = pl.assemble(act_scale_dq, pl.recip(g_sq_row), [g, qt])
+                    g_scale_dq = pl.recip(g_sq_row)
+                    act_scale_dq[g : g + 1, qt : qt + QUANT_TOKEN_TILE] = g_scale_dq
                     g_sq_col = pl.reshape(g_sq_row, [QUANT_TOKEN_TILE, 1])
-                    # Reuse the amax load: this is the same [QUANT_TOKEN_TILE, O_LORA]
-                    # window with no intervening writer, and no pass in the pipeline
-                    # does CSE, so a second read is a real second GM round-trip.
                     oq_scaled = pl.row_expand_mul(oc_amax, g_sq_col)
                     oq_i32 = pl.cast(oq_scaled, target_type=pl.INT32, mode="rint")
                     oq_half = pl.cast(oq_i32, target_type=pl.FP16, mode="round")
                     oq_i8 = pl.cast(oq_half, target_type=pl.INT8, mode="trunc")
-                    o_r_i8_pad = pl.assemble(o_r_i8_pad, oq_i8, [qt, col_g])
-                    # Rows [T, T_PAD) are write-only: proj_b_act reads partials[0:T]
-                    # only (PB_ACT_TBLKS == T // PROJ_B_ACT_TBLK == 1), so the pad rows
-                    # never reach an output. proj_b_mm still multiplies them, but INT8
-                    # over K=O_LORA is bounded well inside INT32 and integer MACs do
-                    # not trap, so seeding them costs a store for nothing.
+                    o_r_i8_pad[qt : qt + QUANT_TOKEN_TILE, col_g : col_g + O_LORA] = oq_i8
 
             with pl.spmd(
-                O_GROUPS_PER_SPMD * PB_DCHUNKS,
+                O_GROUP_TILE * (D // PROJ_B_D_TILE),
                 name_hint="proj_b_mm",
                 deps=[q_tid],
                 allow_early_resolve=True,
             ) as pb_tid:
                 pb_idx = pl.tile.get_block_idx()
-                pb_local_group = pb_idx // PB_DCHUNKS
-                dc = pb_idx - pb_local_group * PB_DCHUNKS
-                g = group_bundle * O_GROUPS_PER_SPMD + pb_local_group
+                pb_local_group = pb_idx // (D // PROJ_B_D_TILE)
+                dc = pb_idx - pb_local_group * (D // PROJ_B_D_TILE)
+                g = group_bundle * O_GROUP_TILE + pb_local_group
                 col_g = g * O_LORA
-                d0 = dc * PROJ_B_D_CHUNK
-                for nf in pl.range(PROJ_B_D_CHUNK // PROJ_B_MM_N_TILE):
+                d0 = dc * PROJ_B_D_TILE
+                for nf in pl.range(PROJ_B_D_TILE // PROJ_B_MM_N_TILE):
                     n0 = d0 + nf * PROJ_B_MM_N_TILE
                     acc_b = pl.create_tensor([MM_T_TILE, PROJ_B_MM_N_TILE], dtype=pl.INT32)
                     for kb in pl.pipeline(0, O_LORA // B_K_TILE, stage=2):
@@ -598,27 +477,24 @@ def sparse_attn(
                             b_act = o_r_i8_pad[:, k0 : k0 + B_K_TILE]
                             b_weight = wo_b[n0 : n0 + PROJ_B_MM_N_TILE, k0 : k0 + B_K_TILE]
                             acc_b = pl.matmul_acc(acc_b, b_act, b_weight, b_trans=True)
-                    partials = pl.assemble(partials, acc_b, [0, g * D + n0])
+                    partial_n0 = g * D + n0
+                    partials[0:MM_T_TILE, partial_n0 : partial_n0 + PROJ_B_MM_N_TILE] = acc_b
             proj_b_tids[group_bundle] = pb_tid
 
-    # proj_b_act (PURE-VECTOR consolidated writer, auto region): sum the O_GROUPS INT32
-    # partials -- each dequantized by its group's per-row act scale -- then apply the
-    # per-channel weight scale -> BF16. Explicit deps on all proj_b_mm tasks bridge
-    # manual_scope -> the return's auto-dep (this auto-region write registers the edge).
     with pl.spmd(
-        PB_ACT_NREG * PB_ACT_TBLKS,
+        (D // PROJ_B_ACT_N_TILE) * (T // PROJ_B_ACT_TASK_T_TILE),
         name_hint="proj_b_act",
-        deps=[proj_b_tids[i] for i in range(O_GROUPS // O_GROUPS_PER_SPMD)],
+        deps=[proj_b_tids[i] for i in range(O_GROUPS // O_GROUP_TILE)],
         allow_early_resolve=True,
     ) as _act_tid:
         act_idx = pl.tile.get_block_idx()
-        nreg = act_idx // PB_ACT_TBLKS
-        tblk = act_idx - nreg * PB_ACT_TBLKS
+        nreg = act_idx // (T // PROJ_B_ACT_TASK_T_TILE)
+        tblk = act_idx - nreg * (T // PROJ_B_ACT_TASK_T_TILE)
         ob_n0 = nreg * PROJ_B_ACT_N_TILE
-        t0 = tblk * PROJ_B_ACT_TBLK
+        t0 = tblk * PROJ_B_ACT_TASK_T_TILE
         wb_scale = wo_b_scale[ob_n0 : ob_n0 + PROJ_B_ACT_N_TILE]
-        wb_scale_chunk = pl.reshape(wb_scale, [1, PROJ_B_ACT_N_TILE])
-        for b_tb in pl.range(t0, t0 + PROJ_B_ACT_TBLK, PROJ_B_ACT_T_TILE):
+        wb_scale_tile = pl.reshape(wb_scale, [1, PROJ_B_ACT_N_TILE])
+        for b_tb in pl.range(t0, t0 + PROJ_B_ACT_TASK_T_TILE, PROJ_B_ACT_T_TILE):
             acc = pl.full([PROJ_B_ACT_T_TILE, PROJ_B_ACT_N_TILE], dtype=pl.FP32, value=0.0)
             for act_g in pl.pipeline(O_GROUPS, stage=2):
                 p_col0 = act_g * D + ob_n0
@@ -628,7 +504,7 @@ def sparse_attn(
                 p_g_f32 = pl.cast(p_g, target_type=pl.FP32, mode="none")
                 p_g_scaled = pl.row_expand_mul(p_g_f32, g_scale)
                 acc = pl.add(acc, p_g_scaled)
-            out_t = pl.col_expand_mul(acc, wb_scale_chunk)
+            out_t = pl.col_expand_mul(acc, wb_scale_tile)
             out_bf16 = pl.cast(out_t, target_type=pl.BF16, mode="rint")
             attn_out[b_tb : b_tb + PROJ_B_ACT_T_TILE, ob_n0 : ob_n0 + PROJ_B_ACT_N_TILE] = out_bf16
 
@@ -652,19 +528,10 @@ def sparse_attn_test(
     attn_out: pl.Out[pl.Tensor[[T, D], pl.BF16]],
 ):
     sparse_attn(
-        q,
-        ori_kv,
-        window_swa_indices,
-        cmp_kv,
-        cmp_block_table,
-        idx_topk,
-        position_ids,
-        attn_sink,
-        freqs_cos,
-        freqs_sin,
-        wo_a,
-        wo_b,
-        wo_b_scale,
+        q, ori_kv, window_swa_indices,
+        cmp_kv, cmp_block_table, idx_topk, position_ids,
+        attn_sink, freqs_cos, freqs_sin,
+        wo_a, wo_b, wo_b_scale,
         attn_out,
     )
     return attn_out
@@ -703,8 +570,7 @@ def golden_sparse_attn(tensors):
     window_swa_indices = tensors["window_swa_indices"]
     cmp_kv = tensors["cmp_kv"].float()
     cmp_block_table = tensors["cmp_block_table"]
-    # Compressed slots: keep raw indexer topk iff 0 <= raw < floor((pos + 1) /
-    # COMPRESS_RATIO), else -1 -- the masking sparse_attn now folds in internally.
+    # Mask raw compressed slots by each token's causal bound.
     raw = tensors["idx_topk"][:, :CMP_TOPK].to(torch.int64)
     bound = ((tensors["position_ids"][:, 0].to(torch.int64) + 1) // DEFAULT_COMPRESS_RATIO).unsqueeze(1)
     keep = (raw >= 0) & (raw < bound)
@@ -718,8 +584,6 @@ def golden_sparse_attn(tensors):
 
     o = torch.zeros(T, H, HEAD_DIM)
 
-    # Per-query-token attention. The window prefix is driven by window_swa_indices;
-    # cmp_sparse_indices contains compressed-cache slots only.
     for t in range(T):
         b = t // S
         kv_rows = []
@@ -802,11 +666,7 @@ def golden_sparse_attn(tensors):
     seq_per_batch = T // B
     o_model = o.float().view(B, seq_per_batch, O_GROUPS, O_GROUP_IN)
     o_r = torch.einsum("bsgd,grd->bsgr", o_model, wo_a)
-    # PER-GROUP INT8 activation quant (one amax per O_LORA group, not per full row):
-    # this localizes the reduction so proj_a[g]->quant[g]->proj_b[g] can pipeline
-    # back-to-back. Each group's INT32 partial is dequantized by its OWN per-row
-    # activation scale before the groups are summed (the per-group scale cannot
-    # factor out of the K-sum), then the per-channel weight scale is applied.
+    # Quantize each output-projection group independently.
     o_r_g = o_r.reshape(T, O_GROUPS, O_LORA)
     amax_g = o_r_g.abs().amax(dim=-1, keepdim=True).clamp_min(INT8_AMAX_EPS)   # [T, G, 1]
     scale_q_g = INT8_SCALE_MAX / amax_g
@@ -836,10 +696,9 @@ def build_tensor_specs(
 
     cmp_valid = get_standalone_cmp_valid(compress_ratio)
     shared_freqs_cos, shared_freqs_sin = build_deepseek_v4_rope_tables(M, compress_ratio, dtype=torch.bfloat16)
+    token_positions = torch.arange(T, dtype=torch.int32)
     shared_rope_cos, shared_rope_sin = materialize_token_rope_tables(
-        shared_freqs_cos,
-        shared_freqs_sin,
-        torch.arange(T, dtype=torch.int32),
+        shared_freqs_cos, shared_freqs_sin, token_positions
     )
 
     def init_q():
@@ -881,19 +740,11 @@ def build_tensor_specs(
 
     def init_window_block_table():
         """Build the demo block table for the sliding-window cache pages."""
-        return block_table(
-            batch=B,
-            table_blocks=ORI_MAX_BLOCKS,
-            physical_blocks=ORI_BLOCK_NUM,
-        )
+        return block_table(batch=B, table_blocks=ORI_MAX_BLOCKS, physical_blocks=ORI_BLOCK_NUM)
 
     def init_cmp_block_table():
         """Build the demo block table for the compressed-cache pages."""
-        return block_table(
-            batch=B,
-            table_blocks=CMP_MAX_BLOCKS,
-            physical_blocks=CMP_BLOCK_NUM,
-        )
+        return block_table(batch=B, table_blocks=CMP_MAX_BLOCKS, physical_blocks=CMP_BLOCK_NUM)
 
     def init_cmp_sparse_indices():
         """Build the compressed sparse index list."""
@@ -906,7 +757,8 @@ def build_tensor_specs(
             indices[:, :] = -1
             mixed_cmp_valid = min(cmp_valid, IDX_TOPK)
             if mixed_cmp_valid:
-                indices[:, :mixed_cmp_valid] = torch.arange(mixed_cmp_valid, dtype=torch.int32).unsqueeze(0).expand(T, -1)
+                mixed_indices = torch.arange(mixed_cmp_valid, dtype=torch.int32)
+                indices[:, :mixed_cmp_valid] = mixed_indices.unsqueeze(0).expand(T, -1)
         if cache_window_replacement_fixture:
             indices[:, :] = -1
         if causal_regression_fixture:
@@ -914,16 +766,13 @@ def build_tensor_specs(
         return indices
 
     def init_idx_topk():
-        """Raw indexer topk feeding sparse_attn's compressed-slot masking. Only the
-        first CMP_TOPK cols are read; identity mask here (see init_position_ids), so
-        the masked output equals this fixture pattern."""
+        """Build the raw indexer top-k fixture."""
         topk = torch.full((T, INDEXER_SCORE_LEN), -1, dtype=torch.int32)
         topk[:, :CMP_TOPK] = init_cmp_sparse_indices()
         return topk
 
     def init_position_ids():
-        """Large enough that floor((pos + 1) / COMPRESS_RATIO) >= CMP_TOPK, so the
-        per-token bound never clips the fixture slots (mask reduces to raw >= 0)."""
+        """Build position IDs whose compressed-slot bound covers the fixture."""
         return torch.full((T, 1), DEFAULT_COMPRESS_RATIO * CMP_TOPK, dtype=torch.int32)
 
     def init_cos():
@@ -972,33 +821,30 @@ if __name__ == "__main__":
     from golden import ratio_allclose, run_jit
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("-p", "--platform", type=str, default="a2a3",
-                        choices=["a2a3", "a2a3sim", "a5", "a5sim"])
+    parser.add_argument("-p", "--platform", type=str, default="a2a3", choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    # --compress-ratio only selects which compressed-tail data pattern to validate;
-    # the pruned widths are covered by the swa/hca variant tests.
-    parser.add_argument("--compress-ratio", type=int, default=DEFAULT_COMPRESS_RATIO,
-                        choices=list(SUPPORTED_COMPRESS_RATIOS))
-    parser.add_argument("--causal-regression-fixture", action="store_true", default=False,
-                        help="Amplify the S=2 future-window-slot regression; use with --compress-ratio 0.")
-    parser.add_argument("--short-window-fixture", action="store_true", default=False,
-                        help="Use a short-window topk row with valid prefix + -1 padding.")
-    parser.add_argument("--mixed-topk-fixture", action="store_true", default=False,
-                        help="Use -1-padded window slots with valid compressed raw indices.")
-    parser.add_argument("--cache-window-replacement-fixture", action="store_true", default=False,
-                        help="Place a sentinel row inside the cache window prefix.")
+    compress_choices = list(SUPPORTED_COMPRESS_RATIOS)
+    parser.add_argument("--compress-ratio", type=int, default=DEFAULT_COMPRESS_RATIO, choices=compress_choices)
+    causal_help = "Amplify the S=2 future-window-slot regression; use with --compress-ratio 0."
+    parser.add_argument("--causal-regression-fixture", action="store_true", default=False, help=causal_help)
+    short_help = "Use a short-window topk row with valid prefix + -1 padding."
+    parser.add_argument("--short-window-fixture", action="store_true", default=False, help=short_help)
+    mixed_help = "Use -1-padded window slots with valid compressed raw indices."
+    parser.add_argument("--mixed-topk-fixture", action="store_true", default=False, help=mixed_help)
+    cache_help = "Place a sentinel row inside the cache window prefix."
+    parser.add_argument("--cache-window-replacement-fixture", action="store_true", default=False, help=cache_help)
     parser.add_argument("--golden-data", type=str, default=None)
     parser.add_argument("--enable-chip-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2))
-    parser.add_argument("--enable-dep-gen", action="store_true", default=False,
-                        help="Capture PTO2 dependency edges (deps.json); the swimlane "
-                             "converter draws fanout/fanin arrows from the sibling file.")
+    dep_help = "Capture PTO2 dependency edges (deps.json); the swimlane "
+    dep_help += "converter draws fanout/fanin arrows from the sibling file."
+    parser.add_argument("--enable-dep-gen", action="store_true", default=False, help=dep_help)
     parser.add_argument("--enable-pmu", nargs="?", const=2, default=0, type=int, choices=[0, 1, 2, 4])
     parser.add_argument("--dump-passes", action="store_true", default=False)
     args = parser.parse_args()
 
     compress_ratio = args.compress_ratio
-    print(f"compress_ratio={compress_ratio} "
-          f"-> TOPK={TOPK} SPARSE_BLOCKS={SPARSE_BLOCKS} PADDED_TOPK={PADDED_TOPK}", flush=True)
+    summary = f"compress_ratio={compress_ratio} -> TOPK={TOPK} SPARSE_BLOCKS={SPARSE_BLOCKS} PADDED_TOPK={PADDED_TOPK}"
+    print(summary, flush=True)
 
     result = run_jit(
         fn=sparse_attn_test,

--- a/models/deepseek_v4_pro/decode_sparse_attn_hca.py
+++ b/models/deepseek_v4_pro/decode_sparse_attn_hca.py
@@ -38,104 +38,53 @@ NOPE_DIM = M.nope_head_dim
 WIN = M.sliding_window
 MAX_SEQ_LEN = M.max_position_embeddings
 IDX_TOPK = M.index_topk
-TOPK_FULL = WIN + IDX_TOPK           # full sparse-K width (window + indexer topk)
+CMP_TOPK = min(MAX_SEQ_LEN // 128, IDX_TOPK)
+TOPK = WIN + CMP_TOPK
 SOFTMAX_SCALE = M.softmax_scale
 O_LORA = M.o_lora_rank
 O_GROUPS = M.o_groups
 HEADS_PER_GROUP = H // O_GROUPS
 O_GROUP_IN = HEADS_PER_GROUP * HEAD_DIM
-
-# kernel-local
 SUPPORTED_COMPRESS_RATIOS = (0, 4, 128)
 DEFAULT_COMPRESS_RATIO = 128
 ORI_MAX_BLOCKS = KV_ORI_MAX_BLOCKS
 ORI_BLOCK_NUM = DECODE_ORI_BLOCK_NUM
 CMP_MAX_BLOCKS = KV_CMP_MAX_BLOCKS
 CMP_BLOCK_NUM = DECODE_CMP_BLOCK_NUM
+NEG_INF = -1.0e20
 
 # tiling
 VALID_TOKEN_TILE = 8
-GATHER_FILL_TILE = 128
-ROPE_OUT_TOK_TILE = 8
-# Sparse-K gather runs in its own spmd grid (cf. decode_sparse_attn_swa) that
-# materializes the per-token KV rows into a contiguous GM buffer, so qk_pv loads
-# a plain [ATTN_K_TILE, HEAD_DIM] slice instead of running a 128-iteration
-# scalar-read + gather_row loop ahead of its cube work.
-# Gather segments per token. 4 keeps the grid at T*4 = 32 blocks, which co-resides
-# with the 16 qproj_dequant blocks in one AIV wave -- the gather must overlap the
-# Q chain, and a wider grid queues behind it instead.
-GATHER_SEGS = 4
-# Every segment carries BOTH a slice of the window and a slice of the compressed
-# tail. The two have opposite per-row costs (bulk-run window vs scattered per-row
-# topk), so splitting them across separate tasks makes the compressed ones the
-# straggler that gates qk_pv; interleaving them balances every block instead.
-# Window sub-tile probed for physical contiguity: a decode window is a run of
-# consecutive logical positions, so a sub-tile that stays inside one paged block
-# maps to consecutive cache rows and moves in ONE bulk DMA. Only the sub-tile
-# straddling a block boundary falls back to the per-row copy (~0.44us/row vs
-# ~0.02us/row bulk).
-GATHER_RUN = 16
+GATHER_SEG_TILE = 4
+GATHER_RUN_TILE = 16
 H_TILE = 16
-# qk_pv cube-batch tile (M for the QK/PV matmuls). Batching QK_M_TILE head rows
-# per matmul extracts the shared KV tile L1->L0 once per QK_M_TILE/H_TILE
-# head-tiles (2x reuse at 32) instead of per H_TILE head-tile, then slices the
-# [QK_M_TILE, ...] result back into H_TILE-row stores so the sparse_blk_* layout
-# and merge_norm stay unchanged. 32 keeps the [32,128] softmax inside the 192KB
-# Vec budget without a cross-core split. 64 is infeasible without further work
-# (its [64,128] softmax and co-resident QK+PV L0C accumulators overflow Vec/L0C).
 QK_M_TILE = 32
 ATTN_K_TILE = 128
-ROPE_TILE = 16
-ROPE_INTERLEAVE_TILE = 2 * ROPE_TILE
-# proj_a cube K-frag. 256 (not 128) keeps the B-cache-line floor: B is K-contiguous
-# under b_trans, so K*2B(bf16) = 512B == the a2a3 L2 line (K=128 was 256B, half a
-# line -> wasted MTE2 DMA). At 256 the cube's L0A/L0B operand staging hits 100%
-# (the wall); 512 would spill it for no gain (swept: K=512 net-negative).
+CS_DUP_FLAT_LEN = T * ROPE_DIM
+ROPE_DIM_F = float(ROPE_DIM)
+ROPE_DIM_INV = 1.0 / ROPE_DIM
 A_K_TILE = 256
-# proj_a is a pure-cube matmul scope (proj_a_mm) writing the fp32 GM intermediate
-# o_r (cf. expert_routed w2 decouple), consumed directly by the fused amax+quant
-# scope below; the decouple frees the cube N-frag from any vector-side UB constraint.
 PROJ_A_MM_N_TILE = 128
 MM_T_TILE = 16
 T_PAD = ((T + MM_T_TILE - 1) // MM_T_TILE) * MM_T_TILE
 B_K_TILE = 256
-# proj_b_mm writes grouped INT32 partials; proj_b_act dequantizes and sums them.
 PROJ_B_MM_N_TILE = 256
-PROJ_B_ACT_N_TILE = 512   # vector N frag for the decoupled per-group dequant+sum (proj_b_act
-                          # now sums O_GROUPS INT32 partials, each x its group act scale, then
-                          # x the per-channel weight scale -> BF16). 512 (not 1024) keeps the
-                          # O_GROUPS-way accumulate inside UB and gives D/512 = 8 vector tasks.
-# Fused per-group amax+quant processes the full [8, 1024] row tile.
+PROJ_B_ACT_N_TILE = 512
 QUANT_TOKEN_TILE = 8
-# Per-group back-to-back o_proj (manual-scope, qwen3-style fine-grained deps):
-# proj_a[g] -> quant[g] (PER-GROUP amax, no global barrier) -> proj_b[g] pipeline.
-PA_NFRAGS = O_LORA // PROJ_A_MM_N_TILE   # proj_a cube N-frags per group
-# Each proj_b group has eight blocks with two N-fragments per block.
-PROJ_B_D_CHUNK = 512
-PB_DCHUNKS = D // PROJ_B_D_CHUNK
-# proj_b_act is split per (D-region, token-block) so the O_GROUPS-way dequant+sum spreads
-# over vector cores.
-PROJ_B_ACT_T_TILE = 8    # inner token tile for the proj_b_act O_GROUPS-way INT32->FP32 accumulate
-PROJ_B_ACT_TBLK = 8      # proj_b_act token block per task
-PB_ACT_NREG = D // PROJ_B_ACT_N_TILE
-PB_ACT_TBLKS = T // PROJ_B_ACT_TBLK
-NEG_INF = -1.0e20
-
-assert T % VALID_TOKEN_TILE == 0
-assert T % 2 == 0
-assert H % 4 == 0
-assert QK_M_TILE % H_TILE == 0
-assert H % QK_M_TILE == 0
-assert T % QUANT_TOKEN_TILE == 0
+O_GROUP_TILE = 2
+assert H % H_TILE == 0
 assert H % O_GROUPS == 0
-assert O_LORA % PROJ_A_MM_N_TILE == 0, "proj_a cube N-grid must cover O_LORA"
-assert (O_GROUPS * O_LORA) % B_K_TILE == 0
-assert D % PROJ_B_MM_N_TILE == 0, "proj_b_mm cube N-loop must cover D"
-assert D % PROJ_B_D_CHUNK == 0, "proj_b D-chunk loop must cover D"
-assert PROJ_B_D_CHUNK % PROJ_B_MM_N_TILE == 0, "proj_b inner N-frag loop must cover the D-chunk"
-assert T % PROJ_B_ACT_TBLK == 0 and PROJ_B_ACT_TBLK % PROJ_B_ACT_T_TILE == 0
-assert D % PROJ_B_ACT_N_TILE == 0, "proj_b_act vector N-loop must cover D"
-assert O_LORA % B_K_TILE == 0, "proj_b group K-loop covers O_LORA in B_K_TILE iters"
+assert O_GROUPS % O_GROUP_TILE == 0
+assert H // H_TILE == O_GROUPS // O_GROUP_TILE
+PA_NF_TILE = 2
+PROJ_B_D_TILE = 512 if M.name == "flash" else 1792
+PROJ_B_ACT_T_TILE = 8
+PROJ_B_ACT_TASK_T_TILE = 8
+# HCA uses at least two sparse blocks.
+SPARSE_BLOCKS = max(2, (TOPK + ATTN_K_TILE - 1) // ATTN_K_TILE)
+PADDED_TOPK = SPARSE_BLOCKS * ATTN_K_TILE
+GATHER_WIN_ROW_TILE = WIN // GATHER_SEG_TILE
+GATHER_CMP_ROW_TILE = (PADDED_TOPK - WIN) // GATHER_SEG_TILE
 
 
 def get_standalone_cmp_valid(compress_ratio: int) -> int:
@@ -147,24 +96,6 @@ def get_standalone_cmp_valid(compress_ratio: int) -> int:
     if compress_ratio == 128:
         return MAX_SEQ_LEN // compress_ratio
     raise ValueError(f"Unsupported compress_ratio={compress_ratio}; expected one of {SUPPORTED_COMPRESS_RATIOS}")
-
-
-CMP_TOPK = min(MAX_SEQ_LEN // 128, IDX_TOPK)
-# HCA sparse-K width: cache-first window slots + the deterministic
-# ratio-128 compressed tail.
-TOPK = WIN + CMP_TOPK
-# Floor to 2: a single sparse-K block miscompiles in pypto (S-stride cross-token
-# output mixup); a 2-block build with an all-invalid 2nd block is bit-exact.
-SPARSE_BLOCKS = max(2, (TOPK + ATTN_K_TILE - 1) // ATTN_K_TILE)
-PADDED_TOPK = SPARSE_BLOCKS * ATTN_K_TILE
-GATHER_WIN_ROWS = WIN // GATHER_SEGS
-GATHER_CMP_ROWS = (PADDED_TOPK - WIN) // GATHER_SEGS
-assert WIN <= TOPK <= TOPK_FULL, f"TOPK ({TOPK}) must be in [WIN={WIN}, TOPK_FULL={TOPK_FULL}]"
-assert WIN == ATTN_K_TILE, f"HCA window tile requires WIN ({WIN}) == ATTN_K_TILE ({ATTN_K_TILE})"
-assert WIN % GATHER_SEGS == 0 and (PADDED_TOPK - WIN) % GATHER_SEGS == 0
-assert GATHER_WIN_ROWS % GATHER_RUN == 0, "window bulk-copy runs must tile the window slice"
-assert BLOCK_SIZE % GATHER_RUN == 0, "a contiguous run must not straddle two paged blocks by construction"
-
 
 @pl.jit.inline
 def sparse_attn_hca(
@@ -183,82 +114,67 @@ def sparse_attn_hca(
     attn_out: pl.Tensor[[T, D], pl.BF16],
 ):
     """Run sparse decode attention, inverse RoPE, and grouped output projection."""
-    # Gather the historical/current window + compressed-cache rows.
-    # Compressed index contract:
-    #   -1              invalid
-    #   [0, ...)        compressed KV slots
-    ori_kv_flat = pl.reshape(ori_kv, [ORI_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
-    cmp_kv_flat = pl.reshape(cmp_kv, [CMP_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
     sparse_bias = pl.create_tensor([T, PADDED_TOPK], dtype=pl.FP32)
-
-    # Additive softmax bias (0 valid / NEG_INF invalid) that qk_pv adds onto the
-    # scaled scores, so invalid lanes exp to ~0 with no per-block mask multiply.
     for v_blk in pl.spmd(T // VALID_TOKEN_TILE, name_hint="build_valid", allow_early_resolve=True):
         v_t0 = v_blk * VALID_TOKEN_TILE
         v_win_f = pl.cast(window_swa_indices[v_t0 : v_t0 + VALID_TOKEN_TILE, 0 : WIN], target_type=pl.FP32)
         v_idx_f = pl.cast(cmp_sparse_indices[v_t0 : v_t0 + VALID_TOKEN_TILE, 0 : CMP_TOPK], target_type=pl.FP32)
-        v_win_valid = pl.minimum(pl.maximum(pl.add(v_win_f, 1.0), 0.0), 1.0)
-        v_cmp_valid = pl.minimum(pl.maximum(pl.add(v_idx_f, 1.0), 0.0), 1.0)
-        sparse_bias[v_t0 : v_t0 + VALID_TOKEN_TILE, 0 : WIN] = pl.mul(pl.sub(v_win_valid, 1.0), -NEG_INF)
-        sparse_bias[v_t0 : v_t0 + VALID_TOKEN_TILE, WIN : TOPK] = pl.mul(pl.sub(v_cmp_valid, 1.0), -NEG_INF)
+        v_win_one = pl.add(v_win_f, 1.0)
+        v_win_floor = pl.maximum(v_win_one, 0.0)
+        v_win_valid = pl.minimum(v_win_floor, 1.0)
+        v_cmp_one = pl.add(v_idx_f, 1.0)
+        v_cmp_floor = pl.maximum(v_cmp_one, 0.0)
+        v_cmp_valid = pl.minimum(v_cmp_floor, 1.0)
+        v_win_mask = pl.sub(v_win_valid, 1.0)
+        sparse_bias[v_t0 : v_t0 + VALID_TOKEN_TILE, 0 : WIN] = pl.mul(v_win_mask, -NEG_INF)
+        v_cmp_mask = pl.sub(v_cmp_valid, 1.0)
+        sparse_bias[v_t0 : v_t0 + VALID_TOKEN_TILE, WIN : TOPK] = pl.mul(v_cmp_mask, -NEG_INF)
         if PADDED_TOPK > TOPK:
-            sparse_bias[v_t0 : v_t0 + VALID_TOKEN_TILE, TOPK : PADDED_TOPK] = pl.full(
-                [VALID_TOKEN_TILE, PADDED_TOPK - TOPK], dtype=pl.FP32, value=NEG_INF)
+            v_pad = pl.full([VALID_TOKEN_TILE, PADDED_TOPK - TOPK], dtype=pl.FP32, value=NEG_INF)
+            sparse_bias[v_t0 : v_t0 + VALID_TOKEN_TILE, TOPK : PADDED_TOPK] = v_pad
 
-    # Sparse-K gather, hoisted out of qk_pv into its own grid, writing one token's
-    # sparse-K rows into the contiguous hca_kv_flat buffer. Every block carries a
-    # GATHER_WIN_ROWS slice of the window AND a GATHER_CMP_ROWS slice of the
-    # compressed tail, so the cheap bulk runs and the costly scattered rows are
-    # spread evenly. Invalid (-1) and padded lanes are zero-filled to match the
-    # golden's zero rows; the NEG_INF bias then kills them in the softmax.
+    ori_kv_flat = pl.reshape(ori_kv, [ORI_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
+    cmp_kv_flat = pl.reshape(cmp_kv, [CMP_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
     hca_kv_flat = pl.create_tensor([T * PADDED_TOPK, HEAD_DIM], dtype=pl.BF16)
-    with pl.spmd(T * GATHER_SEGS, name_hint="hca_gather_kv") as gather_tid:
+    with pl.spmd(T * GATHER_SEG_TILE, name_hint="hca_gather_kv") as gather_tid:
         g_task = pl.tile.get_block_idx()
-        g_t = g_task // GATHER_SEGS
-        g_seg = g_task - g_t * GATHER_SEGS
+        g_t = g_task // GATHER_SEG_TILE
+        g_seg = g_task - g_t * GATHER_SEG_TILE
         g_b = g_t // S
         g_row0 = g_t * PADDED_TOPK
 
-        # Window slice: probe each sub-tile's first/last slot. Endpoints that are
-        # GATHER_RUN-1 apart mean the whole run sits in one paged block.
-        g_wk0 = g_seg * GATHER_WIN_ROWS
-        for g_sub in pl.range(GATHER_WIN_ROWS // GATHER_RUN):
-            g_sk0 = g_wk0 + g_sub * GATHER_RUN
+        g_wk0 = g_seg * GATHER_WIN_ROW_TILE
+        for g_sub in pl.range(GATHER_WIN_ROW_TILE // GATHER_RUN_TILE):
+            g_sk0 = g_wk0 + g_sub * GATHER_RUN_TILE
             g_sdst = g_row0 + g_sk0
             g_first = pl.read(window_swa_indices, [g_t, g_sk0])
-            g_last = pl.read(window_swa_indices, [g_t, g_sk0 + GATHER_RUN - 1])
-            # A -1 slot anywhere in the run pins g_run_ok below the match value,
-            # so an invalid or block-straddling run takes the per-row path.
-            g_run_ok = (g_last - g_first) + pl.min(g_first, 0) * GATHER_RUN
-            if g_run_ok == GATHER_RUN - 1:
+            g_last = pl.read(window_swa_indices, [g_t, g_sk0 + GATHER_RUN_TILE - 1])
+            g_run_ok = (g_last - g_first) + pl.min(g_first, 0) * GATHER_RUN_TILE
+            if g_run_ok == GATHER_RUN_TILE - 1:
                 g_run_src = pl.cast(g_first, pl.INDEX)
-                hca_kv_flat[g_sdst : g_sdst + GATHER_RUN, 0:HEAD_DIM] = ori_kv_flat[
-                    g_run_src : g_run_src + GATHER_RUN, 0:HEAD_DIM
-                ]
+                g_run_tile = ori_kv_flat[g_run_src : g_run_src + GATHER_RUN_TILE, 0:HEAD_DIM]
+                hca_kv_flat[g_sdst : g_sdst + GATHER_RUN_TILE, 0:HEAD_DIM] = g_run_tile
             else:
-                for g_dr in pl.range(GATHER_RUN):
+                for g_dr in pl.range(GATHER_RUN_TILE):
                     g_wdst = g_sdst + g_dr
                     g_win_slot_i32 = pl.read(window_swa_indices, [g_t, g_sk0 + g_dr])
                     if g_win_slot_i32 >= 0:
                         g_win_slot = pl.cast(g_win_slot_i32, pl.INDEX)
-                        hca_kv_flat[g_wdst : g_wdst + 1, 0:HEAD_DIM] = ori_kv_flat[
-                            g_win_slot : g_win_slot + 1, 0:HEAD_DIM
-                        ]
+                        g_win_tile = ori_kv_flat[g_win_slot : g_win_slot + 1, 0:HEAD_DIM]
+                        hca_kv_flat[g_wdst : g_wdst + 1, 0:HEAD_DIM] = g_win_tile
                     else:
-                        hca_kv_flat[g_wdst : g_wdst + 1, 0:HEAD_DIM] = pl.full(
-                            [1, HEAD_DIM], dtype=pl.BF16, value=0.0)
+                        hca_kv_flat[g_wdst : g_wdst + 1, 0:HEAD_DIM] = pl.full([1, HEAD_DIM], dtype=pl.BF16, value=0.0)
 
-        # Compressed slice: topk slots are scattered, so each row is its own
-        # block-table lookup + copy.
-        g_ck0 = g_seg * GATHER_CMP_ROWS
+        g_ck0 = g_seg * GATHER_CMP_ROW_TILE
         g_cdst0 = g_row0 + WIN + g_ck0
-        for g_dr in pl.range(GATHER_CMP_ROWS):
+        for g_dr in pl.range(GATHER_CMP_ROW_TILE):
             g_dst = g_cdst0 + g_dr
             g_cmp_k = g_ck0 + g_dr
             if g_cmp_k < CMP_TOPK:
                 g_ridx = pl.read(cmp_sparse_indices, [g_t, g_cmp_k])
                 if g_ridx >= 0:
-                    g_cblk = pl.cast(pl.read(cmp_block_table, [g_b, g_ridx // BLOCK_SIZE]), pl.INDEX)
+                    g_cblk_i32 = pl.read(cmp_block_table, [g_b, g_ridx // BLOCK_SIZE])
+                    g_cblk = pl.cast(g_cblk_i32, pl.INDEX)
                     g_csrc = g_cblk * BLOCK_SIZE + g_ridx % BLOCK_SIZE
                     hca_kv_flat[g_dst : g_dst + 1, 0:HEAD_DIM] = cmp_kv_flat[g_csrc : g_csrc + 1, 0:HEAD_DIM]
                 else:
@@ -266,45 +182,33 @@ def sparse_attn_hca(
             else:
                 hca_kv_flat[g_dst : g_dst + 1, 0:HEAD_DIM] = pl.full([1, HEAD_DIM], dtype=pl.BF16, value=0.0)
 
-    # qk_pv writes per-tile (mi, li, oi) to GM; merge_norm reads them back. Not
-    # fused on a2a3: the PV output (Acc) -> online rescale (Vec) needs an
-    # unsupported tmov, and a [H_TILE, HEAD_DIM] carry overflows the Vec buffer.
     q_flat = pl.reshape(q, [T * H, HEAD_DIM])
-    o_packed = pl.create_tensor([O_GROUPS * T, O_GROUP_IN], dtype=pl.BF16)
     sparse_blk_mi = pl.create_tensor([T * (H // H_TILE) * SPARSE_BLOCKS * H_TILE, 1], dtype=pl.FP32)
     sparse_blk_li = pl.create_tensor([T * (H // H_TILE) * SPARSE_BLOCKS * H_TILE, 1], dtype=pl.FP32)
     sparse_blk_oi = pl.create_tensor([T * (H // H_TILE) * SPARSE_BLOCKS * H_TILE, HEAD_DIM], dtype=pl.FP32)
 
-    with pl.spmd(T * SPARSE_BLOCKS, name_hint="qk_pv", deps=[gather_tid], allow_early_resolve=True) as qk_tid:
+    with pl.spmd(T * SPARSE_BLOCKS, name_hint="qk_pv", deps=[gather_tid], allow_early_resolve=True) as _qk_tid:
         qk_item = pl.tile.get_block_idx()
         qk_t = qk_item // SPARSE_BLOCKS
         qk_sb = qk_item - qk_t * SPARSE_BLOCKS
         qk_token_base = qk_t * (H // H_TILE) * SPARSE_BLOCKS * H_TILE
-        # Sparse-block OUTER / head-tile INNER: both head-batches' QK (b_trans)
-        # and PV consume the SAME pre-gathered KV tile.
         qk_s0 = qk_sb * ATTN_K_TILE
         qk_bias_row = sparse_bias[qk_t : qk_t + 1, qk_s0 : qk_s0 + ATTN_K_TILE]
         qk_base = qk_t * PADDED_TOPK + qk_s0
         qk_kv = hca_kv_flat[qk_base : qk_base + ATTN_K_TILE, 0:HEAD_DIM]
 
-        # Cube-batch QK_M_TILE head rows per QK/PV matmul so the shared KV
-        # tile is extracted L1->L0 once per QK_M_TILE/H_TILE head-tiles
-        # (2x reuse at QK_M_TILE=32) instead of per head-tile. The
-        # [QK_M_TILE, ...] softmax result is sliced back into H_TILE-row
-        # stores at the SAME offsets as the per-head-tile path
-        # (qk_h_idx == qk_hb * (QK_M_TILE // H_TILE) + qk_sub), so the
-        # sparse_blk_* layout and merge_norm are bit-identical.
         for qk_hb in pl.pipeline(H // QK_M_TILE, stage=2):
             qk_h0 = qk_hb * QK_M_TILE
             qk_head_row = qk_t * H + qk_h0
             qk_q_tile = q_flat[qk_head_row : qk_head_row + QK_M_TILE, 0 : HEAD_DIM]
             qk_raw = pl.matmul(qk_q_tile, qk_kv, b_trans=True, out_dtype=pl.FP32)
             qk_scaled = pl.mul(qk_raw, SOFTMAX_SCALE)
-            qk_scores = pl.add(qk_scaled, pl.col_expand(pl.full([QK_M_TILE, ATTN_K_TILE], dtype=pl.FP32, value=0.0), qk_bias_row))
+            qk_bias_base = pl.full([QK_M_TILE, ATTN_K_TILE], dtype=pl.FP32, value=0.0)
+            qk_bias = pl.col_expand(qk_bias_base, qk_bias_row)
+            qk_scores = pl.add(qk_scaled, qk_bias)
             qk_mi = pl.row_max(qk_scores)
-            # Invalid lanes (NEG_INF bias, zero kv rows) exp to ~0; all-invalid
-            # blocks die in the merge alpha/beta -- no mask multiply needed.
-            qk_exp = pl.exp(pl.row_expand_sub(qk_scores, qk_mi))
+            qk_centered = pl.row_expand_sub(qk_scores, qk_mi)
+            qk_exp = pl.exp(qk_centered)
             qk_li = pl.row_sum(qk_exp)
             qk_exp_bf16 = pl.cast(qk_exp, target_type=pl.BF16, mode="rint")
             qk_oi = pl.matmul(qk_exp_bf16, qk_kv, out_dtype=pl.FP32)
@@ -317,154 +221,161 @@ def sparse_attn_hca(
                 sparse_blk_li[qk_row : qk_row + H_TILE, 0 : 1] = qk_li[qk_r0 : qk_r0 + H_TILE, 0 : 1]
                 sparse_blk_oi[qk_row : qk_row + H_TILE, 0 : HEAD_DIM] = qk_oi[qk_r0 : qk_r0 + H_TILE, 0 : HEAD_DIM]
 
-    # Precompute the head-invariant interleaved cos and sign*sin once: they depend
-    # only on (token, column), not head, so building them per head would repeat the
-    # same dup-gather H times on the bottleneck Vec engine. sign is folded into sin
-    # (multiply by +/-1). The conjugate (inverse) rotation is:
-    #   out[j] = x[j]*cos_il[j] + x[j^1]*sign[j]*sin_il[j]
-    # Hoisted ABOVE merge_norm (which now fuses the rotation): independent of qk_pv,
-    # so it overlaps it and is off merge_norm's critical path.
+    # Inverse RoPE: out[j] = x[j] * cos[j] + x[j ^ 1] * sign[j] * sin[j].
     rope_cos_il = pl.create_tensor([T, ROPE_DIM], dtype=pl.FP32)
     rope_sin_signed = pl.create_tensor([T, ROPE_DIM], dtype=pl.FP32)
-    for cp in pl.spmd(HALF_ROPE // ROPE_TILE, name_hint="rope_cs"):
-        cp_r0 = cp * ROPE_TILE
-        cp_c0 = 2 * cp_r0
-        cs_col = pl.col_expand_mul(
-            pl.full([T, ROPE_INTERLEAVE_TILE], dtype=pl.FP32, value=1.0),
-            pl.cast(pl.arange(0, [1, ROPE_INTERLEAVE_TILE], dtype=pl.INT32), target_type=pl.FP32))
-        cs_dup_f = pl.cast(pl.cast(pl.mul(cs_col, 0.5), target_type=pl.INT32, mode="trunc"), target_type=pl.FP32)
-        cs_dup_idx = pl.cast(cs_dup_f, target_type=pl.INT32)                                      # j>>1
-        cs_lane = pl.sub(cs_col, pl.mul(cs_dup_f, 2.0))                                           # j%2
-        cs_sign = pl.neg(pl.sub(pl.mul(cs_lane, 2.0), 1.0))                                       # [+1,-1,...] (conjugate)
-        cs_cos = pl.cast(freqs_cos[0:T, cp_r0 : cp_r0 + ROPE_TILE], target_type=pl.FP32)
-        cs_sin = pl.cast(freqs_sin[0:T, cp_r0 : cp_r0 + ROPE_TILE], target_type=pl.FP32)
-        rope_cos_il[0:T, cp_c0 : cp_c0 + ROPE_INTERLEAVE_TILE] = pl.gather(cs_cos, dim=-1, index=cs_dup_idx)
-        rope_sin_signed[0:T, cp_c0 : cp_c0 + ROPE_INTERLEAVE_TILE] = pl.mul(
-            pl.gather(cs_sin, dim=-1, index=cs_dup_idx), cs_sign)
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="rope_cs", allow_early_resolve=True):
+        sw_col_i_m = pl.arange(0, [1, CS_DUP_FLAT_LEN], dtype=pl.INT32)
+        sw_col_m = pl.cast(sw_col_i_m, target_type=pl.FP32)
+        sw_row_f_m = pl.mul(sw_col_m, ROPE_DIM_INV)
+        sw_row_i_m = pl.cast(sw_row_f_m, target_type=pl.INT32, mode="trunc")
+        sw_row_m = pl.cast(sw_row_i_m, target_type=pl.FP32)
+        sw_rowbase_m = pl.mul(sw_row_m, ROPE_DIM_F)
+        sw_j_m = pl.sub(sw_col_m, sw_rowbase_m)
+        sw_half_m = pl.mul(sw_j_m, 0.5)
+        sw_dup_i_m = pl.cast(sw_half_m, target_type=pl.INT32, mode="trunc")
+        sw_dup_f_m = pl.cast(sw_dup_i_m, target_type=pl.FP32)
+        sw_dup2_m = pl.mul(sw_dup_f_m, 2.0)
+        sw_lane_m = pl.sub(sw_j_m, sw_dup2_m)
+        cs_rowbase = pl.mul(sw_rowbase_m, 0.5)
+        cs_dup_f = sw_dup_f_m
+        cs_dup_idx_f = pl.add(cs_rowbase, cs_dup_f)
+        cs_dup_idx = pl.cast(cs_dup_idx_f, target_type=pl.INT32)
+        cs_lane2 = pl.mul(sw_lane_m[0:1, 0:ROPE_DIM], 2.0)
+        cs_sign_base = pl.sub(cs_lane2, 1.0)
+        cs_sign = pl.neg(cs_sign_base)
+        cs_cos_f32 = pl.cast(freqs_cos[0:T, 0:HALF_ROPE], target_type=pl.FP32)
+        cs_cos = pl.reshape(cs_cos_f32, [1, T * HALF_ROPE])
+        cs_sin_f32 = pl.cast(freqs_sin[0:T, 0:HALF_ROPE], target_type=pl.FP32)
+        cs_sin = pl.reshape(cs_sin_f32, [1, T * HALF_ROPE])
+        cs_cos_gather = pl.gather(cs_cos, dim=-1, index=cs_dup_idx)
+        cs_cos_il = pl.reshape(cs_cos_gather, [T, ROPE_DIM])
+        rope_cos_il[0:T, 0:ROPE_DIM] = cs_cos_il
+        cs_sin_gather = pl.gather(cs_sin, dim=-1, index=cs_dup_idx)
+        cs_sin_il = pl.reshape(cs_sin_gather, [T, ROPE_DIM])
+        rope_sin_signed[0:T, 0:ROPE_DIM] = pl.col_expand_mul(cs_sin_il, cs_sign)
 
-    # Online-softmax merge across sparse-K tiles, sink-norm, then fused inverse RoPE.
-    # One spmd block per (token, head-tile) -- T*(H//H_TILE) blocks -- so the merge
-    # fans out over that many AIVs instead of T blocks each running a serial head-tile
-    # loop. The inverse-RoPE rotation + rope-column pack is fused in (was a separate
-    # "rope" spmd reading an attn_rope_stage GM round-trip): the head-tile's fp32 rope
-    # segment is rotated in UB and packed straight into o_packed's rope columns.
-    # with-form spmd so the dispatch TaskId (merge_tid) can be an explicit dep of
-    # the manual-scope proj_a tasks below (which read merge_norm's o_packed cols).
-    with pl.spmd(T * (H // H_TILE), name_hint="merge_norm") as merge_tid:
-        m_idx = pl.tile.get_block_idx()
-        m_t = m_idx // (H // H_TILE)
-        m_h_idx = m_idx - m_t * (H // H_TILE)
-        m_h0 = m_h_idx * H_TILE
-        m_blk_base = m_idx * SPARSE_BLOCKS * H_TILE
-        m_mi = sparse_blk_mi[m_blk_base : m_blk_base + H_TILE, 0 : 1]
-        m_li = sparse_blk_li[m_blk_base : m_blk_base + H_TILE, 0 : 1]
-        m_oi = sparse_blk_oi[m_blk_base : m_blk_base + H_TILE, 0 : HEAD_DIM]
+    o_packed = pl.create_tensor([O_GROUPS * T, O_GROUP_IN], dtype=pl.BF16)
+    merge_tids = pl.array.create(O_GROUPS // O_GROUP_TILE, pl.TASK_ID)
 
-        # Guarded so the SWA (SPARSE_BLOCKS == 1) specialization uses the
-        # single block's stats directly instead of an empty merge loop.
-        if SPARSE_BLOCKS > 1:
-            for m_sb in pl.range(1, SPARSE_BLOCKS):
-                m_row = m_blk_base + m_sb * H_TILE
-                m_cur_mi = sparse_blk_mi[m_row : m_row + H_TILE, 0 : 1]
-                m_cur_li = sparse_blk_li[m_row : m_row + H_TILE, 0 : 1]
-                m_cur_oi = sparse_blk_oi[m_row : m_row + H_TILE, 0 : HEAD_DIM]
-                m_mi_new = pl.maximum(m_mi, m_cur_mi)
-                m_alpha = pl.exp(pl.sub(m_mi, m_mi_new))
-                m_beta = pl.exp(pl.sub(m_cur_mi, m_mi_new))
-                m_li = pl.add(pl.mul(m_alpha, m_li), pl.mul(m_beta, m_cur_li))
-                m_oi = pl.add(pl.row_expand_mul(m_oi, m_alpha), pl.row_expand_mul(m_cur_oi, m_beta))
-                m_mi = m_mi_new
+    for merge_group in pl.parallel(O_GROUPS // O_GROUP_TILE):
+        with pl.spmd(T, name_hint="merge_norm") as merge_tid:
+            m_t = pl.tile.get_block_idx()
+            m_h_idx = merge_group
+            m_h0 = m_h_idx * H_TILE
+            m_idx = m_t * (H // H_TILE) + m_h_idx
+            m_blk_base = m_idx * SPARSE_BLOCKS * H_TILE
+            m_mi = sparse_blk_mi[m_blk_base : m_blk_base + H_TILE, 0 : 1]
+            m_li = sparse_blk_li[m_blk_base : m_blk_base + H_TILE, 0 : 1]
+            m_oi = sparse_blk_oi[m_blk_base : m_blk_base + H_TILE, 0 : HEAD_DIM]
 
-        n_sink_bias = pl.reshape(attn_sink[m_h0 : m_h0 + H_TILE], [H_TILE, 1])
-        n_sink_tile = pl.add(pl.sub(m_mi, m_mi), n_sink_bias)
-        n_denom = pl.add(m_li, pl.exp(pl.sub(n_sink_tile, m_mi)))
-        n_full = pl.row_expand_div(m_oi, n_denom)[0 : H_TILE, 0 : HEAD_DIM]
-        n_bf16 = pl.cast(n_full, target_type=pl.BF16, mode="rint")
+            if SPARSE_BLOCKS > 1:
+                for m_sb in pl.range(1, SPARSE_BLOCKS):
+                    m_row = m_blk_base + m_sb * H_TILE
+                    m_cur_mi = sparse_blk_mi[m_row : m_row + H_TILE, 0 : 1]
+                    m_cur_li = sparse_blk_li[m_row : m_row + H_TILE, 0 : 1]
+                    m_cur_oi = sparse_blk_oi[m_row : m_row + H_TILE, 0 : HEAD_DIM]
+                    m_mi_new = pl.maximum(m_mi, m_cur_mi)
+                    m_alpha_delta = pl.sub(m_mi, m_mi_new)
+                    m_alpha = pl.exp(m_alpha_delta)
+                    m_beta_delta = pl.sub(m_cur_mi, m_mi_new)
+                    m_beta = pl.exp(m_beta_delta)
+                    m_li_prev = pl.mul(m_alpha, m_li)
+                    m_li_cur = pl.mul(m_beta, m_cur_li)
+                    m_li = pl.add(m_li_prev, m_li_cur)
+                    m_oi_prev = pl.row_expand_mul(m_oi, m_alpha)
+                    m_oi_cur = pl.row_expand_mul(m_cur_oi, m_beta)
+                    m_oi = pl.add(m_oi_prev, m_oi_cur)
+                    m_mi = m_mi_new
 
-        # Inverse RoPE on this head-tile's fp32 rope segment. cos_il / sign*sin are
-        # head-invariant for token m_t, so col_expand them over the H_TILE head rows;
-        # swap_idx (j^1) pairs the interleaved real/imag lanes. Rounded to bf16 (golden
-        # also rounds inverse-RoPE to bf16) and packed into o_packed's rope columns.
-        m_col = pl.col_expand_mul(
-            pl.full([H_TILE, ROPE_DIM], dtype=pl.FP32, value=1.0),
-            pl.cast(pl.arange(0, [1, ROPE_DIM], dtype=pl.INT32), target_type=pl.FP32))
-        m_dup_f = pl.cast(pl.cast(pl.mul(m_col, 0.5), target_type=pl.INT32, mode="trunc"), target_type=pl.FP32)
-        m_lane = pl.sub(m_col, pl.mul(m_dup_f, 2.0))                                              # j%2
-        m_swap_idx = pl.cast(pl.sub(pl.add(m_col, 1.0), pl.mul(m_lane, 2.0)), target_type=pl.INT32)  # j^1
-        m_rope = n_full[0 : H_TILE, NOPE_DIM : HEAD_DIM]
-        m_cos_il = rope_cos_il[m_t : m_t + 1, 0 : ROPE_DIM]
-        m_sin_signed = rope_sin_signed[m_t : m_t + 1, 0 : ROPE_DIM]
-        m_swapped = pl.gather(m_rope, dim=-1, index=m_swap_idx)
-        m_rot = pl.add(pl.col_expand_mul(m_rope, m_cos_il), pl.col_expand_mul(m_swapped, m_sin_signed))
-        n_rope_bf16 = pl.cast(m_rot, target_type=pl.BF16, mode="rint")
+            n_sink_bias = pl.reshape(attn_sink[m_h0 : m_h0 + H_TILE], [H_TILE, 1])
+            n_zero = pl.sub(m_mi, m_mi)
+            n_sink_tile = pl.add(n_zero, n_sink_bias)
+            n_sink_delta = pl.sub(n_sink_tile, m_mi)
+            n_sink_exp = pl.exp(n_sink_delta)
+            n_denom = pl.add(m_li, n_sink_exp)
+            n_full = pl.row_expand_div(m_oi, n_denom)[0 : H_TILE, 0 : HEAD_DIM]
+            n_bf16 = pl.cast(n_full, target_type=pl.BF16, mode="rint")
 
-        for n_hi in pl.range(H_TILE):
-            n_gh = m_h0 + n_hi
-            n_g = n_gh // HEADS_PER_GROUP
-            n_hh = n_gh - n_g * HEADS_PER_GROUP
-            n_pack_row = n_g * T + m_t
-            n_col = n_hh * HEAD_DIM
-            o_packed[n_pack_row : n_pack_row + 1, n_col : n_col + NOPE_DIM] = n_bf16[n_hi : n_hi + 1, 0 : NOPE_DIM]
-            o_packed[n_pack_row : n_pack_row + 1, n_col + NOPE_DIM : n_col + HEAD_DIM] = n_rope_bf16[n_hi : n_hi + 1, 0 : ROPE_DIM]
+            m_col_base = pl.full([H_TILE, ROPE_DIM], dtype=pl.FP32, value=1.0)
+            m_col_i = pl.arange(0, [1, ROPE_DIM], dtype=pl.INT32)
+            m_col_f = pl.cast(m_col_i, target_type=pl.FP32)
+            m_col = pl.col_expand_mul(m_col_base, m_col_f)
+            m_half = pl.mul(m_col, 0.5)
+            m_dup_i = pl.cast(m_half, target_type=pl.INT32, mode="trunc")
+            m_dup_f = pl.cast(m_dup_i, target_type=pl.FP32)
+            m_dup2 = pl.mul(m_dup_f, 2.0)
+            m_lane = pl.sub(m_col, m_dup2)
+            m_col_next = pl.add(m_col, 1.0)
+            m_lane2 = pl.mul(m_lane, 2.0)
+            m_swap_f = pl.sub(m_col_next, m_lane2)
+            m_swap_idx = pl.cast(m_swap_f, target_type=pl.INT32)
+            m_rope = n_full[0 : H_TILE, NOPE_DIM : HEAD_DIM]
+            m_cos_il = rope_cos_il[m_t : m_t + 1, 0 : ROPE_DIM]
+            m_sin_signed = rope_sin_signed[m_t : m_t + 1, 0 : ROPE_DIM]
+            m_swapped = pl.gather(m_rope, dim=-1, index=m_swap_idx)
+            m_rope_cos = pl.col_expand_mul(m_rope, m_cos_il)
+            m_rope_sin = pl.col_expand_mul(m_swapped, m_sin_signed)
+            m_rot = pl.add(m_rope_cos, m_rope_sin)
+            n_rope_bf16 = pl.cast(m_rot, target_type=pl.BF16, mode="rint")
 
-    # ========================================================================
-    # Back-to-back grouped output projection (manual scope, PER-GROUP INT8 quant).
-    #
-    # Per-GROUP amax localizes the quant reduction to each O_LORA group (vs the
-    # per-ROW-amax form, where a full 8192-channel row reduction is a hard barrier between
-    # proj_a and proj_b), so the three stages PIPELINE per group with qwen3-style
-    # fine-grained deps: proj_b[*, g] waits only on quant[g], which waits only on
-    # proj_a[g, *] -- so proj_b's cube for group g runs while proj_a/quant of later
-    # groups are still in flight (a genuine proj_a<->proj_b back-to-back GEMM).
-    #
-    # manual_scope suppresses auto-dep, so every edge is explicit: each proj_a grid
-    # waits on merge_norm; quant[g] waits on the group grid; proj_b[g] waits on
-    # quant[g] and writes a disjoint group partial. proj_b_act combines those partials
-    # and is the consolidated writer that registers attn_out's return tensormap edge.
-    # ========================================================================
+            for n_hi in pl.range(H_TILE):
+                n_gh = m_h0 + n_hi
+                n_g = n_gh // HEADS_PER_GROUP
+                n_hh = n_gh - n_g * HEADS_PER_GROUP
+                n_pack_row = n_g * T + m_t
+                n_col = n_hh * HEAD_DIM
+                o_packed[n_pack_row : n_pack_row + 1, n_col : n_col + NOPE_DIM] = n_bf16[n_hi : n_hi + 1, 0 : NOPE_DIM]
+                n_rope_head = n_rope_bf16[n_hi : n_hi + 1, 0 : ROPE_DIM]
+                o_packed[n_pack_row : n_pack_row + 1, n_col + NOPE_DIM : n_col + HEAD_DIM] = n_rope_head
+        merge_tids[merge_group] = merge_tid
+
     o_r_pad = pl.create_tensor([T_PAD, O_GROUPS * O_LORA], dtype=pl.FP32)
     o_r_i8_pad = pl.create_tensor([T_PAD, O_GROUPS * O_LORA], dtype=pl.INT8)
-    act_scale_dq = pl.create_tensor([O_GROUPS, T], dtype=pl.FP32)   # [G, T] so each group's
-                                                                     # per-row scale is a contiguous
-                                                                     # row (column reads would be a
-                                                                     # strided GM->VecTile load)
-    # Per-group INT32 partials: proj_b_mm (pure cube) writes group g's contribution to
-    # output channel n at partials[:, g*D + n]; proj_b_act (pure vector) sums the
-    # O_GROUPS partials with their per-group act scales. No atomic-add -> no zero-seed.
+    act_scale_dq = pl.create_tensor([O_GROUPS, T], dtype=pl.FP32)
     partials = pl.create_tensor([T_PAD, O_GROUPS * D], dtype=pl.INT32)
-    proj_b_tids = pl.array.create(O_GROUPS, pl.TASK_ID)
+    proj_b_tids = pl.array.create(O_GROUPS // O_GROUP_TILE, pl.TASK_ID)
 
     with pl.manual_scope():
-        # One proj_a SPMD grid per output group.
-        for g in pl.parallel(O_GROUPS):
-            row_base_o = g * T
-            out_col_g = g * O_LORA
+        for group_bundle in pl.parallel(O_GROUPS // O_GROUP_TILE):
             with pl.spmd(
-                PA_NFRAGS,
+                O_GROUP_TILE * (O_LORA // PROJ_A_MM_N_TILE // PA_NF_TILE),
                 name_hint="proj_a_mm",
-                deps=[merge_tid],
+                deps=[merge_tids[group_bundle]],
                 allow_early_resolve=True,
             ) as pa_tid:
-                nf = pl.tile.get_block_idx()
-                n0 = nf * PROJ_A_MM_N_TILE
-                xa0_chunk = pl.slice(o_packed, [MM_T_TILE, A_K_TILE], [row_base_o, 0], valid_shape=[T, A_K_TILE])
-                wa0_chunk = wo_a[g : g + 1, n0 : n0 + PROJ_A_MM_N_TILE, 0:A_K_TILE]
-                acc_a = pl.matmul(xa0_chunk, wa0_chunk, b_trans=True, out_dtype=pl.FP32)
-                for kb in pl.pipeline(1, O_GROUP_IN // A_K_TILE, stage=2):
-                    k0 = kb * A_K_TILE
-                    xa_k_chunk = pl.slice(o_packed, [MM_T_TILE, A_K_TILE], [row_base_o, k0], valid_shape=[T, A_K_TILE])
-                    wa_k_chunk = wo_a[g : g + 1, n0 : n0 + PROJ_A_MM_N_TILE, k0 : k0 + A_K_TILE]
-                    acc_a = pl.matmul_acc(acc_a, xa_k_chunk, wa_k_chunk, b_trans=True)
-                o_r_pad = pl.assemble(o_r_pad, acc_a, [0, out_col_g + n0])
+                pa_idx = pl.tile.get_block_idx()
+                pa_local_group = pa_idx // (O_LORA // PROJ_A_MM_N_TILE // PA_NF_TILE)
+                pa_blk = pa_idx - pa_local_group * (O_LORA // PROJ_A_MM_N_TILE // PA_NF_TILE)
+                g = group_bundle * O_GROUP_TILE + pa_local_group
+                row_base_o = g * T
+                out_col_g = g * O_LORA
+                for anf in pl.range(PA_NF_TILE):
+                    n0 = pa_blk * (PA_NF_TILE * PROJ_A_MM_N_TILE) + anf * PROJ_A_MM_N_TILE
+                    xa0_chunk = pl.slice(o_packed, [MM_T_TILE, A_K_TILE], [row_base_o, 0], valid_shape=[T, A_K_TILE])
+                    wa0_chunk = wo_a[g : g + 1, n0 : n0 + PROJ_A_MM_N_TILE, 0:A_K_TILE]
+                    acc_a = pl.matmul(xa0_chunk, wa0_chunk, b_trans=True, out_dtype=pl.FP32)
+                    for kb in pl.pipeline(1, O_GROUP_IN // A_K_TILE, stage=2):
+                        k0 = kb * A_K_TILE
+                        xa_k_chunk = pl.slice(
+                            o_packed,
+                            [MM_T_TILE, A_K_TILE],
+                            [row_base_o, k0],
+                            valid_shape=[T, A_K_TILE],
+                        )
+                        wa_k_chunk = wo_a[g : g + 1, n0 : n0 + PROJ_A_MM_N_TILE, k0 : k0 + A_K_TILE]
+                        acc_a = pl.matmul_acc(acc_a, xa_k_chunk, wa_k_chunk, b_trans=True)
+                    o_r_pad = pl.assemble(o_r_pad, acc_a, [0, out_col_g + n0])
 
-            # Per-group proj_a -> quant -> proj_b dependency chain.
-            col_g = g * O_LORA
-            with pl.at(
-                level=pl.Level.CORE_GROUP,
+            with pl.spmd(
+                O_GROUP_TILE,
                 name_hint="quant",
                 deps=[pa_tid],
                 allow_early_resolve=True,
             ) as q_tid:
+                q_local_group = pl.tile.get_block_idx()
+                g = group_bundle * O_GROUP_TILE + q_local_group
+                col_g = g * O_LORA
                 for qt in pl.pipeline(0, T, QUANT_TOKEN_TILE, stage=2):
                     oc_amax = o_r_pad[qt : qt + QUANT_TOKEN_TILE, col_g : col_g + O_LORA]
                     g_abs = pl.abs(oc_amax)
@@ -474,65 +385,60 @@ def sparse_attn_hca(
                     g_amax = pl.maximum(g_amax_floor, g_row_max)
                     g_scale_num = pl.full([1, QUANT_TOKEN_TILE], dtype=pl.FP32, value=INT8_SCALE_MAX)
                     g_sq_row = pl.div(g_scale_num, g_amax)
-                    act_scale_dq = pl.assemble(act_scale_dq, pl.recip(g_sq_row), [g, qt])
+                    g_scale_dq = pl.recip(g_sq_row)
+                    act_scale_dq[g : g + 1, qt : qt + QUANT_TOKEN_TILE] = g_scale_dq
                     g_sq_col = pl.reshape(g_sq_row, [QUANT_TOKEN_TILE, 1])
                     oc_q = o_r_pad[qt : qt + QUANT_TOKEN_TILE, col_g : col_g + O_LORA]
                     oq_scaled = pl.row_expand_mul(oc_q, g_sq_col)
                     oq_i32 = pl.cast(oq_scaled, target_type=pl.INT32, mode="rint")
                     oq_half = pl.cast(oq_i32, target_type=pl.FP16, mode="round")
                     oq_i8 = pl.cast(oq_half, target_type=pl.INT8, mode="trunc")
-                    o_r_i8_pad = pl.assemble(o_r_i8_pad, oq_i8, [qt, col_g])
+                    o_r_i8_pad[qt : qt + QUANT_TOKEN_TILE, col_g : col_g + O_LORA] = oq_i8
                     if T_PAD > T:
                         zero_half = pl.full([T_PAD - T, O_LORA], dtype=pl.FP16, value=0.0)
                         zero_i8 = pl.cast(zero_half, target_type=pl.INT8, mode="trunc")
-                        o_r_i8_pad = pl.assemble(o_r_i8_pad, zero_i8, [T, col_g])
+                        o_r_i8_pad[T:T_PAD, col_g : col_g + O_LORA] = zero_i8
 
-            # One proj_b SPMD grid per output group.
             with pl.spmd(
-                PB_DCHUNKS,
+                O_GROUP_TILE * (D // PROJ_B_D_TILE),
                 name_hint="proj_b_mm",
                 deps=[q_tid],
                 allow_early_resolve=True,
             ) as pb_tid:
-                dc = pl.tile.get_block_idx()
-                d0 = dc * PROJ_B_D_CHUNK
-                for nf in pl.range(PROJ_B_D_CHUNK // PROJ_B_MM_N_TILE):
+                pb_idx = pl.tile.get_block_idx()
+                pb_local_group = pb_idx // (D // PROJ_B_D_TILE)
+                dc = pb_idx - pb_local_group * (D // PROJ_B_D_TILE)
+                g = group_bundle * O_GROUP_TILE + pb_local_group
+                col_g = g * O_LORA
+                d0 = dc * PROJ_B_D_TILE
+                for nf in pl.range(PROJ_B_D_TILE // PROJ_B_MM_N_TILE):
                     n0 = d0 + nf * PROJ_B_MM_N_TILE
-                    acc_b = pl.matmul(
-                        o_r_i8_pad[:, col_g : col_g + B_K_TILE],
-                        wo_b[n0 : n0 + PROJ_B_MM_N_TILE, col_g : col_g + B_K_TILE],
-                        b_trans=True,
-                        out_dtype=pl.INT32,
-                    )
+                    b_act = o_r_i8_pad[:, col_g : col_g + B_K_TILE]
+                    b_weight = wo_b[n0 : n0 + PROJ_B_MM_N_TILE, col_g : col_g + B_K_TILE]
+                    acc_b = pl.matmul(b_act, b_weight, b_trans=True, out_dtype=pl.INT32)
                     for kb in pl.pipeline(1, O_LORA // B_K_TILE, stage=2):
                         k0 = col_g + kb * B_K_TILE
-                        acc_b = pl.matmul_acc(
-                            acc_b,
-                            o_r_i8_pad[:, k0 : k0 + B_K_TILE],
-                            wo_b[n0 : n0 + PROJ_B_MM_N_TILE, k0 : k0 + B_K_TILE],
-                            b_trans=True,
-                        )
-                    partials = pl.assemble(partials, acc_b, [0, g * D + n0])
-            proj_b_tids[g] = pb_tid
+                        b_act = o_r_i8_pad[:, k0 : k0 + B_K_TILE]
+                        b_weight = wo_b[n0 : n0 + PROJ_B_MM_N_TILE, k0 : k0 + B_K_TILE]
+                        acc_b = pl.matmul_acc(acc_b, b_act, b_weight, b_trans=True)
+                    partial_n0 = g * D + n0
+                    partials[0:MM_T_TILE, partial_n0 : partial_n0 + PROJ_B_MM_N_TILE] = acc_b
+            proj_b_tids[group_bundle] = pb_tid
 
-    # proj_b_act (PURE-VECTOR consolidated writer, auto region): sum the O_GROUPS INT32
-    # partials -- each dequantized by its group's per-row act scale -- then apply the
-    # per-channel weight scale -> BF16. Explicit deps on the eight proj_b grids bridge
-    # manual_scope -> the return's auto-dep (this auto-region write registers the edge).
     with pl.spmd(
-        PB_ACT_NREG * PB_ACT_TBLKS,
+        (D // PROJ_B_ACT_N_TILE) * (T // PROJ_B_ACT_TASK_T_TILE),
         name_hint="proj_b_act",
-        deps=[proj_b_tids[i] for i in range(O_GROUPS)],
+        deps=[proj_b_tids[i] for i in range(O_GROUPS // O_GROUP_TILE)],
         allow_early_resolve=True,
     ) as _act_tid:
         act_idx = pl.tile.get_block_idx()
-        nreg = act_idx // PB_ACT_TBLKS
-        tblk = act_idx - nreg * PB_ACT_TBLKS
+        nreg = act_idx // (T // PROJ_B_ACT_TASK_T_TILE)
+        tblk = act_idx - nreg * (T // PROJ_B_ACT_TASK_T_TILE)
         ob_n0 = nreg * PROJ_B_ACT_N_TILE
-        t0 = tblk * PROJ_B_ACT_TBLK
+        t0 = tblk * PROJ_B_ACT_TASK_T_TILE
         wb_scale = wo_b_scale[ob_n0 : ob_n0 + PROJ_B_ACT_N_TILE]
-        wb_scale_chunk = pl.reshape(wb_scale, [1, PROJ_B_ACT_N_TILE])
-        for b_tb in pl.range(t0, t0 + PROJ_B_ACT_TBLK, PROJ_B_ACT_T_TILE):
+        wb_scale_tile = pl.reshape(wb_scale, [1, PROJ_B_ACT_N_TILE])
+        for b_tb in pl.range(t0, t0 + PROJ_B_ACT_TASK_T_TILE, PROJ_B_ACT_T_TILE):
             acc = pl.full([PROJ_B_ACT_T_TILE, PROJ_B_ACT_N_TILE], dtype=pl.FP32, value=0.0)
             for act_g in pl.pipeline(O_GROUPS, stage=2):
                 p_col0 = act_g * D + ob_n0
@@ -542,7 +448,7 @@ def sparse_attn_hca(
                 p_g_f32 = pl.cast(p_g, target_type=pl.FP32, mode="none")
                 p_g_scaled = pl.row_expand_mul(p_g_f32, g_scale)
                 acc = pl.add(acc, p_g_scaled)
-            out_t = pl.col_expand_mul(acc, wb_scale_chunk)
+            out_t = pl.col_expand_mul(acc, wb_scale_tile)
             out_bf16 = pl.cast(out_t, target_type=pl.BF16, mode="rint")
             attn_out[b_tb : b_tb + PROJ_B_ACT_T_TILE, ob_n0 : ob_n0 + PROJ_B_ACT_N_TILE] = out_bf16
 
@@ -565,18 +471,10 @@ def sparse_attn_test(
     attn_out: pl.Out[pl.Tensor[[T, D], pl.BF16]],
 ):
     sparse_attn_hca(
-        q,
-        ori_kv,
-        window_swa_indices,
-        cmp_kv,
-        cmp_block_table,
-        cmp_sparse_indices,
-        attn_sink,
-        freqs_cos,
-        freqs_sin,
-        wo_a,
-        wo_b,
-        wo_b_scale,
+        q, ori_kv, window_swa_indices,
+        cmp_kv, cmp_block_table, cmp_sparse_indices,
+        attn_sink, freqs_cos, freqs_sin,
+        wo_a, wo_b, wo_b_scale,
         attn_out,
     )
     return attn_out
@@ -625,8 +523,6 @@ def golden_sparse_attn(tensors):
 
     o = torch.zeros(T, H, HEAD_DIM)
 
-    # Per-query-token attention. The window prefix is driven by window_swa_indices;
-    # cmp_sparse_indices contains compressed-cache slots only.
     for t in range(T):
         b = t // S
         kv_rows = []
@@ -709,11 +605,7 @@ def golden_sparse_attn(tensors):
     seq_per_batch = T // B
     o_model = o.float().view(B, seq_per_batch, O_GROUPS, O_GROUP_IN)
     o_r = torch.einsum("bsgd,grd->bsgr", o_model, wo_a)
-    # PER-GROUP INT8 activation quant (one amax per O_LORA group, not per full row):
-    # this localizes the reduction so proj_a[g]->quant[g]->proj_b[g] can pipeline
-    # back-to-back. Each group's INT32 partial is dequantized by its OWN per-row
-    # activation scale before the groups are summed (the per-group scale cannot
-    # factor out of the K-sum), then the per-channel weight scale is applied.
+    # Quantize each output-projection group independently.
     o_r_g = o_r.reshape(T, O_GROUPS, O_LORA)
     amax_g = o_r_g.abs().amax(dim=-1, keepdim=True).clamp_min(INT8_AMAX_EPS)   # [T, G, 1]
     scale_q_g = INT8_SCALE_MAX / amax_g
@@ -781,27 +673,14 @@ def build_tensor_specs(
 
     def init_window_block_table():
         """Build the demo block table for the sliding-window cache pages."""
-        return block_table(
-            batch=B,
-            table_blocks=ORI_MAX_BLOCKS,
-            physical_blocks=ORI_BLOCK_NUM,
-        )
+        return block_table(batch=B, table_blocks=ORI_MAX_BLOCKS, physical_blocks=ORI_BLOCK_NUM)
 
     def init_cmp_block_table():
         """Build the demo block table for the compressed-cache pages."""
-        return block_table(
-            batch=B,
-            table_blocks=CMP_MAX_BLOCKS,
-            physical_blocks=CMP_BLOCK_NUM,
-        )
+        return block_table(batch=B, table_blocks=CMP_MAX_BLOCKS, physical_blocks=CMP_BLOCK_NUM)
 
     def init_cmp_sparse_indices():
-        """Build the sparse index list with a full window prefix and padded compressed tail.
-
-        The compressed tail width follows the active specialization (TOPK - WIN):
-        the pruned build narrows it to `cmp_valid` columns, the full-blocks
-        baseline keeps the IDX_TOPK-wide padded tail.
-        """
+        """Build the padded compressed sparse-index list."""
         indices = torch.full((T, CMP_TOPK), -1, dtype=torch.int32)
         if cmp_valid:
             indices[:, :cmp_valid] = torch.arange(cmp_valid, dtype=torch.int32)
@@ -867,33 +746,30 @@ if __name__ == "__main__":
     from golden import ratio_allclose, run_jit
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("-p", "--platform", type=str, default="a2a3",
-                        choices=["a2a3", "a2a3sim", "a5", "a5sim"])
+    parser.add_argument("-p", "--platform", type=str, default="a2a3", choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    # --compress-ratio only selects which compressed-tail data pattern to validate;
-    # the pruned widths are covered by the swa/hca variant tests.
-    parser.add_argument("--compress-ratio", type=int, default=DEFAULT_COMPRESS_RATIO,
-                        choices=list(SUPPORTED_COMPRESS_RATIOS))
-    parser.add_argument("--causal-regression-fixture", action="store_true", default=False,
-                        help="Amplify the S=2 future-window-slot regression; use with --compress-ratio 0.")
-    parser.add_argument("--short-window-fixture", action="store_true", default=False,
-                        help="Use a short-window topk row with valid prefix + -1 padding.")
-    parser.add_argument("--mixed-topk-fixture", action="store_true", default=False,
-                        help="Use -1-padded window slots with valid compressed raw indices.")
-    parser.add_argument("--cache-window-replacement-fixture", action="store_true", default=False,
-                        help="Place a sentinel row inside the cache window prefix.")
+    compress_choices = list(SUPPORTED_COMPRESS_RATIOS)
+    parser.add_argument("--compress-ratio", type=int, default=DEFAULT_COMPRESS_RATIO, choices=compress_choices)
+    causal_help = "Amplify the S=2 future-window-slot regression; use with --compress-ratio 0."
+    parser.add_argument("--causal-regression-fixture", action="store_true", default=False, help=causal_help)
+    short_help = "Use a short-window topk row with valid prefix + -1 padding."
+    parser.add_argument("--short-window-fixture", action="store_true", default=False, help=short_help)
+    mixed_help = "Use -1-padded window slots with valid compressed raw indices."
+    parser.add_argument("--mixed-topk-fixture", action="store_true", default=False, help=mixed_help)
+    cache_help = "Place a sentinel row inside the cache window prefix."
+    parser.add_argument("--cache-window-replacement-fixture", action="store_true", default=False, help=cache_help)
     parser.add_argument("--golden-data", type=str, default=None)
     parser.add_argument("--enable-chip-swimlane", action="store_true", default=False)
-    parser.add_argument("--enable-dep-gen", action="store_true", default=False,
-                        help="Capture PTO2 dependency edges (deps.json); the swimlane "
-                             "converter draws fanout/fanin arrows from the sibling file.")
+    dep_help = "Capture PTO2 dependency edges (deps.json); the swimlane "
+    dep_help += "converter draws fanout/fanin arrows from the sibling file."
+    parser.add_argument("--enable-dep-gen", action="store_true", default=False, help=dep_help)
     parser.add_argument("--enable-pmu", nargs="?", const=2, default=0, type=int, choices=[0, 1, 2, 4])
     parser.add_argument("--dump-passes", action="store_true", default=False)
     args = parser.parse_args()
 
     compress_ratio = args.compress_ratio
-    print(f"compress_ratio={compress_ratio} "
-          f"-> TOPK={TOPK} SPARSE_BLOCKS={SPARSE_BLOCKS} PADDED_TOPK={PADDED_TOPK}", flush=True)
+    summary = f"compress_ratio={compress_ratio} -> TOPK={TOPK} SPARSE_BLOCKS={SPARSE_BLOCKS} PADDED_TOPK={PADDED_TOPK}"
+    print(summary, flush=True)
 
     result = run_jit(
         fn=sparse_attn_test,

--- a/models/deepseek_v4_pro/decode_sparse_attn_swa.py
+++ b/models/deepseek_v4_pro/decode_sparse_attn_swa.py
@@ -34,121 +34,46 @@ ROPE_DIM = M.qk_rope_head_dim
 HALF_ROPE = ROPE_DIM // 2
 NOPE_DIM = M.nope_head_dim
 WIN = M.sliding_window
-MAX_SEQ_LEN = M.max_position_embeddings
 SOFTMAX_SCALE = M.softmax_scale
 O_LORA = M.o_lora_rank
 O_GROUPS = M.o_groups
 HEADS_PER_GROUP = H // O_GROUPS
 O_GROUP_IN = HEADS_PER_GROUP * HEAD_DIM
-
-# kernel-local
 ORI_MAX_BLOCKS = KV_ORI_MAX_BLOCKS
 ORI_BLOCK_NUM = DECODE_ORI_BLOCK_NUM
+TOPK = WIN
+NEG_INF = -1.0e20
 
 # tiling
-GATHER_SPLITS = 4
-GATHER_ROWS_PER_TASK = WIN // GATHER_SPLITS
-# Sub-tile probed for physical contiguity: a decode window is a run of consecutive
-# logical positions, so a sub-tile that stays inside one paged block maps to
-# consecutive cache rows and moves in ONE bulk DMA. Only a block-straddling or -1
-# sub-tile falls back to the per-row copy (~0.44us/row vs ~0.02us/row bulk).
-GATHER_RUN = 16
+GATHER_SPLIT_TILE = 4
+GATHER_ROW_TILE = WIN // GATHER_SPLIT_TILE
+GATHER_RUN_TILE = 16
 H_TILE = 16
-# qk_pv cube-batch tile (M for the QK/PV matmuls). Batching QK_M_TILE head rows
-# per matmul extracts the shared KV tile L1->L0 once per QK_M_TILE/H_TILE
-# head-tiles (2x reuse at 32) instead of per H_TILE head-tile, then slices the
-# [QK_M_TILE, ...] result back into H_TILE-row stores so the sparse_blk_* layout
-# and merge_norm stay unchanged. 32 keeps the [32,128] softmax inside the 192KB
-# Vec budget without a cross-core split. 64 is infeasible without further work
-# (its [64,128] softmax and co-resident QK+PV L0C accumulators overflow Vec/L0C).
 QK_M_TILE = 32
 ATTN_K_TILE = 128
 ROPE_TILE = 16
 ROPE_INTERLEAVE_TILE = 2 * ROPE_TILE
-# proj_a cube K-frag. 256 (not 128) keeps the B-cache-line floor: B is K-contiguous
-# under b_trans, so K*2B(bf16) = 512B == the a2a3 L2 line (K=128 was 256B, half a
-# line -> wasted MTE2 DMA). At 256 the cube's L0A/L0B operand staging hits 100%
-# (the wall); 512 would spill it for no gain (swept: K=512 net-negative).
 A_K_TILE = 256
-# proj_a is a pure-cube matmul scope (proj_a_mm) writing the fp32 GM intermediate
-# o_r (cf. expert_routed w2 decouple), consumed directly by the fused amax+quant
-# scope below; the decouple frees the cube N-frag from any vector-side UB constraint.
-PROJ_A_MM_N_TILE = 128   # cube N frag; Mat/L0C have room but L0A/L0B are the wall at
-                         # K=256, and a wider N raised cube exec without a TTT win (swept).
+PROJ_A_MM_N_TILE = 128
 MM_T_TILE = 16
 T_PAD = ((T + MM_T_TILE - 1) // MM_T_TILE) * MM_T_TILE
-B_K_TILE = 256  # proj_b_mm cube K frag; the GEMM is not the proj_b bottleneck (see below),
-                # and a device sweep found growing it (512/1024) only re-streamed more weight
-                # for no TTT gain, so it stays at the cache-line-safe 256 (256 B per INT8 row).
-# proj_b is decoupled into a pure-cube GEMM scope (proj_b_mm) and a pure-vector dequant
-# scope (proj_b_act) meeting through grouped INT32 partials in GM, so each sizes its
-# own N-fragment to its own wall (cf. the expert_routed w2 decouple). A device tile sweep
-# showed the cube is NOT the bottleneck (proj_b_mm ~32us, ~78% Exec, with L0C/L1 headroom)
-# while the vector dequant dominated: growing PROJ_B_ACT_N_TILE 128->1024 cut the per-N-block
-# vector-setup count 4x and dropped standalone TTT ~835->~730us. The vector frag goes to
-# the UB wall; the cube frag sizes to its own L0C wall (below).
-PROJ_B_MM_N_TILE = 256    # cube N frag. A later device-bias-controlled sweep (paired
-                          # within-device, post vector-retune) found 128->256 worth ~1.5-2%
-                          # (fewer matmul setups: per-D-chunk inner N-frags 8->4; proj_b_mm
-                          # exec ~33->31us). Acc = M*N*4 = 128*256*4 = 128KB rides the L0C
-                          # wall exactly (fits a2a3); Mat ~192KB has room. proj_a N stayed
-                          # 128: growing it was TTT-neutral (64->32 task drop offset by 2x
-                          # per-task cube exec). B_K_TILE stayed 256: the K=512 cache-line
-                          # fix was ambiguous (raised proj_b dispatch-prop for no clear gain).
-PROJ_B_ACT_N_TILE = 512   # vector N frag for the decoupled per-group dequant+sum (proj_b_act
-                          # now sums O_GROUPS INT32 partials, each x its group act scale, then
-                          # x the per-channel weight scale -> BF16). 512 keeps the O_GROUPS-way
-                          # accumulate inside UB and avoids the extra dispatch wave seen at 256.
-# Fused amax+quant token tile. The fused scope streams o_r twice (amax pass + quant
-# pass) per token-tile rather than holding the whole row, so UB stays small; 8 keeps
-# the [1, QUANT_TOKEN_TILE] fp32 amax tile 32-byte aligned (8*4=32B, the alloc-tile
-# row floor that a [QUANT_TOKEN_TILE, 1] column accumulator would violate). The
-# full-row hold (read o_r once) needs QUANT_TOKEN_TILE<=4 for UB but >=8 for that
-# alignment -- mutually exclusive -- so we stream; the 2nd pass mostly hits L2.
+B_K_TILE = 256
+PROJ_B_MM_N_TILE = 256
+PROJ_B_ACT_N_TILE = 512
 QUANT_TOKEN_TILE = 8
-# Per-group back-to-back o_proj (manual-scope, qwen3-style fine-grained deps):
-# proj_a[g] -> quant[g] (PER-GROUP amax, no global barrier) -> proj_b[g] pipeline.
-# Each proj_b group writes a disjoint INT32 partial; the final vector task combines
-# all group partials with their row scales, then applies the channel weight scale.
-PA_NFRAGS = O_LORA // PROJ_A_MM_N_TILE   # proj_a cube N-frags per group
-# proj_b is one task per (D-chunk, group): the D-chunk's N-frags loop INSIDE the task,
-# so the per-group split does not multiply the task count by N-frags. A 512-column
-# chunk produces 8 * (4096 / 512) = 64 balanced cube blocks.
-PROJ_B_D_CHUNK = 512
-PB_DCHUNKS = D // PROJ_B_D_CHUNK
-# proj_b_act uses one block per 512-column output region, eight blocks in total.
-PROJ_B_ACT_T_TILE = 8    # inner token tile for the proj_b_act O_GROUPS-way INT32->FP32 accumulate
-PROJ_B_ACT_TBLK = 8      # proj_b_act token block per task
-PB_ACT_NREG = D // PROJ_B_ACT_N_TILE
-PB_ACT_TBLKS = T // PROJ_B_ACT_TBLK
-NEG_INF = -1.0e20
-
-assert T % 2 == 0
-assert WIN % GATHER_SPLITS == 0
-assert GATHER_ROWS_PER_TASK % GATHER_RUN == 0, "bulk-copy runs must tile the gather task"
-assert BLOCK_SIZE % GATHER_RUN == 0, "a contiguous run must not straddle two paged blocks by construction"
-assert H % 4 == 0
-assert QK_M_TILE % H_TILE == 0
-assert H % QK_M_TILE == 0
-assert T % QUANT_TOKEN_TILE == 0
+O_GROUP_TILE = 2
+assert H % H_TILE == 0
 assert H % O_GROUPS == 0
-assert (O_GROUPS * O_LORA) % B_K_TILE == 0
-assert D % PROJ_B_MM_N_TILE == 0, "proj_b_mm cube N-loop must cover D"
-assert D % PROJ_B_D_CHUNK == 0, "proj_b D-chunk loop must cover D"
-assert PROJ_B_D_CHUNK % PROJ_B_MM_N_TILE == 0, "proj_b inner N-frag loop must cover the D-chunk"
-assert T % PROJ_B_ACT_TBLK == 0 and PROJ_B_ACT_TBLK % PROJ_B_ACT_T_TILE == 0
-assert D % PROJ_B_ACT_N_TILE == 0, "proj_b_act vector N-loop must cover D"
-assert O_LORA % B_K_TILE == 0, "proj_b group K-loop covers O_LORA in B_K_TILE iters"
-
-
-# SWA sparse-K width: sliding window only.
-TOPK = WIN
-# Decode SWA consumes metadata-expanded physical KV-cache slots. The current
-# kernel shape keeps the SWA window in one attention K tile.
+assert O_GROUPS % O_GROUP_TILE == 0
+assert H // H_TILE == O_GROUPS // O_GROUP_TILE
+assert H_TILE % HEADS_PER_GROUP == 0
+PA_NF_TILE = 2
+PROJ_B_D_TILE = 512 if M.name == "flash" else 1792
+PROJ_B_ACT_T_TILE = 8
+PROJ_B_ACT_TASK_T_TILE = 8
 SPARSE_BLOCKS = 1
 PADDED_TOPK = SPARSE_BLOCKS * ATTN_K_TILE
-assert TOPK == WIN, f"SWA decode expects TOPK ({TOPK}) == WIN ({WIN})"
-assert WIN == ATTN_K_TILE, f"SWA decode expects WIN ({WIN}) == ATTN_K_TILE ({ATTN_K_TILE})"
+assert WIN == ATTN_K_TILE
 
 
 @pl.jit.inline
@@ -166,54 +91,36 @@ def sparse_attn_swa(
     attn_out: pl.Tensor[[T, D], pl.BF16],
 ):
     """Standalone sparse attention with a BF16 projected output."""
-    partials = pl.create_tensor([T_PAD, O_GROUPS * D], dtype=pl.INT32)
-    act_scale_dq = pl.create_tensor([O_GROUPS, T], dtype=pl.FP32)
-    proj_b_tids = pl.array.create(O_GROUPS, pl.TASK_ID)
-    # SWA metadata already lowered each logical window row to a physical cache
-    # slot. Current decode tokens must be inserted into ori_kv by the caller
-    # before this function runs; there is no MTP overlay path here.
-
     swa_kv_flat = pl.create_tensor([T * WIN, HEAD_DIM], dtype=pl.BF16)
     gather_tids = pl.array.create(1, pl.TASK_ID)
-    with pl.spmd(T * GATHER_SPLITS, name_hint="swa_gather_kv") as gather_tid:
+    with pl.spmd(T * GATHER_SPLIT_TILE, name_hint="swa_gather_kv") as gather_tid:
         g_task = pl.tile.get_block_idx()
-        g_t = g_task // GATHER_SPLITS
-        g_split = g_task - g_t * GATHER_SPLITS
-        g_r0 = g_split * GATHER_ROWS_PER_TASK
+        g_t = g_task // GATHER_SPLIT_TILE
+        g_split = g_task - g_t * GATHER_SPLIT_TILE
+        g_r0 = g_split * GATHER_ROW_TILE
         g_base = g_t * WIN
-        # Probe each sub-tile's first/last slot: endpoints GATHER_RUN-1 apart mean
-        # the whole run sits in one paged block and moves as one bulk copy.
-        for g_sub in pl.range(GATHER_ROWS_PER_TASK // GATHER_RUN):
-            g_sr0 = g_r0 + g_sub * GATHER_RUN
+        for g_sub in pl.range(GATHER_ROW_TILE // GATHER_RUN_TILE):
+            g_sr0 = g_r0 + g_sub * GATHER_RUN_TILE
             g_sdst = g_base + g_sr0
             g_first = pl.read(swa_indices, [g_t, g_sr0])
-            g_last = pl.read(swa_indices, [g_t, g_sr0 + GATHER_RUN - 1])
-            # A -1 slot anywhere in the run pins g_run_ok below the match value,
-            # so an invalid or block-straddling run takes the per-row path.
-            g_run_ok = (g_last - g_first) + pl.min(g_first, 0) * GATHER_RUN
-            if g_run_ok == GATHER_RUN - 1:
+            g_last = pl.read(swa_indices, [g_t, g_sr0 + GATHER_RUN_TILE - 1])
+            g_run_ok = (g_last - g_first) + pl.min(g_first, 0) * GATHER_RUN_TILE
+            if g_run_ok == GATHER_RUN_TILE - 1:
                 g_run_src = pl.cast(g_first, pl.INDEX)
-                swa_kv_flat[g_sdst : g_sdst + GATHER_RUN, 0 : HEAD_DIM] = ori_kv_flat[
-                    g_run_src : g_run_src + GATHER_RUN, 0 : HEAD_DIM
-                ]
+                g_run_tile = ori_kv_flat[g_run_src : g_run_src + GATHER_RUN_TILE, 0 : HEAD_DIM]
+                swa_kv_flat[g_sdst : g_sdst + GATHER_RUN_TILE, 0 : HEAD_DIM] = g_run_tile
             else:
-                for g_dr in pl.range(GATHER_RUN):
+                for g_dr in pl.range(GATHER_RUN_TILE):
                     g_dst = g_sdst + g_dr
                     g_slot_i32 = pl.read(swa_indices, [g_t, g_sr0 + g_dr])
                     if g_slot_i32 >= 0:
                         g_slot = pl.cast(g_slot_i32, pl.INDEX)
                         swa_kv_flat[g_dst : g_dst + 1, 0 : HEAD_DIM] = ori_kv_flat[g_slot : g_slot + 1, 0 : HEAD_DIM]
                     else:
-                        swa_kv_flat[g_dst : g_dst + 1, 0 : HEAD_DIM] = pl.full(
-                            [1, HEAD_DIM], dtype=pl.BF16, value=0.0)
+                        swa_kv_flat[g_dst : g_dst + 1, 0 : HEAD_DIM] = pl.full([1, HEAD_DIM], dtype=pl.BF16, value=0.0)
     gather_tids[0] = gather_tid
 
-    # qk_pv writes per-tile (mi, li, oi) to GM; merge_norm reads them back. Not
-    # fused on a2a3: the PV output (Acc) -> online rescale (Vec) needs an
-    # unsupported tmov, and a [H_TILE, HEAD_DIM] carry overflows the Vec buffer.
     q_flat = pl.reshape(q, [T * H, HEAD_DIM])
-    o_packed_heads = pl.create_tensor([O_GROUPS * T * HEADS_PER_GROUP, HEAD_DIM], dtype=pl.BF16)
-    o_packed = pl.reshape(o_packed_heads, [O_GROUPS * T, O_GROUP_IN])
     sparse_blk_mi = pl.create_tensor([T * (H // H_TILE) * SPARSE_BLOCKS * H_TILE, 1], dtype=pl.FP32)
     sparse_blk_li = pl.create_tensor([T * (H // H_TILE) * SPARSE_BLOCKS * H_TILE, 1], dtype=pl.FP32)
     sparse_blk_oi = pl.create_tensor([T * (H // H_TILE) * SPARSE_BLOCKS * H_TILE, HEAD_DIM], dtype=pl.FP32)
@@ -227,8 +134,6 @@ def sparse_attn_swa(
             qk_base = qk_t * WIN + qk_s0
             qk_kv = swa_kv_flat[qk_base : qk_base + ATTN_K_TILE, 0 : HEAD_DIM]
 
-            # Keep both 32-head batches in one token task so they reuse the KV
-            # tile already resident in L1 instead of loading it once per block.
             for qk_hb in pl.pipeline(H // QK_M_TILE, stage=2):
                 qk_h0 = qk_hb * QK_M_TILE
                 qk_head_row = qk_t * H + qk_h0
@@ -237,9 +142,8 @@ def sparse_attn_swa(
                 qk_scaled = pl.mul(qk_raw, SOFTMAX_SCALE)
                 qk_scores = pl.col_expand_add(qk_scaled, qk_bias_row)
                 qk_mi = pl.row_max(qk_scores)
-                # Invalid lanes (NEG_INF bias, zero kv rows) exp to ~0; all-invalid
-                # blocks die in the merge alpha/beta -- no mask multiply needed.
-                qk_exp = pl.exp(pl.row_expand_sub(qk_scores, qk_mi))
+                qk_centered = pl.row_expand_sub(qk_scores, qk_mi)
+                qk_exp = pl.exp(qk_centered)
                 qk_li = pl.row_sum(qk_exp)
                 qk_exp_bf16 = pl.cast(qk_exp, target_type=pl.BF16, mode="rint")
                 qk_oi = pl.matmul(qk_exp_bf16, qk_kv, out_dtype=pl.FP32)
@@ -252,10 +156,6 @@ def sparse_attn_swa(
                     sparse_blk_li[qk_row : qk_row + H_TILE, 0 : 1] = qk_li[qk_r0 : qk_r0 + H_TILE, 0 : 1]
                     sparse_blk_oi[qk_row : qk_row + H_TILE, 0 : HEAD_DIM] = qk_oi[qk_r0 : qk_r0 + H_TILE, 0 : HEAD_DIM]
 
-    # Materialize the head-invariant interleaved cos and signed-sin rows once.
-    # This runs alongside qk_pv and keeps the exact indexed RoPE arithmetic used
-    # by the reference path while the group merge below changes only scheduling
-    # and store granularity.
     rope_cos_il = pl.create_tensor([T, ROPE_DIM], dtype=pl.FP32)
     rope_sin_signed = pl.create_tensor([T, ROPE_DIM], dtype=pl.FP32)
     rope_swap_idx = pl.create_tensor([H_TILE, ROPE_DIM], dtype=pl.INT32)
@@ -267,7 +167,8 @@ def sparse_attn_swa(
         swap_half = pl.mul(swap_col, 0.5)
         swap_dup_i32 = pl.cast(swap_half, target_type=pl.INT32, mode="trunc")
         swap_dup_f = pl.cast(swap_dup_i32, target_type=pl.FP32)
-        swap_lane = pl.sub(swap_col, pl.mul(swap_dup_f, 2.0))
+        swap_dup2 = pl.mul(swap_dup_f, 2.0)
+        swap_lane = pl.sub(swap_col, swap_dup2)
         swap_next = pl.add(swap_col, 1.0)
         swap_stride = pl.mul(swap_lane, 2.0)
         swap_idx_f = pl.sub(swap_next, swap_stride)
@@ -281,8 +182,10 @@ def sparse_attn_swa(
         cs_dup_i32 = pl.cast(cs_half, target_type=pl.INT32, mode="trunc")
         cs_dup_f = pl.cast(cs_dup_i32, target_type=pl.FP32)
         cs_dup_idx = pl.cast(cs_dup_f, target_type=pl.INT32)
-        cs_lane = pl.sub(cs_col, pl.mul(cs_dup_f, 2.0))
-        cs_sign_base = pl.sub(pl.mul(cs_lane, 2.0), 1.0)
+        cs_dup2 = pl.mul(cs_dup_f, 2.0)
+        cs_lane = pl.sub(cs_col, cs_dup2)
+        cs_lane2 = pl.mul(cs_lane, 2.0)
+        cs_sign_base = pl.sub(cs_lane2, 1.0)
         cs_sign = pl.neg(cs_sign_base)
         for cp in pl.range(HALF_ROPE // ROPE_TILE):
             cp_r0 = cp * ROPE_TILE
@@ -295,101 +198,93 @@ def sparse_attn_swa(
             rope_cos_il[0:T, cp_c0 : cp_c0 + ROPE_INTERLEAVE_TILE] = cs_cos_dup
             rope_sin_signed[0:T, cp_c0 : cp_c0 + ROPE_INTERLEAVE_TILE] = cs_sin_signed
 
-    # Flatten the one-block SWA merge over token/head tiles into a single
-    # 32-block grid, which fits in one AIV wave and avoids eight group-grid
-    # submissions. Each block writes two output-projection groups using the
-    # same contiguous per-group stores.
-    with pl.spmd(T * (H // H_TILE), name_hint="merge_norm", deps=[qk_tid, rope_tid],
-                 allow_early_resolve=True) as merge_tid:
-        m_idx = pl.tile.get_block_idx()
-        m_t = m_idx // (H // H_TILE)
-        m_h_idx = m_idx - m_t * (H // H_TILE)
-        m_h0 = m_h_idx * H_TILE
-        m_blk_base = m_t * H + m_h0
-        m_mi = sparse_blk_mi[m_blk_base : m_blk_base + H_TILE, 0:1]
-        m_li = sparse_blk_li[m_blk_base : m_blk_base + H_TILE, 0:1]
-        m_oi = sparse_blk_oi[m_blk_base : m_blk_base + H_TILE, 0:HEAD_DIM]
+    o_packed_heads = pl.create_tensor([O_GROUPS * T * HEADS_PER_GROUP, HEAD_DIM], dtype=pl.BF16)
+    merge_tids = pl.array.create(O_GROUPS // O_GROUP_TILE, pl.TASK_ID)
 
-        n_sink = pl.reshape(attn_sink[m_h0 : m_h0 + H_TILE], [H_TILE, 1])
-        n_sink_delta = pl.sub(n_sink, m_mi)
-        n_sink_exp = pl.exp(n_sink_delta)
-        n_denom = pl.add(m_li, n_sink_exp)
-        n_normalized = pl.row_expand_div(m_oi, n_denom)
-        n_full = n_normalized[0:H_TILE, 0:HEAD_DIM]
-        n_bf16 = pl.cast(n_full, target_type=pl.BF16, mode="rint")
+    for merge_group in pl.parallel(O_GROUPS // O_GROUP_TILE):
+        with pl.spmd(T, name_hint="merge_norm", deps=[qk_tid, rope_tid], allow_early_resolve=True) as merge_tid:
+            m_t = pl.tile.get_block_idx()
+            m_h_idx = merge_group
+            m_h0 = m_h_idx * H_TILE
+            m_blk_base = m_t * H + m_h0
+            m_mi = sparse_blk_mi[m_blk_base : m_blk_base + H_TILE, 0:1]
+            m_li = sparse_blk_li[m_blk_base : m_blk_base + H_TILE, 0:1]
+            m_oi = sparse_blk_oi[m_blk_base : m_blk_base + H_TILE, 0:HEAD_DIM]
 
-        m_rope = n_full[:, NOPE_DIM:HEAD_DIM]
-        m_swapped = pl.gather(m_rope, dim=-1, index=rope_swap_idx[:, :])
-        m_cos_il = rope_cos_il[m_t : m_t + 1, 0:ROPE_DIM]
-        m_sin_signed = rope_sin_signed[m_t : m_t + 1, 0:ROPE_DIM]
-        m_rope_cos = pl.col_expand_mul(m_rope, m_cos_il)
-        m_swap_sin = pl.col_expand_mul(m_swapped, m_sin_signed)
-        m_rot = pl.add(m_rope_cos, m_swap_sin)
-        n_rope_bf16 = pl.cast(m_rot, target_type=pl.BF16, mode="rint")
+            n_sink = pl.reshape(attn_sink[m_h0 : m_h0 + H_TILE], [H_TILE, 1])
+            n_sink_delta = pl.sub(n_sink, m_mi)
+            n_sink_exp = pl.exp(n_sink_delta)
+            n_denom = pl.add(m_li, n_sink_exp)
+            n_normalized = pl.row_expand_div(m_oi, n_denom)
+            n_full = n_normalized[0:H_TILE, 0:HEAD_DIM]
+            n_bf16 = pl.cast(n_full, target_type=pl.BF16, mode="rint")
 
-        m_g0 = m_h0 // HEADS_PER_GROUP
-        for m_sg in pl.unroll(H_TILE // HEADS_PER_GROUP):
-            m_src_h0 = m_sg * HEADS_PER_GROUP
-            n_pack_row = (m_g0 + m_sg) * T + m_t
-            n_dst_head = n_pack_row * HEADS_PER_GROUP
-            o_packed_heads[n_dst_head : n_dst_head + HEADS_PER_GROUP, 0:NOPE_DIM] = n_bf16[
-                m_src_h0 : m_src_h0 + HEADS_PER_GROUP, 0:NOPE_DIM
-            ]
-            o_packed_heads[n_dst_head : n_dst_head + HEADS_PER_GROUP, NOPE_DIM:HEAD_DIM] = n_rope_bf16[
-                m_src_h0 : m_src_h0 + HEADS_PER_GROUP, 0:ROPE_DIM
-            ]
+            m_rope = n_full[:, NOPE_DIM:HEAD_DIM]
+            m_swapped = pl.gather(m_rope, dim=-1, index=rope_swap_idx[:, :])
+            m_cos_il = rope_cos_il[m_t : m_t + 1, 0:ROPE_DIM]
+            m_sin_signed = rope_sin_signed[m_t : m_t + 1, 0:ROPE_DIM]
+            m_rope_cos = pl.col_expand_mul(m_rope, m_cos_il)
+            m_swap_sin = pl.col_expand_mul(m_swapped, m_sin_signed)
+            m_rot = pl.add(m_rope_cos, m_swap_sin)
+            n_rope_bf16 = pl.cast(m_rot, target_type=pl.BF16, mode="rint")
 
-    # ========================================================================
-    # Back-to-back grouped output projection (manual scope, PER-GROUP INT8 quant).
-    #
-    # Per-GROUP amax localizes the quant reduction to each O_LORA group (vs the
-    # per-ROW-amax form, where a full-8192-row reduction is a hard barrier between
-    # proj_a and proj_b), so the three stages PIPELINE per group with qwen3-style
-    # fine-grained deps: proj_b[*, g] waits only on quant[g], which waits only on
-    # proj_a[g, *] -- so proj_b's cube for group g runs while proj_a/quant of later
-    # groups are still in flight (a genuine proj_a<->proj_b back-to-back GEMM).
-    #
-    # manual_scope SUPPRESSES auto-dep, so every edge is explicit: proj_a[g]
-    # reads only its o_packed slab -> deps=[merge_tid]; quant[g] deps on group
-    # g's proj_a task; proj_b depends directly on quant[g] and writes a disjoint
-    # group partial. proj_b_act combines those partials with their group row scales,
-    # applies the per-channel weight scale, and is the consolidated attn_out writer.
-    # ========================================================================
+            m_g0 = m_h0 // HEADS_PER_GROUP
+            for m_sg in pl.unroll(H_TILE // HEADS_PER_GROUP):
+                m_src_h0 = m_sg * HEADS_PER_GROUP
+                n_pack_row = (m_g0 + m_sg) * T + m_t
+                n_dst_head = n_pack_row * HEADS_PER_GROUP
+                n_nope_group = n_bf16[m_src_h0 : m_src_h0 + HEADS_PER_GROUP, 0:NOPE_DIM]
+                o_packed_heads[n_dst_head : n_dst_head + HEADS_PER_GROUP, 0:NOPE_DIM] = n_nope_group
+                n_rope_group = n_rope_bf16[m_src_h0 : m_src_h0 + HEADS_PER_GROUP, 0:ROPE_DIM]
+                o_packed_heads[n_dst_head : n_dst_head + HEADS_PER_GROUP, NOPE_DIM:HEAD_DIM] = n_rope_group
+        merge_tids[merge_group] = merge_tid
+
+    o_packed = pl.reshape(o_packed_heads, [O_GROUPS * T, O_GROUP_IN])
     o_r_pad = pl.create_tensor([T_PAD, O_GROUPS * O_LORA], dtype=pl.FP32)
     o_r_i8_pad = pl.create_tensor([T_PAD, O_GROUPS * O_LORA], dtype=pl.INT8)
-    # [G, T] keeps each group's per-row scale as one contiguous row;
-    # column reads would become unsupported strided GM->VecTile loads.
-    # Per-group INT32 partials: proj_b_mm (pure cube) writes group g's contribution to
-    # output channel n at partials[:, g*D + n]; proj_b_act (pure vector) sums the
-    # O_GROUPS partials with their per-group act scales. No atomic-add -> no zero-seed.
-    # Package each group's fragments into one grid. The group TaskId is the
-    # exact dependency granularity needed by quant/proj_b, while 80 individual
-    # orchestration submissions disappear from the critical projection tail.
+    partials = pl.create_tensor([T_PAD, O_GROUPS * D], dtype=pl.INT32)
+    act_scale_dq = pl.create_tensor([O_GROUPS, T], dtype=pl.FP32)
+    proj_b_tids = pl.array.create(O_GROUPS // O_GROUP_TILE, pl.TASK_ID)
     with pl.manual_scope():
-        for g in pl.parallel(O_GROUPS):
-            row_base_o = g * T
-            out_col_g = g * O_LORA
+        for group_bundle in pl.parallel(O_GROUPS // O_GROUP_TILE):
+            with pl.spmd(
+                O_GROUP_TILE * (O_LORA // PROJ_A_MM_N_TILE // PA_NF_TILE),
+                name_hint="proj_a_mm",
+                deps=[merge_tids[group_bundle]],
+                allow_early_resolve=True,
+            ) as pa_tid:
+                pa_idx = pl.tile.get_block_idx()
+                pa_local_group = pa_idx // (O_LORA // PROJ_A_MM_N_TILE // PA_NF_TILE)
+                pa_blk = pa_idx - pa_local_group * (O_LORA // PROJ_A_MM_N_TILE // PA_NF_TILE)
+                g = group_bundle * O_GROUP_TILE + pa_local_group
+                row_base_o = g * T
+                out_col_g = g * O_LORA
+                for anf in pl.range(PA_NF_TILE):
+                    n0 = pa_blk * (PA_NF_TILE * PROJ_A_MM_N_TILE) + anf * PROJ_A_MM_N_TILE
+                    xa0_chunk = pl.slice(o_packed, [MM_T_TILE, A_K_TILE], [row_base_o, 0], valid_shape=[T, A_K_TILE])
+                    wa0_chunk = wo_a[g : g + 1, n0 : n0 + PROJ_A_MM_N_TILE, 0:A_K_TILE]
+                    acc_a = pl.matmul(xa0_chunk, wa0_chunk, b_trans=True, out_dtype=pl.FP32)
+                    for kb in pl.pipeline(1, O_GROUP_IN // A_K_TILE, stage=2):
+                        k0 = kb * A_K_TILE
+                        xa_k_chunk = pl.slice(
+                            o_packed,
+                            [MM_T_TILE, A_K_TILE],
+                            [row_base_o, k0],
+                            valid_shape=[T, A_K_TILE],
+                        )
+                        wa_k_chunk = wo_a[g : g + 1, n0 : n0 + PROJ_A_MM_N_TILE, k0 : k0 + A_K_TILE]
+                        acc_a = pl.matmul_acc(acc_a, xa_k_chunk, wa_k_chunk, b_trans=True)
+                    o_r_pad = pl.assemble(o_r_pad, acc_a, [0, out_col_g + n0])
 
-            with pl.spmd(PA_NFRAGS, name_hint="proj_a_mm", deps=[merge_tid], allow_early_resolve=True) as pa_tid:
-                nf = pl.tile.get_block_idx()
-                n0 = nf * PROJ_A_MM_N_TILE
-                xa0_chunk = pl.slice(o_packed, [MM_T_TILE, A_K_TILE], [row_base_o, 0], valid_shape=[T, A_K_TILE])
-                wa0_chunk = wo_a[g : g + 1, n0 : n0 + PROJ_A_MM_N_TILE, 0:A_K_TILE]
-                acc_a = pl.matmul(xa0_chunk, wa0_chunk, b_trans=True, out_dtype=pl.FP32)
-                for kb in pl.pipeline(1, O_GROUP_IN // A_K_TILE, stage=2):
-                    k0 = kb * A_K_TILE
-                    xa_k_chunk = pl.slice(o_packed, [MM_T_TILE, A_K_TILE], [row_base_o, k0], valid_shape=[T, A_K_TILE])
-                    wa_k_chunk = wo_a[g : g + 1, n0 : n0 + PROJ_A_MM_N_TILE, k0 : k0 + A_K_TILE]
-                    acc_a = pl.matmul_acc(acc_a, xa_k_chunk, wa_k_chunk, b_trans=True)
-                o_r_pad = pl.assemble(o_r_pad, acc_a, [0, out_col_g + n0])
-
-            col_g = g * O_LORA
-            with pl.at(
-                level=pl.Level.CORE_GROUP,
+            with pl.spmd(
+                O_GROUP_TILE,
                 name_hint="quant",
                 deps=[pa_tid],
                 allow_early_resolve=True,
             ) as q_tid:
+                q_local_group = pl.tile.get_block_idx()
+                g = group_bundle * O_GROUP_TILE + q_local_group
+                col_g = g * O_LORA
                 for qt in pl.pipeline(0, T, QUANT_TOKEN_TILE, stage=2):
                     oc_amax = o_r_pad[qt : qt + QUANT_TOKEN_TILE, col_g : col_g + O_LORA]
                     g_abs = pl.abs(oc_amax)
@@ -399,24 +294,33 @@ def sparse_attn_swa(
                     g_amax = pl.maximum(g_amax_floor, g_row_max)
                     g_scale_num = pl.full([1, QUANT_TOKEN_TILE], dtype=pl.FP32, value=INT8_SCALE_MAX)
                     g_sq_row = pl.div(g_scale_num, g_amax)
-                    g_scale_dq = pl.mul(g_amax, 1.0 / INT8_SCALE_MAX)
-                    act_scale_dq = pl.assemble(act_scale_dq, g_scale_dq, [g, qt])
+                    g_scale_dq = pl.recip(g_sq_row)
+                    act_scale_dq[g : g + 1, qt : qt + QUANT_TOKEN_TILE] = g_scale_dq
                     g_sq_col = pl.reshape(g_sq_row, [QUANT_TOKEN_TILE, 1])
                     oc_q = o_r_pad[qt : qt + QUANT_TOKEN_TILE, col_g : col_g + O_LORA]
                     oq_scaled = pl.row_expand_mul(oc_q, g_sq_col)
                     oq_i32 = pl.cast(oq_scaled, target_type=pl.INT32, mode="rint")
                     oq_half = pl.cast(oq_i32, target_type=pl.FP16, mode="round")
                     oq_i8 = pl.cast(oq_half, target_type=pl.INT8, mode="trunc")
-                    o_r_i8_pad = pl.assemble(o_r_i8_pad, oq_i8, [qt, col_g])
+                    o_r_i8_pad[qt : qt + QUANT_TOKEN_TILE, col_g : col_g + O_LORA] = oq_i8
                     if T_PAD > T:
                         zero_half = pl.full([T_PAD - T, O_LORA], dtype=pl.FP16, value=0.0)
                         zero_i8 = pl.cast(zero_half, target_type=pl.INT8, mode="trunc")
-                        o_r_i8_pad = pl.assemble(o_r_i8_pad, zero_i8, [T, col_g])
+                        o_r_i8_pad[T:T_PAD, col_g : col_g + O_LORA] = zero_i8
 
-            with pl.spmd(PB_DCHUNKS, name_hint="proj_b_mm", deps=[q_tid], allow_early_resolve=True) as pb_tid:
-                dc = pl.tile.get_block_idx()
-                d0 = dc * PROJ_B_D_CHUNK
-                for nf in pl.range(PROJ_B_D_CHUNK // PROJ_B_MM_N_TILE):
+            with pl.spmd(
+                O_GROUP_TILE * (D // PROJ_B_D_TILE),
+                name_hint="proj_b_mm",
+                deps=[q_tid],
+                allow_early_resolve=True,
+            ) as pb_tid:
+                pb_idx = pl.tile.get_block_idx()
+                pb_local_group = pb_idx // (D // PROJ_B_D_TILE)
+                dc = pb_idx - pb_local_group * (D // PROJ_B_D_TILE)
+                g = group_bundle * O_GROUP_TILE + pb_local_group
+                col_g = g * O_LORA
+                d0 = dc * PROJ_B_D_TILE
+                for nf in pl.range(PROJ_B_D_TILE // PROJ_B_MM_N_TILE):
                     n0 = d0 + nf * PROJ_B_MM_N_TILE
                     acc_b = pl.create_tensor([MM_T_TILE, PROJ_B_MM_N_TILE], dtype=pl.INT32)
                     for kb in pl.pipeline(0, O_LORA // B_K_TILE, stage=2):
@@ -429,22 +333,24 @@ def sparse_attn_swa(
                             b_act = o_r_i8_pad[:, k0 : k0 + B_K_TILE]
                             b_weight = wo_b[n0 : n0 + PROJ_B_MM_N_TILE, k0 : k0 + B_K_TILE]
                             acc_b = pl.matmul_acc(acc_b, b_act, b_weight, b_trans=True)
-                    partials = pl.assemble(partials, acc_b, [0, g * D + n0])
-            proj_b_tids[g] = pb_tid
+                    partial_n0 = g * D + n0
+                    partials[0:MM_T_TILE, partial_n0 : partial_n0 + PROJ_B_MM_N_TILE] = acc_b
+            proj_b_tids[group_bundle] = pb_tid
 
-    # Consolidate the eight grouped INT32 partials in one vector epilogue. Keep
-    # the direct per-group task dependencies so there is no synthetic join task
-    # between the output-projection cubes and dequantization.
-    with pl.spmd(PB_ACT_NREG * PB_ACT_TBLKS, name_hint="proj_b_act",
-                 deps=[proj_b_tids[i] for i in range(O_GROUPS)], allow_early_resolve=True) as _act_tid:
+    with pl.spmd(
+        (D // PROJ_B_ACT_N_TILE) * (T // PROJ_B_ACT_TASK_T_TILE),
+        name_hint="proj_b_act",
+        deps=[proj_b_tids[i] for i in range(O_GROUPS // O_GROUP_TILE)],
+        allow_early_resolve=True,
+    ) as _act_tid:
         act_idx = pl.tile.get_block_idx()
-        nreg = act_idx // PB_ACT_TBLKS
-        tblk = act_idx - nreg * PB_ACT_TBLKS
+        nreg = act_idx // (T // PROJ_B_ACT_TASK_T_TILE)
+        tblk = act_idx - nreg * (T // PROJ_B_ACT_TASK_T_TILE)
         ob_n0 = nreg * PROJ_B_ACT_N_TILE
-        t0 = tblk * PROJ_B_ACT_TBLK
+        t0 = tblk * PROJ_B_ACT_TASK_T_TILE
         wb_scale = wo_b_scale[ob_n0 : ob_n0 + PROJ_B_ACT_N_TILE]
-        wb_scale_chunk = pl.reshape(wb_scale, [1, PROJ_B_ACT_N_TILE])
-        for b_tb in pl.range(t0, t0 + PROJ_B_ACT_TBLK, PROJ_B_ACT_T_TILE):
+        wb_scale_tile = pl.reshape(wb_scale, [1, PROJ_B_ACT_N_TILE])
+        for b_tb in pl.range(t0, t0 + PROJ_B_ACT_TASK_T_TILE, PROJ_B_ACT_T_TILE):
             acc = pl.full([PROJ_B_ACT_T_TILE, PROJ_B_ACT_N_TILE], dtype=pl.FP32, value=0.0)
             for act_g in pl.pipeline(O_GROUPS, stage=2):
                 p_col0 = act_g * D + ob_n0
@@ -454,7 +360,7 @@ def sparse_attn_swa(
                 p_g_f32 = pl.cast(p_g, target_type=pl.FP32, mode="none")
                 p_g_scaled = pl.row_expand_mul(p_g_f32, g_scale)
                 acc = pl.add(acc, p_g_scaled)
-            out_t = pl.col_expand_mul(acc, wb_scale_chunk)
+            out_t = pl.col_expand_mul(acc, wb_scale_tile)
             out_bf16 = pl.cast(out_t, target_type=pl.BF16, mode="rint")
             attn_out[b_tb : b_tb + PROJ_B_ACT_T_TILE, ob_n0 : ob_n0 + PROJ_B_ACT_N_TILE] = out_bf16
     return attn_out
@@ -474,28 +380,30 @@ def sparse_attn_test(
     wo_b_scale: pl.Tensor[[D], pl.FP32],
     attn_out: pl.Out[pl.Tensor[[T, D], pl.BF16]],
 ):
-    ori_kv_flat = pl.reshape(ori_kv, [ORI_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
     sparse_bias = pl.create_tensor([T, PADDED_TOPK], dtype=pl.FP32)
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="swa_valid_bias"):
-        v_col = pl.cast(pl.arange(0, [1, ATTN_K_TILE], dtype=pl.INT32), target_type=pl.FP32)
-        v_col_m = pl.col_expand(pl.full([T, ATTN_K_TILE], dtype=pl.FP32, value=0.0), v_col)
-        v_lens = pl.cast(pl.reshape(swa_lens[0:T], [T, 1]), target_type=pl.FP32)
-        v_valid = pl.minimum(
-            pl.maximum(pl.neg(pl.row_expand_sub(v_col_m, v_lens)), 0.0),
-            1.0,
-        )
-        sparse_bias[0:T, 0:ATTN_K_TILE] = pl.mul(pl.sub(v_valid, 1.0), -NEG_INF)
+        v_col_i32 = pl.arange(0, [1, ATTN_K_TILE], dtype=pl.INT32)
+        v_col = pl.cast(v_col_i32, target_type=pl.FP32)
+        v_col_base = pl.full([T, ATTN_K_TILE], dtype=pl.FP32, value=0.0)
+        v_col_m = pl.col_expand(v_col_base, v_col)
+        v_lens_row = pl.reshape(swa_lens[0:T], [T, 1])
+        v_lens = pl.cast(v_lens_row, target_type=pl.FP32)
+        v_delta = pl.row_expand_sub(v_col_m, v_lens)
+        v_inside = pl.neg(v_delta)
+        v_floor = pl.maximum(v_inside, 0.0)
+        v_len_valid = pl.minimum(v_floor, 1.0)
+        v_idx_f = pl.cast(swa_indices[0:T, 0:ATTN_K_TILE], target_type=pl.FP32)
+        v_idx_one = pl.add(v_idx_f, 1.0)
+        v_idx_floor = pl.maximum(v_idx_one, 0.0)
+        v_idx_valid = pl.minimum(v_idx_floor, 1.0)
+        v_valid = pl.mul(v_len_valid, v_idx_valid)
+        v_mask = pl.sub(v_valid, 1.0)
+        sparse_bias[0:T, 0:ATTN_K_TILE] = pl.mul(v_mask, -NEG_INF)
+    ori_kv_flat = pl.reshape(ori_kv, [ORI_BLOCK_NUM * BLOCK_SIZE, HEAD_DIM])
     sparse_attn_swa(
-        q,
-        ori_kv_flat,
-        swa_indices,
-        sparse_bias,
-        attn_sink,
-        freqs_cos,
-        freqs_sin,
-        wo_a,
-        wo_b,
-        wo_b_scale,
+        q, ori_kv_flat, swa_indices, sparse_bias,
+        attn_sink, freqs_cos, freqs_sin,
+        wo_a, wo_b, wo_b_scale,
         attn_out,
     )
     return attn_out
@@ -543,9 +451,6 @@ def golden_sparse_attn(tensors):
 
     o = torch.zeros(T, H, HEAD_DIM)
 
-    # Per-query-token attention. swa_indices is the authoritative physical
-    # cache-row list; invalid tail columns are -1 and swa_lens gives the valid
-    # prefix length.
     for t in range(T):
         valid_len = int(swa_lens[t].item())
         valid_slots = [int(v) for v in swa_indices[t, :valid_len].tolist() if int(v) >= 0]
@@ -561,15 +466,11 @@ def golden_sparse_attn(tensors):
             start = sb * ATTN_K_TILE
             end = min(start + ATTN_K_TILE, WIN)
             slots = swa_indices[t, start:end].tolist()
-            valid_tile = torch.tensor(
-                [start + i < valid_len and int(slot) >= 0 for i, slot in enumerate(slots)],
-                dtype=torch.bool,
-            )
+            valid_entries = [start + i < valid_len and int(slot) >= 0 for i, slot in enumerate(slots)]
+            valid_tile = torch.tensor(valid_entries, dtype=torch.bool)
             if end - start < ATTN_K_TILE:
-                valid_tile = torch.cat([
-                    valid_tile,
-                    torch.zeros(ATTN_K_TILE - (end - start), dtype=torch.bool),
-                ])
+                valid_pad = torch.zeros(ATTN_K_TILE - (end - start), dtype=torch.bool)
+                valid_tile = torch.cat([valid_tile, valid_pad])
             valid_tile = valid_tile.to(device=ori_kv.device)
             kv_tile = torch.zeros(ATTN_K_TILE, HEAD_DIM, dtype=ori_kv.dtype, device=ori_kv.device)
             for r, slot in enumerate(slots):
@@ -615,11 +516,7 @@ def golden_sparse_attn(tensors):
     seq_per_batch = T // B
     o_model = o.float().view(B, seq_per_batch, O_GROUPS, O_GROUP_IN)
     o_r = torch.einsum("bsgd,grd->bsgr", o_model, wo_a)
-    # PER-GROUP INT8 activation quant (one amax per O_LORA group, not per full row):
-    # this localizes the reduction so proj_a[g]->quant[g]->proj_b[g] can pipeline
-    # back-to-back. Each group's INT32 partial is dequantized by its OWN per-row
-    # activation scale before the groups are summed (the per-group scale cannot
-    # factor out of the K-sum), then the per-channel weight scale is applied.
+    # Quantize each output-projection group independently.
     o_r_g = o_r.reshape(T, O_GROUPS, O_LORA)
     amax_g = o_r_g.abs().amax(dim=-1, keepdim=True).clamp_min(INT8_AMAX_EPS)   # [T, G, 1]
     scale_q_g = INT8_SCALE_MAX / amax_g
@@ -637,11 +534,16 @@ def golden_sparse_attn(tensors):
 def build_tensor_specs(
     causal_regression_fixture: bool = False,
     short_window_fixture: bool = False,
+    unmapped_visible_page_fixture: bool = False,
 ):
     """Build deterministic demo tensors for the merged standalone harness."""
     import torch
     from decode_metadata import block_table
     from golden import TensorSpec
+
+    fixture_count = sum((causal_regression_fixture, short_window_fixture, unmapped_visible_page_fixture))
+    if fixture_count > 1:
+        raise ValueError("regression fixtures are mutually exclusive")
 
     def init_q():
         """Initialize the query tensor used by the decode attention stage."""
@@ -663,11 +565,7 @@ def build_tensor_specs(
 
     def init_ori_block_table():
         """Build the demo block table for the sliding-window cache pages."""
-        return block_table(
-            batch=B,
-            table_blocks=ORI_MAX_BLOCKS,
-            physical_blocks=ORI_BLOCK_NUM,
-        )
+        return block_table(batch=B, table_blocks=ORI_MAX_BLOCKS, physical_blocks=ORI_BLOCK_NUM)
 
     def init_swa_lens():
         lens = torch.full((T,), WIN, dtype=torch.int32)
@@ -677,15 +575,20 @@ def build_tensor_specs(
 
     def init_swa_indices():
         """Build physical cache-row indices for the standalone SWA fixture."""
-        tbl = init_ori_block_table()
+        tbl = init_ori_block_table().clone()
+        window_start = 0
+        if unmapped_visible_page_fixture:
+            tbl[:, 0] = -1
+            window_start = BLOCK_SIZE // 2
         indices = torch.full((T, WIN), -1, dtype=torch.int32)
         lens = init_swa_lens()
         for t in range(T):
             b = t // S
             valid_len = int(lens[t].item())
             for w in range(valid_len):
-                logical_blk = w // BLOCK_SIZE
-                intra = w % BLOCK_SIZE
+                pos = window_start + w
+                logical_blk = pos // BLOCK_SIZE
+                intra = pos % BLOCK_SIZE
                 blk = int(tbl[b, logical_blk].item())
                 if blk >= 0:
                     indices[t, w] = blk * BLOCK_SIZE + intra
@@ -738,18 +641,24 @@ if __name__ == "__main__":
     from golden import ratio_allclose, run_jit
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("-p", "--platform", type=str, default="a2a3",
-                        choices=["a2a3", "a2a3sim", "a5", "a5sim"])
+    parser.add_argument("-p", "--platform", type=str, default="a2a3", choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--causal-regression-fixture", action="store_true", default=False,
-                        help="Amplify the S=2 future-window-slot regression.")
-    parser.add_argument("--short-window-fixture", action="store_true", default=False,
-                        help="Use a short-window topk row with valid prefix + -1 padding.")
+    causal_help = "Amplify the S=2 future-window-slot regression."
+    parser.add_argument("--causal-regression-fixture", action="store_true", default=False, help=causal_help)
+    short_help = "Use a short-window topk row with valid prefix + -1 padding."
+    parser.add_argument("--short-window-fixture", action="store_true", default=False, help=short_help)
+    unmapped_help = "Use a visible window whose older cache page is unmapped."
+    parser.add_argument(
+        "--unmapped-visible-page-fixture",
+        action="store_true",
+        default=False,
+        help=unmapped_help,
+    )
     parser.add_argument("--golden-data", type=str, default=None)
     parser.add_argument("--enable-chip-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2, 4))
-    parser.add_argument("--enable-dep-gen", action="store_true", default=False,
-                        help="Capture PTO2 dependency edges (deps.json); the swimlane "
-                             "converter draws fanout/fanin arrows from the sibling file.")
+    dep_help = "Capture PTO2 dependency edges (deps.json); the swimlane "
+    dep_help += "converter draws fanout/fanin arrows from the sibling file."
+    parser.add_argument("--enable-dep-gen", action="store_true", default=False, help=dep_help)
     parser.add_argument("--enable-pmu", nargs="?", const=2, default=0, type=int, choices=[0, 1, 2, 4])
     parser.add_argument("--dump-passes", action="store_true", default=False)
     args = parser.parse_args()
@@ -761,6 +670,7 @@ if __name__ == "__main__":
         specs=build_tensor_specs(
             args.causal_regression_fixture,
             args.short_window_fixture,
+            args.unmapped_visible_page_fixture,
         ),
         golden_fn=golden_sparse_attn,
         golden_data=args.golden_data,

--- a/models/deepseek_v4_pro/expert_shared.py
+++ b/models/deepseek_v4_pro/expert_shared.py
@@ -6,17 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-"""DeepSeek-V4 MoE shared expert compute (decode, EP single-card).
-
-Split out of ``expert_routed.py``: only the shared-expert FFN path lives here.
-The routed local experts are computed by ``expert_routed.py``; both kernels
-are composed inside ``moe.py``.
-
-The shared expert reuses the per-token INT8 quant already produced by
-``gate`` (``x_norm_i8`` + ``x_norm_scale``) — the same INT8 view
-that ``dispatch`` packs for the routed path. This avoids a second
-amax+rescale of the same tokens.
-"""
+"""DeepSeek-V4 MoE shared-expert FFN for decode."""
 
 
 import pypto.language as pl
@@ -33,38 +23,17 @@ SWIGLU_LIMIT = M.swiglu_limit
 # tiling
 SH_M_TILE = 16
 SH_ROW_PAD = 8
-SH_ROWS_PER_BLOCK = 2
+SH_ROW_TILE = 2
 T_PAD = ((T + SH_M_TILE - 1) // SH_M_TILE) * SH_M_TILE
-# Decode (T <= SH_M_TILE, single partial block) or prefill (T a multiple of
-# SH_M_TILE, fully valid blocks); a T that is neither would need a dynamic
-# per-block row count the static valid_shape below can't express.
-assert T <= SH_M_TILE or T % SH_M_TILE == 0, \
-    "expert_shared needs T <= SH_M_TILE (decode) or T a multiple of SH_M_TILE (prefill)"
 SH_VALID_M = T if T < SH_M_TILE else SH_M_TILE
-N_MTILES = T_PAD // SH_M_TILE
-assert SH_VALID_M % SH_ROWS_PER_BLOCK == 0
-
+assert T < SH_M_TILE or T % SH_M_TILE == 0
+assert SH_VALID_M % SH_ROW_TILE == 0
 K_TILE = 512
-INTER_K = 512
+INTER_K_TILE = 512
 MM_INTER_TILE = 256
 ACT_INTER_TILE = 1024
 D_OUT_TILE = 256
-# The quant loop requires an exact divisor of MOE_INTER. Preserve the existing
-# Flash and Pro tile choices while sharing the implementation.
 QUANT_TILE = 2048 if M.name == "flash" else 1024
-D_OUT_TILE_ACT = 512
-# Keep one w2-dequant task covering the architecture's full hidden dimension.
-W2_ACT_INNER = 8 if M.name == "flash" else 14
-
-# Every tile that is used as `<dim> // <tile>` in a loop bound must divide its dim
-# exactly, otherwise the loop silently covers only part of the tensor.
-assert MOE_INTER % QUANT_TILE == 0, "QUANT_TILE must divide MOE_INTER (silent tail truncation otherwise)"
-assert QUANT_TILE % 512 == 0, "h_tile_i8 stores must cover whole 512-byte cache lines"
-assert D % K_TILE == 0 and MOE_INTER % INTER_K == 0
-assert MOE_INTER % MM_INTER_TILE == 0 and MOE_INTER % ACT_INTER_TILE == 0
-assert D % D_OUT_TILE == 0 and D % D_OUT_TILE_ACT == 0
-assert D % (W2_ACT_INNER * D_OUT_TILE_ACT) == 0, \
-    "W2_ACT_INNER * D_OUT_TILE_ACT must divide D (otherwise the w2-dequant task count truncates)"
 
 
 @pl.jit.inline
@@ -79,20 +48,12 @@ def expert_shared(
     shared_w2_scale: pl.Tensor[[D], pl.FP32],
     sh: pl.Tensor[[T, D], pl.BF16],
 ):
-    # One M-tile of SH_M_TILE rows per iteration (decode: 1 tile, T<=16 rows valid;
-    # prefill: T_PAD/SH_M_TILE fully-valid tiles).
-    for mt in pl.parallel(N_MTILES):
+    for mt in pl.parallel(T_PAD // SH_M_TILE):
         ts0 = mt * SH_M_TILE
 
         gate_i32 = pl.create_tensor([SH_M_TILE, MOE_INTER], dtype=pl.INT32)
-        up_i32 = pl.create_tensor([SH_M_TILE, MOE_INTER], dtype=pl.INT32)
 
-        # gate (w1) cube matmul -> INT32 GM accumulator.
-        for nb_idx in pl.spmd(
-            MOE_INTER // MM_INTER_TILE,
-            name_hint="sh_gate_mm",
-            allow_early_resolve=True,
-        ):
+        for nb_idx in pl.spmd(MOE_INTER // MM_INTER_TILE, name_hint="sh_gate_mm", allow_early_resolve=True):
             n0 = nb_idx * MM_INTER_TILE
             gate_acc = pl.create_tensor([SH_M_TILE, MM_INTER_TILE], dtype=pl.INT32)
             for k0 in pl.pipeline(0, D, K_TILE, stage=2):
@@ -104,12 +65,9 @@ def expert_shared(
                     gate_acc = pl.matmul_acc(gate_acc, xs_k, sw1_k, b_trans=True)
             gate_i32[:, n0 : n0 + MM_INTER_TILE] = gate_acc
 
-        # up (w3) cube matmul -> INT32 GM accumulator.
-        for nb_idx in pl.spmd(
-            MOE_INTER // MM_INTER_TILE,
-            name_hint="sh_up_mm",
-            allow_early_resolve=True,
-        ):
+        up_i32 = pl.create_tensor([SH_M_TILE, MOE_INTER], dtype=pl.INT32)
+
+        for nb_idx in pl.spmd(MOE_INTER // MM_INTER_TILE, name_hint="sh_up_mm", allow_early_resolve=True):
             n0 = nb_idx * MM_INTER_TILE
             up_acc = pl.create_tensor([SH_M_TILE, MM_INTER_TILE], dtype=pl.INT32)
             for k0 in pl.pipeline(0, D, K_TILE, stage=2):
@@ -121,161 +79,92 @@ def expert_shared(
                     up_acc = pl.matmul_acc(up_acc, xs_k, sw3_k, b_trans=True)
             up_i32[:, n0 : n0 + MM_INTER_TILE] = up_acc
 
-        # Each AIV block owns two rows across the full intermediate axis (four
-        # blocks for the decode shape). Activation, row-amax, scale, and requant
-        # stay in one task so this stage can start alongside dispatch_push.
         h_tile_fp32 = pl.create_tensor([SH_M_TILE, MOE_INTER], dtype=pl.FP32)
-        h_tile_i8 = pl.create_tensor(
-            [SH_M_TILE, MOE_INTER], dtype=pl.INT8, init_value=0
-        )
-        h_tile_scale_dq = pl.create_tensor(
-            [SH_M_TILE, SH_ROW_PAD], dtype=pl.FP32, manual_dep=True
-        )
-        for row_block in pl.spmd(
-            SH_VALID_M // SH_ROWS_PER_BLOCK,
-            name_hint="sh_gate_up_act_q",
-            allow_early_resolve=True,
-        ):
-            row0 = row_block * SH_ROWS_PER_BLOCK
-            x_scale = pl.slice(
-                x_local_scale_dq,
-                [SH_ROW_PAD, 1],
-                [ts0 + row0, 0],
-                valid_shape=[SH_ROWS_PER_BLOCK, 1],
-            )
-            row_amax = pl.full(
-                [1, SH_ROW_PAD],
-                dtype=pl.FP32,
-                value=INT8_AMAX_EPS,
-            )
-            for part in pl.pipeline(0, MOE_INTER // ACT_INTER_TILE, stage=1):
+        h_tile_i8 = pl.create_tensor([SH_M_TILE, MOE_INTER], dtype=pl.INT8, init_value=0)
+        h_tile_scale_dq = pl.create_tensor([SH_M_TILE, SH_ROW_PAD], dtype=pl.FP32, manual_dep=True)
+        for row_block in pl.spmd(SH_VALID_M // SH_ROW_TILE, name_hint="sh_gate_up_act_q", allow_early_resolve=True):
+            row0 = row_block * SH_ROW_TILE
+            x_scale = pl.slice(x_local_scale_dq, [SH_ROW_PAD, 1], [ts0 + row0, 0], valid_shape=[SH_ROW_TILE, 1])
+            row_amax = pl.full([1, SH_ROW_PAD], dtype=pl.FP32, value=INT8_AMAX_EPS)
+            for part in pl.pipeline(0, MOE_INTER // ACT_INTER_TILE, stage=2):
                 n0 = part * ACT_INTER_TILE
                 gate_rows_i32 = pl.slice(
                     gate_i32,
                     [SH_ROW_PAD, ACT_INTER_TILE],
                     [row0, n0],
-                    valid_shape=[SH_ROWS_PER_BLOCK, ACT_INTER_TILE],
+                    valid_shape=[SH_ROW_TILE, ACT_INTER_TILE],
                 )
                 up_rows_i32 = pl.slice(
                     up_i32,
                     [SH_ROW_PAD, ACT_INTER_TILE],
                     [row0, n0],
-                    valid_shape=[SH_ROWS_PER_BLOCK, ACT_INTER_TILE],
+                    valid_shape=[SH_ROW_TILE, ACT_INTER_TILE],
                 )
-                w1_scale = pl.reshape(
-                    shared_w1_scale[n0 : n0 + ACT_INTER_TILE],
-                    [1, ACT_INTER_TILE],
-                )
-                w3_scale = pl.reshape(
-                    shared_w3_scale[n0 : n0 + ACT_INTER_TILE],
-                    [1, ACT_INTER_TILE],
-                )
-                gate_fp32 = pl.cast(
-                    gate_rows_i32, target_type=pl.FP32, mode="none"
-                )
-                up_fp32 = pl.cast(
-                    up_rows_i32, target_type=pl.FP32, mode="none"
-                )
-                gate_fp32 = pl.col_expand_mul(
-                    pl.row_expand_mul(gate_fp32, x_scale), w1_scale
-                )
-                up_fp32 = pl.col_expand_mul(
-                    pl.row_expand_mul(up_fp32, x_scale), w3_scale
-                )
+                w1_scale = pl.reshape(shared_w1_scale[n0 : n0 + ACT_INTER_TILE], [1, ACT_INTER_TILE])
+                w3_scale = pl.reshape(shared_w3_scale[n0 : n0 + ACT_INTER_TILE], [1, ACT_INTER_TILE])
+                gate_fp32 = pl.cast(gate_rows_i32, target_type=pl.FP32, mode="none")
+                up_fp32 = pl.cast(up_rows_i32, target_type=pl.FP32, mode="none")
+                gate_scaled = pl.row_expand_mul(gate_fp32, x_scale)
+                gate_fp32 = pl.col_expand_mul(gate_scaled, w1_scale)
+                up_scaled = pl.row_expand_mul(up_fp32, x_scale)
+                up_fp32 = pl.col_expand_mul(up_scaled, w3_scale)
                 if SWIGLU_LIMIT > 0.0:
                     gate_fp32 = pl.minimum(gate_fp32, SWIGLU_LIMIT)
-                    up_fp32 = pl.maximum(
-                        pl.minimum(up_fp32, SWIGLU_LIMIT), -SWIGLU_LIMIT
-                    )
-                sigmoid = pl.recip(pl.add(pl.exp(pl.neg(gate_fp32)), 1.0))
-                gated = pl.mul(pl.mul(gate_fp32, sigmoid), up_fp32)
-                chunk_amax = pl.reshape(
-                    pl.row_max(pl.abs(gated)), [1, SH_ROW_PAD]
-                )
-                row_amax = pl.maximum(row_amax, chunk_amax)
-                h_tile_fp32[
-                    row0 : row0 + SH_ROWS_PER_BLOCK,
-                    n0 : n0 + ACT_INTER_TILE,
-                ] = gated[0:SH_ROWS_PER_BLOCK, :]
+                    up_max = pl.minimum(up_fp32, SWIGLU_LIMIT)
+                    up_fp32 = pl.maximum(up_max, -SWIGLU_LIMIT)
+                gate_neg = pl.neg(gate_fp32)
+                gate_exp = pl.exp(gate_neg)
+                gate_exp_one = pl.add(gate_exp, 1.0)
+                sigmoid = pl.recip(gate_exp_one)
+                silu = pl.mul(gate_fp32, sigmoid)
+                gated = pl.mul(silu, up_fp32)
+                gated_abs = pl.abs(gated)
+                gated_amax = pl.row_max(gated_abs)
+                part_amax = pl.reshape(gated_amax, [1, SH_ROW_PAD])
+                row_amax = pl.maximum(row_amax, part_amax)
+                h_tile_fp32[row0 : row0 + SH_ROW_TILE, n0 : n0 + ACT_INTER_TILE] = gated[0:SH_ROW_TILE, :]
 
-            row_scale_q = pl.div(
-                pl.full(
-                    [1, SH_ROW_PAD],
-                    dtype=pl.FP32,
-                    value=INT8_SCALE_MAX,
-                ),
-                row_amax,
-            )
+            scale_numerator = pl.full([1, SH_ROW_PAD], dtype=pl.FP32, value=INT8_SCALE_MAX)
+            row_scale_q = pl.div(scale_numerator, row_amax)
             row_scale_q_col = pl.reshape(row_scale_q, [SH_ROW_PAD, 1])
-            row_scale_dq_col = pl.reshape(
-                pl.recip(row_scale_q), [SH_ROW_PAD, 1]
-            )
-            row_scale_dq = pl.row_expand(
-                pl.full(
-                    [SH_ROW_PAD, SH_ROW_PAD], dtype=pl.FP32, value=0.0
-                ),
-                row_scale_dq_col,
-            )
-            h_tile_scale_dq[
-                row0 : row0 + SH_ROWS_PER_BLOCK, :
-            ] = row_scale_dq[0:SH_ROWS_PER_BLOCK, :]
-            for q_idx in pl.pipeline(0, MOE_INTER // QUANT_TILE, stage=1):
+            row_scale_dq = pl.recip(row_scale_q)
+            row_scale_dq_col = pl.reshape(row_scale_dq, [SH_ROW_PAD, 1])
+            scale_base = pl.full([SH_ROW_PAD, SH_ROW_PAD], dtype=pl.FP32, value=0.0)
+            row_scale_dq_full = pl.row_expand(scale_base, row_scale_dq_col)
+            h_tile_scale_dq[row0 : row0 + SH_ROW_TILE, :] = row_scale_dq_full[0:SH_ROW_TILE, :]
+            for q_idx in pl.pipeline(0, MOE_INTER // QUANT_TILE, stage=2):
                 k0 = q_idx * QUANT_TILE
                 h_fp32 = pl.slice(
                     h_tile_fp32,
                     [SH_ROW_PAD, QUANT_TILE],
                     [row0, k0],
-                    valid_shape=[SH_ROWS_PER_BLOCK, QUANT_TILE],
+                    valid_shape=[SH_ROW_TILE, QUANT_TILE],
                 )
                 h_scaled = pl.row_expand_mul(h_fp32, row_scale_q_col)
                 h_i32 = pl.cast(h_scaled, target_type=pl.INT32, mode="rint")
                 h_fp16 = pl.cast(h_i32, target_type=pl.FP16, mode="round")
-                h_tile_i8[
-                    row0 : row0 + SH_ROWS_PER_BLOCK,
-                    k0 : k0 + QUANT_TILE,
-                ] = pl.cast(h_fp16, target_type=pl.INT8, mode="trunc")[
-                    0:SH_ROWS_PER_BLOCK, :
-                ]
+                h_i8 = pl.cast(h_fp16, target_type=pl.INT8, mode="trunc")
+                h_tile_i8[row0 : row0 + SH_ROW_TILE, k0 : k0 + QUANT_TILE] = h_i8[0:SH_ROW_TILE, :]
 
-        # w2 (down) cube matmul -> INT32 GM accumulator.
-        y_i32 = pl.create_tensor([SH_M_TILE, D], dtype=pl.INT32)
-        for db_idx in pl.spmd(
-            D // D_OUT_TILE,
-            name_hint="sh_w2_mm",
-            allow_early_resolve=True,
-        ):
+        for db_idx in pl.spmd(D // D_OUT_TILE, name_hint="sh_w2_mm", allow_early_resolve=True):
             d0 = db_idx * D_OUT_TILE
             y_acc = pl.create_tensor([SH_M_TILE, D_OUT_TILE], dtype=pl.INT32)
-            for k0 in pl.pipeline(0, MOE_INTER, INTER_K, stage=2):
-                hs_k = h_tile_i8[:, k0 : k0 + INTER_K]
-                sw2_k = shared_w2[
-                    d0 : d0 + D_OUT_TILE, k0 : k0 + INTER_K
-                ]
+            for k0 in pl.pipeline(0, MOE_INTER, INTER_K_TILE, stage=2):
+                hs_k = h_tile_i8[:, k0 : k0 + INTER_K_TILE]
+                sw2_k = shared_w2[d0 : d0 + D_OUT_TILE, k0 : k0 + INTER_K_TILE]
                 if k0 == 0:
                     y_acc = pl.matmul(hs_k, sw2_k, b_trans=True, out_dtype=pl.INT32)
                 else:
                     y_acc = pl.matmul_acc(y_acc, hs_k, sw2_k, b_trans=True)
-            y_i32[:, d0 : d0 + D_OUT_TILE] = y_acc
 
-        # Dequant w2 output (per-row h scale x per-channel w2 scale) -> BF16.
-        for db_idx in pl.spmd(D // (W2_ACT_INNER * D_OUT_TILE_ACT), name_hint="sh_w2_act"):
-            d_base = db_idx * (W2_ACT_INNER * D_OUT_TILE_ACT)
             h_scale = pl.row_max(h_tile_scale_dq[:, :])
-            for dg in pl.pipeline(W2_ACT_INNER, stage=2):
-                d0 = d_base + dg * D_OUT_TILE_ACT
-                y_2d_i32 = y_i32[:, d0 : d0 + D_OUT_TILE_ACT]
-                w2_scale_chunk = pl.reshape(shared_w2_scale[d0 : d0 + D_OUT_TILE_ACT], [1, D_OUT_TILE_ACT])
-                y_2d = pl.cast(y_2d_i32, target_type=pl.FP32, mode="none")
-                y_2d = pl.col_expand_mul(
-                    pl.row_expand_mul(y_2d, h_scale), w2_scale_chunk
-                )
-                # Write valid rows straight to the (unpadded) output, mirroring
-                # expert_routed's direct recv_y store; no sh_pad round-trip.
-                y_bf16 = pl.cast(y_2d, target_type=pl.BF16, mode="rint")
-                sh[ts0 : ts0 + SH_VALID_M, d0 : d0 + D_OUT_TILE_ACT] = y_bf16[0:SH_VALID_M, :]
+            w2_scale_tile = pl.reshape(shared_w2_scale[d0 : d0 + D_OUT_TILE], [1, D_OUT_TILE])
+            y_2d = pl.cast(y_acc, target_type=pl.FP32, mode="none")
+            y_scaled = pl.row_expand_mul(y_2d, h_scale)
+            y_2d = pl.col_expand_mul(y_scaled, w2_scale_tile)
+            y_bf16 = pl.cast(y_2d, target_type=pl.BF16, mode="rint")
+            sh[ts0 : ts0 + SH_VALID_M, d0 : d0 + D_OUT_TILE] = y_bf16[0:SH_VALID_M, :]
 
-    # The @pl.inline parser requires inline call expressions to have a return
-    # value; sh is convenient because it's already pl.Out.
     return sh
 
 
@@ -301,7 +190,7 @@ def expert_shared_test(
 
 
 def _int8_quant_per_row(x):
-    """Per-row (per-token) INT8 symmetric quant matching v3.2 scope2 Stage 2.6."""
+    """Quantize each row symmetrically to INT8."""
     import torch
     rows = x.float().reshape(-1, x.shape[-1])
     amax = rows.abs().amax(dim=-1, keepdim=True).clamp_min(INT8_AMAX_EPS)
@@ -313,30 +202,18 @@ def _int8_quant_per_row(x):
 
 
 def golden_expert_shared(tensors):
-    """Torch reference for the shared expert.
-
-    Input is the per-token INT8 quant produced by gate (shared with
-    dispatch / routed expert); we dequant inside to match the kernel's
-    dequant-then-matmul pattern."""
+    """Compute the shared-expert reference with INT32 accumulation."""
     import torch
     import torch.nn.functional as F
 
-    # Mirror the kernel's numerics exactly. Every matmul in the kernel is an
-    # exact INT8 x INT8 -> INT32 accumulate, dequantized AFTER the reduction by
-    # the per-row input scale x per-channel weight scale. Integer accumulation
-    # is exact and order-independent, so an int32 matmul here is bit-identical
-    # to the kernel's tiled int32 accumulate regardless of K-tiling. A fp32
-    # matmul of pre-dequantized operands (the previous form) instead accumulates
-    # fp32 rounding error that flips bf16 last-bit ties on the final cast; mirror
-    # the kernel's "accumulate-int32, then one fp32 dequant mul" order to match.
-    x_local_i8 = tensors["x_local_i8"]                       # [T, D] int8
-    x_local_scale_dq = tensors["x_local_scale_dq"].float()   # [T, 1]
-    w1_i8 = tensors["shared_w1"]                        # [MOE_INTER, D] int8
-    w1_scale = tensors["shared_w1_scale"].float()       # [MOE_INTER]
-    w3_i8 = tensors["shared_w3"]                        # [MOE_INTER, D] int8
-    w3_scale = tensors["shared_w3_scale"].float()       # [MOE_INTER]
-    w2_i8 = tensors["shared_w2"]                        # [D, MOE_INTER] int8
-    w2_scale = tensors["shared_w2_scale"].float()       # [D]
+    x_local_i8 = tensors["x_local_i8"]
+    x_local_scale_dq = tensors["x_local_scale_dq"].float()
+    w1_i8 = tensors["shared_w1"]
+    w1_scale = tensors["shared_w1_scale"].float()
+    w3_i8 = tensors["shared_w3"]
+    w3_scale = tensors["shared_w3_scale"].float()
+    w2_i8 = tensors["shared_w2"]
+    w2_scale = tensors["shared_w2_scale"].float()
 
     gate_int = x_local_i8.to(torch.int32) @ w1_i8.to(torch.int32).T
     sh_gate = gate_int.to(torch.float32) * x_local_scale_dq * w1_scale.unsqueeze(0)
@@ -347,7 +224,6 @@ def golden_expert_shared(tensors):
         sh_up = sh_up.clamp(-SWIGLU_LIMIT, SWIGLU_LIMIT)
     sh_h = F.silu(sh_gate) * sh_up
     sh_h_i8, sh_h_sd = _int8_quant_per_row(sh_h)
-    # W2: exact INT32 accumulate, then per-row (h) x per-channel (w2) dequant.
     sh_int = sh_h_i8.to(torch.int32) @ w2_i8.to(torch.int32).T
     sh = sh_int.to(torch.float32) * sh_h_sd * w2_scale.unsqueeze(0)
 
@@ -355,31 +231,24 @@ def golden_expert_shared(tensors):
 
 
 def gen_shared_weight(shape, dequant_std, chan_cv):
-    """Synthesize a shared-expert per-channel-symmetric INT8 weight + FP32 scale by
-    simulating the real DeepSeek-V4-Flash MXFP8 shared-expert quant grid (e4m3, 128x128-block
-    E8M0 scale), then re-quantizing per-output-channel. Unlike routed (MXFP4 -> ~37 discrete
-    levels), shared stays near-Gaussian (~200 levels). The coarse 128-block scale does NOT
-    flatten the real per-output-channel magnitude spread, so ``chan_cv`` (log-space source-gain
-    std) injects it to reproduce the real INT8 scale CV (~0.5 gate/up, ~0.35 down). Per-output-
-    channel INT8 is scale-invariant, so the grid sets the level shape and ``dequant_std`` only
-    sets the absolute scale magnitude. (routed experts use a different grid -- see
-    expert_routed.gen_routed_weight.)
-
-    ``shape`` last dim = reduction (in) dim; leading dims map to the per-output-channel
-    scale shape ([out, in] -> scale [out]).
-    """
+    """Synthesize per-channel INT8 weights and FP32 scales from an MXFP8 grid."""
     import torch
 
     FP8_MAX, TINY = 448.0, 1e-20
 
-    def sim_fp8(W, block=128):   # e4m3 + 128x128-block E8M0 (round-up) scale on (out, in)
+    def sim_fp8(W, block=128):
         out, inn = W.shape
         Wb = W.reshape(out // block, block, inn // block, block)
-        scale = torch.exp2(torch.ceil(torch.log2((Wb.abs().amax(dim=(1, 3), keepdim=True) / FP8_MAX).clamp_min(TINY))))
+        block_amax = Wb.abs().amax(dim=(1, 3), keepdim=True)
+        block_scale = (block_amax / FP8_MAX).clamp_min(TINY)
+        scale = torch.exp2(torch.ceil(torch.log2(block_scale)))
         q = (Wb / scale).to(torch.float8_e4m3fn).float() * scale
         return q.reshape(out, inn)
 
-    W = torch.randn(*shape) * torch.exp(chan_cv * torch.randn(*shape[:-1], 1))  # per-channel gain
+    weight_base = torch.randn(*shape)
+    channel_noise = torch.randn(*shape[:-1], 1)
+    channel_gain = torch.exp(chan_cv * channel_noise)
+    W = weight_base * channel_gain
     Wq = sim_fp8(W)
     amax = Wq.abs().amax(dim=-1, keepdim=True).clamp_min(INT8_AMAX_EPS)
     scale = amax / INT8_SCALE_MAX
@@ -392,14 +261,9 @@ def build_tensor_specs():
     import torch
     from golden import TensorSpec
 
-    # Pre-quantize x_local once so the i8 / scale specs see consistent values
-    # (mirrors what gate produces in the full pipeline).
     x_local_bf16 = torch.randn(T, D, dtype=torch.bfloat16)
     x_local_i8_pre, x_local_sd_pre = _int8_quant_per_row(x_local_bf16)
 
-    # Synthesize (int8, per-channel scale) by simulating the real MXFP8 shared-expert
-    # quant grid (gen_shared_weight). chan_cv reproduces the real per-output-channel scale
-    # CV (~0.5 gate/up, ~0.35 down) the coarse FP8 block scale leaves behind.
     SHARED_DEQUANT_STD = {"w1": 1.71e-2, "w2": 1.68e-2, "w3": 1.70e-2}
     sw1_i8, sw1_s = gen_shared_weight((MOE_INTER, D), SHARED_DEQUANT_STD["w1"], chan_cv=0.50)
     sw3_i8, sw3_s = gen_shared_weight((MOE_INTER, D), SHARED_DEQUANT_STD["w3"], chan_cv=0.50)
@@ -423,8 +287,7 @@ if __name__ == "__main__":
     from golden import ratio_reldiff, run_jit
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("-p", "--platform", type=str, default="a2a3",
-                        choices=["a2a3", "a2a3sim", "a5", "a5sim"])
+    parser.add_argument("-p", "--platform", type=str, default="a2a3", choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
     parser.add_argument("--enable-chip-swimlane", action="store_true", default=False)
     parser.add_argument("--dump-passes", action="store_true", default=False)
@@ -443,7 +306,6 @@ if __name__ == "__main__":
         rtol=1e-3,
         atol=1e-3,
         compare_fn={
-            # BF16 sh, ~1 ULP. Gen weights reproduce real(L21): 0.01% vs 0.004% of points > 1e-3.
             "sh": ratio_reldiff(diff_thd=2e-3, pct_thd=0.01),
         },
     )

--- a/models/deepseek_v4_pro/gate.py
+++ b/models/deepseek_v4_pro/gate.py
@@ -11,17 +11,13 @@
 
 import pypto.language as pl
 
-from config import (ACTIVE as M, MOE_TOKENS, FP32_NEG_INF,
-                    INT8_SCALE_MAX, INT8_AMAX_EPS)
+from config import ACTIVE as M, FP32_NEG_INF, INT8_AMAX_EPS, INT8_SCALE_MAX, MOE_TOKENS
 
 
 # model config
 T = MOE_TOKENS
 D = M.hidden_size
 NORM_EPS = M.rms_norm_eps
-# Routing space: every rank routes over the full global expert set so dispatch
-# can fan tokens across ranks. moe.py shrinks config.ACTIVE.n_routed_experts to
-# 32*EP before importing this module, so N_EXPERTS follows the active EP world.
 N_EXPERTS = M.n_routed_experts
 TOPK = M.num_experts_per_tok
 ROUTE_SCALE = M.routed_scaling_factor
@@ -31,46 +27,31 @@ N_HASH_LAYERS = M.num_hash_layers
 # tiling
 T_TILE = 8
 GATE_T_TILE = 8
-GATE_M_TILE = 16        # cube M-tile: matmul rows must be a multiple of 16 (fractal)
-GATE_N_TILE = 16        # expert columns per gate spmd block
-assert N_EXPERTS % GATE_N_TILE == 0
+assert T % GATE_T_TILE == 0
+GATE_M_TILE = 16
+GATE_N_TILE = 16
 T_PAD = ((T + GATE_M_TILE - 1) // GATE_M_TILE) * GATE_M_TILE
-D_TILE = 256
-ROW_PAD = 8
-FFN_REDUCE_TILE = D // ROW_PAD
-assert D % ROW_PAD == 0
-# Flash uses two 2048-wide K tiles. Pro uses 512 because D=7168 is not a
-# multiple of 2048; the resulting 14 trips also keep the stage-2 accumulator
-# pipeline even and avoid an unsupported acc-to-acc tmov.
+ROW_TILE = 8
+FFN_REDUCE_TILE = D // ROW_TILE
 GATE_D_TILE = 2048 if M.name == "flash" else 512
-assert D % GATE_D_TILE == 0, "gate K-loop must cover D"
-assert (D // GATE_D_TILE) % 2 == 0, "gate K-loop trip count must be even (stage=2 acc pipeline)"
+assert (D // GATE_D_TILE) % 2 == 0, "gate K-loop trip count must be even (A5 accumulator-buffer constraint)"
 QUANT_TILE = 256
-# Padded expert row for sort32 + mrgsort.
-#
-# MUST be >= N_EXPERTS: the score buffers are [T_PAD, SCORE_PAD] and the topk runs
-# over that width. Flash fits 256 exactly; Pro's 384 experts need 512.
-SCORE_PAD = 256 if M.name == "flash" else 512
-assert SCORE_PAD >= N_EXPERTS, (
-    f"SCORE_PAD ({SCORE_PAD}) must cover every routed expert (N_EXPERTS={N_EXPERTS})"
-)
-assert SCORE_PAD in (256, 512)
-TOPK_PAD = 8            # TOPK padded to 32B-aligned width
-SORT_PAD = TOPK_PAD * 2 # (val, idx) interleaved slice width
-assert TOPK <= TOPK_PAD
+SCORE_PAD = 256 if M.name == "flash" else 384
+TOPK_PAD = 8
+SORT_PAD = TOPK_PAD * 2
 
 
 if M.name == "flash":
     @pl.jit.inline
     def route_topk_row(
         score_row: pl.Tensor[[1, 256], pl.FP32],
+        idx_init: pl.Tensor[[1, 256], pl.UINT32],
     ) -> pl.Tensor[[1, TOPK_PAD], pl.INT32]:
         """Sort one Flash router row and return its leading expert ids."""
 
-        idx_init = pl.arange(0, [1, 256], dtype=pl.UINT32)
-        sorted_pairs = pl.sort32(score_row, idx_init)
-        sorted_pairs = pl.mrgsort(sorted_pairs, block_len=64)
-        sorted_pairs = pl.mrgsort(sorted_pairs[:, 0:256], sorted_pairs[:, 256:512])
+        sorted_32 = pl.sort32(score_row, idx_init)
+        sorted_64 = pl.mrgsort(sorted_32, block_len=64)
+        sorted_pairs = pl.mrgsort(sorted_64[:, 0:256], sorted_64[:, 256:512])
         return pl.gather(
             sorted_pairs[:, 0:SORT_PAD],
             mask_pattern=pl.tile.MaskPattern.P1010,
@@ -79,18 +60,17 @@ if M.name == "flash":
 else:
     @pl.jit.inline
     def route_topk_row(
-        score_row: pl.Tensor[[1, 512], pl.FP32],
+        score_row: pl.Tensor[[1, 384], pl.FP32],
+        idx_init: pl.Tensor[[1, 384], pl.UINT32],
     ) -> pl.Tensor[[1, TOPK_PAD], pl.INT32]:
         """Sort one Pro router row and return its leading expert ids."""
 
-        idx_init = pl.arange(0, [1, 512], dtype=pl.UINT32)
-        sorted_pairs = pl.sort32(score_row, idx_init)
-        sorted_pairs = pl.mrgsort(sorted_pairs, block_len=64)
+        sorted_32 = pl.sort32(score_row, idx_init)
+        sorted_64 = pl.mrgsort(sorted_32, block_len=64)
         sorted_pairs = pl.mrgsort(
-            sorted_pairs[:, 0:256],
-            sorted_pairs[:, 256:512],
-            sorted_pairs[:, 512:768],
-            sorted_pairs[:, 768:1024],
+            sorted_64[:, 0:256],
+            sorted_64[:, 256:512],
+            sorted_64[:, 512:768],
         )
         return pl.gather(
             sorted_pairs[:, 0:SORT_PAD],
@@ -114,20 +94,6 @@ def gate(
     indices: pl.Tensor[[T, TOPK], pl.INT32],
     weights: pl.Tensor[[T, TOPK], pl.FP32],
 ):
-    # Deferred RMSNorm (qwen3-style): store xg = x*gamma (NOT *inv_rms), because
-    # the per-token positive scalar inv_rms factors out of everything downstream:
-    #   - gate logits: inv_rms * (xg @ gate_w.T)  -> applied as a [16,1] row-scale
-    #   - int8 quant : symmetric per-token quant of xg CANCELS inv_rms exactly;
-    #                  inv_rms rides only x_norm_scale (= inv_rms * amax(xg)/127).
-    # This lets sq_sum (needs raw x) and xg share ONE pass over x_mixed instead of
-    # a sqsum pass followed by a separate normalize pass.
-    xg_buf = pl.create_tensor([T_PAD, D], dtype=pl.FP32)
-    inv_rms_buf = pl.create_tensor([T_PAD, 1], dtype=pl.FP32)
-    # per-token int8 quant scale (= INT8_SCALE_MAX / amax(xg)), computed in ffn_norm
-    # and consumed by x_norm_quant so quant skips its own amax pass.
-    xn_scale_buf = pl.create_tensor([T_PAD, 1], dtype=pl.FP32)
-    route_scores_buf = pl.create_tensor([T_PAD, SCORE_PAD], dtype=pl.FP32)
-    biased_scores_buf = pl.create_tensor([T_PAD, SCORE_PAD], dtype=pl.FP32)
     active_tokens = pl.cast(num_tokens, pl.INDEX)
     if active_tokens < 0:
         active_tokens = pl.cast(0, pl.INDEX)
@@ -138,93 +104,91 @@ def gate(
     if active_gate_tokens > T:
         active_gate_tokens = pl.cast(T, pl.INDEX)
 
-    # One token per core with two-level full-row reductions.
     norm_w_2d = pl.reshape(norm_w, [1, D])
+    xg_buf = pl.create_tensor([T_PAD, D], dtype=pl.FP32)
+    inv_rms_buf = pl.create_tensor([T_PAD, 1], dtype=pl.FP32)
+    xn_scale_buf = pl.create_tensor([T_PAD, 1], dtype=pl.FP32)
     for tok in pl.spmd(active_gate_tokens, name_hint="ffn_norm", allow_early_resolve=True):
-        rms_x = pl.cast(pl.tile.load(x_mixed, [tok, 0], [1, D]), pl.FP32)
-        rms_w = pl.cast(pl.tile.load(norm_w_2d, [0, 0], [1, D]), pl.FP32)
+        rms_x_bf16 = pl.tile.load(x_mixed, [tok, 0], [1, D])
+        rms_x = pl.cast(rms_x_bf16, pl.FP32)
+        rms_w_bf16 = pl.tile.load(norm_w_2d, [0, 0], [1, D])
+        rms_w = pl.cast(rms_w_bf16, pl.FP32)
         xg = pl.mul(rms_x, rms_w)
         pl.tile.store(xg, [tok, 0], xg_buf, shapes=[1, D])
 
-        sq_rows = pl.reshape(pl.mul(rms_x, rms_x), [ROW_PAD, FFN_REDUCE_TILE])
-        sq_partial_tmp = pl.create_tile([ROW_PAD, FFN_REDUCE_TILE], dtype=pl.FP32)
+        rms_sq = pl.mul(rms_x, rms_x)
+        sq_rows = pl.reshape(rms_sq, [ROW_TILE, FFN_REDUCE_TILE])
+        sq_partial_tmp = pl.create_tile([ROW_TILE, FFN_REDUCE_TILE], dtype=pl.FP32)
         sq_partial = pl.row_sum(sq_rows, sq_partial_tmp)
-        sq_reduce = pl.create_tile([ROW_PAD, ROW_PAD], dtype=pl.FP32)
-        sq_reduce[0:1, :] = pl.reshape(sq_partial, [1, ROW_PAD])
-        sq_reduce = pl.set_validshape(sq_reduce, 1, ROW_PAD)
-        sq_sum_tmp = pl.create_tile([ROW_PAD, ROW_PAD], dtype=pl.FP32)
-        sq_sum = pl.row_sum(sq_reduce, sq_sum_tmp)
-        sq_sum = pl.set_validshape(pl.reshape(sq_sum, [1, ROW_PAD]), 1, 1)
-        inv_rms = pl.recip(pl.sqrt(pl.add(pl.mul(sq_sum, 1.0 / D), NORM_EPS)))
+        sq_reduce_tile = pl.create_tile([ROW_TILE, ROW_TILE], dtype=pl.FP32)
+        sq_partial_row = pl.reshape(sq_partial, [1, ROW_TILE])
+        sq_reduce_tile[0:1, :] = sq_partial_row
+        sq_reduce_valid = pl.set_validshape(sq_reduce_tile, 1, ROW_TILE)
+        sq_sum_tmp = pl.create_tile([ROW_TILE, ROW_TILE], dtype=pl.FP32)
+        sq_sum_raw = pl.row_sum(sq_reduce_valid, sq_sum_tmp)
+        sq_sum_row = pl.reshape(sq_sum_raw, [1, ROW_TILE])
+        sq_sum_valid = pl.set_validshape(sq_sum_row, 1, 1)
+        sq_mean = pl.mul(sq_sum_valid, 1.0 / D)
+        rms_arg = pl.add(sq_mean, NORM_EPS)
+        rms_root = pl.sqrt(rms_arg)
+        inv_rms = pl.recip(rms_root)
         pl.tile.store(inv_rms, [tok, 0], inv_rms_buf, shapes=[1, 1])
 
-        xg_abs_rows = pl.reshape(pl.abs(xg), [ROW_PAD, FFN_REDUCE_TILE])
-        amax_partial_tmp = pl.create_tile([ROW_PAD, FFN_REDUCE_TILE], dtype=pl.FP32)
+        xg_abs = pl.abs(xg)
+        xg_abs_rows = pl.reshape(xg_abs, [ROW_TILE, FFN_REDUCE_TILE])
+        amax_partial_tmp = pl.create_tile([ROW_TILE, FFN_REDUCE_TILE], dtype=pl.FP32)
         amax_partial = pl.row_max(xg_abs_rows, amax_partial_tmp)
-        amax_reduce = pl.create_tile([ROW_PAD, ROW_PAD], dtype=pl.FP32)
-        amax_reduce[0:1, :] = pl.reshape(amax_partial, [1, ROW_PAD])
-        amax_reduce = pl.set_validshape(amax_reduce, 1, ROW_PAD)
-        amax_tmp = pl.create_tile([ROW_PAD, ROW_PAD], dtype=pl.FP32)
-        xg_amax = pl.row_max(amax_reduce, amax_tmp)
-        xg_amax = pl.set_validshape(pl.reshape(xg_amax, [1, ROW_PAD]), 1, 1)
-        amax_eps = pl.tile.full([1, ROW_PAD], dtype=pl.FP32, value=INT8_AMAX_EPS)
-        amax_eps = pl.set_validshape(amax_eps, 1, 1)
-        xg_amax = pl.maximum(xg_amax, amax_eps)
-        # quant scale = INT8_SCALE_MAX / amax(xg); dequant scale rides inv_rms.
-        scale_max = pl.tile.full([1, ROW_PAD], dtype=pl.FP32, value=INT8_SCALE_MAX)
-        scale_max = pl.set_validshape(scale_max, 1, 1)
+        amax_reduce_tile = pl.create_tile([ROW_TILE, ROW_TILE], dtype=pl.FP32)
+        amax_partial_row = pl.reshape(amax_partial, [1, ROW_TILE])
+        amax_reduce_tile[0:1, :] = amax_partial_row
+        amax_reduce_valid = pl.set_validshape(amax_reduce_tile, 1, ROW_TILE)
+        amax_tmp = pl.create_tile([ROW_TILE, ROW_TILE], dtype=pl.FP32)
+        xg_amax_raw = pl.row_max(amax_reduce_valid, amax_tmp)
+        xg_amax_row = pl.reshape(xg_amax_raw, [1, ROW_TILE])
+        xg_amax_valid = pl.set_validshape(xg_amax_row, 1, 1)
+        amax_eps_tile = pl.tile.full([1, ROW_TILE], dtype=pl.FP32, value=INT8_AMAX_EPS)
+        amax_eps_valid = pl.set_validshape(amax_eps_tile, 1, 1)
+        xg_amax = pl.maximum(xg_amax_valid, amax_eps_valid)
+        scale_max_tile = pl.tile.full([1, ROW_TILE], dtype=pl.FP32, value=INT8_SCALE_MAX)
+        scale_max = pl.set_validshape(scale_max_tile, 1, 1)
         xg_sq = pl.div(scale_max, xg_amax)
         xg_dequant_scale = pl.mul(xg_amax, 1.0 / INT8_SCALE_MAX)
         x_norm_dequant_scale = pl.mul(xg_dequant_scale, inv_rms)
         pl.tile.store(x_norm_dequant_scale, [tok, 0], x_norm_scale, shapes=[1, 1])
         pl.tile.store(xg_sq, [tok, 0], xn_scale_buf, shapes=[1, 1])
 
-    # Per-token symmetric INT8 quant of xg: scale precomputed in ffn_norm. inv_rms
-    # cancels here (symmetric quant is invariant to a positive per-token scalar),
-    # so x_norm_i8 = quant(xg). Early resolution lets the shared-expert chain
-    # pre-stage before dispatch_push.
     for t0 in pl.parallel(0, active_gate_tokens, T_TILE):
-        with pl.at(
-            level=pl.Level.CORE_GROUP,
-            name_hint="x_norm_quant",
-            allow_early_resolve=True,
-        ):
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="x_norm_quant", allow_early_resolve=True):
             xn_sq_col = xn_scale_buf[t0 : t0 + T_TILE, 0:1]
             for xq_b_k in pl.pipeline(0, D, QUANT_TILE, stage=2):
-                xn_q_scaled = pl.row_expand_mul(
-                    xg_buf[t0 : t0 + T_TILE, xq_b_k : xq_b_k + QUANT_TILE],
-                    xn_sq_col,
-                )
+                xn_q_chunk = xg_buf[t0 : t0 + T_TILE, xq_b_k : xq_b_k + QUANT_TILE]
+                xn_q_scaled = pl.row_expand_mul(xn_q_chunk, xn_sq_col)
                 xn_q_i32 = pl.cast(xn_q_scaled, pl.INT32, mode="rint")
                 xn_q_half = pl.cast(xn_q_i32, pl.FP16, mode="round")
-                x_norm_i8[t0 : t0 + T_TILE, xq_b_k : xq_b_k + QUANT_TILE] = \
-                    pl.cast(xn_q_half, pl.INT8, mode="trunc")
+                xn_q_i8 = pl.cast(xn_q_half, pl.INT8, mode="trunc")
+                x_norm_i8[t0 : t0 + T_TILE, xq_b_k : xq_b_k + QUANT_TILE] = xn_q_i8
 
-    # Pre-route setup: zero the inactive-token outputs and NEG_INF the biased pad
-    # columns so the sort ranks pad experts last. Route write-backs are guarded to
-    # active tokens, so the inactive-zero can run here rather than post-route.
+    biased_scores_buf = pl.create_tensor([T_PAD, SCORE_PAD], dtype=pl.FP32)
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="gate_pre_route"):
         for zt in pl.range(T):
             if zt >= active_tokens:
-                pl.write(x_norm_scale, [zt, 0], pl.cast(0.0, pl.FP32))
+                zero_scale = pl.cast(0.0, pl.FP32)
+                pl.write(x_norm_scale, [zt, 0], zero_scale)
                 for zk in pl.range(TOPK):
-                    pl.write(indices, [zt, zk], pl.cast(0, pl.INT32))
-                    pl.write(weights, [zt, zk], pl.cast(0.0, pl.FP32))
+                    zero_index = pl.cast(0, pl.INT32)
+                    pl.write(indices, [zt, zk], zero_index)
+                    zero_weight = pl.cast(0.0, pl.FP32)
+                    pl.write(weights, [zt, zk], zero_weight)
         if N_EXPERTS < SCORE_PAD:
-            biased_scores_buf[:, N_EXPERTS:SCORE_PAD] = \
-                pl.full([T_PAD, SCORE_PAD - N_EXPERTS], dtype=pl.FP32, value=FP32_NEG_INF)
+            biased_pad = pl.full([T_PAD, SCORE_PAD - N_EXPERTS], dtype=pl.FP32, value=FP32_NEG_INF)
+            biased_scores_buf[:, N_EXPERTS:SCORE_PAD] = biased_pad
 
-    # Gate matmul + post: x_norm @ gate_w.T → sqrt(softplus(logits)) (+bias).
-    # Fan the matmul over expert columns so each block computes a [GATE_M_TILE,
-    # GATE_N_TILE] slice on its own core; token-tile is the dynamic dim, so it
-    # stays outermost and // % divide by the compile-time GATE_N_BLOCKS.
-    GATE_N_BLOCKS = N_EXPERTS // GATE_N_TILE
-    for gb_idx in pl.spmd(active_gate_tiles * GATE_N_BLOCKS, name_hint="gate", allow_early_resolve=True):
-        tg = gb_idx // GATE_N_BLOCKS
-        nb = gb_idx % GATE_N_BLOCKS
+    route_scores_buf = pl.create_tensor([T_PAD, SCORE_PAD], dtype=pl.FP32)
+    for gb_idx in pl.spmd(active_gate_tiles * (N_EXPERTS // GATE_N_TILE), name_hint="gate", allow_early_resolve=True):
+        tg = gb_idx // (N_EXPERTS // GATE_N_TILE)
+        nb = gb_idx % (N_EXPERTS // GATE_N_TILE)
         t1 = tg * GATE_M_TILE
         n0 = nb * GATE_N_TILE
-        gp_bias_row = pl.reshape(gate_bias[n0 : n0 + GATE_N_TILE], [1, GATE_N_TILE])
         gate_logits_tile = pl.create_tensor([GATE_M_TILE, GATE_N_TILE], dtype=pl.FP32)
         for kb in pl.pipeline(0, D // GATE_D_TILE, stage=2):
             gd_kd = kb * GATE_D_TILE
@@ -234,104 +198,97 @@ def gate(
                 gate_logits_tile = pl.matmul(gd_x, gd_w, out_dtype=pl.FP32, b_trans=True)
             else:
                 gate_logits_tile = pl.matmul_acc(gate_logits_tile, gd_x, gd_w, b_trans=True)
-        # xg omitted inv_rms; logits = inv_rms * (xg @ gate_w.T). Per-token row-scale.
-        gate_logits_tile = pl.row_expand_mul(gate_logits_tile, inv_rms_buf[t1 : t1 + GATE_M_TILE, 0:1])
+        inv_rms_tile = inv_rms_buf[t1 : t1 + GATE_M_TILE, 0:1]
+        gate_logits_tile = pl.row_expand_mul(gate_logits_tile, inv_rms_tile)
         gp_relu = pl.maximum(gate_logits_tile, 0.0)
-        gp_abs = pl.maximum(gate_logits_tile, pl.neg(gate_logits_tile))
-        gp_softplus_log = pl.add(gp_relu, pl.log(pl.add(pl.exp(pl.neg(gp_abs)), 1.0)))
-        gp_neg_floor_mask = pl.minimum(pl.maximum(pl.sub(pl.neg(gate_logits_tile), 10.0), 0.0), 1.0)
-        gp_neg_floor = pl.mul(gp_neg_floor_mask, pl.exp(pl.minimum(gate_logits_tile, 0.0)))
+        gp_abs = pl.abs(gate_logits_tile)
+        gp_neg_abs = pl.neg(gp_abs)
+        gp_exp_abs = pl.exp(gp_neg_abs)
+        gp_exp_plus = pl.add(gp_exp_abs, 1.0)
+        gp_softplus_tail = pl.log(gp_exp_plus)
+        gp_softplus_log = pl.add(gp_relu, gp_softplus_tail)
+        gp_neg_logits = pl.neg(gate_logits_tile)
+        gp_neg_shift = pl.sub(gp_neg_logits, 10.0)
+        gp_neg_mask_floor = pl.maximum(gp_neg_shift, 0.0)
+        gp_neg_floor_mask = pl.minimum(gp_neg_mask_floor, 1.0)
+        gp_logits_floor = pl.minimum(gate_logits_tile, 0.0)
+        gp_neg_exp = pl.exp(gp_logits_floor)
+        gp_neg_floor = pl.mul(gp_neg_floor_mask, gp_neg_exp)
         gp_softplus = pl.maximum(gp_softplus_log, gp_neg_floor)
         gp_score = pl.sqrt(gp_softplus)
         route_scores_buf[t1 : t1 + GATE_M_TILE, n0 : n0 + GATE_N_TILE] = gp_score
+        gp_bias_row = pl.reshape(gate_bias[n0 : n0 + GATE_N_TILE], [1, GATE_N_TILE])
         if layer_id >= N_HASH_LAYERS:
-            gp_bias = pl.col_expand_mul(pl.full([GATE_M_TILE, GATE_N_TILE], dtype=pl.FP32, value=1.0), gp_bias_row)
-            gp_biased = pl.add(gp_score, gp_bias)
+            gp_biased = pl.col_expand_add(gp_score, gp_bias_row)
             biased_scores_buf[t1 : t1 + GATE_M_TILE, n0 : n0 + GATE_N_TILE] = gp_biased
 
     active_route_tiles = (active_tokens + GATE_T_TILE - 1) // GATE_T_TILE
-    # Hash layers index via tid2eid[input_ids]; score layers sort+gather.
     if layer_id < N_HASH_LAYERS:
         for th_idx in pl.spmd(active_route_tiles, name_hint="route_hash", allow_early_resolve=True):
             t1 = th_idx * GATE_T_TILE
-            # eids from tid2eid[input_ids]: scalar lookup (dynamic row index) into a
-            # Tensor. tid2eid row load hits the 32B tile floor (TOPK*4=24B), so the
-            # index build stays scalar; the score fetch is a batched gather below.
-            # Tail [TOPK, TOPK_PAD) zeroed so fillpad drops it from the sum.
             hs_idx_tile = pl.create_tensor([GATE_T_TILE, TOPK_PAD], dtype=pl.INT32)
             for hs_tt in pl.range(GATE_T_TILE):
-                hs_token = pl.cast(pl.read(input_ids, [t1 + hs_tt]), pl.INDEX)
+                hs_input_id = pl.read(input_ids, [t1 + hs_tt])
+                hs_token = pl.cast(hs_input_id, pl.INDEX)
                 for hs_k in pl.range(TOPK):
-                    pl.write(hs_idx_tile, [hs_tt, hs_k], pl.read(tid2eid, [hs_token, hs_k]))
+                    hs_eid = pl.read(tid2eid, [hs_token, hs_k])
+                    pl.write(hs_idx_tile, [hs_tt, hs_k], hs_eid)
                 for hs_pad_k in pl.range(TOPK, TOPK_PAD):
-                    pl.write(hs_idx_tile, [hs_tt, hs_pad_k], pl.cast(0, pl.INT32))
-            # Batched score gather (replaces per-eid scalar reads); set_validshape +
-            # fillpad zero the [TOPK, TOPK_PAD) tail so row_sum sees only TOPK.
+                    hs_pad = pl.cast(0, pl.INT32)
+                    pl.write(hs_idx_tile, [hs_tt, hs_pad_k], hs_pad)
             local_scores = pl.create_tensor([GATE_T_TILE, SCORE_PAD], dtype=pl.FP32)
             local_scores[:, :] = route_scores_buf[t1 : t1 + GATE_T_TILE, :]
             gather_all = pl.gather(local_scores, dim=-1, index=hs_idx_tile)
             gather_valid = pl.set_validshape(gather_all, GATE_T_TILE, TOPK)
             hs_vals_pad = pl.fillpad(gather_valid, pad_value=pl.PadValue.zero)
-            # Copy to dodge the tensor_view-vs-ptr SSA conflict between the gather
-            # and the scalar pl.read below (pypto #1493).
             hs_idx_read = pl.create_tensor([GATE_T_TILE, TOPK_PAD], dtype=pl.INT32)
             hs_idx_read[:, :] = hs_idx_tile[:, :]
-            hs_denom = pl.reshape(pl.row_sum(hs_vals_pad), [GATE_T_TILE, 1])
-            hs_weights_pad = pl.mul(pl.row_expand_div(hs_vals_pad, hs_denom), ROUTE_SCALE)
+            hs_sum = pl.row_sum(hs_vals_pad)
+            hs_denom = pl.reshape(hs_sum, [GATE_T_TILE, 1])
+            hs_normalized = pl.row_expand_div(hs_vals_pad, hs_denom)
+            hs_weights_pad = pl.mul(hs_normalized, ROUTE_SCALE)
             for hs_wt_tt in pl.range(GATE_T_TILE):
-                if t1 + hs_wt_tt < active_tokens:
+                hs_out_t = t1 + hs_wt_tt
+                if hs_out_t < active_tokens:
                     for hs_wt_k in pl.range(TOPK):
-                        pl.write(indices, [t1 + hs_wt_tt, hs_wt_k], pl.read(hs_idx_read, [hs_wt_tt, hs_wt_k]))
-                        pl.write(weights, [t1 + hs_wt_tt, hs_wt_k], pl.read(hs_weights_pad, [hs_wt_tt, hs_wt_k]))
+                        hs_out_idx = pl.read(hs_idx_read, [hs_wt_tt, hs_wt_k])
+                        pl.write(indices, [hs_out_t, hs_wt_k], hs_out_idx)
+                        hs_out_weight = pl.read(hs_weights_pad, [hs_wt_tt, hs_wt_k])
+                        pl.write(weights, [hs_out_t, hs_wt_k], hs_out_weight)
     else:
         for ts_idx in pl.spmd(active_route_tiles, name_hint="route_sort", allow_early_resolve=True):
             t1 = ts_idx * GATE_T_TILE
-            # ptoas pto.tmrgsort requires src rows == 1; sort path iterates
-            # row-by-row. route_topk_row is selected at module import for the
-            # active preset's concrete 256- or 512-wide merge layout.
+            # ptoas pto.tmrgsort requires a single source row.
             topk_idx_tile = pl.create_tensor([GATE_T_TILE, TOPK_PAD], dtype=pl.INT32)
+            sr_idx_init = pl.create_tensor([1, SCORE_PAD], dtype=pl.UINT32)
+            sr_index_range = pl.arange(0, [1, SCORE_PAD], dtype=pl.UINT32)
+            sr_idx_init[:, :] = sr_index_range
             for sr_tt in pl.range(GATE_T_TILE):
-                sr_row = pl.slice(
-                    biased_scores_buf,
-                    [1, SCORE_PAD],
-                    [t1 + sr_tt, 0],
-                )
-                sr_i = route_topk_row(sr_row)
+                sr_t = t1 + sr_tt
+                sr_row = pl.slice(biased_scores_buf, [1, SCORE_PAD], [sr_t, 0])
+                sr_i = route_topk_row(sr_row, sr_idx_init)
                 topk_idx_tile[sr_tt : sr_tt + 1, :] = sr_i
 
-            # Keep the gather and normalization batched: one-row col-major
-            # tiles violate the 32-byte column alignment required by PTOAS.
             local_scores = pl.create_tensor([GATE_T_TILE, SCORE_PAD], dtype=pl.FP32)
             local_scores[:, :] = route_scores_buf[t1 : t1 + GATE_T_TILE, :]
             gather_all = pl.gather(local_scores, dim=-1, index=topk_idx_tile)
             gather_valid = pl.set_validshape(gather_all, GATE_T_TILE, TOPK)
             topk_vals_pad = pl.fillpad(gather_valid, pad_value=pl.PadValue.zero)
-            # Copy to avoid mixing a tensor view with scalar reads from the same
-            # SSA value after the gather.
             topk_idx_read = pl.create_tensor([GATE_T_TILE, TOPK_PAD], dtype=pl.INT32)
             topk_idx_read[:, :] = topk_idx_tile[:, :]
-            denom = pl.reshape(pl.row_sum(topk_vals_pad), [GATE_T_TILE, 1])
-            normalized_weights = pl.mul(
-                pl.row_expand_div(topk_vals_pad, denom),
-                ROUTE_SCALE,
-            )
+            topk_sum = pl.row_sum(topk_vals_pad)
+            denom = pl.reshape(topk_sum, [GATE_T_TILE, 1])
+            topk_normalized = pl.row_expand_div(topk_vals_pad, denom)
+            normalized_weights = pl.mul(topk_normalized, ROUTE_SCALE)
             for wt_tt in pl.range(GATE_T_TILE):
-                if t1 + wt_tt < active_tokens:
+                wt_out_t = t1 + wt_tt
+                if wt_out_t < active_tokens:
                     for wt_k in pl.range(TOPK):
-                        pl.write(
-                            indices,
-                            [t1 + wt_tt, wt_k],
-                            pl.read(topk_idx_read, [wt_tt, wt_k]),
-                        )
-                        pl.write(
-                            weights,
-                            [t1 + wt_tt, wt_k],
-                            pl.read(normalized_weights, [wt_tt, wt_k]),
-                        )
+                        wt_out_idx = pl.read(topk_idx_read, [wt_tt, wt_k])
+                        pl.write(indices, [wt_out_t, wt_k], wt_out_idx)
+                        wt_out_weight = pl.read(normalized_weights, [wt_tt, wt_k])
+                        pl.write(weights, [wt_out_t, wt_k], wt_out_weight)
 
-    # The @pl.inline parser requires inline call expressions to have a return
-    # value. weights is convenient because it's already pl.Out and reads as
-    # the same SSA name on the caller side.
     return weights
 
 
@@ -377,10 +334,7 @@ def _golden_gate_scores(tensors):
 
     x_f = tensors["x_mixed"].cpu().float().view(T, D)
     norm_w = tensors["norm_w"].cpu().float()
-    # Match ffn_norm's two row_sum stages rather than collapsing the full D
-    # reduction into one torch sum. The outer association affects the FP32
-    # router cutoff for nearly tied experts.
-    sq_rows = (x_f * x_f).reshape(T, ROW_PAD, FFN_REDUCE_TILE)
+    sq_rows = (x_f * x_f).reshape(T, ROW_TILE, FFN_REDUCE_TILE)
     sq_partial = sq_rows.sum(dim=-1)
     sq_sum = sq_partial.sum(dim=-1, keepdim=True)
     inv_rms = torch.rsqrt(sq_sum * (1.0 / D) + NORM_EPS)
@@ -388,10 +342,6 @@ def _golden_gate_scores(tensors):
 
     gate_w = tensors["gate_w"].cpu().float()
     gate_bias = tensors["gate_bias"].cpu().float()
-    # The generated A5 Cube keeps one accumulator live across every source K
-    # tile.  GATE_D_TILE controls source slicing only; it is not an FP32
-    # reduction boundary.  A full host GEMM mirrors that continuous
-    # accumulator more closely than summing independent K-tile GEMMs.
     logits_acc = xg @ gate_w.T
     logits = inv_rms * logits_acc
     softplus = logits.clamp(min=0) + torch.log1p(torch.exp(-logits.abs()))
@@ -405,17 +355,11 @@ def golden_gate_core(tensors):
 
     num_tokens = max(0, min(T, int(tensors.get("num_tokens", T))))
 
-    # FFN RMSNorm, deferred (qwen3-style): xg = bf16(x * gamma), with the
-    # per-token inv_rms scalar folded downstream instead of applied per-element.
     xg, inv_rms, scores, biased = _golden_gate_scores(tensors)
 
-    # Symmetric INT8 quant of xg: inv_rms cancels in the int8 values (a positive
-    # per-token scalar), so it rides only the dequant scale.
     x_norm_i8, scale_dq_g = _per_token_int8_quant(xg)
-    x_norm_scale = scale_dq_g.reshape(T, 1) * inv_rms   # inv_rms * amax(xg)/127
+    x_norm_scale = scale_dq_g.reshape(T, 1) * inv_rms
 
-    # Choose TOPK ids: hash layers take ids from tid2eid[input_ids]; score
-    # layers argsort biased (stable to match NPU sort32 deterministic order).
     layer_id = int(tensors["layer_id"])
     if layer_id < N_HASH_LAYERS:
         tid2eid = tensors["tid2eid"]
@@ -424,7 +368,6 @@ def golden_gate_core(tensors):
     else:
         indices = torch.argsort(-biased, dim=-1, stable=True)[..., :TOPK]
 
-    # Gather unbiased scores, normalize over TOPK, scale by ROUTE_SCALE.
     topk_vals = torch.gather(scores, dim=-1, index=indices.long())
     denom = topk_vals.sum(dim=-1, keepdim=True)
     weights = (topk_vals / denom) * ROUTE_SCALE
@@ -447,17 +390,7 @@ def gate_indices_compare(
     score_rtol=2e-5,
     max_show=10,
 ):
-    """Validate router ids while allowing FP32 top-k boundary ambiguity.
-
-    The AIC Cube matmul and torch GEMM reduce the 7168-wide K dimension in
-    different orders. Their scores can consequently differ by a few 1e-4,
-    which makes an exact id comparison invalid when the CPU top-k cutoff is
-    inside that error band. A device route is legal only when every selected
-    expert lies inside the CPU cutoff band, ids are unique and in range, and
-    their CPU scores preserve device order modulo the same band.
-
-    Hash-routed layers do not perform a floating-point top-k and remain exact.
-    """
+    """Validate router ids against exact hash routes or bounded score routes."""
     import torch
 
     active_tokens = max(0, min(T, int(num_tokens)))
@@ -551,8 +484,6 @@ def gate_indices_compare(
         )
         omitted_better = best_omitted_lower > selected_floor_upper
 
-        # A near tie may reorder any pair, not only adjacent positions. Verify
-        # every earlier/later pair against its candidate-specific score band.
         earlier_upper = selected_upper.unsqueeze(-1)
         later_lower = (actual_biased - actual_error).unsqueeze(-2)
         order_matrix = later_lower > earlier_upper
@@ -704,18 +635,23 @@ def build_tensor_specs(layer_id=0, num_tokens=T):
     from golden import ScalarSpec, TensorSpec
 
     def init_x_mixed():
-        # Mirror post-RMSNorm activation magnitude (~ N(0, 1)).
         return torch.randn(T, D)
+
     def init_norm_w():
         return torch.ones(D)
+
     def init_gate_w():
         return torch.randn(N_EXPERTS, D) / D ** 0.5
+
     def init_gate_bias():
         return torch.randn(N_EXPERTS) * 0.1
+
     def init_tid2eid():
         return torch.randint(0, N_EXPERTS, (VOCAB, TOPK), dtype=torch.int32)
+
     def init_input_ids():
         return torch.randint(0, VOCAB, (T,), dtype=torch.int64)
+
     return [
         TensorSpec("x_mixed", [T, D], torch.bfloat16, init_value=init_x_mixed),
         TensorSpec("norm_w", [D], torch.bfloat16, init_value=init_norm_w),
@@ -743,13 +679,7 @@ def gate_x_norm_scale_compare(num_tokens):
     from golden import ratio_allclose
 
     active_tokens = max(0, min(T, int(num_tokens)))
-    return ratio_allclose(
-        atol=1e-3,
-        rtol=1e-3,
-        max_error_ratio=0.0,
-        valid_rows=active_tokens,
-        zero_tail=True,
-    )
+    return ratio_allclose(atol=1e-3, rtol=1e-3, max_error_ratio=0.0, valid_rows=active_tokens, zero_tail=True)
 
 
 if __name__ == "__main__":
@@ -758,8 +688,7 @@ if __name__ == "__main__":
     from golden import ratio_allclose, run_jit
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("-p", "--platform", type=str, default="a2a3",
-                        choices=["a2a3", "a2a3sim", "a5", "a5sim"])
+    parser.add_argument("-p", "--platform", type=str, default="a2a3", choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
     parser.add_argument("--layer-id", type=int, default=10)
     parser.add_argument("--num-tokens", type=int, default=T)
@@ -782,8 +711,10 @@ if __name__ == "__main__":
         rtol=1e-3,
         atol=1e-3,
         compare_fn={
-            "x_norm_i8": ratio_allclose(atol=1, rtol=0, max_error_ratio=0.001,
-                                        valid_rows=gate_active_rows(args.num_tokens)),
+            "x_norm_i8": ratio_allclose(
+                atol=1, rtol=0, max_error_ratio=0.001,
+                valid_rows=gate_active_rows(args.num_tokens),
+            ),
             "x_norm_scale": gate_x_norm_scale_compare(args.num_tokens),
             "indices": gate_indices_compare(args.layer_id, args.num_tokens),
             "weights": gate_weights_compare(args.num_tokens),

--- a/models/deepseek_v4_pro/hc_head.py
+++ b/models/deepseek_v4_pro/hc_head.py
@@ -6,7 +6,6 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-# ruff: noqa: F401,F403,F405,F821
 """DeepSeek-V4 Hyper-Connections head projection."""
 
 import pypto.language as pl
@@ -14,9 +13,10 @@ import pypto.language as pl
 from config import ACTIVE as M, DECODE_BATCH, DECODE_SEQ, PREFILL_BATCH, PREFILL_SEQ
 
 
-T_DYN = pl.dynamic("T_DYN")
+# Dynamic shape variables.
+T_DYN = pl.dynamic("T_DYN")  # T = B * S
 
-
+# model config
 B = DECODE_BATCH
 S = DECODE_SEQ
 T = B * S
@@ -28,41 +28,19 @@ EPS = M.rms_norm_eps
 HC_EPS = M.hc_eps
 HC_DIM_INV = 1.0 / HC_DIM
 
-HC_PAD = 16
+# tiling
 T_TILE = 8
-LINEAR_T_TILE = 16
-TRANSPOSE_T_TILE = 8
-RMS_K_CHUNK = 512
-LINEAR_K_CHUNK = 256  # cube K-fragment per matmul call; keeps Mat at 352KB (< 512KB L1)
-D_CHUNK = 512
-# Head projection hc_head_fn @ x^T is a skinny GEMM (M=T, N=HC_MULT<=HC_PAD=16,
-# K=HC_DIM=16384). Two structural choices, both ~10-15% over the original fused
-# (UP_DOWN) kernel that was ~151us:
-#  - Pure-AIC matmul: a dedicated cast scope streams the BF16 activations to an
-#    FP32 x_fp32, so both the matmul and the inv_rms reduce read FP32 directly.
-#    The matmul is then a clean cube-only kernel (~86% Exec, no vector subblock)
-#    instead of a mixed cube+cast kernel.
-#  - Split-K: with one task per token-tile only T/T_TILE cube cores run (8 of
-#    ~24). LINEAR_OK splits the K reduction into disjoint FP32 partials, filling
-#    the idle cores and shortening each core's matmul_acc chain. A separate
-#    scope reduces those partials in ascending K order for deterministic output.
-# Tile-size tuning can't help (FP32 operands make L1/Mat the wall at K=512);
-# split-K is the lever hint_l1_tile ranked #1. Golden-validated; device best-of-5
-# median ~128-134us.
-LINEAR_OK = 8
-RMS_K_BLOCKS = HC_DIM // RMS_K_CHUNK
-LINEAR_K_BLOCKS = HC_DIM // LINEAR_K_CHUNK
-D_BLOCKS = D // D_CHUNK
-LINEAR_K_PER_SPLIT = HC_DIM // LINEAR_OK
-LINEAR_CHUNKS_PER_SPLIT = LINEAR_K_PER_SPLIT // LINEAR_K_CHUNK
-assert HC_DIM % LINEAR_OK == 0 and LINEAR_K_PER_SPLIT % LINEAR_K_CHUNK == 0
-# The 4-way reduce (pre0..pre3 / x_h0..x_h3) is hardcoded for HC_MULT == 4, and the
-# fixed-size token tiles must evenly divide T or tail rows are silently dropped.
-assert HC_MULT == 4, f"hc_head reduce is hardcoded for HC_MULT == 4, got {HC_MULT}"
-assert (DECODE_BATCH * DECODE_SEQ) % T_TILE == 0 and (PREFILL_BATCH * PREFILL_SEQ) % T_TILE == 0
-assert (DECODE_BATCH * DECODE_SEQ) % TRANSPOSE_T_TILE == 0 and (PREFILL_BATCH * PREFILL_SEQ) % TRANSPOSE_T_TILE == 0
-assert DECODE_BATCH * DECODE_SEQ <= LINEAR_T_TILE
-assert T_MAX % LINEAR_T_TILE == 0
+MIX_K_TILE = 512
+D_TILE = 512
+MIX_SPLIT_TILE = 4 * MIX_K_TILE
+D_SPLIT_TILE = 2 * D_TILE
+assert (DECODE_BATCH * DECODE_SEQ) % T_TILE == 0
+assert (PREFILL_BATCH * PREFILL_SEQ) % T_TILE == 0
+
+# packed statistics layout
+# Packed stats row: [sum(x^2) | mix_0 | mix_1 | mix_2 | mix_3], T_TILE columns each.
+STAT_COLS = (HC_MULT + 1) * T_TILE
+
 
 @pl.jit.inline
 def hc_head(
@@ -73,125 +51,118 @@ def hc_head(
     y: pl.Tensor[[T_DYN, D], pl.BF16],
 ):
     t_dim = pl.tensor.dim(x_hc, 0)
-    t_linear = pl.max(t_dim, LINEAR_T_TILE)
     x_flat = pl.reshape(x_hc, [t_dim, HC_DIM])
-    y_flat = pl.reshape(y, [t_dim, D])
-    inv_rms = pl.create_tensor([T_MAX, 1], dtype=pl.FP32)
-    # x arrives as FP32 (hc residual stream is FP32 end-to-end), so there is no
-    # x_fp32 staging buffer: the head-projection matmul (pure-AIC) and the inv_rms
-    # reduce below read x_flat directly.
-    mixes_raw = pl.create_tensor([T_MAX, HC_PAD], dtype=pl.FP32)
-    mixes_partials = pl.create_tensor([LINEAR_OK * T_MAX, HC_PAD], dtype=pl.FP32)
-    pre_t = pl.create_tensor([HC_PAD, T_MAX], dtype=pl.FP32)
+    stats = pl.create_tensor([(T_MAX // T_TILE) * (HC_DIM // MIX_SPLIT_TILE), STAT_COLS], dtype=pl.FP32)
 
-    # inv_rms scope: read the FP32 activations back and reduce sum-of-squares -> rsqrt.
-    for t in pl.spmd(t_dim // T_TILE, name_hint="hc_head_rms", allow_early_resolve=True):
-        t0 = t * T_TILE
-        sq_sum = pl.full([1, T_TILE], dtype=pl.FP32, value=0.0)
-        for kb in pl.pipeline(RMS_K_BLOCKS, stage=4):
-            k0 = kb * RMS_K_CHUNK
-            x_chunk = x_flat[t0 : t0 + T_TILE, k0 : k0 + RMS_K_CHUNK]
-            sq_sum = pl.add(
-                sq_sum,
-                pl.reshape(pl.row_sum(pl.mul(x_chunk, x_chunk)), [1, T_TILE]),
-            )
-        head_var = pl.add(pl.mul(sq_sum, HC_DIM_INV), EPS)
-        inv = pl.reshape(pl.rsqrt(head_var, high_precision=True), [T_TILE, 1])
-        inv_rms = pl.assemble(inv_rms, inv, [t0, 0])
-
-    # Split-K head projection: each task owns one token tile and one K slice,
-    # and publishes to a disjoint partial-buffer row range.
-    for task in pl.spmd((t_linear // LINEAR_T_TILE) * LINEAR_OK, name_hint="hc_head_linear", allow_early_resolve=True):
-        t0 = (task // LINEAR_OK) * LINEAR_T_TILE
-        linear_split = task % LINEAR_OK
-        k_base = linear_split * LINEAR_K_PER_SPLIT
-        t_rows = pl.min(LINEAR_T_TILE, t_dim - t0)  # last row-block spills past t_dim; valid_shape zero-fills the tail
-        acc = pl.create_tensor([LINEAR_T_TILE, HC_PAD], dtype=pl.FP32)
-        for kb in pl.pipeline(0, LINEAR_CHUNKS_PER_SPLIT, stage=2):
-            k0 = k_base + kb * LINEAR_K_CHUNK
-            # FP32 input -> pure-AIC matmul. t_linear rounds up to LINEAR_T_TILE, so at
-            # decode dims (t_dim=8) this tile spans rows past the end of x_flat; the
-            # valid_shape clamp keeps the GM read in bounds (cf. hc_pre.py:223).
-            x_linear_chunk = pl.slice(
-                x_flat,
-                [LINEAR_T_TILE, LINEAR_K_CHUNK],
-                [t0, k0],
-                valid_shape=[t_rows, LINEAR_K_CHUNK],
-            )
-            w_chunk = pl.slice(
-                hc_head_fn,
-                [HC_PAD, LINEAR_K_CHUNK],
-                [0, k0],
-                valid_shape=[HC_MULT, LINEAR_K_CHUNK],
-            )
-            if kb == 0:
-                acc = pl.matmul(x_linear_chunk, w_chunk, b_trans=True, out_dtype=pl.FP32)
-            else:
-                acc = pl.matmul_acc(acc, x_linear_chunk, w_chunk, b_trans=True)
-        mixes_partials = pl.assemble(
-            mixes_partials,
-            acc,
-            [linear_split * T_MAX + t0, 0],
-        )
-
-    # Preserve a fixed reduction tree: each split accumulated its K chunks in
-    # ascending order above, and this scope adds split totals from 0 to OK-1.
-    for reduce_idx in pl.spmd(
-        t_linear // LINEAR_T_TILE,
-        name_hint="hc_head_linear_reduce",
-        allow_early_resolve=True,
+    for task in pl.spmd(
+        (t_dim // T_TILE) * (HC_DIM // MIX_SPLIT_TILE),
+        name_hint="hc_head_mix", allow_early_resolve=True,
     ):
-        t0 = reduce_idx * LINEAR_T_TILE
-        total = mixes_partials[t0 : t0 + LINEAR_T_TILE, 0:HC_PAD]
-        for linear_split in pl.range(1, LINEAR_OK):
-            partial_t0 = linear_split * T_MAX + t0
-            total = pl.add(
-                total,
-                mixes_partials[
-                    partial_t0 : partial_t0 + LINEAR_T_TILE,
-                    0:HC_PAD,
-                ],
-            )
-        mixes_raw = pl.assemble(mixes_raw, total, [t0, 0])
+        tt = task // (HC_DIM // MIX_SPLIT_TILE)
+        split = task - tt * (HC_DIM // MIX_SPLIT_TILE)
+        t0 = tt * T_TILE
+        k_base = split * MIX_SPLIT_TILE
+        acc = pl.full([1, STAT_COLS], dtype=pl.FP32, value=0.0)
+        for k0 in pl.pipeline(k_base, k_base + MIX_SPLIT_TILE, MIX_K_TILE, stage=4):
+            x_chunk = x_flat[t0 : t0 + T_TILE, k0 : k0 + MIX_K_TILE]
+            w0 = hc_head_fn[0:1, k0 : k0 + MIX_K_TILE]
+            w1 = hc_head_fn[1:2, k0 : k0 + MIX_K_TILE]
+            w2 = hc_head_fn[2:3, k0 : k0 + MIX_K_TILE]
+            w3 = hc_head_fn[3:4, k0 : k0 + MIX_K_TILE]
+            x_sq = pl.mul(x_chunk, x_chunk)
+            x_sq_sum = pl.row_sum(x_sq)
+            x_sq_row = pl.reshape(x_sq_sum, [1, T_TILE])
+            mix0_weighted = pl.col_expand_mul(x_chunk, w0)
+            mix0_sum = pl.row_sum(mix0_weighted)
+            mix0_row = pl.reshape(mix0_sum, [1, T_TILE])
+            stats01 = pl.concat(x_sq_row, mix0_row)
+            mix1_weighted = pl.col_expand_mul(x_chunk, w1)
+            mix1_sum = pl.row_sum(mix1_weighted)
+            mix1_row = pl.reshape(mix1_sum, [1, T_TILE])
+            mix2_weighted = pl.col_expand_mul(x_chunk, w2)
+            mix2_sum = pl.row_sum(mix2_weighted)
+            mix2_row = pl.reshape(mix2_sum, [1, T_TILE])
+            stats12 = pl.concat(mix1_row, mix2_row)
+            mix3_weighted = pl.col_expand_mul(x_chunk, w3)
+            mix3_sum = pl.row_sum(mix3_weighted)
+            mix3_row = pl.reshape(mix3_sum, [1, T_TILE])
+            stats123 = pl.concat(stats12, mix3_row)
+            chunk_stats = pl.concat(stats01, stats123)
+            acc = pl.add(acc, chunk_stats)
+        stats_row = tt * (HC_DIM // MIX_SPLIT_TILE) + split
+        stats[stats_row : stats_row + 1, 0:STAT_COLS] = acc
 
-    # Fused scale + sigmoid + transpose -> pre_t in one scope (one dispatch).
-    # Per TRANSPOSE_T_TILE block: row-scale the raw projection by inv_rms, apply
-    # sigmoid(mix * scale + base) + HC_EPS, then transpose the [TILE, HC_PAD] block
-    # straight into pre_t[:, tile]. The mixes and pre intermediates never touch GM.
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="hc_head_pre_fused", allow_early_resolve=True):
+    y_flat = pl.reshape(y, [t_dim, D])
+    for task in pl.spmd((t_dim // T_TILE) * (D // D_SPLIT_TILE), name_hint="hc_head_reduce", allow_early_resolve=True):
+        tt = task // (D // D_SPLIT_TILE)
+        d_split = task - tt * (D // D_SPLIT_TILE)
+        t0 = tt * T_TILE
+        s0 = tt * (HC_DIM // MIX_SPLIT_TILE)
+        total = pl.col_sum(stats[s0 : s0 + (HC_DIM // MIX_SPLIT_TILE), 0:STAT_COLS])
+        total_sq = total[0:1, 0:T_TILE]
+        total_sq_mean = pl.mul(total_sq, HC_DIM_INV)
+        total_sq_eps = pl.add(total_sq_mean, EPS)
+        inv = pl.rsqrt(total_sq_eps, high_precision=True)
         scale = pl.read(hc_head_scale, [0])
-        base = pl.reshape(pl.slice(hc_head_base, [HC_PAD], [0], valid_shape=[HC_MULT]), [1, HC_PAD])
-        for t0 in pl.pipeline(0, t_dim, TRANSPOSE_T_TILE, stage=2):
-            scaled = pl.row_expand_mul(
-                mixes_raw[t0 : t0 + TRANSPOSE_T_TILE, 0:HC_PAD],
-                inv_rms[t0 : t0 + TRANSPOSE_T_TILE, 0:1],
-            )
-            logits = pl.add(
-                pl.mul(scaled, scale),
-                pl.col_expand(scaled, base),
-            )
-            pre_val = pl.add(pl.recip(pl.add(pl.exp(pl.neg(logits)), 1.0)), HC_EPS)
-            pre_t[:, t0 : t0 + TRANSPOSE_T_TILE] = pl.transpose(pre_val, axis1=0, axis2=1)
-
-    for t0 in pl.parallel(0, t_dim, T_TILE):
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="hc_head_reduce", allow_early_resolve=True):
-            # Per head h, pre_t[h] is a contiguous row of per-token scales; slice it
-            # and reshape [1, T_TILE] -> [T_TILE, 1] for the row-broadcast multiply.
-            pre0 = pl.reshape(pre_t[0:1, t0 : t0 + T_TILE], [T_TILE, 1])
-            pre1 = pl.reshape(pre_t[1:2, t0 : t0 + T_TILE], [T_TILE, 1])
-            pre2 = pl.reshape(pre_t[2:3, t0 : t0 + T_TILE], [T_TILE, 1])
-            pre3 = pl.reshape(pre_t[3:4, t0 : t0 + T_TILE], [T_TILE, 1])
-            for db in pl.pipeline(D_BLOCKS, stage=2):
-                d0 = db * D_CHUNK
-                x_h0 = x_flat[t0 : t0 + T_TILE, 0 * D + d0 : 0 * D + d0 + D_CHUNK]
-                x_h1 = x_flat[t0 : t0 + T_TILE, 1 * D + d0 : 1 * D + d0 + D_CHUNK]
-                x_h2 = x_flat[t0 : t0 + T_TILE, 2 * D + d0 : 2 * D + d0 + D_CHUNK]
-                x_h3 = x_flat[t0 : t0 + T_TILE, 3 * D + d0 : 3 * D + d0 + D_CHUNK]
-                y_tile = pl.add(
-                    pl.add(pl.row_expand_mul(x_h0, pre0), pl.row_expand_mul(x_h1, pre1)),
-                    pl.add(pl.row_expand_mul(x_h2, pre2), pl.row_expand_mul(x_h3, pre3)),
-                )
-                y_flat[t0 : t0 + T_TILE, d0 : d0 + D_CHUNK] = pl.cast(y_tile, target_type=pl.BF16, mode="rint")
+        mix0 = total[0:1, 1 * T_TILE : 2 * T_TILE]
+        mix1 = total[0:1, 2 * T_TILE : 3 * T_TILE]
+        mix2 = total[0:1, 3 * T_TILE : 4 * T_TILE]
+        mix3 = total[0:1, 4 * T_TILE : 5 * T_TILE]
+        mix0_norm = pl.mul(mix0, inv)
+        mix0_scaled = pl.mul(mix0_norm, scale)
+        base0 = pl.read(hc_head_base, [0])
+        logit0 = pl.add(mix0_scaled, base0)
+        mix1_norm = pl.mul(mix1, inv)
+        mix1_scaled = pl.mul(mix1_norm, scale)
+        base1 = pl.read(hc_head_base, [1])
+        logit1 = pl.add(mix1_scaled, base1)
+        mix2_norm = pl.mul(mix2, inv)
+        mix2_scaled = pl.mul(mix2_norm, scale)
+        base2 = pl.read(hc_head_base, [2])
+        logit2 = pl.add(mix2_scaled, base2)
+        mix3_norm = pl.mul(mix3, inv)
+        mix3_scaled = pl.mul(mix3_norm, scale)
+        base3 = pl.read(hc_head_base, [3])
+        logit3 = pl.add(mix3_scaled, base3)
+        neg0 = pl.neg(logit0)
+        exp0 = pl.exp(neg0)
+        denom0 = pl.add(exp0, 1.0)
+        sigmoid0 = pl.recip(denom0)
+        pre0_eps = pl.add(sigmoid0, HC_EPS)
+        pre0 = pl.reshape(pre0_eps, [T_TILE, 1])
+        neg1 = pl.neg(logit1)
+        exp1 = pl.exp(neg1)
+        denom1 = pl.add(exp1, 1.0)
+        sigmoid1 = pl.recip(denom1)
+        pre1_eps = pl.add(sigmoid1, HC_EPS)
+        pre1 = pl.reshape(pre1_eps, [T_TILE, 1])
+        neg2 = pl.neg(logit2)
+        exp2 = pl.exp(neg2)
+        denom2 = pl.add(exp2, 1.0)
+        sigmoid2 = pl.recip(denom2)
+        pre2_eps = pl.add(sigmoid2, HC_EPS)
+        pre2 = pl.reshape(pre2_eps, [T_TILE, 1])
+        neg3 = pl.neg(logit3)
+        exp3 = pl.exp(neg3)
+        denom3 = pl.add(exp3, 1.0)
+        sigmoid3 = pl.recip(denom3)
+        pre3_eps = pl.add(sigmoid3, HC_EPS)
+        pre3 = pl.reshape(pre3_eps, [T_TILE, 1])
+        d_base = d_split * D_SPLIT_TILE
+        for d0 in pl.pipeline(d_base, d_base + D_SPLIT_TILE, D_TILE, stage=2):
+            x_h0 = x_flat[t0 : t0 + T_TILE, 0 * D + d0 : 0 * D + d0 + D_TILE]
+            x_h1 = x_flat[t0 : t0 + T_TILE, 1 * D + d0 : 1 * D + d0 + D_TILE]
+            x_h2 = x_flat[t0 : t0 + T_TILE, 2 * D + d0 : 2 * D + d0 + D_TILE]
+            x_h3 = x_flat[t0 : t0 + T_TILE, 3 * D + d0 : 3 * D + d0 + D_TILE]
+            y0 = pl.row_expand_mul(x_h0, pre0)
+            y1 = pl.row_expand_mul(x_h1, pre1)
+            y01 = pl.add(y0, y1)
+            y2 = pl.row_expand_mul(x_h2, pre2)
+            y3 = pl.row_expand_mul(x_h3, pre3)
+            y23 = pl.add(y2, y3)
+            y_tile = pl.add(y01, y23)
+            y_bf16 = pl.cast(y_tile, target_type=pl.BF16, mode="rint")
+            y_flat[t0 : t0 + T_TILE, d0 : d0 + D_TILE] = y_bf16
 
     y = pl.reshape(y_flat, [t_dim, D])
     return y
@@ -209,6 +180,28 @@ def hc_head_test(
     return y
 
 
+def hc_head_stats_golden(x_flat_2d, hc_head_fn):
+    """Compute split-K sum-of-squares and raw mixes in kernel order."""
+    import torch
+
+    rows = x_flat_2d.shape[0]
+    sq_sum = torch.zeros(rows, 1, dtype=torch.float32)
+    mixes = torch.zeros(rows, HC_MULT, dtype=torch.float32)
+    for split in range(HC_DIM // MIX_SPLIT_TILE):
+        k_base = split * MIX_SPLIT_TILE
+        sq_split = torch.zeros(rows, 1, dtype=torch.float32)
+        mix_split = torch.zeros(rows, HC_MULT, dtype=torch.float32)
+        for k0 in range(k_base, k_base + MIX_SPLIT_TILE, MIX_K_TILE):
+            x_chunk = x_flat_2d[:, k0:k0 + MIX_K_TILE]
+            sq_split += (x_chunk * x_chunk).sum(dim=1, keepdim=True)
+            for h in range(HC_MULT):
+                w_chunk = hc_head_fn[h:h + 1, k0:k0 + MIX_K_TILE]
+                mix_split[:, h:h + 1] += (x_chunk * w_chunk).sum(dim=1, keepdim=True)
+        sq_sum += sq_split
+        mixes += mix_split
+    return sq_sum, mixes
+
+
 def golden_hc_head(tensors):
     import torch
 
@@ -217,26 +210,9 @@ def golden_hc_head(tensors):
     x_flat_2d = x.reshape(T, HC_DIM).float()
     hc_head_fn = tensors["hc_head_fn"].float()
 
-    sq_sum = torch.zeros(T, 1, dtype=torch.float32)
-    for k0 in range(0, HC_DIM, RMS_K_CHUNK):
-        x_chunk = x_flat_2d[:, k0:k0 + RMS_K_CHUNK]
-        sq_sum += (x_chunk * x_chunk).sum(dim=1, keepdim=True)
+    sq_sum, mixes_raw = hc_head_stats_golden(x_flat_2d, hc_head_fn)
     rsqrt = torch.rsqrt(sq_sum * HC_DIM_INV + EPS)
-
-    mix_cols = []
-    for h in range(HC_MULT):
-        mix_col = torch.zeros(T, 1, dtype=torch.float32)
-        for linear_split in range(LINEAR_OK):
-            split_col = torch.zeros(T, 1, dtype=torch.float32)
-            split_start = linear_split * LINEAR_K_PER_SPLIT
-            split_end = split_start + LINEAR_K_PER_SPLIT
-            for k0 in range(split_start, split_end, LINEAR_K_CHUNK):
-                x_chunk = x_flat_2d[:, k0:k0 + LINEAR_K_CHUNK]
-                w_chunk = hc_head_fn[h:h + 1, k0:k0 + LINEAR_K_CHUNK]
-                split_col += (x_chunk * w_chunk).sum(dim=1, keepdim=True)
-            mix_col += split_col
-        mix_cols.append(mix_col * rsqrt)
-    mixes = torch.cat(mix_cols, dim=1).reshape(T, HC_MULT)
+    mixes = mixes_raw * rsqrt
 
     pre = torch.sigmoid(mixes * tensors["hc_head_scale"].float() + tensors["hc_head_base"].float()) + HC_EPS
     x_view = x.float().view(shape)
@@ -253,7 +229,6 @@ def golden_hc_head(tensors):
         for h in range(HC_MULT):
             y += x_view[:, h, :] * pre[:, h:h + 1]
 
-    # Match the kernel's mode="rint" cast (round to nearest, ties to even).
     tensors["y"][:] = y.to(torch.bfloat16)
 
 
@@ -270,10 +245,11 @@ def build_tensor_specs():
     return [
         TensorSpec("x_hc", [T, HC_MULT, D], torch.float32, init_value=init_x_hc),
         TensorSpec("hc_head_fn", [HC_MULT, HC_DIM], torch.float32, init_value=init_hc_head_fn),
-        TensorSpec("hc_head_scale", [1], torch.float32,
-                   init_value=lambda: torch.tensor([0.076099])),
-        TensorSpec("hc_head_base", [HC_MULT], torch.float32,
-                   init_value=lambda: torch.tensor([5.9166, -3.6223, -2.9324, -3.3124])),
+        TensorSpec("hc_head_scale", [1], torch.float32, init_value=lambda: torch.tensor([0.076099])),
+        TensorSpec(
+            "hc_head_base", [HC_MULT], torch.float32,
+            init_value=lambda: torch.tensor([5.9166, -3.6223, -2.9324, -3.3124]),
+        ),
         TensorSpec("y", [T, D], torch.bfloat16, is_output=True),
     ]
 
@@ -284,12 +260,9 @@ if __name__ == "__main__":
     from golden import ratio_allclose, run_jit
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("-p", "--platform", type=str, default="a2a3",
-                        choices=["a2a3", "a2a3sim", "a5", "a5sim"])
+    parser.add_argument("-p", "--platform", type=str, default="a2a3", choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
     parser.add_argument("--seed", type=int, default=0)
-    # Int mode (0=off; 1=timing only, most accurate; 2=timing + dep graph, two runs).
-    # `nargs="?"` so a bare `--enable-chip-swimlane` -> mode 1 (int, not bool True).
     parser.add_argument("--enable-chip-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2))
     parser.add_argument("--dump-passes", action="store_true", default=False)
     args = parser.parse_args()
@@ -320,13 +293,7 @@ if __name__ == "__main__":
 
 
 def golden_hc_head_rows(tensors):
-    """Row-count-agnostic port of ``hc_head.golden_hc_head``.
-
-    The leaf golden bakes the decode row count (``hc_head.T`` = decode tokens)
-    into its reshape, while the fwd feeds prefill ``T`` rows, so derive the row
-    count from the input instead. The K-chunked accumulation order (RMS and
-    linear mixes) and the HC_MULT==4 paired reduce are preserved bit-for-bit.
-    """
+    """Compute the Hyper-Connections head reference for the input row count."""
     import torch
 
     x = tensors["x_hc"]
@@ -335,30 +302,12 @@ def golden_hc_head_rows(tensors):
     x_flat_2d = x.reshape(rows, hc_dim).float()
     hc_head_fn = tensors["hc_head_fn"].float()
 
-    sq_sum = torch.zeros(rows, 1, dtype=torch.float32)
-    for k0 in range(0, hc_dim, RMS_K_CHUNK):
-        x_chunk = x_flat_2d[:, k0:k0 + RMS_K_CHUNK]
-        sq_sum += (x_chunk * x_chunk).sum(dim=1, keepdim=True)
+    sq_sum, mixes_raw = hc_head_stats_golden(x_flat_2d, hc_head_fn)
     rsqrt = torch.rsqrt(sq_sum * (1.0 / hc_dim) + M.rms_norm_eps)
+    mixes = mixes_raw * rsqrt
 
-    mix_cols = []
-    for h in range(HC_MULT):
-        mix_col = torch.zeros(rows, 1, dtype=torch.float32)
-        for linear_split in range(LINEAR_OK):
-            split_col = torch.zeros(rows, 1, dtype=torch.float32)
-            split_start = linear_split * LINEAR_K_PER_SPLIT
-            split_end = split_start + LINEAR_K_PER_SPLIT
-            for k0 in range(split_start, split_end, LINEAR_K_CHUNK):
-                x_chunk = x_flat_2d[:, k0:k0 + LINEAR_K_CHUNK]
-                w_chunk = hc_head_fn[h:h + 1, k0:k0 + LINEAR_K_CHUNK]
-                split_col += (x_chunk * w_chunk).sum(dim=1, keepdim=True)
-            mix_col += split_col
-        mix_cols.append(mix_col * rsqrt)
-    mixes = torch.cat(mix_cols, dim=1).reshape(rows, HC_MULT)
-
-    pre = torch.sigmoid(
-        mixes * tensors["hc_head_scale"].float() + tensors["hc_head_base"].float()
-    ) + M.hc_eps
+    logits = mixes * tensors["hc_head_scale"].float() + tensors["hc_head_base"].float()
+    pre = torch.sigmoid(logits) + M.hc_eps
     x_view = x.float()
     if HC_MULT == 4:
         y = (
@@ -373,5 +322,4 @@ def golden_hc_head_rows(tensors):
         for h in range(HC_MULT):
             y += x_view[:, h, :] * pre[:, h:h + 1]
 
-    # Match the kernel's mode="rint" cast (round to nearest, ties to even).
     tensors["y"][:] = y.to(torch.bfloat16)

--- a/models/deepseek_v4_pro/hc_post.py
+++ b/models/deepseek_v4_pro/hc_post.py
@@ -6,13 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-"""DeepSeek-V4 Hyper-Connections post-mix (dynamic shape): combines a sublayer
-output with its hc-residual into the next hc-stack via post and comb weights.
-Supports both decode and prefill batch/sequence sizes via dynamic-shape tensors."""
-
-# ``hc_post`` processes a dynamic tensor whose rows are all valid (decode/MoE).
-# ``hc_post_prefill`` processes only the active prefix of a static prefill tensor
-# and deterministically zero-fills its inactive tail.
+"""DeepSeek-V4 Hyper-Connections post-mix for dynamic decode and prefill shapes."""
 
 import pypto.language as pl
 
@@ -25,11 +19,13 @@ T_DYN = pl.dynamic("T_DYN")  # T = B * S
 D = M.hidden_size
 HC_MULT = M.hc_mult
 HC_DIM = M.hc_dim
+DECODE_ROWS_MAX = DECODE_BATCH * DECODE_SEQ
 
 # tiling
 T_TILE = 4
 INACTIVE_FILL_T_TILE = 16
 INACTIVE_FILL_D_TILE = 256
+D_TILE = D // 4
 assert (DECODE_BATCH * DECODE_SEQ) % T_TILE == 0
 assert (PREFILL_BATCH * PREFILL_SEQ) % T_TILE == 0
 
@@ -46,24 +42,40 @@ def hc_post(
 
     residual_flat = pl.reshape(residual, [t_dim, HC_DIM])
     y_flat = pl.reshape(y, [t_dim, HC_DIM])
+    residual_rows = pl.reshape(residual, [t_dim * HC_MULT, D])
+    y_rows = pl.reshape(y, [t_dim * HC_MULT, D])
 
-    for block in pl.spmd((t_dim // T_TILE) * HC_MULT, name_hint="hc_post"):
-        token_block = block // HC_MULT
-        out_h = block % HC_MULT
-        t0 = token_block * T_TILE
-        for t in pl.pipeline(t0, t0 + T_TILE, stage=2):
-            post_w = pl.read(post, [t, out_h])
-            x_row = pl.cast(x[t : t + 1, 0:D], target_type=pl.FP32)
-            y_row = pl.mul(x_row, post_w)
-            for in_h in pl.pipeline(HC_MULT, stage=4):
-                comb_w = pl.read(comb, [t, in_h * HC_MULT + out_h])
-                res_d = in_h * D
-                # residual is already FP32 (hc stream is FP32 end-to-end): no cast, read straight.
-                res_row = residual_flat[t : t + 1, res_d : res_d + D]
-                weighted = pl.mul(res_row, comb_w)
-                y_row = pl.add(y_row, weighted)
-            # y is FP32 (feeds the next layer's hc_pre directly): no BF16 output cast.
-            y_flat[t : t + 1, out_h * D : out_h * D + D] = y_row
+    if t_dim <= DECODE_ROWS_MAX:
+        for t in pl.spmd(t_dim, name_hint="hc_post"):
+            h0 = t * HC_MULT
+            for d0 in pl.pipeline(0, D, D_TILE, stage=2):
+                x_chunk = pl.cast(x[t : t + 1, d0 : d0 + D_TILE], target_type=pl.FP32)
+                res_tile = residual_rows[h0 : h0 + HC_MULT, d0 : d0 + D_TILE]
+                for out_h in pl.unroll(HC_MULT):
+                    post_w_chunk = pl.read(post, [t, out_h])
+                    y_chunk = pl.mul(x_chunk, post_w_chunk)
+                    for in_h in pl.unroll(HC_MULT):
+                        comb_w = pl.read(comb, [t, in_h * HC_MULT + out_h])
+                        res_row = res_tile[in_h : in_h + 1, 0:D_TILE]
+                        res_weighted_chunk = pl.mul(res_row, comb_w)
+                        y_chunk = pl.add(y_chunk, res_weighted_chunk)
+                    y_rows[h0 + out_h : h0 + out_h + 1, d0 : d0 + D_TILE] = y_chunk
+    else:
+        for block in pl.spmd((t_dim // T_TILE) * HC_MULT, name_hint="hc_post"):
+            token_block = block // HC_MULT
+            out_h = block % HC_MULT
+            t0 = token_block * T_TILE
+            for t in pl.pipeline(t0, t0 + T_TILE, stage=2):
+                post_w = pl.read(post, [t, out_h])
+                x_row = pl.cast(x[t : t + 1, 0:D], target_type=pl.FP32)
+                y_row = pl.mul(x_row, post_w)
+                for in_h in pl.pipeline(HC_MULT, stage=4):
+                    comb_wide = pl.read(comb, [t, in_h * HC_MULT + out_h])
+                    res_d = in_h * D
+                    res_wide = residual_flat[t : t + 1, res_d : res_d + D]
+                    weighted = pl.mul(res_wide, comb_wide)
+                    y_row = pl.add(y_row, weighted)
+                y_flat[t : t + 1, out_h * D : out_h * D + D] = y_row
     return y
 
 
@@ -77,19 +89,18 @@ def hc_post_prefill(
     num_tokens: pl.Scalar[pl.INT32],
 ):
     """Compute prefill active rows and deterministically pad the static tail."""
-    t_dim = pl.tensor.dim(x, 0)
     active_tokens = pl.cast(num_tokens, pl.INDEX)
     if active_tokens < 0:
         active_tokens = pl.cast(0, pl.INDEX)
+    t_dim = pl.tensor.dim(x, 0)
     if active_tokens > t_dim:
         active_tokens = t_dim
 
     residual_flat = pl.reshape(residual, [t_dim, HC_DIM])
     y_flat = pl.reshape(y, [t_dim, HC_DIM])
-    active_tiles = (active_tokens + T_TILE - 1) // T_TILE
 
     if active_tokens > 0:
-        for block in pl.spmd(active_tiles * HC_MULT, name_hint="hc_post_prefill"):
+        for block in pl.spmd(((active_tokens + T_TILE - 1) // T_TILE) * HC_MULT, name_hint="hc_post_prefill"):
             token_block = block // HC_MULT
             out_h = block % HC_MULT
             t0 = token_block * T_TILE
@@ -102,13 +113,16 @@ def hc_post_prefill(
                         comb_w = pl.read(comb, [t, in_h * HC_MULT + out_h])
                         res_d = in_h * D
                         res_row = residual_flat[t : t + 1, res_d : res_d + D]
-                        y_row = pl.add(y_row, pl.mul(res_row, comb_w))
+                        weighted = pl.mul(res_row, comb_w)
+                        y_row = pl.add(y_row, weighted)
                     y_flat[t : t + 1, out_h * D : out_h * D + D] = y_row
 
     inactive_tokens = t_dim - active_tokens
     if inactive_tokens > 0:
-        inactive_tiles = (inactive_tokens + INACTIVE_FILL_T_TILE - 1) // INACTIVE_FILL_T_TILE
-        for fill_block in pl.spmd(inactive_tiles * HC_MULT, name_hint="hc_post_inactive_pad"):
+        for fill_block in pl.spmd(
+            ((inactive_tokens + INACTIVE_FILL_T_TILE - 1) // INACTIVE_FILL_T_TILE) * HC_MULT,
+            name_hint="hc_post_inactive_pad",
+        ):
             fill_tile = fill_block // HC_MULT
             out_h = fill_block % HC_MULT
             fill_t0 = active_tokens + fill_tile * INACTIVE_FILL_T_TILE
@@ -141,13 +155,13 @@ def hc_post_test(
 
 
 def golden_hc_post(tensors):
-    """Torch reference, direct port of model.py Block.hc_post 684-687."""
+    """Compute the Hyper-Connections post-mix reference."""
     import torch
 
-    x        = tensors["x"].float()
+    x = tensors["x"].float()
     residual = tensors["residual"].float()
-    post     = tensors["post"].float()
-    comb     = tensors["comb"].float().reshape(-1, HC_MULT, HC_MULT)  # [B, S, HC, HC]
+    post = tensors["post"].float()
+    comb = tensors["comb"].float().reshape(-1, HC_MULT, HC_MULT)
 
     T = x.shape[0]
     y_fp32 = torch.zeros(T, HC_MULT, D, dtype=torch.float32)
@@ -156,9 +170,7 @@ def golden_hc_post(tensors):
         for in_h in range(HC_MULT):
             y_row = y_row + residual[:, in_h, :] * comb[:, in_h, out_h:out_h + 1]
         y_fp32[:, out_h, :] = y_row
-    y = y_fp32  # hc residual stream is FP32 end-to-end: no BF16 rounding
-
-    tensors["y"][:] = y
+    tensors["y"][:] = y_fp32
 
 
 def golden_hc_post_prefill(tensors):
@@ -176,19 +188,23 @@ def build_tensor_specs(B, S):
 
     def init_x():
         return torch.randn(T, D) * 0.05
+
     def init_residual():
         return torch.randn(T, HC_MULT, D) * 0.05
+
     def init_post():
         return 2.0 * torch.sigmoid(torch.randn(T, HC_MULT))
+
     def init_comb():
         c = torch.rand(B, S, HC_MULT, HC_MULT) + 0.1
         return (c / c.sum(dim=-1, keepdim=True)).reshape(T, HC_MULT * HC_MULT)
+
     return [
-        TensorSpec("x",        [T, D],                    torch.bfloat16, init_value=init_x),
-        TensorSpec("residual", [T, HC_MULT, D],           torch.float32,  init_value=init_residual),
-        TensorSpec("post",     [T, HC_MULT],              torch.float32,  init_value=init_post),
-        TensorSpec("comb",     [T, HC_MULT * HC_MULT],    torch.float32,  init_value=init_comb),
-        TensorSpec("y",        [T, HC_MULT, D],           torch.float32,  is_output=True),
+        TensorSpec("x", [T, D], torch.bfloat16, init_value=init_x),
+        TensorSpec("residual", [T, HC_MULT, D], torch.float32, init_value=init_residual),
+        TensorSpec("post", [T, HC_MULT], torch.float32, init_value=init_post),
+        TensorSpec("comb", [T, HC_MULT * HC_MULT], torch.float32, init_value=init_comb),
+        TensorSpec("y", [T, HC_MULT, D], torch.float32, is_output=True),
     ]
 
 
@@ -197,16 +213,15 @@ if __name__ == "__main__":
     from golden import run_jit
 
     MODES = {
-        "decode":  (DECODE_BATCH, DECODE_SEQ),
+        "decode": (DECODE_BATCH, DECODE_SEQ),
         "prefill": (PREFILL_BATCH, PREFILL_SEQ),
     }
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("-p", "--platform", type=str, default="a2a3",
-                        choices=["a2a3", "a2a3sim", "a5", "a5sim"])
+    parser.add_argument("-p", "--platform", type=str, default="a2a3", choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--mode", choices=["decode", "prefill", "all"], default="decode",
-                        help="Use decode or prefill batch sizes, or 'all' to test both.")
+    mode_help = "Use decode or prefill batch sizes, or 'all' to test both."
+    parser.add_argument("--mode", choices=["decode", "prefill", "all"], default="decode", help=mode_help)
     parser.add_argument("--enable-chip-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2))
     parser.add_argument("--compile-only", action="store_true", default=False)
     parser.add_argument("--dump-passes", action="store_true", default=False)

--- a/models/deepseek_v4_pro/hc_pre.py
+++ b/models/deepseek_v4_pro/hc_pre.py
@@ -6,69 +6,8 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-# ci: no-dep-gen  # CI marker: full-occupancy pl.system.syncall -> dep_gen (DFX) trips 507018 (pypto#1931)
-"""DeepSeek-V4 hc_pre -- hyper-connection pre-mix with fused and separate-task implementations.
-
-x[T, hc, D] holds hc streams of the hidden state (x_flat = x.reshape(T, hc*D)). With the
-projection hc_fn[mix_hc, hc*D], the per-group scales hc_scale[3] and biases hc_base[mix_hc]:
-
-    inv_rms[T, 1]   = rsqrt(mean_k(x_flat^2) + eps)
-    mixes[T, mix_hc]= inv_rms * (x_flat @ hc_fn^T)              # 1/rms deferred past the matmul
-    pre [T, hc]     = sigmoid(mixes[:, :hc]   * s0 + base) + eps
-    post[T, hc]     = 2 * sigmoid(mixes[:, hc:2hc] * s1 + base)
-    comb[T, hc, hc] = sinkhorn(softmax(reshape(mixes[:, 2hc:] * s2 + base, hc, hc)))
-    x_mixed[T, D]   = sum_h pre[:, h] * x[:, h, :]
-
-TWO IMPLEMENTATIONS, selected by the ``HC_PRE_IMPL`` module flag (env ``DSV4_HC_PRE_IMPL``
-or ``--impl``); both are UNIFIED over decode + prefill and compute the identical math above:
-  * ``_hc_pre_syncall`` -- the #684 fusion documented below: ONE full-occupancy
-    ``pl.spmd(24)`` with 2 hard ``pl.system.syncall`` barriers, run with dep_gen OFF.
-  * ``_hc_pre_separate`` (default) -- each work-type is its OWN ``pl.spmd`` task
-    (rms / linear / deterministic linear reduce / vector pre / vector post /
-    split_pre_post / write_post / comb_sinkhorn / mix_x), ordered by the runtime
-    task graph, with tile sizes aligned to the syncall path. The standalone harness
-    enables dep-gen to capture that graph.
-The rest of this docstring describes the ``_hc_pre_syncall`` fusion.
-
-FUSION (unified decode + prefill): the whole op is ONE ``pl.spmd(NUM_CORES=24)`` launch --
-24 persistent blocks == 24 AIC + 48 AIV == every 910B core (the full-occupancy contract a
-hard ``pl.system.syncall(core_type="mix")`` requires). The body is 3 phases separated by 2
-barriers; each barrier publishes the prior phase's cross-core HBM writes:
-
-    Phase B  linear (split-K matmul -> disjoint partials, AIC) +
-             rms (split-K SoS -> disjoint partials, AIV)
-    ── syncall ──  (all split-K partials visible)
-    Phase C  reduce linear and RMS partials in ascending K-split order      AIV
-    ── syncall ──  (mixes_raw + sq_sum_acc visible)
-    Phase D  per task: rsqrt(sq_sum) + scale/sigmoid GATE, then                    AIV
-             comb_sinkhorn (-> comb) | mix_x (-> x_mixed) | write_post (-> post)
-
-The old Phase C (a separate rsqrt+scale+sigmoid gate pass, published by a 3rd barrier) is
-FOLDED into Phase D: since the C->D handoff was cross-core (different grid-stride striping),
-it needed a barrier -- but each D task can just recompute the ONE gate it consumes from the
-barrier-2-published mixes_raw + sq_sum_acc on its OWN core (rsqrt+sigmoid is nearly free on
-this latency-bound kernel). That deletes a whole hard FFTS barrier (-8% decode / -11% prefill
-on the device chip swimlane, latency-bound so barrier removal > byte removal). comb_logits /
-post_pad_store survive only as SAME-CORE scratch (assemble then load-back, no barrier) because
-their downstream pl.load->pl.store needs an HC_PAD-wide 32B-aligned tile; the pre gate is
-consumed in tensor-world so it needs no buffer.
-
-Scheduling within a phase: each independent task-type is its OWN unconditional grid-stride
-loop (cube work strides over ``core`` 0..23, vector work over the global AIV-lane id
-``core*2 + aiv_id`` 0..47). Grid-stride IS the static round-robin schedule -- a pool larger
-than the core count wraps into further waves; a smaller one leaves extra cores running a
-0-trip loop that falls straight through to the next type (so a lane with no sinkhorn work
-starts mix_x immediately, overlapping the sinkhorn on a busy lane). LOOP ORDER is the
-scheduling policy: Phase D runs comb_sinkhorn FIRST -- its 20-iteration serial recurrence is
-a latency floor no core count shortens, so starting it first overlaps it with the
-throughput-bound mix_x on the other lanes.
-
-Split-K linear and RMS tasks write disjoint FP32 partial buffers; a fixed ascending-split
-reduction makes results independent of task completion order. The hard barrier is not modeled
-by the a2a3sim / a5sim simulators, so those two sim CI checks are skipped for hc_pre -- validate
-on real device. mix_hc(24) pads to a 32-wide cube N (MIX_PAD) and hc(4) to an 8-wide vector row
-(HC_PAD).
-"""
+# ci: no-dep-gen
+"""DeepSeek-V4 Hyper-Connections pre-mix with syncall-fused and separate-task implementations."""
 
 
 import os
@@ -78,19 +17,10 @@ import pypto.language as pl
 from config import ACTIVE as M, DECODE_BATCH, DECODE_SEQ, PREFILL_BATCH, PREFILL_SEQ
 
 
+# Dynamic shape variables.
 T_DYN = pl.dynamic("T_DYN")  # T = B * S
 
-# Implementation selector (both versions are UNIFIED -- one code path for decode AND
-# prefill; no separate decode/prefill dispatch):
-#   "syncall" -- the #684 fused kernel: ONE full-occupancy pl.spmd(24) with
-#               2 hard pl.system.syncall barriers; runs with dep_gen OFF (pypto#1931).
-#   "separate" (default) -- each work-type is its own pl.spmd task, ordered by the
-#               runtime task graph; dep-gen may capture those dependencies for DFX.
-# Switch via env DSV4_HC_PRE_IMPL={syncall,separate} or by reassigning this module global
-# before the kernel is traced (the __main__ below wires it to --impl).
-HC_PRE_IMPL = os.environ.get("DSV4_HC_PRE_IMPL", "separate").lower()
-
-
+# model config
 D = M.hidden_size
 HC_MULT = M.hc_mult
 MIX_HC = M.mix_hc
@@ -100,53 +30,27 @@ HC_SINKHORN_ITER = M.hc_sinkhorn_iters
 HC_EPS = M.hc_eps
 NORM_EPS = M.rms_norm_eps
 
-MIX_PAD = 32  # mix_hc (24) padded to a 32-wide cube N / vector row
-HC_PAD = 8  # hc (4) padded for 32B-aligned vector ops
+# tiling
+T_TILE = 8
+LINEAR_T_TILE = 16
+COMB_T_TILE = 8
+RMS_K_TILE = 256
+LINEAR_K_TILE = 256
+D_TILE = 256
+MIX_D_TILE = 1024
+LINEAR_K_SPLIT_TILE = HC_DIM // 4
+RMS_K_SPLIT_TILE = HC_DIM // 16
 
-# Full-occupancy launch: NUM_CORES persistent blocks == physical AIC count (910B = 24), so a
-# hard mix-syncall reaches every AIC + AIV. Must equal the physical count exactly -- pypto does
-# NOT cap the launch, and >24 makes the runtime multi-round the blocks so some physical core is
-# in a later round when the barrier fires -> AICore timeout 507018.
+# implementation config
+HC_PRE_IMPL = os.environ.get("DSV4_HC_PRE_IMPL", "separate").lower()
+
+# layout
+MIX_PAD = 32
+HC_PAD = 8
+
+# hardware config
+# Full-chip syncall requires one persistent block per Ascend 910B AIC.
 NUM_CORES = 24
-
-# tiling (unchanged)
-T_TILE = 8  # vector row-tile (RMS / split / mix_x)
-LINEAR_T_TILE = 16  # cube matmul rows must be a 16-row boxed tile
-COMB_T_TILE = 8  # sinkhorn row-tile
-# RMS K-fragment. 256 (not 512) because PRO's HC_DIM = 4 * 7168 = 28672
-# factors as 4096 * 7: with RMS_OK = 16 the per-split K is 1792, which 512 does
-# not divide. Keeping RMS_OK at 16 preserves the decode fan-out this file is
-# tuned around, so the fragment is the knob that moves. 256 also matches
-# LINEAR_K_CHUNK / D_CHUNK.
-RMS_K_CHUNK = 256
-LINEAR_K_CHUNK = 256  # cube K-fragment per matmul_acc (32x256x4 FP32 weight fits L0B)
-D_CHUNK = 256  # mix_x inner D-fragment (BF16 load = 1KB, 512B-aligned)
-D_SPMD = 1024  # mix_x D per spmd block: decode fans 4096 reduce over D/D_SPMD cores
-# Split the K=HC_DIM reduction into LINEAR_OK disjoint partials.
-LINEAR_OK = 4
-LINEAR_K_PER_SPLIT = HC_DIM // LINEAR_OK
-LINEAR_CHUNKS_PER_SPLIT = LINEAR_K_PER_SPLIT // LINEAR_K_CHUNK
-
-# Split the RMS sum-of-squares K reduction into RMS_OK disjoint partials.
-RMS_OK = 16
-RMS_K_PER_SPLIT = HC_DIM // RMS_OK
-RMS_CHUNKS_PER_SPLIT = RMS_K_PER_SPLIT // RMS_K_CHUNK
-
-# Per-phase fan-out factor (the token-tile factor is dynamic in T).
-MIXX_DS = D // D_SPMD  # mix_x tasks per token-tile (PRO: 7168/1024 = 7)
-
-assert HC_MULT == 4, (
-    f"hc_pre is specialized to HC_MULT == 4, got {HC_MULT}; "
-    "regenerate the pre0..pre3 / row0..row3 unrolling before using it."
-)
-assert (DECODE_BATCH * DECODE_SEQ) % T_TILE == 0
-assert (PREFILL_BATCH * PREFILL_SEQ) % T_TILE == 0
-assert (PREFILL_BATCH * PREFILL_SEQ) % LINEAR_T_TILE == 0
-assert DECODE_BATCH * DECODE_SEQ <= LINEAR_T_TILE
-assert HC_DIM % LINEAR_OK == 0
-assert LINEAR_K_PER_SPLIT % LINEAR_K_CHUNK == 0
-assert HC_DIM % RMS_OK == 0 and RMS_K_PER_SPLIT % RMS_K_CHUNK == 0
-assert D % D_SPMD == 0 and D_SPMD % D_CHUNK == 0
 
 
 @pl.jit.inline
@@ -160,160 +64,150 @@ def _hc_pre_syncall(
     comb: pl.Tensor[[T_DYN, HC_MULT * HC_MULT], pl.FP32],
 ):
     t_dim = pl.tensor.dim(x, 0)
-    t_linear = ((t_dim + LINEAR_T_TILE - 1) // LINEAR_T_TILE) * LINEAR_T_TILE  # pad t_dim up to whole 16-row cube tiles
-    x_flat = pl.reshape(x, [t_dim, HC_DIM])
+    t_linear = ((t_dim + LINEAR_T_TILE - 1) // LINEAR_T_TILE) * LINEAR_T_TILE
     scale0 = pl.read(hc_scale, [0])
     scale1 = pl.read(hc_scale, [1])
     scale2 = pl.read(hc_scale, [2])
-    hc_reshaped = pl.reshape(hc_base, [1, MIX_HC])
 
-    # Cross-barrier intermediates: allocated ONCE in GM/HBM, live across the phases.
-    # x arrives as FP32 (hc residual stream is FP32 end-to-end), so there is no x_fp32
-    # staging buffer: linear / rms read x_flat directly.
-    mixes_raw = pl.create_tensor([t_linear, MIX_PAD], dtype=pl.FP32)
-    linear_partial_rows = LINEAR_OK * t_linear
-    mixes_partials = pl.create_tensor([linear_partial_rows, MIX_PAD], dtype=pl.FP32)
-    # post_pad_store is SAME-CORE scratch: write_post writes its token-tile's post gate then
-    # reads it back on the SAME core (no barrier). It is kept (not deleted) because its
-    # downstream pl.load->pl.store needs an HC_PAD-wide (32B-aligned) tile -- a narrow
-    # [T_TILE, HC_MULT] FP32 tile is 16B rows and pto.alloc_tile rejects it. pre (mix_x) and
-    # comb (loaded straight from mixes_raw) are consumed in-tile, so they need no scratch.
-    post_pad_store = pl.create_tensor([t_linear, HC_PAD], dtype=pl.FP32)  # HC_PAD-wide same-core scratch; write_post narrows to post
-    # inv_rms same-core scratch for the comb gate: the per-token inv is a [T_TILE,1] COLUMN,
-    # which the comb groups (Tiles) need as a Tile too. pto rejects a transposed [T_TILE,1]
-    # tile (row-major, 4B row < 32B) and forbids Tile x Tensor ops, so the tensor-world inv
-    # is spilled to this [t_linear,1] buffer and loaded back as a [T_TILE,1] Tile (8 floats,
-    # vs the 128-float [.,16] comb_logits round-trip this replaces).
-    inv_gm = pl.create_tensor([t_linear, 1], dtype=pl.FP32)
-    sq_sum_acc = pl.create_tensor([1, t_linear], dtype=pl.FP32)
-    sq_partials = pl.create_tensor([RMS_OK, t_linear], dtype=pl.FP32)
-
-    # Per-phase grid-stride bounds (dynamic in t_dim; grid-stride round-robins any T over cores).
-    tt_n = t_dim // T_TILE            # token-tiles (pre / post / comb / rsqrt / sinkhorn / write_post base)
-    lin_n = (t_linear // LINEAR_T_TILE) * LINEAR_OK  # linear fans over row-block x OK K-slice
-    rms_n = tt_n * RMS_OK             # rms fans over token-tile x K-slice (split-K sum-of-squares)
+    tt_n = t_dim // T_TILE
+    lin_n = (t_linear // LINEAR_T_TILE) * (HC_DIM // LINEAR_K_SPLIT_TILE)
+    rms_n = tt_n * (HC_DIM // RMS_K_SPLIT_TILE)
     linear_reduce_n = t_linear // LINEAR_T_TILE
     reduce_n = linear_reduce_n + tt_n
-    mixx_n = tt_n * MIXX_DS           # mix_x fans over token-tile x D-slice
-    pool_d = 2 * tt_n + mixx_n        # phase-D flattened pool: sinkhorn(tt_n)|mix_x(mixx_n)|write_post(tt_n)
+    mixx_n = tt_n * (D // MIX_D_TILE)
+    pool_d = 2 * tt_n + mixx_n
 
-    with pl.spmd(NUM_CORES, name_hint="hc_pre_fused", sync_start=True, allow_early_resolve=True) as _hc_tid:  # inline form requires the TaskId capture
-        core = pl.tile.get_block_idx()  # 0 .. NUM_CORES-1
+    x_flat = pl.reshape(x, [t_dim, HC_DIM])
+    hc_reshaped = pl.reshape(hc_base, [1, MIX_HC])
+    mixes_raw = pl.create_tensor([t_linear, MIX_PAD], dtype=pl.FP32)
+    linear_partial_rows = (HC_DIM // LINEAR_K_SPLIT_TILE) * t_linear
+    mixes_partials = pl.create_tensor([linear_partial_rows, MIX_PAD], dtype=pl.FP32)
+    # HC_PAD provides 32-byte rows for the post tile.
+    post_pad_store = pl.create_tensor([t_linear, HC_PAD], dtype=pl.FP32)
+    # The comb gate uses a tile view of the inverse RMS column.
+    inv_gm = pl.create_tensor([t_linear, 1], dtype=pl.FP32)
+    sq_sum_acc = pl.create_tensor([1, t_linear], dtype=pl.FP32)
+    sq_partials = pl.create_tensor([HC_DIM // RMS_K_SPLIT_TILE, t_linear], dtype=pl.FP32)
+    # Capture the TaskId required by the inline spmd form.
+    with pl.spmd(NUM_CORES, name_hint="hc_pre_fused", sync_start=True, allow_early_resolve=True) as _hc_tid:
+        core = pl.tile.get_block_idx()
 
-        # Cube linear partials and vector RMS partials run concurrently.
         for task in pl.range(core, lin_n, NUM_CORES):
-            t0 = (task // LINEAR_OK) * LINEAR_T_TILE
-            linear_split = task % LINEAR_OK
-            k_base = linear_split * LINEAR_K_PER_SPLIT
-            t_rows = pl.min(LINEAR_T_TILE, t_dim - t0)  # last row-block spills past t_dim; valid_shape zero-fills the tail
+            t0 = (task // (HC_DIM // LINEAR_K_SPLIT_TILE)) * LINEAR_T_TILE
+            linear_split = task % (HC_DIM // LINEAR_K_SPLIT_TILE)
+            k_base = linear_split * LINEAR_K_SPLIT_TILE
+            t_rows = pl.min(LINEAR_T_TILE, t_dim - t0)
             acc = pl.create_tensor([LINEAR_T_TILE, MIX_PAD], dtype=pl.FP32)
-            for kb in pl.pipeline(0, LINEAR_CHUNKS_PER_SPLIT, stage=2):
-                k0 = k_base + kb * LINEAR_K_CHUNK
-                x_linear_chunk = pl.slice(x_flat, [LINEAR_T_TILE, LINEAR_K_CHUNK], [t0, k0], valid_shape=[t_rows, LINEAR_K_CHUNK])
-                w_chunk = pl.slice(hc_fn, [MIX_PAD, LINEAR_K_CHUNK], [0, k0], valid_shape=[MIX_HC, LINEAR_K_CHUNK])
+            for kb in pl.pipeline(0, LINEAR_K_SPLIT_TILE // LINEAR_K_TILE, stage=2):
+                k0 = k_base + kb * LINEAR_K_TILE
+                x_linear_chunk = pl.slice(
+                    x_flat, [LINEAR_T_TILE, LINEAR_K_TILE], [t0, k0],
+                    valid_shape=[t_rows, LINEAR_K_TILE],
+                )
+                w_chunk = pl.slice(hc_fn, [MIX_PAD, LINEAR_K_TILE], [0, k0], valid_shape=[MIX_HC, LINEAR_K_TILE])
                 if kb == 0:
                     acc = pl.matmul(x_linear_chunk, w_chunk, b_trans=True, out_dtype=pl.FP32)
                 else:
                     acc = pl.matmul_acc(acc, x_linear_chunk, w_chunk, b_trans=True)
-            mixes_partials = pl.assemble(
-                mixes_partials,
-                acc,
-                [linear_split * t_linear + t0, 0],
-            )
+            partial_t0 = linear_split * t_linear + t0
+            mixes_partials[partial_t0 : partial_t0 + LINEAR_T_TILE, 0:MIX_PAD] = acc
         for aiv_id in pl.split_aiv(2, mode=pl.SplitMode.NONE):
             lane = core * 2 + aiv_id
             for task in pl.range(lane, rms_n, NUM_CORES * 2):
-                t0 = (task // RMS_OK) * T_TILE
-                rms_split = task % RMS_OK
-                k_base = rms_split * RMS_K_PER_SPLIT
+                t0 = (task // (HC_DIM // RMS_K_SPLIT_TILE)) * T_TILE
+                rms_split = task % (HC_DIM // RMS_K_SPLIT_TILE)
+                k_base = rms_split * RMS_K_SPLIT_TILE
                 sq_part = pl.full([1, T_TILE], dtype=pl.FP32, value=0.0)
-                for kb in pl.pipeline(RMS_CHUNKS_PER_SPLIT, stage=4):
-                    k0 = k_base + kb * RMS_K_CHUNK
-                    x_chunk = x_flat[t0:t0 + T_TILE, k0:k0 + RMS_K_CHUNK]
-                    sq_part = pl.add(sq_part, pl.reshape(pl.row_sum(pl.mul(x_chunk, x_chunk)), [1, T_TILE]))
-                sq_partials = pl.assemble(sq_partials, sq_part, [rms_split, t0])
+                for k0 in pl.pipeline(k_base, k_base + RMS_K_SPLIT_TILE, RMS_K_TILE, stage=4):
+                    x_chunk = x_flat[t0:t0 + T_TILE, k0:k0 + RMS_K_TILE]
+                    x_sq = pl.mul(x_chunk, x_chunk)
+                    x_sq_sum = pl.row_sum(x_sq)
+                    x_sq_row = pl.reshape(x_sq_sum, [1, T_TILE])
+                    sq_part = pl.add(sq_part, x_sq_row)
+                sq_partials[rms_split : rms_split + 1, t0 : t0 + T_TILE] = sq_part
         pl.system.syncall(core_type="mix")
 
-        # Split-K partials are reduced in ascending K order.
         for aiv_id in pl.split_aiv(2, mode=pl.SplitMode.NONE):
             lane = core * 2 + aiv_id
             for reduce_task in pl.range(lane, reduce_n, NUM_CORES * 2):
                 if reduce_task < linear_reduce_n:
                     linear_t0 = reduce_task * LINEAR_T_TILE
-                    mixes_total = mixes_partials[
-                        linear_t0 : linear_t0 + LINEAR_T_TILE,
-                        0:MIX_PAD,
-                    ]
-                    for linear_split in pl.range(1, LINEAR_OK):
+                    mixes_total = mixes_partials[linear_t0 : linear_t0 + LINEAR_T_TILE, 0:MIX_PAD]
+                    for linear_split in pl.range(1, HC_DIM // LINEAR_K_SPLIT_TILE):
                         partial_t0 = linear_split * t_linear + linear_t0
-                        mixes_total = pl.add(
-                            mixes_total,
-                            mixes_partials[
-                                partial_t0 : partial_t0 + LINEAR_T_TILE,
-                                0:MIX_PAD,
-                            ],
-                        )
-                    mixes_raw = pl.assemble(mixes_raw, mixes_total, [linear_t0, 0])
+                        partial_mix = mixes_partials[partial_t0 : partial_t0 + LINEAR_T_TILE, 0:MIX_PAD]
+                        mixes_total = pl.add(mixes_total, partial_mix)
+                    mixes_raw[linear_t0 : linear_t0 + LINEAR_T_TILE, 0:MIX_PAD] = mixes_total
                 else:
                     rms_t0 = (reduce_task - linear_reduce_n) * T_TILE
                     sq_total = sq_partials[0:1, rms_t0 : rms_t0 + T_TILE]
-                    for rms_split in pl.range(1, RMS_OK):
-                        sq_total = pl.add(
-                            sq_total,
-                            sq_partials[rms_split : rms_split + 1, rms_t0 : rms_t0 + T_TILE],
-                        )
-                    sq_sum_acc = pl.assemble(sq_sum_acc, sq_total, [0, rms_t0])
+                    for rms_split in pl.range(1, HC_DIM // RMS_K_SPLIT_TILE):
+                        sq_partial = sq_partials[rms_split : rms_split + 1, rms_t0 : rms_t0 + T_TILE]
+                        sq_total = pl.add(sq_total, sq_partial)
+                    sq_sum_acc[0:1, rms_t0 : rms_t0 + T_TILE] = sq_total
         pl.system.syncall(core_type="mix")
 
-        # ===================== PHASE C+D FUSED: gate + sinkhorn/mix_x/write_post (AIV) =====
-        # Phase C (rsqrt + scale + sigmoid gates) is FOLDED into each Phase-D task: every
-        # task recomputes the gate it needs from the published mixes_raw + sq_sum_acc
-        # on its OWN core, just before using it. Recompute is nearly free here (latency-bound
-        # kernel), and it deletes an entire cross-core barrier plus the pre/post/comb gate
-        # round-trips -- the C->D handoff was the reason the old Barrier 3 existed. comb_logits
-        # stays only as SAME-CORE scratch (assemble then load back, no barrier).
-        #
-        # The three kinds share ONE flattened work pool so they run on DISJOINT cores in
-        # parallel -- otherwise per-type loops all start at the same lane base, stacking
-        # sinkhorn (a 20-iter serial-recurrence latency floor) + that lane's mix_x/write_post
-        # onto lane 0 while the other lanes idle. sinkhorn is placed first in the pool so its
-        # long chain starts immediately alongside the mix_x lanes. No trailing barrier
-        # (kernel end publishes the outputs).
         for aiv_id in pl.split_aiv(2, mode=pl.SplitMode.NONE):
             lane = core * 2 + aiv_id
-            # ONE flattened pool [sinkhorn(tt_n) | mix_x(mixx_n) | write_post(tt_n)] so grid-
-            # stride lands the three kinds on DISJOINT lanes -- sinkhorn, all mix_x D-slices,
-            # and write_post run on different cores concurrently (not serialized per lane).
             for gw in pl.range(lane, pool_d, NUM_CORES * 2):
                 if gw < tt_n:
                     t0 = gw * COMB_T_TILE
-                    # Fold Phase C's comb gate here AND skip the comb_logits GM round-trip:
-                    # load the 4 comb groups DIRECTLY from mixes_raw (pad-capable loads at cols
-                    # 8/12/16/20 within the 32-wide MIX_PAD row), then apply inv_rms * scale2 +
-                    # group bias PER GROUP in-tile. The previous version assembled a [.,16]
-                    # comb_logits tile to GM and loaded the 4 misaligned 4-wide groups back
-                    # (pto cannot slice a 16B sub-tile in-register); loading straight from the
-                    # matmul output drops that store+load, matching the prefill path.
-                    # inv_rms for the comb gate must be a TILE (the comb groups below are
-                    # Tiles). Compute it in tensor-world, spill to inv_gm, and load it back as a
-                    # [T_TILE,1] Tile (a transposed [T_TILE,1] tile is rejected -- 4B row).
-                    ssq_row = sq_sum_acc[0:1, t0:t0 + COMB_T_TILE]  # [1,T_TILE] tensor
-                    inv_col_tensor = pl.reshape(pl.rsqrt(pl.add(pl.mul(ssq_row, HC_DIM_INV), NORM_EPS), high_precision=True), [COMB_T_TILE, 1])
-                    inv_gm = pl.assemble(inv_gm, inv_col_tensor, [t0, 0])
-                    inv_col_t = pl.load(inv_gm, [t0, 0], [COMB_T_TILE, 1], target_memory=pl.MemorySpace.Vec)  # [T_TILE,1] tile
+                    ssq_row = sq_sum_acc[0:1, t0:t0 + COMB_T_TILE]
+                    ssq_mean = pl.mul(ssq_row, HC_DIM_INV)
+                    ssq_eps = pl.add(ssq_mean, NORM_EPS)
+                    inv_row = pl.rsqrt(ssq_eps, high_precision=True)
+                    inv_col_tensor = pl.reshape(inv_row, [COMB_T_TILE, 1])
+                    inv_gm[t0 : t0 + COMB_T_TILE, 0:1] = inv_col_tensor
+                    inv_col_t = pl.load(inv_gm, [t0, 0], [COMB_T_TILE, 1], target_memory=pl.MemorySpace.Vec)
                     comb_off = HC_MULT * 2
-                    mix_g0 = pl.load(mixes_raw, [t0, comb_off + 0 * HC_MULT], [COMB_T_TILE, HC_PAD], valid_shape=[COMB_T_TILE, HC_MULT], target_memory=pl.MemorySpace.Vec)
-                    mix_g1 = pl.load(mixes_raw, [t0, comb_off + 1 * HC_MULT], [COMB_T_TILE, HC_PAD], valid_shape=[COMB_T_TILE, HC_MULT], target_memory=pl.MemorySpace.Vec)
-                    mix_g2 = pl.load(mixes_raw, [t0, comb_off + 2 * HC_MULT], [COMB_T_TILE, HC_PAD], valid_shape=[COMB_T_TILE, HC_MULT], target_memory=pl.MemorySpace.Vec)
-                    mix_g3 = pl.load(mixes_raw, [t0, comb_off + 3 * HC_MULT], [COMB_T_TILE, HC_PAD], valid_shape=[COMB_T_TILE, HC_MULT], target_memory=pl.MemorySpace.Vec)
-                    cb0 = pl.load(hc_reshaped, [0, comb_off + 0 * HC_MULT], [1, HC_PAD], valid_shape=[1, HC_MULT], target_memory=pl.MemorySpace.Vec)
-                    cb1 = pl.load(hc_reshaped, [0, comb_off + 1 * HC_MULT], [1, HC_PAD], valid_shape=[1, HC_MULT], target_memory=pl.MemorySpace.Vec)
-                    cb2 = pl.load(hc_reshaped, [0, comb_off + 2 * HC_MULT], [1, HC_PAD], valid_shape=[1, HC_MULT], target_memory=pl.MemorySpace.Vec)
-                    cb3 = pl.load(hc_reshaped, [0, comb_off + 3 * HC_MULT], [1, HC_PAD], valid_shape=[1, HC_MULT], target_memory=pl.MemorySpace.Vec)
-                    row0 = pl.add(pl.mul(pl.row_expand_mul(mix_g0, inv_col_t), scale2), pl.col_expand(mix_g0, cb0))
-                    row1 = pl.add(pl.mul(pl.row_expand_mul(mix_g1, inv_col_t), scale2), pl.col_expand(mix_g1, cb1))
-                    row2 = pl.add(pl.mul(pl.row_expand_mul(mix_g2, inv_col_t), scale2), pl.col_expand(mix_g2, cb2))
-                    row3 = pl.add(pl.mul(pl.row_expand_mul(mix_g3, inv_col_t), scale2), pl.col_expand(mix_g3, cb3))
+                    mix_g0 = pl.load(
+                        mixes_raw, [t0, comb_off + 0 * HC_MULT], [COMB_T_TILE, HC_PAD],
+                        valid_shape=[COMB_T_TILE, HC_MULT], target_memory=pl.MemorySpace.Vec,
+                    )
+                    mix_g1 = pl.load(
+                        mixes_raw, [t0, comb_off + 1 * HC_MULT], [COMB_T_TILE, HC_PAD],
+                        valid_shape=[COMB_T_TILE, HC_MULT], target_memory=pl.MemorySpace.Vec,
+                    )
+                    mix_g2 = pl.load(
+                        mixes_raw, [t0, comb_off + 2 * HC_MULT], [COMB_T_TILE, HC_PAD],
+                        valid_shape=[COMB_T_TILE, HC_MULT], target_memory=pl.MemorySpace.Vec,
+                    )
+                    mix_g3 = pl.load(
+                        mixes_raw, [t0, comb_off + 3 * HC_MULT], [COMB_T_TILE, HC_PAD],
+                        valid_shape=[COMB_T_TILE, HC_MULT], target_memory=pl.MemorySpace.Vec,
+                    )
+                    cb0 = pl.load(
+                        hc_reshaped, [0, comb_off + 0 * HC_MULT], [1, HC_PAD],
+                        valid_shape=[1, HC_MULT], target_memory=pl.MemorySpace.Vec,
+                    )
+                    cb1 = pl.load(
+                        hc_reshaped, [0, comb_off + 1 * HC_MULT], [1, HC_PAD],
+                        valid_shape=[1, HC_MULT], target_memory=pl.MemorySpace.Vec,
+                    )
+                    cb2 = pl.load(
+                        hc_reshaped, [0, comb_off + 2 * HC_MULT], [1, HC_PAD],
+                        valid_shape=[1, HC_MULT], target_memory=pl.MemorySpace.Vec,
+                    )
+                    cb3 = pl.load(
+                        hc_reshaped, [0, comb_off + 3 * HC_MULT], [1, HC_PAD],
+                        valid_shape=[1, HC_MULT], target_memory=pl.MemorySpace.Vec,
+                    )
+                    row0_normed = pl.row_expand_mul(mix_g0, inv_col_t)
+                    row0_scaled = pl.mul(row0_normed, scale2)
+                    row0_base = pl.col_expand(mix_g0, cb0)
+                    row0 = pl.add(row0_scaled, row0_base)
+                    row1_normed = pl.row_expand_mul(mix_g1, inv_col_t)
+                    row1_scaled = pl.mul(row1_normed, scale2)
+                    row1_base = pl.col_expand(mix_g1, cb1)
+                    row1 = pl.add(row1_scaled, row1_base)
+                    row2_normed = pl.row_expand_mul(mix_g2, inv_col_t)
+                    row2_scaled = pl.mul(row2_normed, scale2)
+                    row2_base = pl.col_expand(mix_g2, cb2)
+                    row2 = pl.add(row2_scaled, row2_base)
+                    row3_normed = pl.row_expand_mul(mix_g3, inv_col_t)
+                    row3_scaled = pl.mul(row3_normed, scale2)
+                    row3_base = pl.col_expand(mix_g3, cb3)
+                    row3 = pl.add(row3_scaled, row3_base)
                     row0_p = pl.fillpad(row0, pad_value=pl.PadValue.min)
                     row1_p = pl.fillpad(row1, pad_value=pl.PadValue.min)
                     row2_p = pl.fillpad(row2, pad_value=pl.PadValue.min)
@@ -325,18 +219,26 @@ def _hc_pre_syncall(
                     row1_max = pl.row_max(row1_p, row_max_tmp)
                     row2_max = pl.row_max(row2_p, row_max_tmp)
                     row3_max = pl.row_max(row3_p, row_max_tmp)
-                    row0_exp = pl.exp(pl.row_expand_sub(row0_p, row0_max))
-                    row1_exp = pl.exp(pl.row_expand_sub(row1_p, row1_max))
-                    row2_exp = pl.exp(pl.row_expand_sub(row2_p, row2_max))
-                    row3_exp = pl.exp(pl.row_expand_sub(row3_p, row3_max))
+                    row0_centered = pl.row_expand_sub(row0_p, row0_max)
+                    row0_exp = pl.exp(row0_centered)
+                    row1_centered = pl.row_expand_sub(row1_p, row1_max)
+                    row1_exp = pl.exp(row1_centered)
+                    row2_centered = pl.row_expand_sub(row2_p, row2_max)
+                    row2_exp = pl.exp(row2_centered)
+                    row3_centered = pl.row_expand_sub(row3_p, row3_max)
+                    row3_exp = pl.exp(row3_centered)
                     row0_sum = pl.row_sum(row0_exp, row_sum_tmp)
                     row1_sum = pl.row_sum(row1_exp, row_sum_tmp)
                     row2_sum = pl.row_sum(row2_exp, row_sum_tmp)
                     row3_sum = pl.row_sum(row3_exp, row_sum_tmp)
-                    row0_soft = pl.add(pl.row_expand_div(row0_exp, row0_sum), HC_EPS)
-                    row1_soft = pl.add(pl.row_expand_div(row1_exp, row1_sum), HC_EPS)
-                    row2_soft = pl.add(pl.row_expand_div(row2_exp, row2_sum), HC_EPS)
-                    row3_soft = pl.add(pl.row_expand_div(row3_exp, row3_sum), HC_EPS)
+                    row0_prob = pl.row_expand_div(row0_exp, row0_sum)
+                    row0_soft = pl.add(row0_prob, HC_EPS)
+                    row1_prob = pl.row_expand_div(row1_exp, row1_sum)
+                    row1_soft = pl.add(row1_prob, HC_EPS)
+                    row2_prob = pl.row_expand_div(row2_exp, row2_sum)
+                    row2_soft = pl.add(row2_prob, HC_EPS)
+                    row3_prob = pl.row_expand_div(row3_exp, row3_sum)
+                    row3_soft = pl.add(row3_prob, HC_EPS)
 
                     row0_valid = pl.set_validshape(row0_soft, COMB_T_TILE, HC_MULT)
                     row1_valid = pl.set_validshape(row1_soft, COMB_T_TILE, HC_MULT)
@@ -347,29 +249,40 @@ def _hc_pre_syncall(
                     row2_eff = pl.fillpad(row2_valid, pad_value=pl.PadValue.zero)
                     row3_eff = pl.fillpad(row3_valid, pad_value=pl.PadValue.zero)
 
-                    row_sum_tmp_iter = pl.create_tile([COMB_T_TILE, HC_PAD], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec)
-                    col_sum = pl.add(pl.add(row0_eff, row1_eff), pl.add(row2_eff, row3_eff))
-                    col_sum = pl.add(col_sum, HC_EPS)
-                    row0_cur = pl.div(row0_eff, col_sum)
-                    row1_cur = pl.div(row1_eff, col_sum)
-                    row2_cur = pl.div(row2_eff, col_sum)
-                    row3_cur = pl.div(row3_eff, col_sum)
+                    row_sum_tmp_iter = pl.create_tile(
+                        [COMB_T_TILE, HC_PAD], dtype=pl.FP32,
+                        target_memory=pl.MemorySpace.Vec,
+                    )
+                    row01_eff = pl.add(row0_eff, row1_eff)
+                    row23_eff = pl.add(row2_eff, row3_eff)
+                    col_sum_raw = pl.add(row01_eff, row23_eff)
+                    col_sum_eps = pl.add(col_sum_raw, HC_EPS)
+                    row0_cur = pl.div(row0_eff, col_sum_eps)
+                    row1_cur = pl.div(row1_eff, col_sum_eps)
+                    row2_cur = pl.div(row2_eff, col_sum_eps)
+                    row3_cur = pl.div(row3_eff, col_sum_eps)
 
                     for _sk_it in pl.pipeline(HC_SINKHORN_ITER - 1, stage=2):
-                        row0_rowsum = pl.add(pl.row_sum(row0_cur, row_sum_tmp_iter), HC_EPS)
-                        row1_rowsum = pl.add(pl.row_sum(row1_cur, row_sum_tmp_iter), HC_EPS)
-                        row2_rowsum = pl.add(pl.row_sum(row2_cur, row_sum_tmp_iter), HC_EPS)
-                        row3_rowsum = pl.add(pl.row_sum(row3_cur, row_sum_tmp_iter), HC_EPS)
+                        row0_sum_raw = pl.row_sum(row0_cur, row_sum_tmp_iter)
+                        row0_rowsum = pl.add(row0_sum_raw, HC_EPS)
+                        row1_sum_raw = pl.row_sum(row1_cur, row_sum_tmp_iter)
+                        row1_rowsum = pl.add(row1_sum_raw, HC_EPS)
+                        row2_sum_raw = pl.row_sum(row2_cur, row_sum_tmp_iter)
+                        row2_rowsum = pl.add(row2_sum_raw, HC_EPS)
+                        row3_sum_raw = pl.row_sum(row3_cur, row_sum_tmp_iter)
+                        row3_rowsum = pl.add(row3_sum_raw, HC_EPS)
                         row0_norm = pl.row_expand_div(row0_cur, row0_rowsum)
                         row1_norm = pl.row_expand_div(row1_cur, row1_rowsum)
                         row2_norm = pl.row_expand_div(row2_cur, row2_rowsum)
                         row3_norm = pl.row_expand_div(row3_cur, row3_rowsum)
-                        col_sum = pl.add(pl.add(row0_norm, row1_norm), pl.add(row2_norm, row3_norm))
-                        col_sum = pl.add(col_sum, HC_EPS)
-                        row0_cur = pl.div(row0_norm, col_sum)
-                        row1_cur = pl.div(row1_norm, col_sum)
-                        row2_cur = pl.div(row2_norm, col_sum)
-                        row3_cur = pl.div(row3_norm, col_sum)
+                        row01_norm = pl.add(row0_norm, row1_norm)
+                        row23_norm = pl.add(row2_norm, row3_norm)
+                        col_sum_iter_raw = pl.add(row01_norm, row23_norm)
+                        col_sum_iter_eps = pl.add(col_sum_iter_raw, HC_EPS)
+                        row0_cur = pl.div(row0_norm, col_sum_iter_eps)
+                        row1_cur = pl.div(row1_norm, col_sum_iter_eps)
+                        row2_cur = pl.div(row2_norm, col_sum_iter_eps)
+                        row3_cur = pl.div(row3_norm, col_sum_iter_eps)
 
                     row0_out = pl.set_validshape(row0_cur, COMB_T_TILE, HC_MULT)
                     row1_out = pl.set_validshape(row1_cur, COMB_T_TILE, HC_MULT)
@@ -382,56 +295,68 @@ def _hc_pre_syncall(
 
                 elif gw < tt_n + mixx_n:
                     blk = gw - tt_n
-                    t0 = (blk // MIXX_DS) * T_TILE
-                    d_base = (blk % MIXX_DS) * D_SPMD
-                    # Fold Phase C's pre gate: pre = sigmoid(mix[:, :hc] * inv * scale0 + base) + eps.
-                    # Recomputed here from mixes_raw (every D-slice of a token-tile redoes this
-                    # tiny [T_TILE, HC_PAD] sigmoid -- free, and it drops the pre_val HBM buffer).
-                    ssq_row = sq_sum_acc[0:1, t0:t0 + T_TILE]  # [1,T_TILE] row keeps the rsqrt tile 32B-aligned
-                    inv_col = pl.reshape(pl.rsqrt(pl.add(pl.mul(ssq_row, HC_DIM_INV), NORM_EPS), high_precision=True), [T_TILE, 1])
+                    t0 = (blk // (D // MIX_D_TILE)) * T_TILE
+                    d_base = (blk % (D // MIX_D_TILE)) * MIX_D_TILE
+                    ssq_row = sq_sum_acc[0:1, t0:t0 + T_TILE]
+                    ssq_mean = pl.mul(ssq_row, HC_DIM_INV)
+                    ssq_eps = pl.add(ssq_mean, NORM_EPS)
+                    inv_row = pl.rsqrt(ssq_eps, high_precision=True)
+                    inv_col = pl.reshape(inv_row, [T_TILE, 1])
                     pre_base = hc_reshaped[0:1, 0:HC_PAD]
-                    pre_scaled = pl.mul(pl.row_expand_mul(mixes_raw[t0:t0 + T_TILE, 0:HC_PAD], inv_col), scale0)
-                    pre_logits = pl.add(pre_scaled, pl.col_expand(pre_scaled, pre_base))
-                    pre_val = pl.add(pl.recip(pl.add(pl.exp(pl.neg(pre_logits)), 1.0)), HC_EPS)
-                    # pin the valid shape: the inline gate carries valid=?x? from the dynamic-
-                    # offset mixes_raw slice, but the transpose below wants a static 8x8 tile.
-                    pre_val = pl.set_validshape(pre_val, T_TILE, HC_PAD)
+                    pre_normed = pl.row_expand_mul(mixes_raw[t0:t0 + T_TILE, 0:HC_PAD], inv_col)
+                    pre_scaled = pl.mul(pre_normed, scale0)
+                    pre_base_tile = pl.col_expand(pre_scaled, pre_base)
+                    pre_logits = pl.add(pre_scaled, pre_base_tile)
+                    pre_neg = pl.neg(pre_logits)
+                    pre_exp = pl.exp(pre_neg)
+                    pre_denom = pl.add(pre_exp, 1.0)
+                    pre_sigmoid = pl.recip(pre_denom)
+                    pre_val_raw = pl.add(pre_sigmoid, HC_EPS)
+                    # Fix the dynamic-offset gate to a static tile shape.
+                    pre_val = pl.set_validshape(pre_val_raw, T_TILE, HC_PAD)
                     pre_tile_t = pl.transpose(pre_val, axis1=0, axis2=1)
                     pre0 = pl.reshape(pre_tile_t[0:1, 0:T_TILE], [T_TILE, 1])
                     pre1 = pl.reshape(pre_tile_t[1:2, 0:T_TILE], [T_TILE, 1])
                     pre2 = pl.reshape(pre_tile_t[2:3, 0:T_TILE], [T_TILE, 1])
                     pre3 = pl.reshape(pre_tile_t[3:4, 0:T_TILE], [T_TILE, 1])
-                    for db in pl.pipeline(D_SPMD // D_CHUNK, stage=2):
-                        d0 = d_base + db * D_CHUNK
-                        x0 = x_flat[t0:t0 + T_TILE, 0 * D + d0:0 * D + d0 + D_CHUNK]
-                        x1 = x_flat[t0:t0 + T_TILE, 1 * D + d0:1 * D + d0 + D_CHUNK]
-                        x2 = x_flat[t0:t0 + T_TILE, 2 * D + d0:2 * D + d0 + D_CHUNK]
-                        x3 = x_flat[t0:t0 + T_TILE, 3 * D + d0:3 * D + d0 + D_CHUNK]
+                    for d0 in pl.pipeline(d_base, d_base + MIX_D_TILE, D_TILE, stage=2):
+                        x0 = x_flat[t0:t0 + T_TILE, 0 * D + d0:0 * D + d0 + D_TILE]
+                        x1 = x_flat[t0:t0 + T_TILE, 1 * D + d0:1 * D + d0 + D_TILE]
+                        x2 = x_flat[t0:t0 + T_TILE, 2 * D + d0:2 * D + d0 + D_TILE]
+                        x3 = x_flat[t0:t0 + T_TILE, 3 * D + d0:3 * D + d0 + D_TILE]
                         y0 = pl.row_expand_mul(x0, pre0)
                         y1 = pl.row_expand_mul(x1, pre1)
                         y2 = pl.row_expand_mul(x2, pre2)
                         y3 = pl.row_expand_mul(x3, pre3)
-                        y_tile = pl.add(pl.add(y0, y1), pl.add(y2, y3))
-                        x_mixed = pl.assemble(x_mixed, pl.cast(y_tile, target_type=pl.BF16, mode="rint"), [t0, d0])
+                        y01 = pl.add(y0, y1)
+                        y23 = pl.add(y2, y3)
+                        y_tile = pl.add(y01, y23)
+                        y_bf16 = pl.cast(y_tile, target_type=pl.BF16, mode="rint")
+                        x_mixed[t0 : t0 + T_TILE, d0 : d0 + D_TILE] = y_bf16
 
                 else:
                     ob = gw - tt_n - mixx_n
                     t0 = ob * COMB_T_TILE
-                    # Fold Phase C's post gate: post = 2 * sigmoid(mix[:, hc:2hc] * inv * scale1 + base).
-                    # The gate is tensor-world (mixes_raw slice -> sigmoid), and pl.store needs a Vec
-                    # TILE -- so post_pad is stashed HC_PAD-wide in same-core scratch and loaded back as
-                    # an aligned [COMB_T_TILE, HC_PAD] tile (a direct [.,HC_MULT] store would need a
-                    # 16B-row FP32 tile, which pto.alloc_tile rejects). pl.store then narrows valid
-                    # [COMB_T_TILE, HC_MULT] into the 4-wide post output.
-                    ssq_row = sq_sum_acc[0:1, t0:t0 + COMB_T_TILE]  # [1,COMB_T_TILE] row keeps the rsqrt tile 32B-aligned
-                    inv_col = pl.reshape(pl.rsqrt(pl.add(pl.mul(ssq_row, HC_DIM_INV), NORM_EPS), high_precision=True), [COMB_T_TILE, 1])
+                    ssq_row = sq_sum_acc[0:1, t0:t0 + COMB_T_TILE]
+                    ssq_mean = pl.mul(ssq_row, HC_DIM_INV)
+                    ssq_eps = pl.add(ssq_mean, NORM_EPS)
+                    inv_row = pl.rsqrt(ssq_eps, high_precision=True)
+                    inv_col = pl.reshape(inv_row, [COMB_T_TILE, 1])
                     post_base = hc_reshaped[0:1, HC_MULT:HC_MULT + HC_PAD]
-                    post_scaled = pl.mul(pl.row_expand_mul(mixes_raw[t0:t0 + COMB_T_TILE, HC_MULT:HC_MULT + HC_PAD], inv_col), scale1)
-                    post_logits = pl.add(post_scaled, pl.col_expand(post_scaled, post_base))
-                    post_pad = pl.mul(pl.recip(pl.add(pl.exp(pl.neg(post_logits)), 1.0)), 2.0)
-                    post_pad_store = pl.assemble(post_pad_store, post_pad, [t0, 0])
-                    post_tile = pl.load(post_pad_store, [t0, 0], [COMB_T_TILE, HC_PAD],
-                                        valid_shape=[COMB_T_TILE, HC_MULT], target_memory=pl.MemorySpace.Vec)
+                    post_normed = pl.row_expand_mul(mixes_raw[t0:t0 + COMB_T_TILE, HC_MULT:HC_MULT + HC_PAD], inv_col)
+                    post_scaled = pl.mul(post_normed, scale1)
+                    post_base_tile = pl.col_expand(post_scaled, post_base)
+                    post_logits = pl.add(post_scaled, post_base_tile)
+                    post_neg = pl.neg(post_logits)
+                    post_exp = pl.exp(post_neg)
+                    post_denom = pl.add(post_exp, 1.0)
+                    post_sigmoid = pl.recip(post_denom)
+                    post_pad = pl.mul(post_sigmoid, 2.0)
+                    post_pad_store[t0 : t0 + COMB_T_TILE, 0:HC_PAD] = post_pad
+                    post_tile = pl.load(
+                        post_pad_store, [t0, 0], [COMB_T_TILE, HC_PAD],
+                        valid_shape=[COMB_T_TILE, HC_MULT], target_memory=pl.MemorySpace.Vec,
+                    )
                     pl.store(post_tile, [t0, 0], post)
     return x_mixed
 
@@ -446,283 +371,166 @@ def _hc_pre_separate(
     post: pl.Tensor[[T_DYN, HC_MULT], pl.FP32],
     comb: pl.Tensor[[T_DYN, HC_MULT * HC_MULT], pl.FP32],
 ):
-    """Multi-scope (separate-task) hc_pre -- the pre-#684 structure, applied to ALL T.
-
-    Identical math to _hc_pre_syncall, but each work-type is its OWN pl.spmd task instead
-    of one full-occupancy pl.spmd + hard pl.system.syncall barriers. The runtime task
-    graph orders the scopes by their GM read/write dependencies (linear -> linear reduce ->
-    split_pre_post -> write_post / comb_sinkhorn / mix_x). The scheduler derives that ordering
-    from GM dependencies; the standalone harness enables dep-gen only to capture the graph.
-    Tile sizes are aligned to the
-    tuned syncall version (D_CHUNK / D_SPMD / LINEAR_* / t_linear round-up); cross-barrier
-    buffers are sized to the dynamic t_linear (the 8->16 padded row count), not a static
-    T_MAX. Kept as a switchable alternative to the fused kernel (perf is not the goal here).
-    """
+    """Compute the Hyper-Connections pre-mix with separate tasks."""
     t_dim = pl.tensor.dim(x, 0)
-    t_linear = ((t_dim + LINEAR_T_TILE - 1) // LINEAR_T_TILE) * LINEAR_T_TILE  # pad t_dim up to whole 16-row cube tiles
-    x_flat = pl.reshape(x, [t_dim, HC_DIM])
+    t_linear = ((t_dim + LINEAR_T_TILE - 1) // LINEAR_T_TILE) * LINEAR_T_TILE
     scale0 = pl.read(hc_scale, [0])
     scale1 = pl.read(hc_scale, [1])
     scale2 = pl.read(hc_scale, [2])
-    hc_base_2d = pl.reshape(hc_base, [1, MIX_HC])  # for per-group comb base loads in comb_sinkhorn
 
+    x_flat = pl.reshape(x, [t_dim, HC_DIM])
     inv_rms = pl.create_tensor([t_linear, 1], dtype=pl.FP32)
-    # x arrives as FP32 from the prior hc_post (the hc residual stream is FP32 end-to-end),
-    # so the old BF16->FP32 cast scope + x_fp32 staging buffer are gone: linear / rms read
-    # x_flat directly. The 8->16 pad rows of the cube tile are never materialized -- the
-    # linear matmul masks them with valid_shape (zero-fill past t_dim), and rms only reads
-    # the t_dim real rows.
-    mixes_raw = pl.create_tensor([t_linear, MIX_PAD], dtype=pl.FP32)
-    linear_partial_rows = LINEAR_OK * t_linear
-    mixes_partials = pl.create_tensor([linear_partial_rows, MIX_PAD], dtype=pl.FP32)
-
-    # rms: full-K sum-of-squares per token-tile -> inv_rms (one scope, no split-K).
     for t in pl.spmd(t_dim // T_TILE, name_hint="hc_pre_rms", allow_early_resolve=True):
         t0 = t * T_TILE
         sq_sum = pl.full([1, T_TILE], dtype=pl.FP32, value=0.0)
-        for kb in pl.pipeline(HC_DIM // RMS_K_CHUNK, stage=4):
-            k0 = kb * RMS_K_CHUNK
-            x_chunk = x_flat[t0:t0 + T_TILE, k0:k0 + RMS_K_CHUNK]
-            sq_sum = pl.add(sq_sum, pl.reshape(pl.row_sum(pl.mul(x_chunk, x_chunk)), [1, T_TILE]))
-        inv = pl.reshape(pl.rsqrt(pl.add(pl.mul(sq_sum, HC_DIM_INV), NORM_EPS), high_precision=True), [T_TILE, 1])
-        inv_rms = pl.assemble(inv_rms, inv, [t0, 0])
+        for k0 in pl.pipeline(0, HC_DIM, RMS_K_TILE, stage=4):
+            x_chunk = x_flat[t0:t0 + T_TILE, k0:k0 + RMS_K_TILE]
+            x_sq = pl.mul(x_chunk, x_chunk)
+            x_sq_sum = pl.row_sum(x_sq)
+            x_sq_row = pl.reshape(x_sq_sum, [1, T_TILE])
+            sq_sum = pl.add(sq_sum, x_sq_row)
+        sq_mean = pl.mul(sq_sum, HC_DIM_INV)
+        sq_eps = pl.add(sq_mean, NORM_EPS)
+        inv_row = pl.rsqrt(sq_eps, high_precision=True)
+        inv = pl.reshape(inv_row, [T_TILE, 1])
+        inv_rms[t0 : t0 + T_TILE, 0:1] = inv
 
-    # Linear split-K partials are reduced in ascending K order.
-    for task in pl.spmd((t_linear // LINEAR_T_TILE) * LINEAR_OK, name_hint="hc_pre_linear", allow_early_resolve=True):
-        t0 = (task // LINEAR_OK) * LINEAR_T_TILE
-        linear_split = task % LINEAR_OK
-        k_base = linear_split * LINEAR_K_PER_SPLIT
-        t_rows = pl.min(LINEAR_T_TILE, t_dim - t0)  # last row-block spills past t_dim; valid_shape zero-fills the tail
+    linear_partial_rows = (HC_DIM // LINEAR_K_SPLIT_TILE) * t_linear
+    mixes_partials = pl.create_tensor([linear_partial_rows, MIX_PAD], dtype=pl.FP32)
+    for task in pl.spmd(
+        (t_linear // LINEAR_T_TILE) * (HC_DIM // LINEAR_K_SPLIT_TILE),
+        name_hint="hc_pre_linear", allow_early_resolve=True,
+    ):
+        t0 = (task // (HC_DIM // LINEAR_K_SPLIT_TILE)) * LINEAR_T_TILE
+        linear_split = task % (HC_DIM // LINEAR_K_SPLIT_TILE)
+        k_base = linear_split * LINEAR_K_SPLIT_TILE
+        t_rows = pl.min(LINEAR_T_TILE, t_dim - t0)
         acc = pl.create_tensor([LINEAR_T_TILE, MIX_PAD], dtype=pl.FP32)
-        for kb in pl.pipeline(0, LINEAR_CHUNKS_PER_SPLIT, stage=2):
-            k0 = k_base + kb * LINEAR_K_CHUNK
-            x_linear_chunk = pl.slice(x_flat, [LINEAR_T_TILE, LINEAR_K_CHUNK], [t0, k0], valid_shape=[t_rows, LINEAR_K_CHUNK])
-            w_chunk = pl.slice(hc_fn, [MIX_PAD, LINEAR_K_CHUNK], [0, k0], valid_shape=[MIX_HC, LINEAR_K_CHUNK])
+        for kb in pl.pipeline(0, LINEAR_K_SPLIT_TILE // LINEAR_K_TILE, stage=2):
+            k0 = k_base + kb * LINEAR_K_TILE
+            x_linear_chunk = pl.slice(
+                x_flat, [LINEAR_T_TILE, LINEAR_K_TILE], [t0, k0],
+                valid_shape=[t_rows, LINEAR_K_TILE],
+            )
+            w_chunk = pl.slice(hc_fn, [MIX_PAD, LINEAR_K_TILE], [0, k0], valid_shape=[MIX_HC, LINEAR_K_TILE])
             if kb == 0:
                 acc = pl.matmul(x_linear_chunk, w_chunk, b_trans=True, out_dtype=pl.FP32)
             else:
                 acc = pl.matmul_acc(acc, x_linear_chunk, w_chunk, b_trans=True)
-        mixes_partials = pl.assemble(mixes_partials, acc, [linear_split * t_linear + t0, 0])
+        partial_t0 = linear_split * t_linear + t0
+        mixes_partials[partial_t0 : partial_t0 + LINEAR_T_TILE, 0:MIX_PAD] = acc
 
-    for linear_block in pl.spmd(
-        t_linear // LINEAR_T_TILE,
-        name_hint="hc_pre_linear_reduce",
-        allow_early_resolve=True,
-    ):
-        linear_t0 = linear_block * LINEAR_T_TILE
-        mixes_total = mixes_partials[linear_t0 : linear_t0 + LINEAR_T_TILE, 0:MIX_PAD]
-        for linear_split in pl.range(1, LINEAR_OK):
-            partial_t0 = linear_split * t_linear + linear_t0
-            mixes_total = pl.add(
-                mixes_total,
-                mixes_partials[partial_t0 : partial_t0 + LINEAR_T_TILE, 0:MIX_PAD],
-            )
-        mixes_raw = pl.assemble(mixes_raw, mixes_total, [linear_t0, 0])
-
-    # The pre gate uses an explicit A5 FP32 vector reduction, one token per task.
-    # Each K256 fragment is reduced by TROWSUM and the fragment results accumulate
-    # in ascending K order. Keep this scope independent from the matching post
-    # projection: the proven schedule has one scope for rows 0..3 and one for 4..7.
-    pre_raw_store = pl.create_tensor([t_linear, HC_PAD], dtype=pl.FP32)
-    for task in pl.spmd(t_dim, name_hint="hc_pre_pre_linear_vector", allow_early_resolve=True):
-        trow = task
-        dot_out = pl.tile.full([8, 8], dtype=pl.FP32, value=0.0)
-        for kb in pl.pipeline(HC_DIM // LINEAR_K_CHUNK, stage=1):
-            k0 = kb * LINEAR_K_CHUNK
-            pre_x_chunk = pl.load(
-                x_flat,
-                [trow, k0],
-                [8, LINEAR_K_CHUNK],
-                valid_shape=[1, LINEAR_K_CHUNK],
-                target_memory=pl.MemorySpace.Vec,
-            )
-            pre_w0_chunk = pl.load(
-                hc_fn,
-                [0, k0],
-                [8, LINEAR_K_CHUNK],
-                valid_shape=[1, LINEAR_K_CHUNK],
-                target_memory=pl.MemorySpace.Vec,
-            )
-            pre_w1_chunk = pl.load(
-                hc_fn,
-                [1, k0],
-                [8, LINEAR_K_CHUNK],
-                valid_shape=[1, LINEAR_K_CHUNK],
-                target_memory=pl.MemorySpace.Vec,
-            )
-            pre_w2_chunk = pl.load(
-                hc_fn,
-                [2, k0],
-                [8, LINEAR_K_CHUNK],
-                valid_shape=[1, LINEAR_K_CHUNK],
-                target_memory=pl.MemorySpace.Vec,
-            )
-            pre_w3_chunk = pl.load(
-                hc_fn,
-                [3, k0],
-                [8, LINEAR_K_CHUNK],
-                valid_shape=[1, LINEAR_K_CHUNK],
-                target_memory=pl.MemorySpace.Vec,
-            )
-            pre_row_sum_tmp = pl.tile.create(
-                [8, LINEAR_K_CHUNK],
-                dtype=pl.FP32,
-                target_memory=pl.MemorySpace.Vec,
-            )
-            chunk0 = pl.row_sum(pl.mul(pre_x_chunk, pre_w0_chunk), pre_row_sum_tmp)
-            chunk1 = pl.row_sum(pl.mul(pre_x_chunk, pre_w1_chunk), pre_row_sum_tmp)
-            chunk2 = pl.row_sum(pl.mul(pre_x_chunk, pre_w2_chunk), pre_row_sum_tmp)
-            chunk3 = pl.row_sum(pl.mul(pre_x_chunk, pre_w3_chunk), pre_row_sum_tmp)
-            chunk0_row = pl.set_validshape(pl.reshape(chunk0, [1, 8]), 1, 1)
-            chunk1_row = pl.set_validshape(pl.reshape(chunk1, [1, 8]), 1, 1)
-            chunk2_row = pl.set_validshape(pl.reshape(chunk2, [1, 8]), 1, 1)
-            chunk3_row = pl.set_validshape(pl.reshape(chunk3, [1, 8]), 1, 1)
-            chunk_vec_init = pl.tile.full([8, 8], dtype=pl.FP32, value=0.0)
-            chunk_vec0 = pl.tile.assemble(chunk_vec_init, chunk0_row, [0, 0])
-            chunk_vec1 = pl.tile.assemble(chunk_vec0, chunk1_row, [1, 0])
-            chunk_vec2 = pl.tile.assemble(chunk_vec1, chunk2_row, [2, 0])
-            chunk_vec3 = pl.tile.assemble(chunk_vec2, chunk3_row, [3, 0])
-            dot_out = pl.add(dot_out, chunk_vec3)
-
-        pre_raw_row = pl.transpose(dot_out, axis1=0, axis2=1)
-        pre_raw_valid = pl.set_validshape(pre_raw_row, 1, HC_PAD)
-        pl.store(pre_raw_valid, [trow, 0], pre_raw_store)
-
-    post_raw_store = pl.create_tensor([t_linear, HC_PAD], dtype=pl.FP32)
-    for task in pl.spmd(t_dim, name_hint="hc_pre_post_linear_vector", allow_early_resolve=True):
-        trow = task
-        dot_out = pl.tile.full([8, 8], dtype=pl.FP32, value=0.0)
-        for kb in pl.pipeline(HC_DIM // LINEAR_K_CHUNK, stage=1):
-            k0 = kb * LINEAR_K_CHUNK
-            post_x_chunk = pl.load(
-                x_flat,
-                [trow, k0],
-                [8, LINEAR_K_CHUNK],
-                valid_shape=[1, LINEAR_K_CHUNK],
-                target_memory=pl.MemorySpace.Vec,
-            )
-            post_w0_chunk = pl.load(
-                hc_fn,
-                [HC_MULT + 0, k0],
-                [8, LINEAR_K_CHUNK],
-                valid_shape=[1, LINEAR_K_CHUNK],
-                target_memory=pl.MemorySpace.Vec,
-            )
-            post_w1_chunk = pl.load(
-                hc_fn,
-                [HC_MULT + 1, k0],
-                [8, LINEAR_K_CHUNK],
-                valid_shape=[1, LINEAR_K_CHUNK],
-                target_memory=pl.MemorySpace.Vec,
-            )
-            post_w2_chunk = pl.load(
-                hc_fn,
-                [HC_MULT + 2, k0],
-                [8, LINEAR_K_CHUNK],
-                valid_shape=[1, LINEAR_K_CHUNK],
-                target_memory=pl.MemorySpace.Vec,
-            )
-            post_w3_chunk = pl.load(
-                hc_fn,
-                [HC_MULT + 3, k0],
-                [8, LINEAR_K_CHUNK],
-                valid_shape=[1, LINEAR_K_CHUNK],
-                target_memory=pl.MemorySpace.Vec,
-            )
-            post_row_sum_tmp = pl.tile.create(
-                [8, LINEAR_K_CHUNK],
-                dtype=pl.FP32,
-                target_memory=pl.MemorySpace.Vec,
-            )
-            chunk0 = pl.row_sum(pl.mul(post_x_chunk, post_w0_chunk), post_row_sum_tmp)
-            chunk1 = pl.row_sum(pl.mul(post_x_chunk, post_w1_chunk), post_row_sum_tmp)
-            chunk2 = pl.row_sum(pl.mul(post_x_chunk, post_w2_chunk), post_row_sum_tmp)
-            chunk3 = pl.row_sum(pl.mul(post_x_chunk, post_w3_chunk), post_row_sum_tmp)
-            chunk0_row = pl.set_validshape(pl.reshape(chunk0, [1, 8]), 1, 1)
-            chunk1_row = pl.set_validshape(pl.reshape(chunk1, [1, 8]), 1, 1)
-            chunk2_row = pl.set_validshape(pl.reshape(chunk2, [1, 8]), 1, 1)
-            chunk3_row = pl.set_validshape(pl.reshape(chunk3, [1, 8]), 1, 1)
-            chunk_vec_init = pl.tile.full([8, 8], dtype=pl.FP32, value=0.0)
-            chunk_vec0 = pl.tile.assemble(chunk_vec_init, chunk0_row, [0, 0])
-            chunk_vec1 = pl.tile.assemble(chunk_vec0, chunk1_row, [1, 0])
-            chunk_vec2 = pl.tile.assemble(chunk_vec1, chunk2_row, [2, 0])
-            chunk_vec3 = pl.tile.assemble(chunk_vec2, chunk3_row, [3, 0])
-            dot_out = pl.add(dot_out, chunk_vec3)
-
-        post_raw_row = pl.transpose(dot_out, axis1=0, axis2=1)
-        post_raw_valid = pl.set_validshape(post_raw_row, 1, HC_PAD)
-        pl.store(post_raw_valid, [trow, 0], post_raw_store)
-
-    # split_pre_post: inv_rms-scaled pre gate -> pre_val_store (for mix_x), post gate -> post.
-    # Both compute at HC_PAD width; post narrows to HC_MULT via a valid-shape slice (an 8-wide
-    # 32B tile, 4 cols valid -- a bare 4-wide slice allocs a 16B tile ptoas rejects). comb gate
-    # lives in comb_sinkhorn.
     pre_val_store = pl.create_tensor([t_linear, HC_PAD], dtype=pl.FP32)
     for ob in pl.spmd(t_dim // T_TILE, name_hint="split_pre_post", allow_early_resolve=True):
         t0 = ob * T_TILE
+        inv_col = inv_rms[t0:t0 + T_TILE, 0:1]
+        pre_mixes = mixes_partials[t0:t0 + T_TILE, 0:HC_PAD]
+        post_mixes = mixes_partials[t0:t0 + T_TILE, HC_MULT:HC_MULT + HC_PAD]
+        for linear_split in pl.unroll(1, HC_DIM // LINEAR_K_SPLIT_TILE):
+            p0 = linear_split * t_linear + t0
+            pre_mixes = pl.add(pre_mixes, mixes_partials[p0:p0 + T_TILE, 0:HC_PAD])
+            post_mixes = pl.add(post_mixes, mixes_partials[p0:p0 + T_TILE, HC_MULT:HC_MULT + HC_PAD])
 
-        pre_inv = pl.load(
-            inv_rms,
-            [t0, 0],
-            [T_TILE, 1],
-            target_memory=pl.MemorySpace.Vec,
-        )
-        pre_base = pl.load(
-            hc_base_2d,
-            [0, 0],
-            [1, HC_PAD],
-            target_memory=pl.MemorySpace.Vec,
-        )
-        pre_mixes = pl.load(
-            pre_raw_store,
-            [t0, 0],
-            [T_TILE, HC_PAD],
-            valid_shape=[T_TILE, HC_MULT],
-            target_memory=pl.MemorySpace.Vec,
-        )
-        pre_scaled = pl.mul(pl.row_expand_mul(pre_mixes, pre_inv), scale0)
-        pre_logits = pl.add(pre_scaled, pl.col_expand(pre_scaled, pre_base))
-        pre_sig = pl.recip(pl.add(pl.exp(pl.neg(pre_logits)), 1.0))
+        pre_base = pl.reshape(hc_base[0:HC_PAD], [1, HC_PAD])
+        pre_normed = pl.row_expand_mul(pre_mixes, inv_col)
+        pre_scaled = pl.mul(pre_normed, scale0)
+        pre_base_tile = pl.col_expand(pre_scaled, pre_base)
+        pre_logits = pl.add(pre_scaled, pre_base_tile)
+        pre_neg = pl.neg(pre_logits)
+        pre_exp = pl.exp(pre_neg)
+        pre_denom = pl.add(pre_exp, 1.0)
+        pre_sig = pl.recip(pre_denom)
         pre_val = pl.add(pre_sig, HC_EPS)
-        pre_valid = pl.set_validshape(pre_val, T_TILE, HC_MULT)
-        pl.store(pre_valid, [t0, 0], pre_val_store)
+        pre_val_store[t0 : t0 + T_TILE, 0:HC_PAD] = pre_val
 
-        post_mixes = pl.load(
-            post_raw_store,
-            [t0, 0],
-            [T_TILE, HC_PAD],
-            valid_shape=[T_TILE, HC_MULT],
-            target_memory=pl.MemorySpace.Vec,
-        )
-        post_inv = pl.load(inv_rms, [t0, 0], [T_TILE, 1], target_memory=pl.MemorySpace.Vec)
-        post_base = pl.load(hc_base_2d, [0, HC_MULT], [1, HC_PAD], target_memory=pl.MemorySpace.Vec)
-        post_scaled = pl.mul(pl.row_expand_mul(post_mixes, post_inv), scale1)
-        post_logits = pl.add(post_scaled, pl.col_expand(post_scaled, post_base))
-        post_sig = pl.recip(pl.add(pl.exp(pl.neg(post_logits)), 1.0))
+        post_base = pl.reshape(hc_base[HC_MULT:HC_MULT + HC_PAD], [1, HC_PAD])
+        post_normed = pl.row_expand_mul(post_mixes, inv_col)
+        post_scaled = pl.mul(post_normed, scale1)
+        post_base_tile = pl.col_expand(post_scaled, post_base)
+        post_logits = pl.add(post_scaled, post_base_tile)
+        post_neg = pl.neg(post_logits)
+        post_exp = pl.exp(post_neg)
+        post_denom = pl.add(post_exp, 1.0)
+        post_sig = pl.recip(post_denom)
         post_pad = pl.mul(post_sig, 2.0)
-        post_valid = pl.set_validshape(post_pad, T_TILE, HC_MULT)
-        pl.store(post_valid, [t0, 0], post)
+        # HC_PAD supplies a 32-byte row while HC_MULT marks the valid output width.
+        post[t0:t0 + T_TILE, 0:HC_MULT] = pl.slice(post_pad, [T_TILE, HC_PAD], [0, 0], valid_shape=[T_TILE, HC_MULT])
 
-    # comb_sinkhorn: comb gate (direct from mixes_raw, no comb_logits round-trip) + softmax +
-    # 20-iter Sinkhorn (column-first) -> comb. inv_rms is already a [t_linear,1] column buffer,
-    # so the [T_TILE,1] inv tile loads directly (no transpose / no spill); the 4 comb groups
-    # load pad-capable from mixes_raw at cols 8/12/16/20, then inv_rms * scale2 + group bias.
+    hc_base_2d = pl.reshape(hc_base, [1, MIX_HC])
     for ob in pl.spmd(t_dim // COMB_T_TILE, name_hint="comb_sinkhorn", allow_early_resolve=True):
         t0 = ob * COMB_T_TILE
         inv_col_t = pl.load(inv_rms, [t0, 0], [COMB_T_TILE, 1], target_memory=pl.MemorySpace.Vec)
         comb_off = HC_MULT * 2
-        mix_g0 = pl.load(mixes_raw, [t0, comb_off + 0 * HC_MULT], [COMB_T_TILE, HC_PAD], valid_shape=[COMB_T_TILE, HC_MULT], target_memory=pl.MemorySpace.Vec)
-        mix_g1 = pl.load(mixes_raw, [t0, comb_off + 1 * HC_MULT], [COMB_T_TILE, HC_PAD], valid_shape=[COMB_T_TILE, HC_MULT], target_memory=pl.MemorySpace.Vec)
-        mix_g2 = pl.load(mixes_raw, [t0, comb_off + 2 * HC_MULT], [COMB_T_TILE, HC_PAD], valid_shape=[COMB_T_TILE, HC_MULT], target_memory=pl.MemorySpace.Vec)
-        mix_g3 = pl.load(mixes_raw, [t0, comb_off + 3 * HC_MULT], [COMB_T_TILE, HC_PAD], valid_shape=[COMB_T_TILE, HC_MULT], target_memory=pl.MemorySpace.Vec)
-        cb0 = pl.load(hc_base_2d, [0, comb_off + 0 * HC_MULT], [1, HC_PAD], valid_shape=[1, HC_MULT], target_memory=pl.MemorySpace.Vec)
-        cb1 = pl.load(hc_base_2d, [0, comb_off + 1 * HC_MULT], [1, HC_PAD], valid_shape=[1, HC_MULT], target_memory=pl.MemorySpace.Vec)
-        cb2 = pl.load(hc_base_2d, [0, comb_off + 2 * HC_MULT], [1, HC_PAD], valid_shape=[1, HC_MULT], target_memory=pl.MemorySpace.Vec)
-        cb3 = pl.load(hc_base_2d, [0, comb_off + 3 * HC_MULT], [1, HC_PAD], valid_shape=[1, HC_MULT], target_memory=pl.MemorySpace.Vec)
-        row0 = pl.add(pl.mul(pl.row_expand_mul(mix_g0, inv_col_t), scale2), pl.col_expand(mix_g0, cb0))
-        row1 = pl.add(pl.mul(pl.row_expand_mul(mix_g1, inv_col_t), scale2), pl.col_expand(mix_g1, cb1))
-        row2 = pl.add(pl.mul(pl.row_expand_mul(mix_g2, inv_col_t), scale2), pl.col_expand(mix_g2, cb2))
-        row3 = pl.add(pl.mul(pl.row_expand_mul(mix_g3, inv_col_t), scale2), pl.col_expand(mix_g3, cb3))
+        mix_g0 = pl.load(
+            mixes_partials, [t0, comb_off + 0 * HC_MULT], [COMB_T_TILE, HC_PAD],
+            valid_shape=[COMB_T_TILE, HC_MULT], target_memory=pl.MemorySpace.Vec,
+        )
+        mix_g1 = pl.load(
+            mixes_partials, [t0, comb_off + 1 * HC_MULT], [COMB_T_TILE, HC_PAD],
+            valid_shape=[COMB_T_TILE, HC_MULT], target_memory=pl.MemorySpace.Vec,
+        )
+        mix_g2 = pl.load(
+            mixes_partials, [t0, comb_off + 2 * HC_MULT], [COMB_T_TILE, HC_PAD],
+            valid_shape=[COMB_T_TILE, HC_MULT], target_memory=pl.MemorySpace.Vec,
+        )
+        mix_g3 = pl.load(
+            mixes_partials, [t0, comb_off + 3 * HC_MULT], [COMB_T_TILE, HC_PAD],
+            valid_shape=[COMB_T_TILE, HC_MULT], target_memory=pl.MemorySpace.Vec,
+        )
+        for linear_split in pl.unroll(1, HC_DIM // LINEAR_K_SPLIT_TILE):
+            p0 = linear_split * t_linear + t0
+            partial_g0 = pl.load(
+                mixes_partials, [p0, comb_off + 0 * HC_MULT], [COMB_T_TILE, HC_PAD],
+                valid_shape=[COMB_T_TILE, HC_MULT], target_memory=pl.MemorySpace.Vec,
+            )
+            mix_g0 = pl.add(mix_g0, partial_g0)
+            partial_g1 = pl.load(
+                mixes_partials, [p0, comb_off + 1 * HC_MULT], [COMB_T_TILE, HC_PAD],
+                valid_shape=[COMB_T_TILE, HC_MULT], target_memory=pl.MemorySpace.Vec,
+            )
+            mix_g1 = pl.add(mix_g1, partial_g1)
+            partial_g2 = pl.load(
+                mixes_partials, [p0, comb_off + 2 * HC_MULT], [COMB_T_TILE, HC_PAD],
+                valid_shape=[COMB_T_TILE, HC_MULT], target_memory=pl.MemorySpace.Vec,
+            )
+            mix_g2 = pl.add(mix_g2, partial_g2)
+            partial_g3 = pl.load(
+                mixes_partials, [p0, comb_off + 3 * HC_MULT], [COMB_T_TILE, HC_PAD],
+                valid_shape=[COMB_T_TILE, HC_MULT], target_memory=pl.MemorySpace.Vec,
+            )
+            mix_g3 = pl.add(mix_g3, partial_g3)
+        cb0 = pl.load(
+            hc_base_2d, [0, comb_off + 0 * HC_MULT], [1, HC_PAD],
+            valid_shape=[1, HC_MULT], target_memory=pl.MemorySpace.Vec,
+        )
+        cb1 = pl.load(
+            hc_base_2d, [0, comb_off + 1 * HC_MULT], [1, HC_PAD],
+            valid_shape=[1, HC_MULT], target_memory=pl.MemorySpace.Vec,
+        )
+        cb2 = pl.load(
+            hc_base_2d, [0, comb_off + 2 * HC_MULT], [1, HC_PAD],
+            valid_shape=[1, HC_MULT], target_memory=pl.MemorySpace.Vec,
+        )
+        cb3 = pl.load(
+            hc_base_2d, [0, comb_off + 3 * HC_MULT], [1, HC_PAD],
+            valid_shape=[1, HC_MULT], target_memory=pl.MemorySpace.Vec,
+        )
+        row0_normed = pl.row_expand_mul(mix_g0, inv_col_t)
+        row0_scaled = pl.mul(row0_normed, scale2)
+        row0_base = pl.col_expand(mix_g0, cb0)
+        row0 = pl.add(row0_scaled, row0_base)
+        row1_normed = pl.row_expand_mul(mix_g1, inv_col_t)
+        row1_scaled = pl.mul(row1_normed, scale2)
+        row1_base = pl.col_expand(mix_g1, cb1)
+        row1 = pl.add(row1_scaled, row1_base)
+        row2_normed = pl.row_expand_mul(mix_g2, inv_col_t)
+        row2_scaled = pl.mul(row2_normed, scale2)
+        row2_base = pl.col_expand(mix_g2, cb2)
+        row2 = pl.add(row2_scaled, row2_base)
+        row3_normed = pl.row_expand_mul(mix_g3, inv_col_t)
+        row3_scaled = pl.mul(row3_normed, scale2)
+        row3_base = pl.col_expand(mix_g3, cb3)
+        row3 = pl.add(row3_scaled, row3_base)
         row0_p = pl.fillpad(row0, pad_value=pl.PadValue.min)
         row1_p = pl.fillpad(row1, pad_value=pl.PadValue.min)
         row2_p = pl.fillpad(row2, pad_value=pl.PadValue.min)
@@ -734,18 +542,26 @@ def _hc_pre_separate(
         row1_max = pl.row_max(row1_p, row_max_tmp)
         row2_max = pl.row_max(row2_p, row_max_tmp)
         row3_max = pl.row_max(row3_p, row_max_tmp)
-        row0_exp = pl.exp(pl.row_expand_sub(row0_p, row0_max))
-        row1_exp = pl.exp(pl.row_expand_sub(row1_p, row1_max))
-        row2_exp = pl.exp(pl.row_expand_sub(row2_p, row2_max))
-        row3_exp = pl.exp(pl.row_expand_sub(row3_p, row3_max))
+        row0_centered = pl.row_expand_sub(row0_p, row0_max)
+        row0_exp = pl.exp(row0_centered)
+        row1_centered = pl.row_expand_sub(row1_p, row1_max)
+        row1_exp = pl.exp(row1_centered)
+        row2_centered = pl.row_expand_sub(row2_p, row2_max)
+        row2_exp = pl.exp(row2_centered)
+        row3_centered = pl.row_expand_sub(row3_p, row3_max)
+        row3_exp = pl.exp(row3_centered)
         row0_sum = pl.row_sum(row0_exp, row_sum_tmp)
         row1_sum = pl.row_sum(row1_exp, row_sum_tmp)
         row2_sum = pl.row_sum(row2_exp, row_sum_tmp)
         row3_sum = pl.row_sum(row3_exp, row_sum_tmp)
-        row0_soft = pl.add(pl.row_expand_div(row0_exp, row0_sum), HC_EPS)
-        row1_soft = pl.add(pl.row_expand_div(row1_exp, row1_sum), HC_EPS)
-        row2_soft = pl.add(pl.row_expand_div(row2_exp, row2_sum), HC_EPS)
-        row3_soft = pl.add(pl.row_expand_div(row3_exp, row3_sum), HC_EPS)
+        row0_prob = pl.row_expand_div(row0_exp, row0_sum)
+        row0_soft = pl.add(row0_prob, HC_EPS)
+        row1_prob = pl.row_expand_div(row1_exp, row1_sum)
+        row1_soft = pl.add(row1_prob, HC_EPS)
+        row2_prob = pl.row_expand_div(row2_exp, row2_sum)
+        row2_soft = pl.add(row2_prob, HC_EPS)
+        row3_prob = pl.row_expand_div(row3_exp, row3_sum)
+        row3_soft = pl.add(row3_prob, HC_EPS)
 
         row0_valid = pl.set_validshape(row0_soft, COMB_T_TILE, HC_MULT)
         row1_valid = pl.set_validshape(row1_soft, COMB_T_TILE, HC_MULT)
@@ -757,28 +573,36 @@ def _hc_pre_separate(
         row3_eff = pl.fillpad(row3_valid, pad_value=pl.PadValue.zero)
 
         row_sum_tmp_iter = pl.create_tile([COMB_T_TILE, HC_PAD], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec)
-        col_sum = pl.add(pl.add(row0_eff, row1_eff), pl.add(row2_eff, row3_eff))
-        col_sum = pl.add(col_sum, HC_EPS)
-        row0_cur = pl.div(row0_eff, col_sum)
-        row1_cur = pl.div(row1_eff, col_sum)
-        row2_cur = pl.div(row2_eff, col_sum)
-        row3_cur = pl.div(row3_eff, col_sum)
+        row01_eff = pl.add(row0_eff, row1_eff)
+        row23_eff = pl.add(row2_eff, row3_eff)
+        col_sum_raw = pl.add(row01_eff, row23_eff)
+        col_sum_eps = pl.add(col_sum_raw, HC_EPS)
+        row0_cur = pl.div(row0_eff, col_sum_eps)
+        row1_cur = pl.div(row1_eff, col_sum_eps)
+        row2_cur = pl.div(row2_eff, col_sum_eps)
+        row3_cur = pl.div(row3_eff, col_sum_eps)
 
         for _sk_it in pl.pipeline(HC_SINKHORN_ITER - 1, stage=2):
-            row0_rowsum = pl.add(pl.row_sum(row0_cur, row_sum_tmp_iter), HC_EPS)
-            row1_rowsum = pl.add(pl.row_sum(row1_cur, row_sum_tmp_iter), HC_EPS)
-            row2_rowsum = pl.add(pl.row_sum(row2_cur, row_sum_tmp_iter), HC_EPS)
-            row3_rowsum = pl.add(pl.row_sum(row3_cur, row_sum_tmp_iter), HC_EPS)
+            row0_sum_raw = pl.row_sum(row0_cur, row_sum_tmp_iter)
+            row0_rowsum = pl.add(row0_sum_raw, HC_EPS)
+            row1_sum_raw = pl.row_sum(row1_cur, row_sum_tmp_iter)
+            row1_rowsum = pl.add(row1_sum_raw, HC_EPS)
+            row2_sum_raw = pl.row_sum(row2_cur, row_sum_tmp_iter)
+            row2_rowsum = pl.add(row2_sum_raw, HC_EPS)
+            row3_sum_raw = pl.row_sum(row3_cur, row_sum_tmp_iter)
+            row3_rowsum = pl.add(row3_sum_raw, HC_EPS)
             row0_norm = pl.row_expand_div(row0_cur, row0_rowsum)
             row1_norm = pl.row_expand_div(row1_cur, row1_rowsum)
             row2_norm = pl.row_expand_div(row2_cur, row2_rowsum)
             row3_norm = pl.row_expand_div(row3_cur, row3_rowsum)
-            col_sum = pl.add(pl.add(row0_norm, row1_norm), pl.add(row2_norm, row3_norm))
-            col_sum = pl.add(col_sum, HC_EPS)
-            row0_cur = pl.div(row0_norm, col_sum)
-            row1_cur = pl.div(row1_norm, col_sum)
-            row2_cur = pl.div(row2_norm, col_sum)
-            row3_cur = pl.div(row3_norm, col_sum)
+            row01_norm = pl.add(row0_norm, row1_norm)
+            row23_norm = pl.add(row2_norm, row3_norm)
+            col_sum_iter_raw = pl.add(row01_norm, row23_norm)
+            col_sum_iter_eps = pl.add(col_sum_iter_raw, HC_EPS)
+            row0_cur = pl.div(row0_norm, col_sum_iter_eps)
+            row1_cur = pl.div(row1_norm, col_sum_iter_eps)
+            row2_cur = pl.div(row2_norm, col_sum_iter_eps)
+            row3_cur = pl.div(row3_norm, col_sum_iter_eps)
 
         row0_out = pl.set_validshape(row0_cur, COMB_T_TILE, HC_MULT)
         row1_out = pl.set_validshape(row1_cur, COMB_T_TILE, HC_MULT)
@@ -789,42 +613,33 @@ def _hc_pre_separate(
         pl.store(row2_out, [t0, 2 * HC_MULT], comb)
         pl.store(row3_out, [t0, 3 * HC_MULT], comb)
 
-    # mix_x: x_mixed = sum_h pre[:,h]*x[:,h,:], fanned over D (D/D_SPMD tasks per tile).
-    for blk in pl.spmd((t_dim // T_TILE) * (D // D_SPMD), name_hint="mix_x", allow_early_resolve=True):
-        t0 = (blk // (D // D_SPMD)) * T_TILE
-        d_base = (blk % (D // D_SPMD)) * D_SPMD
+    for blk in pl.spmd((t_dim // T_TILE) * (D // MIX_D_TILE), name_hint="mix_x", allow_early_resolve=True):
+        t0 = (blk // (D // MIX_D_TILE)) * T_TILE
+        d_base = (blk % (D // MIX_D_TILE)) * MIX_D_TILE
         pre_tile_t = pl.transpose(pre_val_store[t0:t0 + T_TILE, 0:HC_PAD], axis1=0, axis2=1)
         pre0 = pl.reshape(pre_tile_t[0:1, 0:T_TILE], [T_TILE, 1])
         pre1 = pl.reshape(pre_tile_t[1:2, 0:T_TILE], [T_TILE, 1])
         pre2 = pl.reshape(pre_tile_t[2:3, 0:T_TILE], [T_TILE, 1])
         pre3 = pl.reshape(pre_tile_t[3:4, 0:T_TILE], [T_TILE, 1])
-        for db in pl.pipeline(D_SPMD // D_CHUNK, stage=2):
-            d0 = d_base + db * D_CHUNK
-            x0 = x_flat[t0:t0 + T_TILE, 0 * D + d0:0 * D + d0 + D_CHUNK]
-            x1 = x_flat[t0:t0 + T_TILE, 1 * D + d0:1 * D + d0 + D_CHUNK]
-            x2 = x_flat[t0:t0 + T_TILE, 2 * D + d0:2 * D + d0 + D_CHUNK]
-            x3 = x_flat[t0:t0 + T_TILE, 3 * D + d0:3 * D + d0 + D_CHUNK]
+        for d0 in pl.pipeline(d_base, d_base + MIX_D_TILE, D_TILE, stage=2):
+            x0 = x_flat[t0:t0 + T_TILE, 0 * D + d0:0 * D + d0 + D_TILE]
+            x1 = x_flat[t0:t0 + T_TILE, 1 * D + d0:1 * D + d0 + D_TILE]
+            x2 = x_flat[t0:t0 + T_TILE, 2 * D + d0:2 * D + d0 + D_TILE]
+            x3 = x_flat[t0:t0 + T_TILE, 3 * D + d0:3 * D + d0 + D_TILE]
             y0 = pl.row_expand_mul(x0, pre0)
             y1 = pl.row_expand_mul(x1, pre1)
             y2 = pl.row_expand_mul(x2, pre2)
             y3 = pl.row_expand_mul(x3, pre3)
-            y_tile = pl.add(pl.add(y0, y1), pl.add(y2, y3))
-            x_mixed[t0:t0 + T_TILE, d0:d0 + D_CHUNK] = pl.cast(y_tile, target_type=pl.BF16, mode="rint")
+            y01 = pl.add(y0, y1)
+            y23 = pl.add(y2, y3)
+            y_tile = pl.add(y01, y23)
+            y_bf16 = pl.cast(y_tile, target_type=pl.BF16, mode="rint")
+            x_mixed[t0:t0 + T_TILE, d0:d0 + D_TILE] = y_bf16
     return x_mixed
 
 
 def _bind_hc_pre():
-    """Define and return the public `hc_pre` inline kernel for the selected HC_PRE_IMPL.
-
-    pypto constrains how the choice can be expressed:
-      * a kernel-body branch on the module-global string (``if HC_PRE_IMPL == ...``) fails
-        -- pypto's frontend treats it as device control flow and cannot resolve the name;
-      * an alias (``hc_pre = _hc_pre_syncall``) fails at the call site -- pypto matches the
-        call-site NAME against the callee's registered ``__name__`` ("hc_pre" != the impl).
-    So `hc_pre` must BE a decorated inline named ``hc_pre`` that calls the chosen impl by
-    its literal name; the selection is a plain-Python ``if`` at import (never seen by a
-    kernel). Re-invoke to rebind after changing HC_PRE_IMPL (the __main__ --impl path).
-    """
+    """Bind the public inline kernel for HC_PRE_IMPL."""
     if HC_PRE_IMPL == "separate":
         @pl.jit.inline
         def hc_pre(
@@ -854,8 +669,6 @@ def _bind_hc_pre():
     return hc_pre
 
 
-# Public entry point. Callers do `from hc_pre import hc_pre`; env DSV4_HC_PRE_IMPL (or the
-# __main__ --impl flag, which rebinds) picks the implementation at import time.
 hc_pre = _bind_hc_pre()
 
 
@@ -888,14 +701,10 @@ def _golden_a5_trowsum_fp32(values):
     if values.dtype != torch.float32:
         raise ValueError(f"A5 FP32 TROWSUM golden requires float32, got {values.dtype}")
     if values.shape[-1] % _A5_FP32_VECTOR_LANES != 0:
-        raise ValueError(
-            f"A5 FP32 TROWSUM width must be divisible by {_A5_FP32_VECTOR_LANES}, "
-            f"got {values.shape[-1]}"
-        )
+        message = f"A5 FP32 TROWSUM width must be divisible by {_A5_FP32_VECTOR_LANES}, got {values.shape[-1]}"
+        raise ValueError(message)
 
-    # A5 processes 64 FP32 lanes per vector repeat. vcadd recursively adds
-    # adjacent pairs inside each repeat; TRowReduce then accumulates the repeat
-    # scalars from zero in ascending address order.
+    # Reduce 64-lane groups pairwise, then accumulate the group sums in address order.
     groups = values.reshape(*values.shape[:-1], -1, _A5_FP32_VECTOR_LANES)
     while groups.shape[-1] > 1:
         pairs = groups.reshape(*groups.shape[:-1], -1, 2)
@@ -909,14 +718,14 @@ def _golden_a5_trowsum_fp32(values):
 
 
 def _golden_a5_high_precision_rsqrt(value):
-    """Match A5 high-precision FP32 rsqrt without host FP32 double rounding."""
+    """Compute the A5 high-precision FP32 reciprocal square root."""
     import torch
 
     return torch.rsqrt(value.to(torch.float64)).to(torch.float32)
 
 
 def _golden_a5_rms_inv(x_flat_2d):
-    """Host mirror of hc_pre_rms: K256 chunks, A5 TROWSUM, then HP rsqrt."""
+    """Compute the hc_pre inverse RMS with A5 reduction order."""
     import torch
 
     if x_flat_2d.dtype != torch.float32:
@@ -924,74 +733,17 @@ def _golden_a5_rms_inv(x_flat_2d):
     if x_flat_2d.shape[-1] != HC_DIM:
         raise ValueError(f"hc_pre RMS width must be HC_DIM={HC_DIM}, got {x_flat_2d.shape[-1]}")
 
-    sq_sum = torch.zeros(
-        x_flat_2d.shape[0], 1, dtype=torch.float32, device=x_flat_2d.device
-    )
-    for k0 in range(0, HC_DIM, RMS_K_CHUNK):
-        x_chunk = x_flat_2d[:, k0:k0 + RMS_K_CHUNK]
+    sq_sum = torch.zeros(x_flat_2d.shape[0], 1, dtype=torch.float32, device=x_flat_2d.device)
+    for k0 in range(0, HC_DIM, RMS_K_TILE):
+        x_chunk = x_flat_2d[:, k0:k0 + RMS_K_TILE]
         sq_sum += _golden_a5_trowsum_fp32(x_chunk * x_chunk)
 
     rms_arg = sq_sum * HC_DIM_INV + NORM_EPS
     return _golden_a5_high_precision_rsqrt(rms_arg)
 
 
-def _golden_a5_gate_raw(x_flat_2d, hc_fn, row_start):
-    """Mirror one four-row A5 gate projection's K256 FP32 reduction order."""
-    import torch
-
-    if x_flat_2d.dtype != torch.float32 or hc_fn.dtype != torch.float32:
-        raise ValueError(
-            f"A5 gate golden requires float32 inputs, got {x_flat_2d.dtype} and {hc_fn.dtype}"
-        )
-    if x_flat_2d.shape[-1] != HC_DIM or hc_fn.shape[-1] != HC_DIM:
-        raise ValueError(
-            f"A5 gate golden widths must be HC_DIM={HC_DIM}, "
-            f"got {x_flat_2d.shape[-1]} and {hc_fn.shape[-1]}"
-        )
-    if row_start < 0 or row_start + HC_MULT > hc_fn.shape[0]:
-        raise ValueError(
-            f"A5 gate rows [{row_start}, {row_start + HC_MULT}) exceed "
-            f"hc_fn rows={hc_fn.shape[0]}"
-        )
-
-    gate_raw = torch.zeros(
-        x_flat_2d.shape[0], HC_MULT, dtype=torch.float32, device=x_flat_2d.device
-    )
-    gate_fn = hc_fn[row_start:row_start + HC_MULT]
-    for k0 in range(0, HC_DIM, LINEAR_K_CHUNK):
-        x_chunk = x_flat_2d[:, k0:k0 + LINEAR_K_CHUNK]
-        w_chunk = gate_fn[:, k0:k0 + LINEAR_K_CHUNK]
-        products = x_chunk[:, None, :] * w_chunk[None, :, :]
-        gate_raw += _golden_a5_trowsum_fp32(products)[..., 0]
-    return gate_raw
-
-
-def _golden_a5_pre_raw(x_flat_2d, hc_fn):
-    """Mirror the separate pre projection over hc_fn rows 0..3."""
-    return _golden_a5_gate_raw(x_flat_2d, hc_fn, row_start=0)
-
-
-def _golden_a5_post_raw(x_flat_2d, hc_fn):
-    """Mirror the separate post projection over hc_fn rows 4..7."""
-    return _golden_a5_gate_raw(x_flat_2d, hc_fn, row_start=HC_MULT)
-
-
-def _golden_hc_pre_pre_raw(x_flat_2d, hc_fn, cube_mixes_raw):
-    """Select the pre projection reduction used by the active implementation."""
-    if HC_PRE_IMPL == "separate":
-        return _golden_a5_pre_raw(x_flat_2d, hc_fn)
-    return cube_mixes_raw[..., :HC_MULT].clone()
-
-
-def _golden_hc_pre_post_raw(x_flat_2d, hc_fn, cube_mixes_raw):
-    """Select the post projection reduction used by the active HC-pre implementation."""
-    if HC_PRE_IMPL == "separate":
-        return _golden_a5_post_raw(x_flat_2d, hc_fn)
-    return cube_mixes_raw[..., HC_MULT:HC_MULT * 2].clone()
-
-
 def golden_hc_pre(tensors):
-    """Torch reference, direct port of model.py Block.hc_pre + hc_split_sinkhorn."""
+    """Compute the Hyper-Connections pre-mix reference."""
     import torch
 
     x = tensors["x"].float()  # [T, hc, D]
@@ -1004,26 +756,28 @@ def golden_hc_pre(tensors):
 
     rsqrt = _golden_a5_rms_inv(x_flat_2d)
 
-    # Per-K-chunk partial dots in one reduction, then accumulated in chunk order
-    # to match the cube K-fragment accumulation. Summing over n_chunk with a
-    # single torch.sum instead reorders the adds and is not bit-exact.
-    n_chunk = HC_DIM // LINEAR_K_CHUNK
-    x_k = x_flat_2d.reshape(t_dim, 1, n_chunk, LINEAR_K_CHUNK)
-    w_k = hc_fn.reshape(1, MIX_HC, n_chunk, LINEAR_K_CHUNK)
-    per_chunk = (x_k * w_k).sum(dim=3)                       # [T, mix_hc, n_chunk]
-    mixes = torch.zeros(t_dim, MIX_HC, dtype=torch.float32)  # [T, mix_hc]
-    for c in range(n_chunk):
-        mixes += per_chunk[:, :, c]
-    pre_raw = _golden_hc_pre_pre_raw(x_flat_2d, hc_fn, mixes)
-    post_raw = _golden_hc_pre_post_raw(x_flat_2d, hc_fn, mixes)
+    # Mirror the split-K cube accumulation and consumer reduction order.
+    split_count = HC_DIM // LINEAR_K_SPLIT_TILE
+    chunks_per_split = LINEAR_K_SPLIT_TILE // LINEAR_K_TILE
+    x_k = x_flat_2d.reshape(t_dim, 1, split_count, chunks_per_split, LINEAR_K_TILE)
+    w_k = hc_fn.reshape(1, MIX_HC, split_count, chunks_per_split, LINEAR_K_TILE)
+    per_chunk = (x_k * w_k).sum(dim=4)
+    split_partials = []
+    for split in range(split_count):
+        partial = per_chunk[:, :, split, 0]
+        for chunk in range(1, chunks_per_split):
+            partial = partial + per_chunk[:, :, split, chunk]
+        split_partials.append(partial)
+    mixes = split_partials[0]
+    for split in range(1, split_count):
+        mixes = mixes + split_partials[split]
     mixes *= rsqrt
 
-    pre_mixes = pre_raw * rsqrt
-    pre = torch.sigmoid(pre_mixes * hc_scale[0] + hc_base[:HC_MULT]) + HC_EPS
-    post_mixes = post_raw * rsqrt
-    post_t = 2 * torch.sigmoid(post_mixes * hc_scale[1] + hc_base[HC_MULT:HC_MULT * 2])
-    comb_t = (mixes[..., HC_MULT * 2:] * hc_scale[2] + hc_base[HC_MULT * 2:]
-              ).view(t_dim, HC_MULT, HC_MULT)
+    pre = torch.sigmoid(mixes[..., :HC_MULT] * hc_scale[0] + hc_base[:HC_MULT]) + HC_EPS
+    post_logits = mixes[..., HC_MULT:HC_MULT * 2] * hc_scale[1] + hc_base[HC_MULT:HC_MULT * 2]
+    post_t = 2 * torch.sigmoid(post_logits)
+    comb_logits = mixes[..., HC_MULT * 2:] * hc_scale[2] + hc_base[HC_MULT * 2:]
+    comb_t = comb_logits.view(t_dim, HC_MULT, HC_MULT)
 
     comb_t = torch.softmax(comb_t, dim=-1) + HC_EPS
     comb_t = comb_t / (comb_t.sum(-2, keepdim=True) + HC_EPS)
@@ -1037,7 +791,6 @@ def golden_hc_pre(tensors):
     y3 = x[:, 3, :] * pre[:, 3:4]
     y = (y0 + y1) + (y2 + y3)
 
-    # Match the kernel's mode="rint" cast (round to nearest, ties to even).
     tensors["x_mixed"][:] = y.to(torch.bfloat16).reshape(t_dim, D)
     tensors["post"][:] = post_t.reshape(t_dim, HC_MULT)
     tensors["comb"][:] = comb_t.reshape(t_dim, HC_MULT * HC_MULT)
@@ -1051,19 +804,24 @@ def build_tensor_specs(B, S):
 
     def init_x():
         return torch.randn(T, HC_MULT, D) * 0.05
+
     def init_hc_fn():
         return torch.randn(MIX_HC, HC_DIM) * 0.0519
+
     def init_hc_scale():
         return torch.tensor([0.076099, 0.032597, 0.226994])
+
     def init_hc_base():
-        return torch.tensor([
-            5.9166, -3.6223, -2.9324, -3.3124,
-            -3.9100, -0.9384, -3.3256, -2.5240,
-            2.0706, -2.5728, 0.1424, -3.9453,
-            -3.8859, 3.4634, -3.3799, -2.6077,
-            -2.7191, -2.4846, 2.0395, -0.5010,
-            -3.5992, -2.7520, -3.3493, 3.1587,
-        ])
+        return torch.tensor(
+            [
+                5.9166, -3.6223, -2.9324, -3.3124,
+                -3.9100, -0.9384, -3.3256, -2.5240,
+                2.0706, -2.5728, 0.1424, -3.9453,
+                -3.8859, 3.4634, -3.3799, -2.6077,
+                -2.7191, -2.4846, 2.0395, -0.5010,
+                -3.5992, -2.7520, -3.3493, 3.1587,
+            ]
+        )
 
     return [
         TensorSpec("x", [T, HC_MULT, D], torch.float32, init_value=init_x),
@@ -1081,45 +839,31 @@ if __name__ == "__main__":
     from golden import ratio_allclose, run_jit
 
     MODES = {
-        "decode":  (DECODE_BATCH, DECODE_SEQ),
+        "decode": (DECODE_BATCH, DECODE_SEQ),
         "prefill": (PREFILL_BATCH, PREFILL_SEQ),
     }
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("-p", "--platform", type=str, default="a2a3",
-                        choices=["a2a3", "a2a3sim", "a5", "a5sim"])
+    parser.add_argument("-p", "--platform", type=str, default="a2a3", choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--mode", choices=["decode", "prefill", "all"], default="all",
-                        help="Use decode or prefill batch sizes, or 'all' to test both.")
+    mode_help = "Use decode or prefill batch sizes, or 'all' to test both."
+    parser.add_argument("--mode", choices=["decode", "prefill", "all"], default="all", help=mode_help)
     parser.add_argument("--enable-chip-swimlane", action="store_true", default=False)
     parser.add_argument("--runtime-dir", type=str, default=None)
     parser.add_argument("--golden-data", type=str, default=None)
     parser.add_argument("--compile-only", action="store_true", default=False)
     parser.add_argument("--dump-passes", action="store_true", default=False)
-    parser.add_argument("--no-dep-gen", action="store_true", default=False,
-                        help="deprecated no-op: dep_gen is auto-selected per --impl (OFF for "
-                             "'syncall' per pypto#1931, ON for 'separate'); kept for CLI / CI back-compat.")
-    parser.add_argument("--impl", choices=["syncall", "separate"], default=HC_PRE_IMPL,
-                        help="hc_pre implementation: 'syncall' (fused single task, #684) or "
-                             "'separate' (multi-scope task graph, pre-#684). Both are unified "
-                             "over decode+prefill. Default from env DSV4_HC_PRE_IMPL.")
+    no_dep_gen_help = "Deprecated no-op retained for CLI compatibility; dep_gen follows --impl."
+    impl_help = "Select the syncall-fused or separate-task implementation."
+    parser.add_argument("--no-dep-gen", action="store_true", default=False, help=no_dep_gen_help)
+    parser.add_argument("--impl", choices=["syncall", "separate"], default=HC_PRE_IMPL, help=impl_help)
     args = parser.parse_args()
 
-    # Select the implementation for this run: set the flag, then rebind the module-global
-    # `hc_pre` to the chosen inline kernel BEFORE run_jit traces hc_pre_test (which resolves
-    # `hc_pre` from the module namespace at trace time).
     HC_PRE_IMPL = args.impl
     hc_pre = _bind_hc_pre()
     print(f"hc_pre implementation: {HC_PRE_IMPL}")
 
-    # hc_pre "syncall" is specialized to Ascend 910B: it sets NUM_CORES=24 == the physical
-    # AIC count and its hard full-occupancy mix-syncall hangs (AICore timeout 507018) unless
-    # the launch fills every physical core; A5 (Ascend950) has a different AIC count (36), so
-    # the syncall impl is rejected on A5. The "separate" impl has no such barrier -- it uses
-    # data-derived pl.spmd(work_count) scopes ordered by their GM dependencies, so it is
-    # core-count-agnostic and runs on A5. Its tile sizes are 910B-tuned (perf, not correctness);
-    # a5 perf may be suboptimal
-    # until re-swept, but precision is unaffected.
+    # Full-chip syncall is limited to Ascend 910B.
     if args.platform in ("a5", "a5sim") and HC_PRE_IMPL == "syncall":
         raise SystemExit(
             f"hc_pre 'syncall' impl is specialized to Ascend 910B (NUM_CORES={NUM_CORES} == physical "
@@ -1143,19 +887,15 @@ if __name__ == "__main__":
                 platform=args.platform,
                 device_id=args.device,
                 enable_chip_swimlane=args.enable_chip_swimlane,
-                # dep_gen: the "syncall" version's full-occupancy pl.system.syncall is
-                # incompatible with dep_gen -- the DFX instrumentation perturbs core
-                # occupancy and trips AICore timeout 507018 (pypto#1931) -- so it runs with
-                # dep_gen OFF. The "separate" version has no hard syncall, so the harness
-                # enables dep-gen to capture its scheduler-derived dependency graph.
+                # Full-chip syncall runs with dependency generation disabled.
                 enable_dep_gen=(HC_PRE_IMPL == "separate"),
             ),
             rtol=1e-3,
             atol=1e-3,
             compare_fn={
                 "x_mixed": ratio_allclose(atol=1e-4, rtol=1.0 / 128),
-                "post":    ratio_allclose(atol=2.5e-5, rtol=5e-3),
-                "comb":    ratio_allclose(atol=2.5e-5, rtol=5e-3),
+                "post": ratio_allclose(atol=2.5e-5, rtol=5e-3),
+                "comb": ratio_allclose(atol=2.5e-5, rtol=5e-3),
             },
             compile_only=args.compile_only,
         )

--- a/models/deepseek_v4_pro/mtp_projection.py
+++ b/models/deepseek_v4_pro/mtp_projection.py
@@ -6,15 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-# ruff: noqa: F401,F403,F405,F821
-"""DeepSeek-V4 MTP input projection scaffold.
-
-Mirrors the MTP-only prolog in the official implementation:
-``e_proj(enorm(hidden_states)) + h_proj(hnorm(prev_hidden_states))``.
-
-``prev_hidden_states`` and ``hidden_states_out`` use token-major pre-``hc_head``
-hidden states with HC lanes: ``[T, HC_MULT, D]``.
-"""
+"""DeepSeek-V4 MTP input projection: e_proj(enorm(hidden_states)) + h_proj(hnorm(prev_hidden_states))."""
 
 import pypto.language as pl
 
@@ -28,21 +20,24 @@ from config import (
     PREFILL_SEQ,
 )
 
+# Dynamic shape variables.
+T_DYN = pl.dynamic("T_DYN")  # T = B * S
 
-T_DYN = pl.dynamic("T_DYN")
+# model config
 D = M.hidden_size
 HC_MULT = M.hc_mult
 HC_DIM = HC_MULT * D
 EPS = M.rms_norm_eps
 D_INV = 1.0 / D
 
+# tiling
 T_TILE = 8
 LINEAR_T_TILE = 16
-D_CHUNK = 128
-OUT_CHUNK = 128
-D_BLOCKS = D // D_CHUNK
-OUT_BLOCKS = D // OUT_CHUNK
-QUANT_CHUNK = 128
+LINEAR_HC_TILE = LINEAR_T_TILE * HC_MULT
+LINEAR_K_TILE = 512
+OUT_TILE = 256
+NORM_K_TILE = 1024
+QUANT_TILE = 1024
 assert (DECODE_BATCH * DECODE_SEQ) % T_TILE == 0
 assert (PREFILL_BATCH * PREFILL_SEQ) % T_TILE == 0
 
@@ -62,157 +57,138 @@ def mtp_projection(
     hidden_states_out: pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32],
 ):
     t_dim = pl.tensor.dim(hidden_states, 0)
-    t_linear = ((t_dim + LINEAR_T_TILE - 1) // LINEAR_T_TILE) * LINEAR_T_TILE
     hidden_flat = pl.reshape(hidden_states, [t_dim, D])
-    prev_flat = pl.reshape(prev_hidden_states, [t_dim, HC_DIM])
-    out_flat = pl.reshape(hidden_states_out, [t_dim, HC_DIM])
-    hidden_norm = pl.create_tensor([t_linear, D], dtype=pl.FP32)
-    prev_norm = pl.create_tensor([t_linear, HC_DIM], dtype=pl.FP32)
+    t_linear = ((t_dim + LINEAR_T_TILE - 1) // LINEAR_T_TILE) * LINEAR_T_TILE
     hidden_i8 = pl.create_tensor([t_linear, D], dtype=pl.INT8)
-    prev_i8 = pl.create_tensor([t_linear, HC_DIM], dtype=pl.INT8)
-    hidden_inv_rms = pl.create_tensor([t_linear, 1], dtype=pl.FP32)
-    prev_inv_rms = pl.create_tensor([HC_MULT, t_linear], dtype=pl.FP32)
-    hidden_amax_parts = pl.create_tensor([D_BLOCKS, t_linear], dtype=pl.FP32)
-    prev_amax_parts = pl.create_tensor([HC_MULT * D_BLOCKS, t_linear], dtype=pl.FP32)
     hidden_scale_dq = pl.create_tensor([t_linear, 1], dtype=pl.FP32)
+    for hidden_block in pl.spmd(t_dim // T_TILE, name_hint="mtp_projection_hidden", allow_early_resolve=True):
+        t0 = hidden_block * T_TILE
+        hidden_sq_sum = pl.full([1, T_TILE], dtype=pl.FP32, value=0.0)
+        hidden_amax = pl.full([1, T_TILE], dtype=pl.FP32, value=INT8_AMAX_EPS)
+        for k0 in pl.pipeline(0, D, NORM_K_TILE, stage=4):
+            hidden_chunk_bf16 = hidden_flat[t0 : t0 + T_TILE, k0 : k0 + NORM_K_TILE]
+            hidden_chunk = pl.cast(hidden_chunk_bf16, target_type=pl.FP32)
+            enorm = pl.reshape(enorm_w[k0 : k0 + NORM_K_TILE], [1, NORM_K_TILE])
+            e_smooth = pl.reshape(e_proj_smooth[k0 : k0 + NORM_K_TILE], [1, NORM_K_TILE])
+            enorm_smooth = pl.mul(enorm, e_smooth)
+            hidden_xg = pl.col_expand_mul(hidden_chunk, enorm_smooth)
+            hidden_sq = pl.mul(hidden_chunk, hidden_chunk)
+            hidden_sq_row = pl.row_sum(hidden_sq)
+            hidden_sq_partial = pl.reshape(hidden_sq_row, [1, T_TILE])
+            hidden_sq_sum = pl.add(hidden_sq_sum, hidden_sq_partial)
+            hidden_abs = pl.abs(hidden_xg)
+            hidden_amax_row = pl.row_max(hidden_abs)
+            hidden_amax_col = pl.reshape(hidden_amax_row, [1, T_TILE])
+            hidden_amax = pl.maximum(hidden_amax, hidden_amax_col)
+        hidden_sq_mean = pl.mul(hidden_sq_sum, D_INV)
+        hidden_rms_arg = pl.add(hidden_sq_mean, EPS)
+        hidden_inv = pl.rsqrt(hidden_rms_arg, high_precision=True)
+        hidden_scale_max = pl.full([1, T_TILE], dtype=pl.FP32, value=INT8_SCALE_MAX)
+        hidden_quant_scale_row = pl.div(hidden_scale_max, hidden_amax)
+        hidden_sq_recip = pl.recip(hidden_quant_scale_row)
+        hidden_scale_row = pl.mul(hidden_inv, hidden_sq_recip)
+        hidden_scale_col = pl.reshape(hidden_scale_row, [T_TILE, 1])
+        hidden_scale_dq[t0 : t0 + T_TILE, 0:1] = hidden_scale_col
+        hidden_quant_scale_col = pl.reshape(hidden_quant_scale_row, [T_TILE, 1])
+        for k0 in pl.pipeline(0, D, QUANT_TILE, stage=4):
+            hidden_q_bf16 = hidden_flat[t0 : t0 + T_TILE, k0 : k0 + QUANT_TILE]
+            hidden_q_chunk = pl.cast(hidden_q_bf16, target_type=pl.FP32)
+            enorm_q = pl.reshape(enorm_w[k0 : k0 + QUANT_TILE], [1, QUANT_TILE])
+            e_smooth_q = pl.reshape(e_proj_smooth[k0 : k0 + QUANT_TILE], [1, QUANT_TILE])
+            enorm_smooth_q = pl.mul(enorm_q, e_smooth_q)
+            hidden_q_xg = pl.col_expand_mul(hidden_q_chunk, enorm_smooth_q)
+            hidden_q_scaled = pl.row_expand_mul(hidden_q_xg, hidden_quant_scale_col)
+            hidden_q_i32 = pl.cast(hidden_q_scaled, target_type=pl.INT32, mode="rint")
+            hidden_q_half = pl.cast(hidden_q_i32, target_type=pl.FP16, mode="round")
+            hidden_q_i8 = pl.cast(hidden_q_half, target_type=pl.INT8, mode="trunc")
+            hidden_i8[t0 : t0 + T_TILE, k0 : k0 + QUANT_TILE] = hidden_q_i8
+
+    prev_flat = pl.reshape(prev_hidden_states, [t_dim, HC_DIM])
+    prev_linear_rows = t_linear * HC_MULT
+    prev_i8 = pl.create_tensor([prev_linear_rows, D], dtype=pl.INT8)
     prev_scale_dq = pl.create_tensor([HC_MULT, t_linear], dtype=pl.FP32)
-    out_pad = pl.create_tensor([t_linear, HC_DIM], dtype=pl.FP32)
+    for prev_block in pl.spmd((t_dim // T_TILE) * HC_MULT, name_hint="mtp_projection_prev", allow_early_resolve=True):
+        prev_t = prev_block // HC_MULT
+        hc = prev_block - prev_t * HC_MULT
+        t0 = prev_t * T_TILE
+        prev_base = hc * D
+        prev_sq_sum = pl.full([1, T_TILE], dtype=pl.FP32, value=0.0)
+        prev_amax = pl.full([1, T_TILE], dtype=pl.FP32, value=INT8_AMAX_EPS)
+        for k0 in pl.pipeline(0, D, NORM_K_TILE, stage=4):
+            prev_chunk = prev_flat[t0 : t0 + T_TILE, prev_base + k0 : prev_base + k0 + NORM_K_TILE]
+            hnorm = pl.reshape(hnorm_w[k0 : k0 + NORM_K_TILE], [1, NORM_K_TILE])
+            h_smooth = pl.reshape(h_proj_smooth[k0 : k0 + NORM_K_TILE], [1, NORM_K_TILE])
+            hnorm_smooth = pl.mul(hnorm, h_smooth)
+            prev_xg = pl.col_expand_mul(prev_chunk, hnorm_smooth)
+            prev_sq = pl.mul(prev_chunk, prev_chunk)
+            prev_sq_row = pl.row_sum(prev_sq)
+            prev_sq_partial = pl.reshape(prev_sq_row, [1, T_TILE])
+            prev_sq_sum = pl.add(prev_sq_sum, prev_sq_partial)
+            prev_abs = pl.abs(prev_xg)
+            prev_amax_row = pl.row_max(prev_abs)
+            prev_amax_col = pl.reshape(prev_amax_row, [1, T_TILE])
+            prev_amax = pl.maximum(prev_amax, prev_amax_col)
+        prev_sq_mean = pl.mul(prev_sq_sum, D_INV)
+        prev_rms_arg = pl.add(prev_sq_mean, EPS)
+        prev_inv = pl.rsqrt(prev_rms_arg, high_precision=True)
+        prev_scale_max = pl.full([1, T_TILE], dtype=pl.FP32, value=INT8_SCALE_MAX)
+        prev_quant_scale_row = pl.div(prev_scale_max, prev_amax)
+        prev_sq_recip = pl.recip(prev_quant_scale_row)
+        prev_scale_row = pl.mul(prev_inv, prev_sq_recip)
+        prev_scale_dq[hc : hc + 1, t0 : t0 + T_TILE] = prev_scale_row
+        prev_quant_scale_col = pl.reshape(prev_quant_scale_row, [T_TILE, 1])
+        prev_q_block = t0 // LINEAR_T_TILE
+        prev_q_row0 = prev_q_block * LINEAR_HC_TILE + hc * LINEAR_T_TILE + (t0 - prev_q_block * LINEAR_T_TILE)
+        for k0 in pl.pipeline(0, D, QUANT_TILE, stage=4):
+            prev_q_chunk = prev_flat[t0 : t0 + T_TILE, prev_base + k0 : prev_base + k0 + QUANT_TILE]
+            hnorm_q = pl.reshape(hnorm_w[k0 : k0 + QUANT_TILE], [1, QUANT_TILE])
+            h_smooth_q = pl.reshape(h_proj_smooth[k0 : k0 + QUANT_TILE], [1, QUANT_TILE])
+            hnorm_smooth_q = pl.mul(hnorm_q, h_smooth_q)
+            prev_q_xg = pl.col_expand_mul(prev_q_chunk, hnorm_smooth_q)
+            prev_q_scaled = pl.row_expand_mul(prev_q_xg, prev_quant_scale_col)
+            prev_q_i32 = pl.cast(prev_q_scaled, target_type=pl.INT32, mode="rint")
+            prev_q_half = pl.cast(prev_q_i32, target_type=pl.FP16, mode="round")
+            prev_q_i8 = pl.cast(prev_q_half, target_type=pl.INT8, mode="trunc")
+            prev_i8[prev_q_row0 : prev_q_row0 + T_TILE, k0 : k0 + QUANT_TILE] = prev_q_i8
 
-    for t0 in pl.parallel(0, t_dim, T_TILE):
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="mtp_projection_rms"):
-            hidden_sq_sum = pl.full([1, T_TILE], dtype=pl.FP32, value=0.0)
-            for kb in pl.pipeline(D_BLOCKS, stage=2):
-                k0 = kb * D_CHUNK
-                hidden_chunk = pl.cast(hidden_flat[t0 : t0 + T_TILE, k0 : k0 + D_CHUNK], target_type=pl.FP32)
-                hidden_sq_sum = pl.add(
-                    hidden_sq_sum,
-                    pl.reshape(pl.row_sum(pl.mul(hidden_chunk, hidden_chunk)), [1, T_TILE]),
-                )
-            hidden_var = pl.add(pl.mul(hidden_sq_sum, D_INV), EPS)
-            hidden_inv = pl.reshape(pl.rsqrt(hidden_var, high_precision=True), [T_TILE, 1])
-            hidden_inv_rms = pl.assemble(hidden_inv_rms, hidden_inv, [t0, 0])
-            for hc in pl.range(HC_MULT):
-                prev_sq_sum = pl.full([1, T_TILE], dtype=pl.FP32, value=0.0)
-                for kb in pl.pipeline(D_BLOCKS, stage=2):
-                    k0 = kb * D_CHUNK
-                    prev_k0 = hc * D + k0
-                    prev_chunk = prev_flat[t0 : t0 + T_TILE, prev_k0 : prev_k0 + D_CHUNK]
-                    prev_sq_sum = pl.add(
-                        prev_sq_sum,
-                        pl.reshape(pl.row_sum(pl.mul(prev_chunk, prev_chunk)), [1, T_TILE]),
-                    )
-                prev_var = pl.add(pl.mul(prev_sq_sum, D_INV), EPS)
-                prev_inv = pl.reshape(pl.rsqrt(prev_var, high_precision=True), [T_TILE, 1])
-                prev_inv_rms = pl.assemble(prev_inv_rms, pl.reshape(prev_inv, [1, T_TILE]), [hc, t0])
-
-    for t0 in pl.parallel(0, t_dim, T_TILE):
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="mtp_projection_norm"):
-            hidden_inv = hidden_inv_rms[t0 : t0 + T_TILE, 0:1]
-            for kb in pl.range(D_BLOCKS):
-                k0 = kb * D_CHUNK
-                hidden_chunk = pl.cast(hidden_flat[t0 : t0 + T_TILE, k0 : k0 + D_CHUNK], target_type=pl.FP32)
-                enorm = pl.reshape(enorm_w[k0 : k0 + D_CHUNK], [1, D_CHUNK])
-                e_smooth = pl.reshape(e_proj_smooth[k0 : k0 + D_CHUNK], [1, D_CHUNK])
-                hidden_norm_tile = pl.col_expand_mul(
-                    pl.col_expand_mul(pl.row_expand_mul(hidden_chunk, hidden_inv), enorm),
-                    e_smooth,
-                )
-                hidden_norm = pl.assemble(hidden_norm, hidden_norm_tile, [t0, k0])
-                hidden_abs = pl.maximum(hidden_norm_tile, pl.neg(hidden_norm_tile))
-                hidden_amax_parts = pl.assemble(hidden_amax_parts, pl.reshape(pl.row_max(hidden_abs), [1, T_TILE]), [kb, t0])
-                hnorm = pl.reshape(hnorm_w[k0 : k0 + D_CHUNK], [1, D_CHUNK])
-                h_smooth = pl.reshape(h_proj_smooth[k0 : k0 + D_CHUNK], [1, D_CHUNK])
-                for hc in pl.range(HC_MULT):
-                    prev_k0 = hc * D + k0
-                    prev_inv = pl.reshape(prev_inv_rms[hc : hc + 1, t0 : t0 + T_TILE], [T_TILE, 1])
-                    prev_chunk = prev_flat[t0 : t0 + T_TILE, prev_k0 : prev_k0 + D_CHUNK]
-                    prev_norm_tile = pl.col_expand_mul(
-                        pl.col_expand_mul(pl.row_expand_mul(prev_chunk, prev_inv), hnorm),
-                        h_smooth,
-                    )
-                    prev_norm = pl.assemble(prev_norm, prev_norm_tile, [t0, prev_k0])
-                    prev_abs = pl.maximum(prev_norm_tile, pl.neg(prev_norm_tile))
-                    prev_amax_parts = pl.assemble(
-                        prev_amax_parts,
-                        pl.reshape(pl.row_max(prev_abs), [1, T_TILE]),
-                        [hc * D_BLOCKS + kb, t0],
-                    )
-
-    for t0 in pl.parallel(0, t_dim, T_TILE):
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="mtp_projection_quant"):
-            hidden_amax = pl.full([1, T_TILE], dtype=pl.FP32, value=INT8_AMAX_EPS)
-            for ab in pl.range(D_BLOCKS):
-                hidden_amax = pl.maximum(hidden_amax, hidden_amax_parts[ab : ab + 1, t0 : t0 + T_TILE])
-            hidden_sq_row = pl.div(pl.full([1, T_TILE], dtype=pl.FP32, value=INT8_SCALE_MAX), hidden_amax)
-            hidden_scale_dq = pl.assemble(hidden_scale_dq, pl.reshape(pl.recip(hidden_sq_row), [T_TILE, 1]), [t0, 0])
-            hidden_sq_col = pl.reshape(hidden_sq_row, [T_TILE, 1])
-            for k0 in pl.range(0, D, QUANT_CHUNK):
-                hidden_q_f32 = hidden_norm[t0 : t0 + T_TILE, k0 : k0 + QUANT_CHUNK]
-                hidden_q_i32 = pl.cast(pl.row_expand_mul(hidden_q_f32, hidden_sq_col), target_type=pl.INT32, mode="rint")
-                hidden_q_half = pl.cast(hidden_q_i32, target_type=pl.FP16, mode="round")
-                hidden_i8 = pl.assemble(hidden_i8, pl.cast(hidden_q_half, target_type=pl.INT8, mode="trunc"), [t0, k0])
-            for hc in pl.range(HC_MULT):
-                prev_amax = pl.full([1, T_TILE], dtype=pl.FP32, value=INT8_AMAX_EPS)
-                for ab in pl.range(D_BLOCKS):
-                    prev_amax = pl.maximum(prev_amax, prev_amax_parts[hc * D_BLOCKS + ab : hc * D_BLOCKS + ab + 1, t0 : t0 + T_TILE])
-                prev_sq_row = pl.div(pl.full([1, T_TILE], dtype=pl.FP32, value=INT8_SCALE_MAX), prev_amax)
-                prev_scale_dq = pl.assemble(prev_scale_dq, pl.reshape(pl.recip(prev_sq_row), [1, T_TILE]), [hc, t0])
-                prev_sq_col = pl.reshape(prev_sq_row, [T_TILE, 1])
-                for k0 in pl.range(0, D, QUANT_CHUNK):
-                    prev_k0 = hc * D + k0
-                    prev_q_f32 = prev_norm[t0 : t0 + T_TILE, prev_k0 : prev_k0 + QUANT_CHUNK]
-                    prev_q_i32 = pl.cast(pl.row_expand_mul(prev_q_f32, prev_sq_col), target_type=pl.INT32, mode="rint")
-                    prev_q_half = pl.cast(prev_q_i32, target_type=pl.FP16, mode="round")
-                    prev_i8 = pl.assemble(prev_i8, pl.cast(prev_q_half, target_type=pl.INT8, mode="trunc"), [t0, prev_k0])
-    for t0 in pl.parallel(0, t_linear, LINEAR_T_TILE):
-        for nb in pl.parallel(0, OUT_BLOCKS, 1):
-            with pl.at(level=pl.Level.CORE_GROUP, name_hint="mtp_projection_linear"):
-                n0 = nb * OUT_CHUNK
-                hidden_a0 = hidden_i8[t0 : t0 + LINEAR_T_TILE, 0:D_CHUNK]
-                e_w0 = e_proj_w[n0 : n0 + OUT_CHUNK, 0:D_CHUNK]
-                hidden_acc = pl.matmul(hidden_a0, e_w0, b_trans=True, out_dtype=pl.INT32)
-                for kb in pl.pipeline(1, D_BLOCKS, stage=2):
-                    k0 = kb * D_CHUNK
-                    hidden_a = hidden_i8[t0 : t0 + LINEAR_T_TILE, k0 : k0 + D_CHUNK]
-                    e_w = e_proj_w[n0 : n0 + OUT_CHUNK, k0 : k0 + D_CHUNK]
-                    hidden_acc = pl.matmul_acc(hidden_acc, hidden_a, e_w, b_trans=True)
-                e_scale = pl.reshape(e_proj_w_scale[n0 : n0 + OUT_CHUNK], [1, OUT_CHUNK])
-                hidden_deq = pl.col_expand_mul(
-                    pl.row_expand_mul(pl.cast(hidden_acc, target_type=pl.FP32, mode="none"), hidden_scale_dq[t0 : t0 + LINEAR_T_TILE, 0:1]),
-                    e_scale,
-                )
-                h_w0 = h_proj_w[n0 : n0 + OUT_CHUNK, 0:D_CHUNK]
-                h_scale = pl.reshape(h_proj_w_scale[n0 : n0 + OUT_CHUNK], [1, OUT_CHUNK])
-                for hc in pl.range(HC_MULT):
-                    prev_base = hc * D
-                    prev_out = prev_base + n0
-                    prev_a0 = prev_i8[t0 : t0 + LINEAR_T_TILE, prev_base : prev_base + D_CHUNK]
-                    prev_acc = pl.matmul(prev_a0, h_w0, b_trans=True, out_dtype=pl.INT32)
-                    for kb in pl.pipeline(1, D_BLOCKS, stage=2):
-                        k0 = kb * D_CHUNK
-                        prev_k0 = prev_base + k0
-                        prev_a = prev_i8[t0 : t0 + LINEAR_T_TILE, prev_k0 : prev_k0 + D_CHUNK]
-                        h_w = h_proj_w[n0 : n0 + OUT_CHUNK, k0 : k0 + D_CHUNK]
-                        prev_acc = pl.matmul_acc(prev_acc, prev_a, h_w, b_trans=True)
-                    prev_deq = pl.col_expand_mul(
-                        pl.row_expand_mul(
-                            pl.cast(prev_acc, target_type=pl.FP32, mode="none"),
-                            pl.reshape(prev_scale_dq[hc : hc + 1, t0 : t0 + LINEAR_T_TILE], [LINEAR_T_TILE, 1]),
-                        ),
-                        h_scale,
-                    )
-                    acc = pl.add(hidden_deq, prev_deq)
-                    out_pad = pl.assemble(out_pad, acc, [t0, prev_out])
-
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="mtp_projection_output"):
-        for t0 in pl.pipeline(0, t_dim, T_TILE, stage=2):
-            for hc in pl.range(HC_MULT):
-                out_base = hc * D
-                for n0 in pl.range(0, D, OUT_CHUNK):
-                    out_flat[t0 : t0 + T_TILE, out_base + n0 : out_base + n0 + OUT_CHUNK] = out_pad[
-                        t0 : t0 + T_TILE,
-                        out_base + n0 : out_base + n0 + OUT_CHUNK,
-                    ]
+    out_flat = pl.reshape(hidden_states_out, [t_dim, HC_DIM])
+    for linear_block in pl.spmd((t_linear // LINEAR_T_TILE) * (D // OUT_TILE), name_hint="mtp_projection_linear"):
+        linear_t = linear_block // (D // OUT_TILE)
+        t0 = linear_t * LINEAR_T_TILE
+        n0 = (linear_block - linear_t * (D // OUT_TILE)) * OUT_TILE
+        t_rows = pl.min(LINEAR_T_TILE, t_dim - t0)
+        hidden_a0 = hidden_i8[t0 : t0 + LINEAR_T_TILE, 0:LINEAR_K_TILE]
+        e_w0 = e_proj_w[n0 : n0 + OUT_TILE, 0:LINEAR_K_TILE]
+        hidden_acc = pl.matmul(hidden_a0, e_w0, b_trans=True, out_dtype=pl.INT32)
+        for k0 in pl.pipeline(LINEAR_K_TILE, D, LINEAR_K_TILE, stage=2):
+            hidden_a = hidden_i8[t0 : t0 + LINEAR_T_TILE, k0 : k0 + LINEAR_K_TILE]
+            e_w = e_proj_w[n0 : n0 + OUT_TILE, k0 : k0 + LINEAR_K_TILE]
+            hidden_acc = pl.matmul_acc(hidden_acc, hidden_a, e_w, b_trans=True)
+        e_scale = pl.reshape(e_proj_w_scale[n0 : n0 + OUT_TILE], [1, OUT_TILE])
+        hidden_acc_fp32 = pl.cast(hidden_acc, target_type=pl.FP32, mode="none")
+        hidden_row_deq = pl.row_expand_mul(hidden_acc_fp32, hidden_scale_dq[t0 : t0 + LINEAR_T_TILE, 0:1])
+        hidden_deq = pl.col_expand_mul(hidden_row_deq, e_scale)
+        prev_row0 = linear_t * LINEAR_HC_TILE
+        prev_a0 = prev_i8[prev_row0 : prev_row0 + LINEAR_HC_TILE, 0:LINEAR_K_TILE]
+        h_w0 = h_proj_w[n0 : n0 + OUT_TILE, 0:LINEAR_K_TILE]
+        prev_acc = pl.matmul(prev_a0, h_w0, b_trans=True, out_dtype=pl.INT32)
+        for k0 in pl.pipeline(LINEAR_K_TILE, D, LINEAR_K_TILE, stage=2):
+            prev_a = prev_i8[prev_row0 : prev_row0 + LINEAR_HC_TILE, k0 : k0 + LINEAR_K_TILE]
+            h_w = h_proj_w[n0 : n0 + OUT_TILE, k0 : k0 + LINEAR_K_TILE]
+            prev_acc = pl.matmul_acc(prev_acc, prev_a, h_w, b_trans=True)
+        prev_deq_all = pl.cast(prev_acc, target_type=pl.FP32, mode="none")
+        h_scale = pl.reshape(h_proj_w_scale[n0 : n0 + OUT_TILE], [1, OUT_TILE])
+        for hc in pl.unroll(HC_MULT):
+            hc_row0 = hc * LINEAR_T_TILE
+            prev_deq_tile = prev_deq_all[hc_row0 : hc_row0 + LINEAR_T_TILE, 0:OUT_TILE]
+            prev_scale = prev_scale_dq[hc : hc + 1, t0 : t0 + LINEAR_T_TILE]
+            prev_scale_col = pl.reshape(prev_scale, [LINEAR_T_TILE, 1])
+            prev_row_deq = pl.row_expand_mul(prev_deq_tile, prev_scale_col)
+            prev_deq = pl.col_expand_mul(prev_row_deq, h_scale)
+            acc = pl.add(hidden_deq, prev_deq)
+            prev_out = hc * D + n0
+            acc_valid = pl.set_validshape(acc, t_rows, OUT_TILE)
+            out_flat[t0 : t0 + LINEAR_T_TILE, prev_out : prev_out + OUT_TILE] = acc_valid
 
     hidden_states_out = pl.reshape(out_flat, [t_dim, HC_MULT, D])
     return hidden_states_out
@@ -236,16 +212,10 @@ def mtp_projection_test(
     prev_hidden_states.bind_dynamic(0, T_DYN)
     hidden_states_out.bind_dynamic(0, T_DYN)
     return mtp_projection(
-        hidden_states,
-        prev_hidden_states,
-        enorm_w,
-        hnorm_w,
-        e_proj_w,
-        e_proj_w_scale,
-        e_proj_smooth,
-        h_proj_w,
-        h_proj_w_scale,
-        h_proj_smooth,
+        hidden_states, prev_hidden_states,
+        enorm_w, hnorm_w,
+        e_proj_w, e_proj_w_scale, e_proj_smooth,
+        h_proj_w, h_proj_w_scale, h_proj_smooth,
         hidden_states_out,
     )
 
@@ -256,8 +226,8 @@ def _rms_norm(x, weight):
     shape = x.shape
     x_2d = x.reshape(-1, D).float()
     sq_sum = torch.zeros(x_2d.shape[0], 1, dtype=torch.float32)
-    for k0 in range(0, D, D_CHUNK):
-        x_chunk = x_2d[:, k0:k0 + D_CHUNK]
+    for k0 in range(0, D, NORM_K_TILE):
+        x_chunk = x_2d[:, k0:k0 + NORM_K_TILE]
         sq_sum += (x_chunk * x_chunk).sum(dim=1, keepdim=True)
     inv = torch.rsqrt(sq_sum * D_INV + EPS)
     return (x_2d * inv * weight.float().view(1, D)).reshape(shape)
@@ -352,8 +322,7 @@ if __name__ == "__main__":
     from golden import ratio_allclose, run_jit
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("-p", "--platform", type=str, default="a2a3",
-                        choices=["a2a3", "a2a3sim", "a5", "a5sim"])
+    parser.add_argument("-p", "--platform", type=str, default="a2a3", choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
     parser.add_argument("--mode", choices=["decode", "prefill", "all"], default="all")
     parser.add_argument("--seed", type=int, default=0)
@@ -381,9 +350,6 @@ if __name__ == "__main__":
             rtol=1e-3,
             atol=1e-3,
             compare_fn={
-                # Raw MTP projection adds two W8A8 terms before the next block's
-                # normalization, so near-zero cancellation leaves more relative
-                # outliers than qkv_proj_rope's post-RMSNorm q/kv outputs.
                 "hidden_states_out": ratio_allclose(atol=1e-3, rtol=1e-3, max_error_ratio=0.05),
             },
         )

--- a/models/deepseek_v4_pro/prefill_mtp.py
+++ b/models/deepseek_v4_pro/prefill_mtp.py
@@ -8,15 +8,7 @@
 # -----------------------------------------------------------------------------------------------------------
 # ci: devices=2
 # ci: no-sim
-"""DeepSeek-V4 MTP packed-prefill forward.
-
-This mirrors the official MTP block:
-``e_proj(enorm(hidden_states)).unsqueeze(2) + h_proj(hnorm(prev_hidden_states))``
-followed by one SWA block, MoE, MTP ``hc_head`` and MTP RMSNorm.  The input
-``prev_hidden_states`` and ``pre_hc_hidden_out`` keep the official pre-hc layout
-``[T, HC_MULT, D]``.  ``hidden_states`` is the shared embedding/current-token
-hidden input in token-major ``[T, D]`` layout.
-"""
+"""DeepSeek-V4 packed-prefill MTP projection, SWA, MoE, HC head, and RMSNorm."""
 
 import argparse
 
@@ -34,9 +26,8 @@ from hc_head import (
     EPS as HC_HEAD_RMS_EPS,
     HC_DIM_INV as HC_HEAD_DIM_INV,
     HC_EPS as HC_HEAD_EPS,
-    LINEAR_K_CHUNK as HC_HEAD_LINEAR_K_CHUNK,
-    RMS_K_CHUNK as HC_HEAD_RMS_K_CHUNK,
     hc_head,
+    hc_head_stats_golden,
 )
 from moe import (
     AUX_PAD,
@@ -76,6 +67,7 @@ from prefill_fwd import build_single_layer_tensor_specs
 from rmsnorm import golden_rms_norm, rms_norm
 
 
+# model config
 T = PREFILL_TOKENS
 MTP_LAYER_ID = M.num_hidden_layers
 MTP_MOE_EPOCH = 1
@@ -150,22 +142,7 @@ def mtp_prefill_fwd(
     my_rank: pl.Scalar[pl.INT32],
     num_tokens: pl.Scalar[pl.INT32],
 ) -> pl.Tensor[[T, D], pl.BF16]:
-    nt: pl.Scalar[pl.INT32] = num_tokens
-    swa_cos_profile: pl.Tensor[[1, MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16] = pl.slice(
-        freqs_cos, [1, MAX_SEQ_LEN, ROPE_HEAD_DIM], [0, 0, 0]
-    )
-    swa_sin_profile: pl.Tensor[[1, MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16] = pl.slice(
-        freqs_sin, [1, MAX_SEQ_LEN, ROPE_HEAD_DIM], [0, 0, 0]
-    )
-    swa_freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16] = pl.reshape(
-        swa_cos_profile, [MAX_SEQ_LEN, ROPE_HEAD_DIM]
-    )
-    swa_freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16] = pl.reshape(
-        swa_sin_profile, [MAX_SEQ_LEN, ROPE_HEAD_DIM]
-    )
     projected = pl.create_tensor([T, HC_MULT, D], dtype=pl.FP32)
-    x_attn = pl.create_tensor([T, HC_MULT, D], dtype=pl.FP32)
-
     mtp_projection(
         hidden_states, prev_hidden_states,
         enorm_w, hnorm_w,
@@ -174,17 +151,25 @@ def mtp_prefill_fwd(
         projected,
     )
 
+    nt: pl.Scalar[pl.INT32] = num_tokens
+    cos_profile: pl.Tensor[[1, MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16] = freqs_cos[0:1, 0:MAX_SEQ_LEN, 0:ROPE_HEAD_DIM]
+    sin_profile: pl.Tensor[[1, MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16] = freqs_sin[0:1, 0:MAX_SEQ_LEN, 0:ROPE_HEAD_DIM]
+    swa_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16] = pl.reshape(cos_profile, [MAX_SEQ_LEN, ROPE_HEAD_DIM])
+    swa_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16] = pl.reshape(sin_profile, [MAX_SEQ_LEN, ROPE_HEAD_DIM])
+    x_attn = pl.create_tensor([T, HC_MULT, D], dtype=pl.FP32)
     prefill_attention_swa(
         projected,
         hc_attn_fn, hc_attn_scale, hc_attn_base, attn_norm_w,
         wq_a, wq_b, wq_b_scale, wkv, gamma_cq, gamma_ckv,
-        swa_freqs_cos, swa_freqs_sin,
+        swa_cos, swa_sin,
         kv_cache, ori_block_table, ori_slot_mapping,
         position_ids,
         attn_sink, wo_a, wo_b, wo_b_scale,
         x_attn, nt,
     )
 
+    mtp_layer_id = pl.cast(MTP_LAYER_ID, pl.INT32)
+    mtp_moe_epoch = pl.cast(MTP_MOE_EPOCH, pl.INT32)
     moe(
         x_attn,
         hc_ffn_fn, hc_ffn_scale, hc_ffn_base,
@@ -196,44 +181,32 @@ def mtp_prefill_fwd(
         pre_hc_hidden_out,
         recv_meta, recv_x, recv_aux, recv_route, arrived, data_arrived,
         routed_y_buf, combine_arrived,
-        pl.cast(MTP_LAYER_ID, pl.INT32), nt, my_rank, pl.cast(MTP_MOE_EPOCH, pl.INT32),
+        mtp_layer_id, nt, my_rank, mtp_moe_epoch,
     )
 
-    # Retire this dispatch's persistent MoE signal credits.
+    # Reset persistent MoE signal credits.
     neg_epochs = pl.cast(0 - MTP_MOE_EPOCH, pl.INT32)
     neg_data = pl.cast(0 - MTP_MOE_EPOCH * N_LOCAL, pl.INT32)
     neg_combine = pl.cast(0 - MTP_MOE_EPOCH * (N_LOCAL + 1), pl.INT32)
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="moe_signal_retire"):
         _pre_hc_anchor = pl.read(pre_hc_hidden_out, [0, 0, 0])
         pld.system.notify(
-            target=combine_arrived,
-            peer=my_rank,
-            offsets=[my_rank, 0],
-            value=neg_epochs,
-            op=pld.NotifyOp.AtomicAdd,
+            target=combine_arrived, peer=my_rank, offsets=[my_rank, 0],
+            value=neg_epochs, op=pld.NotifyOp.AtomicAdd,
         )
         for src in pl.range(N_RANKS):
             if src != my_rank:
                 pld.system.notify(
-                    target=arrived,
-                    peer=my_rank,
-                    offsets=[src, 0],
-                    value=neg_epochs,
-                    op=pld.NotifyOp.AtomicAdd,
+                    target=arrived, peer=my_rank, offsets=[src, 0],
+                    value=neg_epochs, op=pld.NotifyOp.AtomicAdd,
                 )
                 pld.system.notify(
-                    target=data_arrived,
-                    peer=my_rank,
-                    offsets=[src, 0],
-                    value=neg_data,
-                    op=pld.NotifyOp.AtomicAdd,
+                    target=data_arrived, peer=my_rank, offsets=[src, 0],
+                    value=neg_data, op=pld.NotifyOp.AtomicAdd,
                 )
                 pld.system.notify(
-                    target=combine_arrived,
-                    peer=my_rank,
-                    offsets=[src, 0],
-                    value=neg_combine,
-                    op=pld.NotifyOp.AtomicAdd,
+                    target=combine_arrived, peer=my_rank, offsets=[src, 0],
+                    value=neg_combine, op=pld.NotifyOp.AtomicAdd,
                 )
 
     x_head = pl.create_tensor([T, D], dtype=pl.BF16)
@@ -311,7 +284,8 @@ def l3_mtp_prefill_fwd(
     routed_y_buf_buf = pld.alloc_window_buffer([N_ROUTES, D], dtype=pl.BF16)
     combine_arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
 
-    for r in pl.range(pld.world_size()):
+    world_size = pld.world_size()
+    for r in pl.range(world_size):
         recv_meta: pld.DistributedTensor[[N_RANKS, N_LOCAL], pl.INT32] = pld.window(recv_meta_buf, [N_RANKS, N_LOCAL], dtype=pl.INT32)
         recv_x: pld.DistributedTensor[[N_LOCAL * RECV_MAX, D], pl.INT8] = pld.window(recv_x_buf, [N_LOCAL * RECV_MAX, D], dtype=pl.INT8)
         recv_aux: pld.DistributedTensor[[N_LOCAL * RECV_MAX, AUX_PAD], pl.FP32] = pld.window(recv_aux_buf, [N_LOCAL * RECV_MAX, AUX_PAD], dtype=pl.FP32)
@@ -350,13 +324,7 @@ def l3_mtp_prefill_fwd(
 def _ranked(spec, torch, is_output=False):
     from golden import TensorSpec
 
-    return TensorSpec(
-        spec.name,
-        list(spec.shape),
-        spec.dtype,
-        init_value=spec.init_value,
-        is_output=is_output,
-    )
+    return TensorSpec(spec.name, list(spec.shape), spec.dtype, init_value=spec.init_value, is_output=is_output)
 
 
 def _projection_specs():
@@ -374,7 +342,9 @@ def _projection_specs():
             w_i8, scale = _quantize_weight_per_out(w)
             weights.append(w_i8)
             scales.append(scale.float())
-        return torch.stack(weights, dim=0).contiguous(), torch.stack(scales, dim=0).contiguous()
+        weight_stack = torch.stack(weights, dim=0).contiguous()
+        scale_stack = torch.stack(scales, dim=0).contiguous()
+        return weight_stack, scale_stack
 
     def init_e_proj_w():
         nonlocal e_proj_cache
@@ -399,7 +369,10 @@ def _projection_specs():
         return h_proj_cache[1]
 
     return [
-        TensorSpec("hidden_states", [N_RANKS, T, D], torch.bfloat16, init_value=lambda: torch.randn(N_RANKS, T, D).to(torch.bfloat16)),
+        TensorSpec(
+            "hidden_states", [N_RANKS, T, D], torch.bfloat16,
+            init_value=lambda: torch.randn(N_RANKS, T, D).to(torch.bfloat16),
+        ),
         TensorSpec("prev_hidden_states", [N_RANKS, T, HC_MULT, D], torch.float32,
                    init_value=lambda: torch.randn(N_RANKS, T, HC_MULT, D).to(torch.bfloat16)),
         TensorSpec("enorm_w", [N_RANKS, D], torch.float32, init_value=lambda: torch.ones(N_RANKS, D)),
@@ -418,13 +391,18 @@ def _mtp_head_specs():
     from golden import TensorSpec
 
     base = [5.9166, -3.6223, -2.9324, -3.3124]
+
+    def init_mtp_hc_head_base():
+        base_tensor = torch.tensor(base, dtype=torch.float32)
+        base_row = base_tensor.view(1, HC_MULT)
+        return base_row.expand(N_RANKS, -1).contiguous()
+
     return [
         TensorSpec("mtp_hc_head_fn", [N_RANKS, HC_MULT, HC_DIM], torch.float32,
                    init_value=lambda: torch.randn(N_RANKS, HC_MULT, HC_DIM) * 0.0519),
         TensorSpec("mtp_hc_head_scale", [N_RANKS, 1], torch.float32,
                    init_value=lambda: torch.full((N_RANKS, 1), 0.076099, dtype=torch.float32)),
-        TensorSpec("mtp_hc_head_base", [N_RANKS, HC_MULT], torch.float32,
-                   init_value=lambda: torch.tensor(base, dtype=torch.float32).view(1, HC_MULT).expand(N_RANKS, -1).contiguous()),
+        TensorSpec("mtp_hc_head_base", [N_RANKS, HC_MULT], torch.float32, init_value=init_mtp_hc_head_base),
         TensorSpec("mtp_norm_w", [N_RANKS, D], torch.bfloat16,
                    init_value=lambda: (torch.randn(N_RANKS, D) * 0.1 + 1.0).to(torch.bfloat16)),
     ]
@@ -441,7 +419,8 @@ def build_tensor_specs(start_pos=0, num_tokens=T):
     }
     projection = {spec.name: spec for spec in _projection_specs()}
     mtp_head = {spec.name: spec for spec in _mtp_head_specs()}
-    moe_specs = {spec.name: spec for spec in build_moe_tensor_specs(layer_id=MTP_LAYER_ID, num_tokens=num_tokens) if isinstance(spec, TensorSpec)}
+    moe_spec_list = build_moe_tensor_specs(layer_id=MTP_LAYER_ID, num_tokens=num_tokens)
+    moe_specs = {spec.name: spec for spec in moe_spec_list if isinstance(spec, TensorSpec)}
 
     ordered_names = [
         "hidden_states", "prev_hidden_states",
@@ -486,21 +465,9 @@ def _golden_hc_head_prefill(x_hc, hc_head_fn, hc_head_scale, hc_head_base):
     x_flat_2d = x_hc.reshape(token_count, HC_DIM).float()
     hc_head_fn = hc_head_fn.float()
 
-    sq_sum = torch.zeros(token_count, 1, dtype=torch.float32)
-    for k0 in range(0, HC_DIM, HC_HEAD_RMS_K_CHUNK):
-        x_chunk = x_flat_2d[:, k0:k0 + HC_HEAD_RMS_K_CHUNK]
-        sq_sum += (x_chunk * x_chunk).sum(dim=1, keepdim=True)
+    sq_sum, mixes_raw = hc_head_stats_golden(x_flat_2d, hc_head_fn)
     rsqrt = torch.rsqrt(sq_sum * HC_HEAD_DIM_INV + HC_HEAD_RMS_EPS)
-
-    mix_cols = []
-    for h in range(HC_MULT):
-        mix_col = torch.zeros(token_count, 1, dtype=torch.float32)
-        for k0 in range(0, HC_DIM, HC_HEAD_LINEAR_K_CHUNK):
-            x_chunk = x_flat_2d[:, k0:k0 + HC_HEAD_LINEAR_K_CHUNK]
-            w_chunk = hc_head_fn[h:h + 1, k0:k0 + HC_HEAD_LINEAR_K_CHUNK]
-            mix_col += (x_chunk * w_chunk).sum(dim=1, keepdim=True)
-        mix_cols.append(mix_col * rsqrt)
-    mixes = torch.cat(mix_cols, dim=1).reshape(token_count, HC_MULT)
+    mixes = mixes_raw * rsqrt
 
     pre = torch.sigmoid(mixes * hc_head_scale.float() + hc_head_base.float()) + HC_HEAD_EPS
     x_view = x_hc.float().view(shape)
@@ -517,7 +484,6 @@ def _golden_hc_head_prefill(x_hc, hc_head_fn, hc_head_scale, hc_head_base):
         for h in range(HC_MULT):
             y += x_view[:, h, :] * pre[:, h:h + 1]
 
-    # Match the kernel's mode="rint" cast (round to nearest, ties to even).
     return y.to(torch.bfloat16)
 
 
@@ -590,10 +556,14 @@ def golden_mtp_prefill_fwd(tensors):
 def main():
     parser = argparse.ArgumentParser(description="DeepSeek-V4 MTP packed-prefill forward driver.")
     parser.add_argument("-p", "--platform", type=str, default="a2a3", choices=["a2a3", "a5"])
-    parser.add_argument("--ep", type=int, default=N_RANKS, choices=[2, 4, 8],
-                        help="EP world size / rank count (parsed at import by moe).")
-    parser.add_argument("-d", "--device", type=str, default=",".join(str(i) for i in range(N_RANKS)),
-                        help=f"comma-separated device ids; need at least {N_RANKS}")
+    parser.add_argument(
+        "--ep", type=int, default=N_RANKS, choices=[2, 4, 8],
+        help="EP world size / rank count (parsed at import by moe).",
+    )
+    parser.add_argument(
+        "-d", "--device", type=str, default=",".join(str(i) for i in range(N_RANKS)),
+        help=f"comma-separated device ids; need at least {N_RANKS}",
+    )
     parser.add_argument("--start-pos", type=int, default=0)
     parser.add_argument("--num-tokens", type=int, default=T)
     parser.add_argument("--enable-chip-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2))
@@ -604,7 +574,8 @@ def main():
     args = parser.parse_args()
 
     device_ids = [int(d) for d in args.device.split(",")]
-    assert len(device_ids) >= N_RANKS, f"need at least {N_RANKS} devices, got {device_ids}"
+    if len(device_ids) < N_RANKS:
+        raise ValueError(f"need at least {N_RANKS} devices, got {device_ids}")
 
     result = run_jit(
         fn=l3_mtp_prefill_fwd,
@@ -625,10 +596,14 @@ def main():
         rtol=1e-3,
         atol=1e-3,
         compare_fn={
-            "hidden_out": ratio_reldiff(diff_thd=0.02, pct_thd=0.05,
-                                        valid_rows=args.num_tokens, valid_axis=1),
-            "pre_hc_hidden_out": ratio_reldiff(diff_thd=0.02, pct_thd=0.05,
-                                               valid_rows=args.num_tokens, valid_axis=1),
+            "hidden_out": ratio_reldiff(
+                diff_thd=0.02, pct_thd=0.05,
+                valid_rows=args.num_tokens, valid_axis=1,
+            ),
+            "pre_hc_hidden_out": ratio_reldiff(
+                diff_thd=0.02, pct_thd=0.05,
+                valid_rows=args.num_tokens, valid_axis=1,
+            ),
         },
     )
     if not result.passed:

--- a/models/deepseek_v4_pro/qkv_proj_rope.py
+++ b/models/deepseek_v4_pro/qkv_proj_rope.py
@@ -29,80 +29,47 @@ NOPE_DIM = M.nope_head_dim
 Q_LORA = M.q_lora_rank
 EPS = M.rms_norm_eps
 MAX_SEQ_LEN = M.max_position_embeddings
+T_MAX = max(DECODE_BATCH * DECODE_SEQ, PREFILL_BATCH * PREFILL_SEQ)
+ROPE_DIM_F = float(ROPE_DIM)
+ROPE_DIM_INV = 1.0 / ROPE_DIM
 
 # tiling
-Q_PROJ_TILE = 128       # qproj K-tile (Q_LORA reduction); 8 slices -> deep stage=2 pipeline, double-buffered Mat fits
-QPROJ_MM_N_TILE = 1024  # full L2 lines per wq_b row (no over-fetch)
-# N-tiles folded into one qproj_matmul SPMD block; the grid is
-# (H*HEAD_DIM // QPROJ_MM_N_TILE) // QPROJ_TILES_PER_BLOCK. PRO's 64 N-tiles over a5's
-# 28 AIC cores make the block count the dominant term: 4 gives 16 blocks in a single
-# wave, while 2 gives 32 -- one full wave plus 4 stragglers that run with 24 cores idle
-# -- and 1 gives 64, whose per-shard launch stagger exceeds the wave it saves. The cube
-# tile itself is unchanged, so L0A/L0B/L0C occupancy is identical at every setting.
-QPROJ_TILES_PER_BLOCK = 4
-Q_LORA_TILE = 256       # qr rms-norm / quant N granularity (decoupled from qr_proj matmul)
-KV_TILE = 64            # kv rms-norm / rope / NOPE N granularity (decoupled from kv_proj matmul)
-QUANT_TILE = 256
+Q_PROJ_TILE = 128
+QPROJ_MM_N_TILE = 1024
+QPROJ_BLOCK_TILE = 4
+Q_LORA_TILE = 512
+KV_TILE = 64
+QUANT_TILE = 512
 T_TILE = 8
 MATMUL_T_TILE = 16
-T_MAX = max(DECODE_BATCH * DECODE_SEQ, PREFILL_BATCH * PREFILL_SEQ)
-
-# Per-projection matmul tiles. Decoupled so each projection's M/N/K can be tuned
-# independently of one another AND of the downstream rms/rope granularity above
-# (e.g. the matmul N-tile is no longer chained to KV_TILE / Q_LORA_TILE, which the
-# NOPE_DIM=448 constraint caps at <=64).
-QR_M_TILE = MATMUL_T_TILE  # qr_proj token (M) tile; cube rows must be a 16-row boxed tile
-QR_N_TILE = 128         # qr_proj Q_LORA (N) per matmul
-QR_K_TILE = 256         # qr_proj D (K) reduction tile    | divides QR_K_SLICE
-QR_OK = 2               # qr_proj split-K factor          | D//QR_OK cores share each N-group
-QR_K_SLICE = D // QR_OK # qr_proj K per split (=2048)     | QR_K_SLICE//QR_K_TILE inner chunks
-KV_M_TILE = MATMUL_T_TILE  # kv_proj token (M) tile; decode pads from 8 real rows to 16
-KV_N_TILE = 128         # kv_proj HEAD_DIM (N) per matmul
-# 128 (not 256) so the inner pipeline trip count stays EVEN -- see the
-# _even_pipeline_trip assert below. PRO's D = 7168 gives KV_K_SLICE = 1792,
-# which at a 256 tile is 7 chunks; 128 gives 14.
-KV_K_TILE = 128         # kv_proj D (K) reduction tile    | divides KV_K_SLICE
-KV_OK = 4               # kv_proj split-K factor          | D//KV_OK cores share each N-group
-KV_K_SLICE = D // KV_OK # kv_proj K per split (PRO: 1792) | KV_K_SLICE//KV_K_TILE inner chunks
-QPROJ_M_TILE = MATMUL_T_TILE  # qproj token (M) tile; decode pads from 8 real rows to 16
-KV_RMS_T_TILE = 8       # kv rms-norm + rope fused token (T) tile
+QR_M_TILE = MATMUL_T_TILE
+QR_N_TILE = 128
+QR_K_TILE = 256
+QR_SPLIT_TILE = 2
+QR_K_SPLIT_TILE = D // QR_SPLIT_TILE
+KV_M_TILE = MATMUL_T_TILE
+KV_N_TILE = 128
+KV_K_TILE = 128
+KV_SPLIT_TILE = 4
+KV_K_SPLIT_TILE = D // KV_SPLIT_TILE
+QPROJ_M_TILE = MATMUL_T_TILE
+KV_RMS_T_TILE = 8
 Q_ROPE_T_TILE = 8
-Q_ROPE_H_TILE = 4       # heads per fused qproj dequant/rms/rope task; cos/sin build amortizes over them
-assert H % Q_ROPE_H_TILE == 0
-assert (DECODE_BATCH * DECODE_SEQ) % T_TILE == 0
-assert (PREFILL_BATCH * PREFILL_SEQ) % T_TILE == 0
-assert DECODE_BATCH * DECODE_SEQ <= MATMUL_T_TILE
-for _m_tile in (QR_M_TILE, KV_M_TILE, QPROJ_M_TILE):
-    assert (PREFILL_BATCH * PREFILL_SEQ) % _m_tile == 0
-assert Q_LORA % QR_N_TILE == 0 and D % QR_OK == 0 and QR_K_SLICE % QR_K_TILE == 0
-assert HEAD_DIM % KV_N_TILE == 0 and D % KV_OK == 0 and KV_K_SLICE % KV_K_TILE == 0
+Q_ROPE_FLAT_LEN = Q_ROPE_T_TILE * ROPE_DIM
+Q_ROPE_H_TILE = 4
 
 
 def _even_pipeline_trip(name: str, trip: int) -> None:
-    """Split-K matmul loops run as ``pl.pipeline(..., stage=2)`` over a loop-carried
-    L0C accumulator. With an ODD trip count the final partial lands in the alternate
-    pipeline buffer, so codegen has to reconcile the two with an acc->acc ``pto.tmov``
-    -- an address-space pair A5 does not implement, and ptoas rejects the kernel with
-    ``'pto.tmov' op expects a supported tmov address-space pair for this target``.
-    An even trip count leaves the result in the canonical buffer and emits no move.
-
-    This bit us switching FLASH (D=4096) -> PRO (D=7168): kv_proj went 4 -> 7 chunks.
-    """
+    """Require even split-K pipeline trips for A5 accumulator-buffer selection."""
     assert trip % 2 == 0, (
         f"{name} pipeline trip count must be even, got {trip}; an odd count makes "
         "codegen emit an unsupported acc->acc pto.tmov. Retune the K tile or split-K factor."
     )
 
 
-_even_pipeline_trip("qr_proj", QR_K_SLICE // QR_K_TILE)
-_even_pipeline_trip("kv_proj", KV_K_SLICE // KV_K_TILE)
-assert (H * HEAD_DIM) % QPROJ_MM_N_TILE == 0 and ((H * HEAD_DIM) // QPROJ_MM_N_TILE) % 4 == 0
-assert ((H * HEAD_DIM) // QPROJ_MM_N_TILE) % QPROJ_TILES_PER_BLOCK == 0
-assert Q_LORA % Q_PROJ_TILE == 0 and QPROJ_MM_N_TILE * QPROJ_M_TILE * 4 <= 128 * 1024  # L0C Acc cap
-assert (DECODE_BATCH * DECODE_SEQ) % KV_RMS_T_TILE == 0
-assert (PREFILL_BATCH * PREFILL_SEQ) % KV_RMS_T_TILE == 0
-assert (DECODE_BATCH * DECODE_SEQ) % Q_ROPE_T_TILE == 0
-assert (PREFILL_BATCH * PREFILL_SEQ) % Q_ROPE_T_TILE == 0
+_even_pipeline_trip("qr_proj", QR_K_SPLIT_TILE // QR_K_TILE)
+_even_pipeline_trip("kv_proj", KV_K_SPLIT_TILE // KV_K_TILE)
+assert QPROJ_MM_N_TILE * QPROJ_M_TILE * 4 <= 128 * 1024  # L0C accumulator capacity
 
 
 @pl.jit.inline
@@ -120,7 +87,8 @@ def materialize_rope_rows(
         for rope_dt in pl.range(KV_RMS_T_TILE):
             rope_t = t0 + rope_dt
             if rope_t < num_tokens:
-                rope_pos = pl.cast(pl.read(position_ids, [rope_t]), pl.INDEX)
+                rope_pos_i32 = pl.read(position_ids, [rope_t])
+                rope_pos = pl.cast(rope_pos_i32, pl.INDEX)
                 rope_cos_t[rope_t : rope_t + 1, 0:ROPE_DIM] = freqs_cos[rope_pos : rope_pos + 1, 0:ROPE_DIM]
                 rope_sin_t[rope_t : rope_t + 1, 0:ROPE_DIM] = freqs_sin[rope_pos : rope_pos + 1, 0:ROPE_DIM]
 
@@ -141,61 +109,75 @@ def qkv_proj_rope(
     qr_scale: pl.Tensor[[T_DYN, 1], pl.FP32],
     late_dep: pl.Scalar[pl.TASK_ID],
 ):
+    # Task resolution is ordered across the kernel.
+    q_rope_dup_flat = pl.create_tensor([1, Q_ROPE_FLAT_LEN], dtype=pl.INT32)
+    q_rope_swap_flat = pl.create_tensor([1, Q_ROPE_FLAT_LEN], dtype=pl.INT32)
+    q_rope_sign = pl.create_tensor([1, ROPE_DIM], dtype=pl.FP32)
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="q_rope_index"):
+        qri_col_i32 = pl.arange(0, [1, Q_ROPE_FLAT_LEN], dtype=pl.INT32)
+        qri_col = pl.cast(qri_col_i32, target_type=pl.FP32)
+        qri_row_scaled = pl.mul(qri_col, ROPE_DIM_INV)
+        qri_row_i32 = pl.cast(qri_row_scaled, target_type=pl.INT32, mode="trunc")
+        qri_row = pl.cast(qri_row_i32, target_type=pl.FP32)
+        qri_rowbase = pl.mul(qri_row, ROPE_DIM_F)
+        qri_j = pl.sub(qri_col, qri_rowbase)
+        qri_half = pl.mul(qri_j, 0.5)
+        qri_dup_i32 = pl.cast(qri_half, target_type=pl.INT32, mode="trunc")
+        qri_dup_f = pl.cast(qri_dup_i32, target_type=pl.FP32)
+        qri_dup_twice = pl.mul(qri_dup_f, 2.0)
+        qri_lane = pl.sub(qri_j, qri_dup_twice)
+        qri_dup_index_f = pl.add(qri_rowbase, qri_dup_f)
+        qri_dup_index = pl.cast(qri_dup_index_f, target_type=pl.INT32)
+        q_rope_dup_flat[0:1, 0:Q_ROPE_FLAT_LEN] = qri_dup_index
+        qri_j_next = pl.add(qri_j, 1.0)
+        qri_lane_twice = pl.mul(qri_lane, 2.0)
+        qri_swap = pl.sub(qri_j_next, qri_lane_twice)
+        qri_swap_index_f = pl.add(qri_rowbase, qri_swap)
+        qri_swap_index = pl.cast(qri_swap_index_f, target_type=pl.INT32)
+        q_rope_swap_flat[0:1, 0:Q_ROPE_FLAT_LEN] = qri_swap_index
+        qrs_col_i32 = pl.arange(0, [1, ROPE_DIM], dtype=pl.INT32)
+        qrs_col = pl.cast(qrs_col_i32, target_type=pl.FP32)
+        qrs_half = pl.mul(qrs_col, 0.5)
+        qrs_dup_i32 = pl.cast(qrs_half, target_type=pl.INT32, mode="trunc")
+        qrs_dup_f = pl.cast(qrs_dup_i32, target_type=pl.FP32)
+        qrs_dup_twice = pl.mul(qrs_dup_f, 2.0)
+        qrs_lane = pl.sub(qrs_col, qrs_dup_twice)
+        qrs_lane_twice = pl.mul(qrs_lane, 2.0)
+        qrs_sign = pl.sub(qrs_lane_twice, 1.0)
+        q_rope_sign[0:1, 0:ROPE_DIM] = qrs_sign
+
     t_dim = pl.tensor.dim(x, 0)
-    x_view = pl.reshape(x, [t_dim, D])
     rope_cos_view = pl.reshape(rope_cos, [t_dim, ROPE_DIM])
     rope_sin_view = pl.reshape(rope_sin, [t_dim, ROPE_DIM])
-    kv_view = pl.reshape(kv, [t_dim, HEAD_DIM])
-    qr_view = pl.reshape(qr, [t_dim, Q_LORA])
-    qr_scale_view = pl.reshape(qr_scale, [t_dim, 1])
-    t_matmul = pl.max(t_dim, MATMUL_T_TILE)
-
-    # RoPE indices and interleaved cos/signed-sin rows are head-invariant.
-    # Prepare them once per token tile so the 16 Q head-group tasks do not each
-    # rebuild the same arange/cast/gather chain on their critical AIV path.
     q_rope_cos_il = pl.create_tensor([t_dim, ROPE_DIM], dtype=pl.FP32)
     q_rope_sin_signed = pl.create_tensor([t_dim, ROPE_DIM], dtype=pl.FP32)
-    q_rope_swap_idx = pl.create_tensor([t_dim, ROPE_DIM], dtype=pl.INT32)
-    for qrp_idx in pl.spmd(t_dim // Q_ROPE_T_TILE, name_hint="q_rope_prepare", allow_early_resolve=True):
+    for qrp_idx in pl.spmd(t_dim // Q_ROPE_T_TILE, name_hint="q_rope_prepare"):
         qrp_t0 = qrp_idx * Q_ROPE_T_TILE
-        # A5 gather indices stay row-sized because wider TCI tiles can overrun UB.
-        qrp_ones = pl.full([1, ROPE_DIM], dtype=pl.FP32, value=1.0)
-        qrp_idx_i32 = pl.arange(0, [1, ROPE_DIM], dtype=pl.INT32)
-        qrp_idx_fp32 = pl.cast(qrp_idx_i32, target_type=pl.FP32)
-        qrp_col = pl.col_expand_mul(qrp_ones, qrp_idx_fp32)
-        qrp_half = pl.mul(qrp_col, 0.5)
-        qrp_dup_i32 = pl.cast(qrp_half, target_type=pl.INT32, mode="trunc")
-        qrp_dup_f = pl.cast(qrp_dup_i32, target_type=pl.FP32)
-        qrp_dup_idx = pl.cast(qrp_dup_f, target_type=pl.INT32)
-        qrp_lane = pl.sub(qrp_col, pl.mul(qrp_dup_f, 2.0))
-        qrp_next_col = pl.add(qrp_col, 1.0)
-        qrp_lane_offset = pl.mul(qrp_lane, 2.0)
-        qrp_swap_f = pl.sub(qrp_next_col, qrp_lane_offset)
-        qrp_swap_idx = pl.cast(qrp_swap_f, target_type=pl.INT32)
-        qrp_sign = pl.sub(pl.mul(qrp_lane, 2.0), 1.0)
-        for qrp_dt in pl.range(Q_ROPE_T_TILE):
-            qrp_t = qrp_t0 + qrp_dt
-            qrp_cos = pl.cast(rope_cos_view[qrp_t : qrp_t + 1, :], target_type=pl.FP32)
-            qrp_sin = pl.cast(rope_sin_view[qrp_t : qrp_t + 1, :], target_type=pl.FP32)
-            qrp_cos_il = pl.gather(qrp_cos, dim=-1, index=qrp_dup_idx)
-            qrp_sin_il = pl.gather(qrp_sin, dim=-1, index=qrp_dup_idx)
-            qrp_sin_signed = pl.mul(qrp_sin_il, qrp_sign)
-            q_rope_cos_il[qrp_t : qrp_t + 1, :] = qrp_cos_il
-            q_rope_sin_signed[qrp_t : qrp_t + 1, :] = qrp_sin_signed
-            q_rope_swap_idx[qrp_t : qrp_t + 1, :] = qrp_swap_idx
+        qrp_dup = q_rope_dup_flat[0:1, 0:Q_ROPE_FLAT_LEN]
+        qrp_sign = q_rope_sign[0:1, 0:ROPE_DIM]
+        qrp_cos = pl.cast(rope_cos_view[qrp_t0 : qrp_t0 + Q_ROPE_T_TILE, :], target_type=pl.FP32)
+        qrp_sin = pl.cast(rope_sin_view[qrp_t0 : qrp_t0 + Q_ROPE_T_TILE, :], target_type=pl.FP32)
+        qrp_cos_flat = pl.reshape(qrp_cos, [1, Q_ROPE_FLAT_LEN])
+        qrp_cos_il = pl.gather(qrp_cos_flat, dim=-1, index=qrp_dup)
+        qrp_sin_flat = pl.reshape(qrp_sin, [1, Q_ROPE_FLAT_LEN])
+        qrp_sin_il = pl.gather(qrp_sin_flat, dim=-1, index=qrp_dup)
+        qrp_cos_rows = pl.reshape(qrp_cos_il, [Q_ROPE_T_TILE, ROPE_DIM])
+        q_rope_cos_il[qrp_t0 : qrp_t0 + Q_ROPE_T_TILE, :] = qrp_cos_rows
+        qrp_sin_rows = pl.reshape(qrp_sin_il, [Q_ROPE_T_TILE, ROPE_DIM])
+        qrp_sin_signed = pl.col_expand_mul(qrp_sin_rows, qrp_sign)
+        q_rope_sin_signed[qrp_t0 : qrp_t0 + Q_ROPE_T_TILE, :] = qrp_sin_signed
 
-    # Split-K qr_proj partials are reduced in ascending K order.
-    qr_fp32 = pl.create_tensor([T_MAX, Q_LORA], dtype=pl.FP32)
-    qr_partials = pl.create_tensor([QR_OK * T_MAX, Q_LORA], dtype=pl.FP32)
-    qr_i8_matmul = pl.create_tensor([T_MAX, Q_LORA], dtype=pl.INT8)
-    for qbg_idx in pl.spmd((Q_LORA // QR_N_TILE) * QR_OK, name_hint="qr_proj_matmul", allow_early_resolve=True):
-        q_a_col0 = (qbg_idx // QR_OK) * QR_N_TILE
-        qr_split = qbg_idx % QR_OK
-        qr_k_base = qr_split * QR_K_SLICE
+    x_view = pl.reshape(x, [t_dim, D])
+    t_matmul = pl.max(t_dim, MATMUL_T_TILE)
+    qr_partials = pl.create_tensor([QR_SPLIT_TILE * T_MAX, Q_LORA], dtype=pl.FP32)
+    for qbg_idx in pl.spmd((Q_LORA // QR_N_TILE) * QR_SPLIT_TILE, name_hint="qr_proj_matmul"):
+        q_a_col0 = (qbg_idx // QR_SPLIT_TILE) * QR_N_TILE
+        qr_split = qbg_idx % QR_SPLIT_TILE
+        qr_k_base = qr_split * QR_K_SPLIT_TILE
         for tc in pl.range(t_matmul // QR_M_TILE):
             t0 = tc * QR_M_TILE
             q_acc = pl.create_tensor([QR_M_TILE, QR_N_TILE], dtype=pl.FP32)
-            for db in pl.pipeline(QR_K_SLICE // QR_K_TILE, stage=2):
+            for db in pl.pipeline(QR_K_SPLIT_TILE // QR_K_TILE, stage=2):
                 qr_d0 = qr_k_base + db * QR_K_TILE
                 qr_rows = pl.min(QR_M_TILE, t_dim - t0)
                 q_x_chunk_bf16 = pl.slice(x_view, [QR_M_TILE, QR_K_TILE], [t0, qr_d0], valid_shape=[qr_rows, QR_K_TILE])
@@ -204,57 +186,59 @@ def qkv_proj_rope(
                     q_acc = pl.matmul(q_x_chunk_bf16, w_chunk, out_dtype=pl.FP32)
                 else:
                     q_acc = pl.matmul_acc(q_acc, q_x_chunk_bf16, w_chunk)
-            qr_partials = pl.assemble(qr_partials, q_acc, [qr_split * T_MAX + t0, q_a_col0])
+            qr_partial_t0 = qr_split * T_MAX + t0
+            qr_partials[qr_partial_t0 : qr_partial_t0 + QR_M_TILE, q_a_col0 : q_a_col0 + QR_N_TILE] = q_acc
 
-    for qr_reduce_idx in pl.spmd(
-        (t_matmul // QR_M_TILE) * (Q_LORA // QR_N_TILE),
-        name_hint="qr_proj_reduce",
-        allow_early_resolve=True,
-    ):
-        qr_t0 = (qr_reduce_idx // (Q_LORA // QR_N_TILE)) * QR_M_TILE
-        qr_col0 = (qr_reduce_idx % (Q_LORA // QR_N_TILE)) * QR_N_TILE
-        qr_total = qr_partials[qr_t0 : qr_t0 + QR_M_TILE, qr_col0 : qr_col0 + QR_N_TILE]
-        for qr_split in pl.range(1, QR_OK):
-            qr_partial_t0 = qr_split * T_MAX + qr_t0
-            qr_total = pl.add(
-                qr_total,
-                qr_partials[
-                    qr_partial_t0 : qr_partial_t0 + QR_M_TILE,
-                    qr_col0 : qr_col0 + QR_N_TILE,
-                ],
-            )
-        qr_fp32 = pl.assemble(qr_fp32, qr_total, [qr_t0, qr_col0])
-
-    # Two passes per block: pass 1 computes amax; pass 2 recomputes norm and quantizes.
-    for tg_idx in pl.spmd(t_dim // T_TILE, name_hint="qr_rms_norm_quant", allow_early_resolve=True):
+    qr_view = pl.reshape(qr, [t_dim, Q_LORA])
+    qr_scale_view = pl.reshape(qr_scale, [t_dim, 1])
+    qr_i8_matmul = pl.create_tensor([T_MAX, Q_LORA], dtype=pl.INT8)
+    for tg_idx in pl.spmd(t_dim // T_TILE, name_hint="qr_rms_norm_quant"):
         tg = tg_idx * T_TILE
         qr_sq_sum = pl.full([1, T_TILE], dtype=pl.FP32, value=0.0)
         qr_amax_g = pl.full([1, T_TILE], dtype=pl.FP32, value=0.0)
         for qr_rms_qb in pl.pipeline(Q_LORA // Q_LORA_TILE, stage=2):
             qr_rms_col0 = qr_rms_qb * Q_LORA_TILE
-            qr_rms_chunk = qr_fp32[tg : tg + T_TILE, qr_rms_col0 : qr_rms_col0 + Q_LORA_TILE]
-            qr_sq_sum = pl.add(qr_sq_sum, pl.reshape(pl.row_sum(pl.mul(qr_rms_chunk, qr_rms_chunk)), [1, T_TILE]))
+            qr_rms_chunk = qr_partials[tg : tg + T_TILE, qr_rms_col0 : qr_rms_col0 + Q_LORA_TILE]
+            for qr_rms_split in pl.range(1, QR_SPLIT_TILE):
+                qr_rms_p0 = qr_rms_split * T_MAX + tg
+                qr_rms_partial = qr_partials[qr_rms_p0 : qr_rms_p0 + T_TILE, qr_rms_col0 : qr_rms_col0 + Q_LORA_TILE]
+                qr_rms_chunk = pl.add(qr_rms_chunk, qr_rms_partial)
+            qr_sq = pl.mul(qr_rms_chunk, qr_rms_chunk)
+            qr_sq_row = pl.row_sum(qr_sq)
+            qr_sq_partial = pl.reshape(qr_sq_row, [1, T_TILE])
+            qr_sq_sum = pl.add(qr_sq_sum, qr_sq_partial)
             gamma_rms_cast = pl.cast(gamma_cq[qr_rms_col0 : qr_rms_col0 + Q_LORA_TILE], target_type=pl.FP32)
             gamma_rms_chunk = pl.reshape(gamma_rms_cast, [1, Q_LORA_TILE])
             qr_g = pl.col_expand_mul(qr_rms_chunk, gamma_rms_chunk)
             qr_g_abs = pl.abs(qr_g)
-            qr_amax_g = pl.maximum(qr_amax_g, pl.reshape(pl.row_max(qr_g_abs), [1, T_TILE]))
-        qr_inv_rms = pl.rsqrt(pl.add(pl.mul(qr_sq_sum, 1.0 / Q_LORA), EPS), high_precision=True)
+            qr_amax_row = pl.row_max(qr_g_abs)
+            qr_amax_partial = pl.reshape(qr_amax_row, [1, T_TILE])
+            qr_amax_g = pl.maximum(qr_amax_g, qr_amax_partial)
+        qr_sq_mean = pl.mul(qr_sq_sum, 1.0 / Q_LORA)
+        qr_rms_arg = pl.add(qr_sq_mean, EPS)
+        qr_inv_rms = pl.rsqrt(qr_rms_arg, high_precision=True)
         qr_inv_rms_t = pl.reshape(qr_inv_rms, [T_TILE, 1])
         qr_amax_floor = pl.full([1, T_TILE], dtype=pl.FP32, value=INT8_AMAX_EPS)
         qr_amax_normed = pl.mul(qr_inv_rms, qr_amax_g)
         qr_tile_amax = pl.maximum(qr_amax_floor, qr_amax_normed)
 
-        qr_scale_quant_row = pl.div(pl.full([1, T_TILE], dtype=pl.FP32, value=INT8_SCALE_MAX), qr_tile_amax)
+        qr_scale_max = pl.full([1, T_TILE], dtype=pl.FP32, value=INT8_SCALE_MAX)
+        qr_scale_quant_row = pl.div(qr_scale_max, qr_tile_amax)
         qr_scale_quant_t = pl.reshape(qr_scale_quant_row, [T_TILE, 1])
-        qr_tile_scale_dq = pl.reshape(pl.recip(qr_scale_quant_row), [T_TILE, 1])
+        qr_scale_recip = pl.recip(qr_scale_quant_row)
+        qr_tile_scale_dq = pl.reshape(qr_scale_recip, [T_TILE, 1])
         qr_scale_view[tg : tg + T_TILE, :] = qr_tile_scale_dq
 
         for qa in pl.pipeline(0, Q_LORA, QUANT_TILE, stage=2):
-            qr_chunk = qr_fp32[tg : tg + T_TILE, qa : qa + QUANT_TILE]
+            qr_chunk = qr_partials[tg : tg + T_TILE, qa : qa + QUANT_TILE]
+            for qr_q_split in pl.range(1, QR_SPLIT_TILE):
+                qr_q_p0 = qr_q_split * T_MAX + tg
+                qr_q_partial = qr_partials[qr_q_p0 : qr_q_p0 + T_TILE, qa : qa + QUANT_TILE]
+                qr_chunk = pl.add(qr_chunk, qr_q_partial)
             gamma_q_cast = pl.cast(gamma_cq[qa : qa + QUANT_TILE], target_type=pl.FP32)
             gamma_q_chunk = pl.reshape(gamma_q_cast, [1, QUANT_TILE])
-            qr_q_normed = pl.col_expand_mul(pl.row_expand_mul(qr_chunk, qr_inv_rms_t), gamma_q_chunk)
+            qr_q_rms = pl.row_expand_mul(qr_chunk, qr_inv_rms_t)
+            qr_q_normed = pl.col_expand_mul(qr_q_rms, gamma_q_chunk)
             qr_q_scaled = pl.row_expand_mul(qr_q_normed, qr_scale_quant_t)
             qr_q_i32 = pl.cast(qr_q_scaled, target_type=pl.INT32, mode="rint")
             qr_q_half = pl.cast(qr_q_i32, target_type=pl.FP16, mode="round")
@@ -262,19 +246,15 @@ def qkv_proj_rope(
             qr_view[tg : tg + T_TILE, qa : qa + QUANT_TILE] = qr_q_i8
             qr_i8_matmul[tg : tg + T_TILE, qa : qa + QUANT_TILE] = qr_q_i8
 
-    # UN-MIXED qproj: keep the pure-matmul scope (cube, INT32 -> GM) separate from
-    # downstream vector work. Normal dependency dispatch keeps q dequant off AIV
-    # until qproj finishes producing its INT32 output.
     q_proj_i32 = pl.create_tensor([T_MAX, H * HEAD_DIM], dtype=pl.INT32)
-    for hg_idx in pl.spmd(((H * HEAD_DIM) // QPROJ_MM_N_TILE) // QPROJ_TILES_PER_BLOCK, name_hint="qproj_matmul"):
-        hg = hg_idx * QPROJ_TILES_PER_BLOCK
-        for h_inner in pl.range(QPROJ_TILES_PER_BLOCK):
+    for hg_idx in pl.spmd(((H * HEAD_DIM) // QPROJ_MM_N_TILE) // QPROJ_BLOCK_TILE, name_hint="qproj_matmul"):
+        hg = hg_idx * QPROJ_BLOCK_TILE
+        for h_inner in pl.range(QPROJ_BLOCK_TILE):
             w_col0 = (hg + h_inner) * QPROJ_MM_N_TILE
             for tc in pl.range(t_matmul // QPROJ_M_TILE):
                 t0 = tc * QPROJ_M_TILE
                 col_acc = pl.create_tensor([QPROJ_M_TILE, QPROJ_MM_N_TILE], dtype=pl.INT32)
-                for qb in pl.pipeline(0, Q_LORA // Q_PROJ_TILE, stage=2):
-                    qr_proj_col0 = qb * Q_PROJ_TILE
+                for qr_proj_col0 in pl.pipeline(0, Q_LORA, Q_PROJ_TILE, stage=2):
                     qr_i8_chunk = qr_i8_matmul[t0 : t0 + QPROJ_M_TILE, qr_proj_col0 : qr_proj_col0 + Q_PROJ_TILE]
                     wq_chunk = wq_b[qr_proj_col0 : qr_proj_col0 + Q_PROJ_TILE, w_col0 : w_col0 + QPROJ_MM_N_TILE]
                     if qr_proj_col0 == 0:
@@ -283,9 +263,6 @@ def qkv_proj_rope(
                         col_acc = pl.matmul_acc(col_acc, qr_i8_chunk, wq_chunk)
                 q_proj_i32[t0 : t0 + QPROJ_M_TILE, w_col0 : w_col0 + QPROJ_MM_N_TILE] = col_acc
 
-    # Fuse qproj dequant, per-head RMSNorm, NOPE writeback, and interleaved RoPE.
-    # A full [token, head] tile fits in Vec UB, so dequantize each head once and
-    # retain it across the RMS reduction instead of rereading/recomputing NOPE.
     # RoPE: out[j] = inv_rms * (x[j] * cos[j] + x[j^1] * sign[j] * sin[j]).
     q_flat = pl.reshape(q, [t_dim, H * HEAD_DIM])
     for hg_idx in pl.spmd(H // Q_ROPE_H_TILE, name_hint="qproj_dequant_rms_nope_rope"):
@@ -295,9 +272,7 @@ def qkv_proj_rope(
             qr_scale_dq_t = qr_scale_view[tg : tg + Q_ROPE_T_TILE, :]
             q_cos_il = q_rope_cos_il[tg : tg + Q_ROPE_T_TILE, :]
             q_sin_signed = q_rope_sin_signed[tg : tg + Q_ROPE_T_TILE, :]
-            q_swap_idx = q_rope_swap_idx[tg : tg + Q_ROPE_T_TILE, :]
-            # Pipeline adjacent heads so the next head's GM reads overlap the
-            # current head's vector RMS/rotation work, as in Qwen's decode loop.
+            q_swap_flat = q_rope_swap_flat[0:1, 0:Q_ROPE_FLAT_LEN]
             for h_inner in pl.pipeline(Q_ROPE_H_TILE, stage=2):
                 h = hg + h_inner
                 h0 = h * HEAD_DIM
@@ -318,46 +293,29 @@ def qkv_proj_rope(
                 q_nope_bf16 = pl.cast(q_nope_normed, target_type=pl.BF16, mode="rint")
                 q_flat[tg : tg + Q_ROPE_T_TILE, h0 : h0 + NOPE_DIM] = q_nope_bf16
 
-                # RoPE writeback on columns [h0+NOPE_DIM:h0+HEAD_DIM). Fold inv_rms in
-                # BEFORE the rotation (normalize-then-rotate), matching the kv path. This
-                # is mathematically equivalent to rotating then normalizing — inv_rms is a
-                # per-row scalar so inv_rms*(a*cos+b*sin) == (a*inv_rms)*cos+(b*inv_rms)*sin
-                # — but keeps the rotation intermediates small. Rotating the raw (large)
-                # dequantized values first produced large intermediates that lost precision
-                # on Ascend950 (A5), corrupting the query RoPE region; normalizing first
-                # avoids that without changing the result on A2A3.
                 q_rope_chunk_raw = q_head_dq[:, NOPE_DIM:HEAD_DIM]
                 q_rope_chunk = pl.row_expand_mul(q_rope_chunk_raw, q_head_inv_rms_t)
                 q_rope_col0 = h0 + NOPE_DIM
                 q_rope_col1 = q_rope_col0 + ROPE_DIM
-                for q_rope_row in pl.range(Q_ROPE_T_TILE):
-                    q_rope_row_chunk = q_rope_chunk[q_rope_row : q_rope_row + 1, :]
-                    q_rope_swap_row = q_swap_idx[q_rope_row : q_rope_row + 1, :]
-                    q_rope_cos_row = q_cos_il[q_rope_row : q_rope_row + 1, :]
-                    q_rope_sin_row = q_sin_signed[q_rope_row : q_rope_row + 1, :]
-                    q_rope_swapped = pl.gather(q_rope_row_chunk, dim=-1, index=q_rope_swap_row)
-                    q_rope_base = pl.mul(q_rope_row_chunk, q_rope_cos_row)
-                    q_rope_delta = pl.mul(q_rope_swapped, q_rope_sin_row)
-                    q_rope_rot = pl.add(q_rope_base, q_rope_delta)
-                    q_rope_bf16 = pl.cast(q_rope_rot, target_type=pl.BF16, mode="rint")
-                    q_rope_out_row = tg + q_rope_row
-                    q_flat[q_rope_out_row : q_rope_out_row + 1, q_rope_col0:q_rope_col1] = q_rope_bf16
+                q_rope_flat = pl.reshape(q_rope_chunk, [1, Q_ROPE_FLAT_LEN])
+                q_rope_gathered = pl.gather(q_rope_flat, dim=-1, index=q_swap_flat)
+                q_rope_swapped = pl.reshape(q_rope_gathered, [Q_ROPE_T_TILE, ROPE_DIM])
+                q_rope_base = pl.mul(q_rope_chunk, q_cos_il)
+                q_rope_delta = pl.mul(q_rope_swapped, q_sin_signed)
+                q_rope_rot = pl.add(q_rope_base, q_rope_delta)
+                q_rope_bf16 = pl.cast(q_rope_rot, target_type=pl.BF16, mode="rint")
+                q_flat[tg : tg + Q_ROPE_T_TILE, q_rope_col0:q_rope_col1] = q_rope_bf16
 
-    # Split-K kv_proj partials are reduced in ascending K order.
-    kv_fp32 = pl.create_tensor([T_MAX, HEAD_DIM], dtype=pl.FP32)
-    kv_partials = pl.create_tensor([KV_OK * T_MAX, HEAD_DIM], dtype=pl.FP32)
-    # `late_dep` is a dummy barrier hung off the rms_norm TaskId: kv_proj is off the
-    # critical path, so it resolves one hop after rms_norm and lets qr_proj_matmul
-    # take the cores first.
-    with pl.spmd((HEAD_DIM // KV_N_TILE) * KV_OK, name_hint="kv_proj_matmul", deps=[late_dep]) as _kv_tid:
+    kv_partials = pl.create_tensor([KV_SPLIT_TILE * T_MAX, HEAD_DIM], dtype=pl.FP32)
+    with pl.spmd((HEAD_DIM // KV_N_TILE) * KV_SPLIT_TILE, name_hint="kv_proj_matmul", deps=[late_dep]) as _kv_tid:
         kbg = pl.tile.get_block_idx()
-        kv_col0 = (kbg // KV_OK) * KV_N_TILE
-        kv_split = kbg % KV_OK
-        kv_k_base = kv_split * KV_K_SLICE
+        kv_col0 = (kbg // KV_SPLIT_TILE) * KV_N_TILE
+        kv_split = kbg % KV_SPLIT_TILE
+        kv_k_base = kv_split * KV_K_SPLIT_TILE
         for tc in pl.range(t_matmul // KV_M_TILE):
             t0 = tc * KV_M_TILE
             kv_acc = pl.create_tensor([KV_M_TILE, KV_N_TILE], dtype=pl.FP32)
-            for db in pl.pipeline(KV_K_SLICE // KV_K_TILE, stage=2):
+            for db in pl.pipeline(KV_K_SPLIT_TILE // KV_K_TILE, stage=2):
                 d0 = kv_k_base + db * KV_K_TILE
                 kv_rows = pl.min(KV_M_TILE, t_dim - t0)
                 kv_x_chunk_bf16 = pl.slice(x_view, [KV_M_TILE, KV_K_TILE], [t0, d0], valid_shape=[kv_rows, KV_K_TILE])
@@ -366,71 +324,66 @@ def qkv_proj_rope(
                     kv_acc = pl.matmul(kv_x_chunk_bf16, wkv_chunk, out_dtype=pl.FP32)
                 else:
                     kv_acc = pl.matmul_acc(kv_acc, kv_x_chunk_bf16, wkv_chunk)
-            kv_partials = pl.assemble(kv_partials, kv_acc, [kv_split * T_MAX + t0, kv_col0])
+            kv_partial_t0 = kv_split * T_MAX + t0
+            kv_partials[kv_partial_t0 : kv_partial_t0 + KV_M_TILE, kv_col0 : kv_col0 + KV_N_TILE] = kv_acc
 
-    for kv_reduce_idx in pl.spmd(
-        (t_matmul // KV_M_TILE) * (HEAD_DIM // KV_N_TILE),
-        name_hint="kv_proj_reduce",
-        allow_early_resolve=True,
-    ):
+    kv_fp32 = pl.create_tensor([T_MAX, HEAD_DIM], dtype=pl.FP32)
+    for kv_reduce_idx in pl.spmd((t_matmul // KV_M_TILE) * (HEAD_DIM // KV_N_TILE), name_hint="kv_proj_reduce"):
         kv_t0 = (kv_reduce_idx // (HEAD_DIM // KV_N_TILE)) * KV_M_TILE
         kv_col0 = (kv_reduce_idx % (HEAD_DIM // KV_N_TILE)) * KV_N_TILE
         kv_total = kv_partials[kv_t0 : kv_t0 + KV_M_TILE, kv_col0 : kv_col0 + KV_N_TILE]
-        for kv_split in pl.range(1, KV_OK):
+        for kv_split in pl.range(1, KV_SPLIT_TILE):
             kv_partial_t0 = kv_split * T_MAX + kv_t0
-            kv_total = pl.add(
-                kv_total,
-                kv_partials[
-                    kv_partial_t0 : kv_partial_t0 + KV_M_TILE,
-                    kv_col0 : kv_col0 + KV_N_TILE,
-                ],
-            )
-        kv_fp32 = pl.assemble(kv_fp32, kv_total, [kv_t0, kv_col0])
+            kv_partial = kv_partials[kv_partial_t0 : kv_partial_t0 + KV_M_TILE, kv_col0 : kv_col0 + KV_N_TILE]
+            kv_total = pl.add(kv_total, kv_partial)
+        kv_fp32[kv_t0 : kv_t0 + KV_M_TILE, kv_col0 : kv_col0 + KV_N_TILE] = kv_total
 
-    # Fused KV RMSNorm + interleaved (CANN A3) RoPE. One spmd task per [KV_RMS_T_TILE, HEAD_DIM]
-    # row block computes the per-row inv_rms once (pass 1) and consumes it locally for
-    # BOTH the NOPE writeback and the rope rotation -- so inv_rms no longer round-trips
-    # through GM (the old kv_inv_rms_tensor) and the two passes collapse into a single
-    # dispatch. NOPE columns [0:NOPE_DIM) and rope columns [NOPE_DIM:HEAD_DIM) are
-    # disjoint, so each task writes a clean, conflict-free row block of kv. Vec UB stays
-    # well under the 192 KB cap (chunks are at most [KV_RMS_T_TILE, KV_TILE] fp32).
+    kv_view = pl.reshape(kv, [t_dim, HEAD_DIM])
     for tg_idx in pl.spmd(t_dim // KV_RMS_T_TILE, name_hint="kv_rms_norm_rope"):
         tg = tg_idx * KV_RMS_T_TILE
-        # Pass 1: per-row sum of squares over the full HEAD_DIM -> inv_rms.
         kv_sq_sum = pl.full([1, KV_RMS_T_TILE], dtype=pl.FP32, value=0.0)
-        for kb in pl.pipeline(HEAD_DIM // KV_TILE, stage=2):
-            kv_sq_col0 = kb * KV_TILE
+        for kv_sq_col0 in pl.pipeline(0, HEAD_DIM, KV_TILE, stage=2):
             kv_chunk = kv_fp32[tg : tg + KV_RMS_T_TILE, kv_sq_col0 : kv_sq_col0 + KV_TILE]
-            kv_sq_sum = pl.add(kv_sq_sum, pl.reshape(pl.row_sum(pl.mul(kv_chunk, kv_chunk)), [1, KV_RMS_T_TILE]))
-        kv_inv_rms = pl.rsqrt(pl.add(pl.mul(kv_sq_sum, 1.0 / HEAD_DIM), EPS), high_precision=True)
+            kv_sq = pl.mul(kv_chunk, kv_chunk)
+            kv_sq_row = pl.row_sum(kv_sq)
+            kv_sq_partial = pl.reshape(kv_sq_row, [1, KV_RMS_T_TILE])
+            kv_sq_sum = pl.add(kv_sq_sum, kv_sq_partial)
+        kv_sq_mean = pl.mul(kv_sq_sum, 1.0 / HEAD_DIM)
+        kv_rms_arg = pl.add(kv_sq_mean, EPS)
+        kv_inv_rms = pl.rsqrt(kv_rms_arg, high_precision=True)
         kv_inv_rms_t = pl.reshape(kv_inv_rms, [KV_RMS_T_TILE, 1])
 
-        # NOPE writeback: rms-normalize columns [0:NOPE_DIM) with per-column gamma.
-        for nb in pl.pipeline(NOPE_DIM // KV_TILE, stage=2):
-            n0 = nb * KV_TILE
+        for n0 in pl.pipeline(0, NOPE_DIM, KV_TILE, stage=2):
             kv_chunk = kv_fp32[tg : tg + KV_RMS_T_TILE, n0 : n0 + KV_TILE]
             gamma_kv_cast = pl.cast(gamma_ckv[n0 : n0 + KV_TILE], target_type=pl.FP32)
             gamma_kv_chunk = pl.reshape(gamma_kv_cast, [1, KV_TILE])
-            kv_normed = pl.col_expand_mul(pl.row_expand_mul(kv_chunk, kv_inv_rms_t), gamma_kv_chunk)
-            kv_view[tg : tg + KV_RMS_T_TILE, n0 : n0 + KV_TILE] = pl.cast(kv_normed, target_type=pl.BF16, mode="rint")
+            kv_rms = pl.row_expand_mul(kv_chunk, kv_inv_rms_t)
+            kv_normed = pl.col_expand_mul(kv_rms, gamma_kv_chunk)
+            kv_normed_bf16 = pl.cast(kv_normed, target_type=pl.BF16, mode="rint")
+            kv_view[tg : tg + KV_RMS_T_TILE, n0 : n0 + KV_TILE] = kv_normed_bf16
 
-        # RoPE writeback on columns [NOPE_DIM:HEAD_DIM), interleaved (CANN A3) swap-gather
-        # (same form as qproj_dequant_rms_nope_rope), built in-kernel. inv_rms (per-row, the same
-        # factor used for NOPE above) and gamma (per-column, full ROPE_DIM) are folded into
-        # kv_rope_norm_chunk BEFORE the swap so the swapped lane n[j^1] carries gamma[j^1]
-        # (gamma does NOT commute with the rotation; inv_rms does).
-        #   out[j] = n[j]*cos_il[j] + n[j^1]*sign[j]*sin_il[j]
+        # RoPE: out[j] = n[j] * cos_il[j] + n[j^1] * sign[j] * sin_il[j].
         gamma_rope_cast = pl.cast(gamma_ckv[NOPE_DIM : NOPE_DIM + ROPE_DIM], target_type=pl.FP32)
         gamma_rope = pl.reshape(gamma_rope_cast, [1, ROPE_DIM])
         kv_rope_chunk = kv_fp32[tg : tg + KV_RMS_T_TILE, NOPE_DIM : NOPE_DIM + ROPE_DIM]
-        kv_rope_norm_chunk = pl.col_expand_mul(pl.row_expand_mul(kv_rope_chunk, kv_inv_rms_t), gamma_rope)
+        kv_rope_rms = pl.row_expand_mul(kv_rope_chunk, kv_inv_rms_t)
+        kv_rope_norm_chunk = pl.col_expand_mul(kv_rope_rms, gamma_rope)
         kv_ones = pl.full([1, ROPE_DIM], dtype=pl.FP32, value=1.0)
-        kv_col = pl.col_expand_mul(kv_ones, pl.cast(pl.arange(0, [1, ROPE_DIM], dtype=pl.INT32), target_type=pl.FP32))
-        kv_dup_f = pl.cast(pl.cast(pl.mul(kv_col, 0.5), target_type=pl.INT32, mode="trunc"), target_type=pl.FP32)
-        kv_dup_idx = pl.cast(kv_dup_f, target_type=pl.INT32)                                       # j>>1
-        kv_lane = pl.sub(kv_col, pl.mul(kv_dup_f, 2.0))                                            # j%2
-        kv_swap_idx = pl.cast(pl.sub(pl.add(kv_col, 1.0), pl.mul(kv_lane, 2.0)), target_type=pl.INT32)  # j^1
-        kv_sign = pl.sub(pl.mul(kv_lane, 2.0), 1.0)                                                # [-1,+1,...]
+        kv_col_i32 = pl.arange(0, [1, ROPE_DIM], dtype=pl.INT32)
+        kv_col_f32 = pl.cast(kv_col_i32, target_type=pl.FP32)
+        kv_col = pl.col_expand_mul(kv_ones, kv_col_f32)
+        kv_half = pl.mul(kv_col, 0.5)
+        kv_dup_i32 = pl.cast(kv_half, target_type=pl.INT32, mode="trunc")
+        kv_dup_f = pl.cast(kv_dup_i32, target_type=pl.FP32)
+        kv_dup_idx = pl.cast(kv_dup_f, target_type=pl.INT32)
+        kv_dup_twice = pl.mul(kv_dup_f, 2.0)
+        kv_lane = pl.sub(kv_col, kv_dup_twice)
+        kv_col_next = pl.add(kv_col, 1.0)
+        kv_swap_lane_twice = pl.mul(kv_lane, 2.0)
+        kv_swap = pl.sub(kv_col_next, kv_swap_lane_twice)
+        kv_swap_idx = pl.cast(kv_swap, target_type=pl.INT32)
+        kv_sign_lane_twice = pl.mul(kv_lane, 2.0)
+        kv_sign = pl.sub(kv_sign_lane_twice, 1.0)
         for kv_rope_row in pl.range(KV_RMS_T_TILE):
             kv_rope_t = tg + kv_rope_row
             kv_cos = pl.cast(rope_cos_view[kv_rope_t : kv_rope_t + 1, :], target_type=pl.FP32)
@@ -473,22 +426,13 @@ def qkv_proj_rope_test(
     qr.bind_dynamic(0, T_DYN)
     qr_scale.bind_dynamic(0, T_DYN)
 
-    # Standalone: no rms_norm producer, so the barrier fences nothing (ready on submit).
     late_dep = pl.system.task_dummy(deps=[])
     qkv_proj_rope(
         x,
-        wq_a,
-        wq_b,
-        wq_b_scale,
-        wkv,
-        rope_cos,
-        rope_sin,
-        gamma_cq,
-        gamma_ckv,
-        q,
-        kv,
-        qr,
-        qr_scale,
+        wq_a, wq_b, wq_b_scale, wkv,
+        rope_cos, rope_sin,
+        gamma_cq, gamma_ckv,
+        q, kv, qr, qr_scale,
         late_dep,
     )
     return q
@@ -496,8 +440,8 @@ def qkv_proj_rope_test(
 
 _A5_FP32_VECTOR_LANES = 64
 _A5_CUBE_ACC_K = 16
-_A5_CUBE_N_BLOCK = 128
-_A5_CUBE_K_GROUP_BLOCK = 64
+_A5_CUBE_N_TILE = 128
+_A5_CUBE_K_GROUP_TILE = 64
 
 
 def _golden_a5_trowsum_fp32(values):
@@ -546,18 +490,14 @@ def _golden_a5_cube_bf16_matmul(lhs, rhs):
         )
 
     k_groups = k_dim // _A5_CUBE_ACC_K
-    x_groups = lhs.to(torch.bfloat16).reshape(
-        m_dim, k_groups, _A5_CUBE_ACC_K
-    ).double()
-    w_groups = rhs.to(torch.bfloat16).T.contiguous().reshape(
-        n_dim, k_groups, _A5_CUBE_ACC_K
-    ).double()
+    x_groups = lhs.to(torch.bfloat16).reshape(m_dim, k_groups, _A5_CUBE_ACC_K).double()
+    w_groups = rhs.to(torch.bfloat16).T.contiguous().reshape(n_dim, k_groups, _A5_CUBE_ACC_K).double()
     out = torch.zeros(m_dim, n_dim, dtype=torch.float32, device=lhs.device)
-    for n0 in range(0, n_dim, _A5_CUBE_N_BLOCK):
-        n1 = min(n0 + _A5_CUBE_N_BLOCK, n_dim)
+    for n0 in range(0, n_dim, _A5_CUBE_N_TILE):
+        n1 = min(n0 + _A5_CUBE_N_TILE, n_dim)
         acc = torch.zeros(m_dim, n1 - n0, dtype=torch.float32, device=lhs.device)
-        for group0 in range(0, k_groups, _A5_CUBE_K_GROUP_BLOCK):
-            group1 = min(group0 + _A5_CUBE_K_GROUP_BLOCK, k_groups)
+        for group0 in range(0, k_groups, _A5_CUBE_K_GROUP_TILE):
+            group1 = min(group0 + _A5_CUBE_K_GROUP_TILE, k_groups)
             group_dots = torch.einsum(
                 "mgk,ngk->mng",
                 x_groups[:, group0:group1],
@@ -610,20 +550,15 @@ def _golden_qr_rms_norm_quant(qr_fp32, gamma_cq):
     import torch
 
     gamma_fp32 = gamma_cq.to(torch.bfloat16).float()
-    qr_inv_rms = _golden_a5_chunked_rms_inv(
-        qr_fp32, chunk_size=Q_LORA_TILE, eps=EPS
-    )
+    qr_inv_rms = _golden_a5_chunked_rms_inv(qr_fp32, chunk_size=Q_LORA_TILE, eps=EPS)
 
-    qr_amax_g = torch.zeros(
-        *qr_fp32.shape[:-1], 1, dtype=torch.float32, device=qr_fp32.device
-    )
+    qr_amax_g = torch.zeros(*qr_fp32.shape[:-1], 1, dtype=torch.float32, device=qr_fp32.device)
     for k0 in range(0, qr_fp32.shape[-1], Q_LORA_TILE):
         qr_chunk = qr_fp32[..., k0:k0 + Q_LORA_TILE]
         gamma_chunk = gamma_fp32[k0:k0 + Q_LORA_TILE]
-        qr_amax_g = torch.maximum(
-            qr_amax_g,
-            (qr_chunk * gamma_chunk).abs().amax(dim=-1, keepdim=True),
-        )
+        qr_gamma = qr_chunk * gamma_chunk
+        qr_gamma_amax = qr_gamma.abs().amax(dim=-1, keepdim=True)
+        qr_amax_g = torch.maximum(qr_amax_g, qr_gamma_amax)
 
     qr_tile_amax = (qr_inv_rms * qr_amax_g).clamp_min(INT8_AMAX_EPS)
     qr_scale_quant = torch.full_like(qr_tile_amax, INT8_SCALE_MAX) / qr_tile_amax
@@ -636,9 +571,7 @@ def _golden_qr_rms_norm_quant(qr_fp32, gamma_cq):
 
 def _golden_a5_q_head_rms_norm(q_full):
     """Mirror the fused Q dequant kernel's HEAD_DIM TROWSUM and HP rsqrt."""
-    q_inv_rms = _golden_a5_chunked_rms_inv(
-        q_full, chunk_size=HEAD_DIM, eps=EPS
-    )
+    q_inv_rms = _golden_a5_chunked_rms_inv(q_full, chunk_size=HEAD_DIM, eps=EPS)
     return q_full * q_inv_rms
 
 
@@ -687,15 +620,8 @@ def golden_qkv_proj_rope(tensors):
     t_dim = active_t_dim
     token_x = x.view(t_dim, D)
 
-    # Q path
-    qr_fp32 = _golden_a5_split_k_bf16_matmul(
-        token_x,
-        wq_a,
-        splits=QR_OK,
-        k_per_split=QR_K_SLICE,
-    )   # [T, Q_LORA]
+    qr_fp32 = _golden_a5_split_k_bf16_matmul(token_x, wq_a, splits=QR_SPLIT_TILE, k_per_split=QR_K_SPLIT_TILE)
     # W8A8C16: wq_b W8 per-output-channel int8; qr_out A8 per-token int8.
-    # flash: also quantizes wq_a/wkv to fp8 (default Linear dtype).
     qr_i8, qr_scale = _golden_qr_rms_norm_quant(qr_fp32, gamma_cq)
     q_i32 = torch.matmul(qr_i8.to(torch.int32), wq_b.to(torch.int32))
     q_full = (q_i32.float() * qr_scale * wq_b_scale.view(1, -1)).view(t_dim, H, HEAD_DIM)
@@ -704,18 +630,8 @@ def golden_qkv_proj_rope(tensors):
     q_rope = apply_rope(q_full[..., NOPE_DIM:], rope_cos, rope_sin)
     q_out = torch.cat([q_nope, q_rope], dim=-1)
 
-    # KV path: kv_proj_matmul is the same construct as qr_proj_matmul (BF16
-    # inputs, one FP32 Cube accumulator per split, ordered split reduction), so
-    # it takes the same A5 K16 reference; only the tile geometry differs.
-    kv_full = rms_norm(
-        _golden_a5_split_k_bf16_matmul(
-            token_x,
-            wkv,
-            splits=KV_OK,
-            k_per_split=KV_K_SLICE,
-        ),
-        gamma_ckv,
-    )  # [T, HEAD_DIM]
+    kv_proj = _golden_a5_split_k_bf16_matmul(token_x, wkv, splits=KV_SPLIT_TILE, k_per_split=KV_K_SPLIT_TILE)
+    kv_full = rms_norm(kv_proj, gamma_ckv)
     kv_nope = kv_full[..., :NOPE_DIM]
     kv_rope_in = kv_full[..., NOPE_DIM:].unsqueeze(1)               # add a pseudo head dim
     kv_rope = apply_rope(kv_rope_in, rope_cos, rope_sin).squeeze(1)
@@ -740,11 +656,9 @@ def _reference_q_from_quantized_qr(
 
     t_dim = qr.shape[0]
     q_i32 = torch.matmul(qr.to(torch.int32), wq_b.to(torch.int32))
-    q_full = (
-        q_i32.float()
-        * qr_scale.float()
-        * wq_b_scale.float().view(1, -1)
-    ).view(t_dim, H, HEAD_DIM)
+    q_scaled = q_i32.float() * qr_scale.float()
+    q_scaled = q_scaled * wq_b_scale.float().view(1, -1)
+    q_full = q_scaled.view(t_dim, H, HEAD_DIM)
     q_full = _golden_a5_q_head_rms_norm(q_full)
 
     q_pair = q_full[..., NOPE_DIM:].unflatten(-1, (-1, 2))
@@ -854,13 +768,7 @@ def qr_scale_compare(
     max_error_ratio=0.0,
     max_show=10,
 ):
-    """Validate QR dequant scales with ratio and per-row bounds.
-
-    A scale is a whole-row quantization boundary: one bad value affects every
-    downstream channel for that token. Keep the aggregate ratio for parity
-    with the numeric harness, but also reject any individual scale outside a
-    small absolute/relative cap so conditioned Q validation cannot hide it.
-    """
+    """Validate QR dequant scales with aggregate and per-row bounds."""
     import torch
 
     if atol < 0 or rtol < 0:
@@ -900,8 +808,6 @@ def qr_scale_compare(
         bad = diff > tolerance
         bad_count = int(bad.count_nonzero().item())
         threshold = round(max_error_ratio * actual.numel())
-        # Even if a caller opts into an aggregate budget, no individual scale
-        # may exceed a modest 2x cap.
         hard_bad = diff > (2.0 * tolerance)
         hard_bad_count = int(hard_bad.count_nonzero().item())
         if bad_count <= threshold and hard_bad_count == 0:
@@ -940,21 +846,10 @@ def q_from_runtime_qr_compare(
     rtol=1.0 / 128,
     max_error_ratio=0.005,
 ):
-    """Validate Q after conditioning the reference on the emitted QR codes.
-
-    CPU and A5 split-K reductions can place a few QR values on opposite sides
-    of an INT8 rounding boundary. Comparing Q against the CPU QR path amplifies
-    one legal code-step across an entire projected token. QR and QR scale are
-    validated independently, so the downstream Q reference must start from the
-    device-emitted quantized boundary to isolate Q projection/RMS/RoPE accuracy.
-    """
+    """Validate Q against a reference conditioned on the emitted QR codes."""
     from golden import ratio_allclose
 
-    base_compare = ratio_allclose(
-        atol=atol,
-        rtol=rtol,
-        max_error_ratio=max_error_ratio,
-    )
+    base_compare = ratio_allclose(atol=atol, rtol=rtol, max_error_ratio=max_error_ratio)
 
     def compare(
         actual,
@@ -1025,21 +920,27 @@ def build_tensor_specs(B, S):
         w_i8 = w_i32.to(torch.float16).to(torch.int8)
         return w_i8, (1.0 / scale_quant).float()
 
-    # Inputs match cann test_mla_prolog_quant_pypto gen_mla_prolog_input_data (uniform).
     def init_x():
         return torch.empty([T, D], dtype=torch.bfloat16).uniform_(-1, 1)
+
     def init_wq_a():
         return torch.empty([D, Q_LORA], dtype=torch.bfloat16).uniform_(-0.1, 0.1)
+
     def init_wq_b():
         return torch.empty([Q_LORA, H * HEAD_DIM], dtype=torch.bfloat16).uniform_(-0.1, 0.1)
+
     def init_wkv():
         return torch.empty([D, HEAD_DIM], dtype=torch.bfloat16).uniform_(-0.1, 0.1)
+
     def init_cos():
         return torch.empty([T, ROPE_DIM], dtype=torch.bfloat16).uniform_(-1, 1)
+
     def init_sin():
         return torch.empty([T, ROPE_DIM], dtype=torch.bfloat16).uniform_(-1, 1)
+
     def init_gamma_cq():
         return torch.empty([Q_LORA], dtype=torch.bfloat16).uniform_(-1, 1)
+
     def init_gamma_ckv():
         return torch.empty([HEAD_DIM], dtype=torch.bfloat16).uniform_(-1, 1)
 
@@ -1074,14 +975,17 @@ if __name__ == "__main__":
     }
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("-p", "--platform", type=str, default="a2a3",
-                        choices=["a2a3", "a2a3sim", "a5", "a5sim"])
+    parser.add_argument("-p", "--platform", type=str, default="a2a3", choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--mode", choices=["decode", "prefill", "all"], default="all",
-                        help="Use decode or prefill batch sizes, or 'all' to test both.")
-    parser.add_argument("--enable-chip-swimlane", type=int, choices=[0, 1, 2, 4], default=0,
-                        help="chip swimlane level: 0=off, 1=per-kernel AICore timing "
-                             "(prints the per-function Task Statistics table), 2=+AICPU timing.")
+    parser.add_argument(
+        "--mode", choices=["decode", "prefill", "all"], default="all",
+        help="Use decode or prefill batch sizes, or 'all' to test both.",
+    )
+    parser.add_argument(
+        "--enable-chip-swimlane", type=int, choices=[0, 1, 2, 4], default=0,
+        help="chip swimlane level: 0=off, 1=per-kernel AICore timing "
+        "(prints the per-function Task Statistics table), 2=+AICPU timing.",
+    )
     parser.add_argument("--runtime-dir", type=str, default=None)
     parser.add_argument("--golden-data", type=str, default=None)
     parser.add_argument("--compile-only", action="store_true", default=False)
@@ -1097,20 +1001,13 @@ if __name__ == "__main__":
             fn=qkv_proj_rope_test,
             specs=build_tensor_specs(B, S),
             golden_fn=golden_qkv_proj_rope,
-            # W8A8C16 q_proj adds INT8 quant/dequant round-off before per-head RMSNorm.
             rtol=5e-3,
             atol=5e-3,
-            # Precision reference: pypto mla_prolog —
-            # cann-recipes-infer/ops/pypto_python/example/test_mla_prolog_pypto.py
             compare_fn={
                 "q":        q_from_runtime_qr_compare(atol=1e-4, rtol=1.0 / 128),
                 "kv":       ratio_allclose(atol=1e-4, rtol=1.0 / 128),
                 "qr":       quantized_qr_compare(max_code_step=1, max_changed_ratio=0.005),
-                "qr_scale": qr_scale_compare(
-                    atol=2.5e-5,
-                    rtol=5e-3,
-                    max_error_ratio=0.0,
-                ),
+                "qr_scale": qr_scale_compare(atol=2.5e-5, rtol=5e-3, max_error_ratio=0.0),
             },
             runtime_dir=args.runtime_dir,
             golden_data=args.golden_data,

--- a/models/deepseek_v4_pro/rmsnorm.py
+++ b/models/deepseek_v4_pro/rmsnorm.py
@@ -6,8 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-"""DeepSeek-V4 attention RMSNorm (dynamic shape): normalizes token-major
-activations for both decode and prefill attention paths."""
+"""DeepSeek-V4 attention RMSNorm for dynamic decode and prefill shapes."""
 
 import pypto.language as pl
 
@@ -23,30 +22,9 @@ D = M.hidden_size
 EPS = M.rms_norm_eps
 
 # tiling
-D_TILE = 128
+REDUCE_D_TILE = D // 4
+APPLY_D_TILE = D // 4
 T_TILE = 8
-# Blocks per token-tile. A decode step has t_dim == T == 8 == T_TILE, so the grid was
-# ONE block and rms_norm sat on the observed critical path as 22.4us of single-core
-# work with 83 cores idle (level-4 capture: it is task #4 of the 24-task path, and the
-# 0-88us window averages 5% engine occupancy).
-#
-# The token axis cannot go finer: T_TILE < 8 puts the [1, T_TILE] FP32 row accumulator
-# below the 32-byte alloc-tile row floor and codegen rejects it. So split D instead.
-# Each block recomputes the SAME full-row sum of squares -- deliberately redundant, so
-# the task stays one dispatch with no cross-block reduction -- and then applies the
-# normalization to its own D // RMS_D_SPLIT columns only. Bit-identical: every block
-# derives x_inv_rms from the same inputs in the same chunk order, and the applied
-# column ranges are disjoint.
-#
-# The trade is core-time for wall-time: 4-way costs ~35us of extra vector busy but the
-# task's wall drops 26.1 -> 16.0us in the swimlane. Device-measured on the a5 CSA decode
-# case, paired interleaved A/B, 5 reps x 100 rounds: 715.6 -> 709.7us (-5.9). 2-way gave
-# -4.2us and 7-way -8.1us with more variance, so 4 is the knee.
-RMS_D_SPLIT = 4
-assert D % D_TILE == 0, "D must be divisible by D_TILE"
-assert (D // D_TILE) % RMS_D_SPLIT == 0, "apply-pass D-chunk loop must cover D"
-assert (DECODE_BATCH * DECODE_SEQ) % T_TILE == 0
-assert (PREFILL_BATCH * PREFILL_SEQ) % T_TILE == 0
 
 
 @pl.jit.inline
@@ -56,31 +34,31 @@ def rms_norm(
     x_normed: pl.Tensor[[T_DYN, D], pl.BF16],
 ):
     t_dim = pl.tensor.dim(x, 0)
-    # Capture form (not `for ... in pl.spmd`): callers need the producer TaskId to
-    # hang a `pl.system.task_dummy` barrier off it and defer non-critical consumers.
-    with pl.spmd((t_dim // T_TILE) * RMS_D_SPLIT, name_hint="rms_norm", allow_early_resolve=True) as rms_tid:
+    with pl.spmd((t_dim // T_TILE) * (D // APPLY_D_TILE), name_hint="rms_norm", allow_early_resolve=True) as rms_tid:
         rms_blk = pl.tile.get_block_idx()
-        tg_idx = rms_blk // RMS_D_SPLIT
-        rms_dsplit = rms_blk - tg_idx * RMS_D_SPLIT
+        tg_idx = rms_blk // (D // APPLY_D_TILE)
+        rms_dsplit = rms_blk - tg_idx * (D // APPLY_D_TILE)
         tg = tg_idx * T_TILE
         x_sq_sum = pl.full([1, T_TILE], dtype=pl.FP32, value=0.0)
-        for rms_db in pl.pipeline(D // D_TILE, stage=2):
-            rms_d0 = rms_db * D_TILE
-            rms_x_chunk = pl.cast(x[tg : tg + T_TILE, rms_d0 : rms_d0 + D_TILE], target_type=pl.FP32)
-            x_sq_sum = pl.add(x_sq_sum, pl.reshape(pl.row_sum(pl.mul(rms_x_chunk, rms_x_chunk)), [1, T_TILE]))
-        x_inv_rms = pl.rsqrt(pl.add(pl.mul(x_sq_sum, 1.0 / D), EPS), high_precision=True)
+        for rms_d0 in pl.pipeline(0, D, REDUCE_D_TILE, stage=2):
+            rms_x_chunk = pl.cast(x[tg : tg + T_TILE, rms_d0 : rms_d0 + REDUCE_D_TILE], target_type=pl.FP32)
+            rms_x_sq = pl.mul(rms_x_chunk, rms_x_chunk)
+            rms_x_sq_sum = pl.row_sum(rms_x_sq)
+            rms_x_sq_row = pl.reshape(rms_x_sq_sum, [1, T_TILE])
+            x_sq_sum = pl.add(x_sq_sum, rms_x_sq_row)
+        x_sq_mean = pl.mul(x_sq_sum, 1.0 / D)
+        x_sq_eps = pl.add(x_sq_mean, EPS)
+        x_inv_rms = pl.rsqrt(x_sq_eps, high_precision=True)
         x_inv_rms_t = pl.reshape(x_inv_rms, [T_TILE, 1])
-        apply_dbs = (D // D_TILE) // RMS_D_SPLIT
-        for apply_db in pl.pipeline(apply_dbs, stage=2):
-            apply_d0 = (rms_dsplit * apply_dbs + apply_db) * D_TILE
-            apply_x_chunk = pl.cast(x[tg : tg + T_TILE, apply_d0 : apply_d0 + D_TILE], target_type=pl.FP32)
-            norm_w_chunk = pl.cast(pl.reshape(norm_w[apply_d0 : apply_d0 + D_TILE], [1, D_TILE]), pl.FP32)
-            x_normed_chunk = pl.col_expand_mul(pl.row_expand_mul(apply_x_chunk, x_inv_rms_t), norm_w_chunk)
-            x_normed[tg : tg + T_TILE, apply_d0 : apply_d0 + D_TILE] = pl.cast(
-                x_normed_chunk,
-                target_type=pl.BF16,
-                mode="rint",
-            )
+        apply_d_base = rms_dsplit * APPLY_D_TILE
+        for apply_d0 in pl.pipeline(apply_d_base, apply_d_base + APPLY_D_TILE, APPLY_D_TILE, stage=2):
+            apply_x_chunk = pl.cast(x[tg : tg + T_TILE, apply_d0 : apply_d0 + APPLY_D_TILE], target_type=pl.FP32)
+            norm_w_row = pl.reshape(norm_w[apply_d0 : apply_d0 + APPLY_D_TILE], [1, APPLY_D_TILE])
+            norm_w_chunk = pl.cast(norm_w_row, pl.FP32)
+            x_scaled = pl.row_expand_mul(apply_x_chunk, x_inv_rms_t)
+            x_normed_chunk = pl.col_expand_mul(x_scaled, norm_w_chunk)
+            x_normed_bf16 = pl.cast(x_normed_chunk, target_type=pl.BF16, mode="rint")
+            x_normed[tg : tg + T_TILE, apply_d0 : apply_d0 + APPLY_D_TILE] = x_normed_bf16
 
     return rms_tid
 
@@ -103,12 +81,10 @@ def golden_rms_norm(x, norm_w):
 
     x = x.float()
     norm_w = norm_w.float()
-    # Mirror rms_norm's loop-carried FP32 reduction exactly.  A monolithic
-    # torch.mean uses a different reduction tree and can cross a BF16 rounding
-    # boundary even though both expressions are algebraically equivalent.
+    # Accumulate squared chunks in kernel order.
     sq_sum = torch.zeros(*x.shape[:-1], 1, dtype=torch.float32)
-    for d0 in range(0, D, D_TILE):
-        x_chunk = x[..., d0:d0 + D_TILE]
+    for d0 in range(0, D, REDUCE_D_TILE):
+        x_chunk = x[..., d0:d0 + REDUCE_D_TILE]
         sq_sum += (x_chunk * x_chunk).sum(dim=-1, keepdim=True)
     inv = torch.rsqrt(sq_sum * (1.0 / D) + EPS)
     return (x * inv * norm_w).to(torch.bfloat16)
@@ -142,15 +118,15 @@ if __name__ == "__main__":
     from golden import ratio_allclose, run_jit
 
     MODES = {
-        "decode":  (DECODE_BATCH, DECODE_SEQ),
+        "decode": (DECODE_BATCH, DECODE_SEQ),
         "prefill": (PREFILL_BATCH, PREFILL_SEQ),
     }
 
     parser = argparse.ArgumentParser(description="Standalone DeepSeek V4 attention RMSNorm validation.")
     parser.add_argument("-p", "--platform", type=str, default="a2a3", choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--mode", choices=["decode", "prefill", "all"], default="all",
-                        help="Use decode or prefill batch sizes, or 'all' to test both.")
+    mode_help = "Use decode or prefill batch sizes, or 'all' to test both."
+    parser.add_argument("--mode", choices=["decode", "prefill", "all"], default="all", help=mode_help)
     parser.add_argument("--enable-chip-swimlane", type=int, nargs="?", const=1, default=0, choices=(0, 1, 2, 4))
     parser.add_argument("--runtime-dir", type=str, default=None)
     parser.add_argument("--golden-data", type=str, default=None)

--- a/tests/golden/conftest.py
+++ b/tests/golden/conftest.py
@@ -70,7 +70,15 @@ def _install_pypto_stubs() -> None:
 
     for name in ("Tensor", "Scalar", "Array", "InOut", "Out"):
         setattr(language, name, _TypeSpec)
-    for name in ("BF16", "FP32", "INT8", "INT32", "INT64", "TASK_ID"):
+    for name in (
+        "BF16",
+        "FP32",
+        "INT8",
+        "INT32",
+        "INT64",
+        "TASK_ID",
+        "UINT32",
+    ):
         setattr(language, name, object())
     language.dynamic = lambda name: name
     language.jit = _identity_jit


### PR DESCRIPTION
- Parallelize and retile compressor, normalization, routing, HC, MTP,
  and shared-expert stages to reduce task hops and GM round trips
- Flatten RoPE gathers and sort-index construction, retile indexer score
  stages, and pass AIC results to AIV explicitly through GM
- Bundle attention projection grids and fold fixed-order reductions into
  their consumers to reduce dispatch and synchronization overhead

On A5 devices 0-2, the 22 measured Flash cases improve by a 1.60x
unweighted geometric mean; MTP projection decode/prefill is
417.1 -> 70.2 / 3782.9 -> 206.5 us (effective-us mean, 100 rounds,
5 warmups, fresh goldens; baseline 634e77b, PyPTO 7292b8d,
simpler 3165cc8, pto-isa 83d0131).
