### PR TITLE
Add: DeepSeek V4 Flash temperature sampling

### DIFF
--- a/docs/models/deepseek_v4_flash_mtp.md
+++ b/docs/models/deepseek_v4_flash_mtp.md
@@ -155,7 +155,13 @@ collectives (per-source lanes with folded notifies); `expert_shared` and
 `rms_norm` normalizes it, and `lm_head` all-gathers hidden rows across the DP
 owners, projects them against this card's vocab shard, then all-to-alls the
 logits so each owner ends with its own rows over the full vocabulary. Greedy
-sampling is fused into the same program.
+or temperature sampling is fused into the same program. Each logits row takes
+a temperature, seed, and position. Temperatures below `1e-5` select greedy
+sampling; other values use counter-based Gumbel-max over the full vocabulary.
+The fused `decode_fwd_mtp` entry shares temperature and seed tensors between
+the main and draft paths while taking positions from each path's
+device-resident metadata. Top-p filtering is not part of this kernel;
+temperature sampling currently uses the full vocabulary (`top_p = 1`).
 
 ### MTP path
 
@@ -185,6 +191,10 @@ follows the tuning of this decode path in order — contracts and golden first,
 then the general tiling / parallelism / fusion levers, the attention,
 hyper-connection, MoE and router rewrites, scheduling, and finally
 serving-level residency and lowering — with the limit measured at each step.
+
+The fused fixture defaults to greedy sampling. Use
+`--temperature <positive-value> --seed <value>` to exercise temperature
+sampling on both the main and MTP LM-head tails.
 
 ## Files
 

--- a/models/deepseek_v4_flash_mtp/decode_fwd.py
+++ b/models/deepseek_v4_flash_mtp/decode_fwd.py
@@ -288,6 +288,8 @@ def decode_fwd(
     final_norm_w: pl.Tensor[[D], pl.BF16],
     lm_head_weight: pl.Tensor[[VOCAB_PER_TP, D], pl.BF16],
     logit_row_indices: pl.Tensor[[MAX_LOGIT_ROWS], pl.INT32],
+    sampling_temperatures: pl.Tensor[[MAX_LOGIT_ROWS], pl.FP32],
+    sampling_seeds: pl.Tensor[[MAX_LOGIT_ROWS], pl.INT32],
     pre_hc_hidden_out: pl.Out[pl.Tensor[[T, HC_MULT, D], pl.FP32]],
     x_out: pl.Out[pl.Tensor[[T, D], pl.BF16]],
     logits: pl.Out[pl.Tensor[[MAX_LOGIT_ROWS, LM_HEAD_VOCAB], pl.FP32]],
@@ -725,7 +727,9 @@ def decode_fwd(
         hc_head(pre_hc_hidden_out, hc_head_fn, hc_head_scale, hc_head_base, x_head)
         rms_norm(x_head, final_norm_w, x_out)
         lm_head_with_sampling(
-            x_out, lm_head_weight, logit_row_indices, logits,
+            x_out, lm_head_weight, logit_row_indices,
+            sampling_temperatures, sampling_seeds, position_ids,
+            logits,
             sampled_ids,
             lm_head_hidden_window, lm_head_hidden_done,
             lm_head_logits_window, lm_head_logits_done,
@@ -814,6 +818,8 @@ def l2_decode_fwd(
     final_norm_w: pl.Tensor[[D], pl.BF16],
     lm_head_weight: pl.Tensor[[VOCAB_PER_TP, D], pl.BF16],
     logit_row_indices: pl.Tensor[[MAX_LOGIT_ROWS], pl.INT32],
+    sampling_temperatures: pl.Tensor[[MAX_LOGIT_ROWS], pl.FP32],
+    sampling_seeds: pl.Tensor[[MAX_LOGIT_ROWS], pl.INT32],
     pre_hc_hidden_out: pl.Out[pl.Tensor[[T, HC_MULT, D], pl.FP32]],
     x_out: pl.Out[pl.Tensor[[T, D], pl.BF16]],
     logits: pl.Out[pl.Tensor[[MAX_LOGIT_ROWS, LM_HEAD_VOCAB], pl.FP32]],
@@ -892,6 +898,7 @@ def l2_decode_fwd(
         input_ids,
         hc_head_fn, hc_head_scale, hc_head_base, final_norm_w,
         lm_head_weight, logit_row_indices,
+        sampling_temperatures, sampling_seeds,
         pre_hc_hidden_out, x_out, logits, sampled_ids,
         recv_meta, recv_x, recv_aux, recv_route,
         arrived, data_arrived, routed_y_buf, combine_arrived,
@@ -979,6 +986,8 @@ def l3_decode_fwd(
     final_norm_w: pl.Tensor[[N_RANKS, D], pl.BF16],
     pre_hc_hidden_out: pl.Out[pl.Tensor[[N_RANKS, T, HC_MULT, D], pl.FP32]],
     lm_head_weight: pl.Tensor[[N_RANKS, VOCAB_PER_TP, D], pl.BF16],
+    sampling_temperatures: pl.Tensor[[N_RANKS, MAX_LOGIT_ROWS], pl.FP32],
+    sampling_seeds: pl.Tensor[[N_RANKS, MAX_LOGIT_ROWS], pl.INT32],
     hidden_out: pl.Out[pl.Tensor[[N_RANKS, T, D], pl.BF16]],
     logits: pl.Out[pl.Tensor[[N_RANKS, MAX_LOGIT_ROWS, LM_HEAD_VOCAB], pl.FP32]],
     sampled_ids: pl.Out[
@@ -1038,6 +1047,7 @@ def l3_decode_fwd(
             hca_cmp_block_table[r], csa_cmp_block_table[r], idx_block_table[r],
             block_counts[r], input_ids[r], hc_head_fn[r], hc_head_scale[r], hc_head_base[r], final_norm_w[r],
             lm_head_weight[r], logit_row_indices[r],
+            sampling_temperatures[r], sampling_seeds[r],
             pre_hc_hidden_out[r], hidden_out[r], logits[r], sampled_ids[r],
             recv_meta, recv_x, recv_aux, recv_route, arrived,
             data_arrived, routed_y_buf, combine_arrived,
@@ -1793,6 +1803,18 @@ def build_tensor_specs(
     specs.append(TensorSpec(
         "lm_head_weight", [N_RANKS, VOCAB_PER_TP, D], torch.bfloat16,
         init_value=init_lm_head_weight, resident="stacked",
+    ))
+    specs.append(TensorSpec(
+        "sampling_temperatures",
+        [N_RANKS, MAX_LOGIT_ROWS],
+        torch.float32,
+        init_value=lambda: torch.zeros(N_RANKS, MAX_LOGIT_ROWS, dtype=torch.float32),
+    ))
+    specs.append(TensorSpec(
+        "sampling_seeds",
+        [N_RANKS, MAX_LOGIT_ROWS],
+        torch.int32,
+        init_value=lambda: torch.zeros(N_RANKS, MAX_LOGIT_ROWS, dtype=torch.int32),
     ))
     specs.append(TensorSpec("hidden_out", [N_RANKS, T, D], torch.bfloat16, is_output=True))
     specs.append(TensorSpec("logits", [N_RANKS, MAX_LOGIT_ROWS, LM_HEAD_VOCAB], torch.float32, is_output=True))

--- a/models/deepseek_v4_flash_mtp/decode_fwd_mtp.py
+++ b/models/deepseek_v4_flash_mtp/decode_fwd_mtp.py
@@ -392,6 +392,8 @@ def l2_decode_fwd_mtp(
     final_norm_w: pl.Tensor[[D], pl.BF16],
     lm_head_weight: pl.Tensor[[VOCAB_PER_TP, D], pl.BF16],
     logit_row_indices: pl.Tensor[[MAX_LOGIT_ROWS], pl.INT32],
+    sampling_temperatures: pl.Tensor[[MAX_LOGIT_ROWS], pl.FP32],
+    sampling_seeds: pl.Tensor[[MAX_LOGIT_ROWS], pl.INT32],
     pre_hc_hidden_out: pl.Out[pl.Tensor[[T, HC_MULT, D], pl.FP32]],
     hidden_out: pl.Out[pl.Tensor[[T, D], pl.BF16]],
     logits: pl.Out[pl.Tensor[[MAX_LOGIT_ROWS, LM_HEAD_VOCAB], pl.FP32]],
@@ -554,6 +556,7 @@ def l2_decode_fwd_mtp(
         input_ids,
         hc_head_fn, hc_head_scale, hc_head_base, final_norm_w,
         lm_head_weight, logit_row_indices,
+        sampling_temperatures, sampling_seeds,
         pre_hc_hidden_out, hidden_out, logits, sampled_ids,
         recv_meta, recv_x, recv_aux, recv_route,
         arrived, data_arrived, routed_y_buf, combine_arrived,
@@ -603,6 +606,7 @@ def l2_decode_fwd_mtp(
         mtp_shared_w1, mtp_shared_w1_scale, mtp_shared_w3, mtp_shared_w3_scale, mtp_shared_w2, mtp_shared_w2_scale,
         mtp_mtp_hc_head_fn, mtp_mtp_hc_head_scale, mtp_mtp_hc_head_base, mtp_mtp_norm_w,
         lm_head_weight, mtp_logit_row_indices,
+        sampling_temperatures, sampling_seeds,
         mtp_hidden_out, mtp_next_pre_hc_hidden, mtp_logits, mtp_sampled_ids,
         mtp_recv_meta, mtp_recv_x, mtp_recv_aux, mtp_recv_route,
         mtp_arrived, mtp_data_arrived, mtp_routed_y_buf, mtp_combine_arrived,
@@ -715,6 +719,8 @@ def l3_decode_fwd_mtp(
     final_norm_w: pl.Tensor[[N_RANKS, D], pl.BF16],
     pre_hc_hidden_out: pl.Out[pl.Tensor[[N_RANKS, T, HC_MULT, D], pl.FP32]],
     lm_head_weight: pl.Tensor[[N_RANKS, VOCAB_PER_TP, D], pl.BF16],
+    sampling_temperatures: pl.Tensor[[N_RANKS, MAX_LOGIT_ROWS], pl.FP32],
+    sampling_seeds: pl.Tensor[[N_RANKS, MAX_LOGIT_ROWS], pl.INT32],
     hidden_out: pl.Out[pl.Tensor[[N_RANKS, T, D], pl.BF16]],
     logits: pl.Out[pl.Tensor[[N_RANKS, MAX_LOGIT_ROWS, LM_HEAD_VOCAB], pl.FP32]],
     sampled_ids: pl.Out[pl.Tensor[[N_RANKS, MAX_LOGIT_ROWS, SAMPLED_IDS_PAD], pl.INT32]],
@@ -866,6 +872,7 @@ def l3_decode_fwd_mtp(
             input_ids[rank],
             hc_head_fn[rank], hc_head_scale[rank], hc_head_base[rank], final_norm_w[rank],
             lm_head_weight[rank], logit_row_indices[rank],
+            sampling_temperatures[rank], sampling_seeds[rank],
             pre_hc_hidden_out[rank], hidden_out[rank], logits[rank], sampled_ids[rank],
             recv_meta, recv_x, recv_aux, recv_route,
             arrived, data_arrived, routed_y_buf, combine_arrived,
@@ -911,6 +918,8 @@ def build_tensor_specs(
     hca_state_block_num=HCA_COMPRESS_STATE_BLOCK_NUM,
     csa_state_block_num=CSA_MAIN_STATE_BLOCK_NUM,
     inner_state_block_num=CSA_INNER_STATE_BLOCK_NUM,
+    sampling_temperature=0.0,
+    sampling_seed=0,
 ):
     import torch
     from golden import ScalarSpec, TensorSpec
@@ -936,6 +945,19 @@ def build_tensor_specs(
             ori_block_num=ori_block_num,
         )
     }
+
+    forward_specs["sampling_temperatures"] = replace(
+        forward_specs["sampling_temperatures"],
+        init_value=lambda: torch.full(
+            (N_RANKS, MAX_LOGIT_ROWS), sampling_temperature, dtype=torch.float32
+        ),
+    )
+    forward_specs["sampling_seeds"] = replace(
+        forward_specs["sampling_seeds"],
+        init_value=lambda: torch.full(
+            (N_RANKS, MAX_LOGIT_ROWS), sampling_seed, dtype=torch.int32
+        ),
+    )
 
     specs = {
         name: spec
@@ -1073,6 +1095,8 @@ def build_tensor_specs(
         "freqs_cos",
         "freqs_sin",
         "lm_head_weight",
+        "sampling_temperatures",
+        "sampling_seeds",
         "num_tokens",
     }
     # Built on device from the main step's outputs, or built explicitly below.
@@ -1141,6 +1165,8 @@ def main():
     parser.add_argument("--hca-state-block-num", type=int, default=HCA_COMPRESS_STATE_BLOCK_NUM)
     parser.add_argument("--csa-state-block-num", type=int, default=CSA_MAIN_STATE_BLOCK_NUM)
     parser.add_argument("--inner-state-block-num", type=int, default=CSA_INNER_STATE_BLOCK_NUM)
+    parser.add_argument("--temperature", type=float, default=0.0)
+    parser.add_argument("--seed", type=int, default=0)
     parser.add_argument(
         "--enable-chip-swimlane",
         type=int,
@@ -1164,6 +1190,7 @@ def main():
     )
     assert N_RANKS == args.ep, f"import-time N_RANKS must match --ep, got {N_RANKS} vs {args.ep}"
     assert args.start_pos >= 1, f"--start-pos must be at least 1, got {args.start_pos}"
+    assert args.temperature >= 0.0, f"--temperature must be non-negative, got {args.temperature}"
 
     device_ids = [int(device) for device in args.device.split(",")]
     assert len(device_ids) >= N_RANKS, f"need at least {N_RANKS} devices, got {device_ids}"
@@ -1179,6 +1206,8 @@ def main():
             hca_state_block_num=args.hca_state_block_num,
             csa_state_block_num=args.csa_state_block_num,
             inner_state_block_num=args.inner_state_block_num,
+            sampling_temperature=args.temperature,
+            sampling_seed=args.seed,
         ),
         golden_fn=None,
         compile_only=args.compile_only,
@@ -1205,4 +1234,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-

--- a/models/deepseek_v4_flash_mtp/decode_mtp.py
+++ b/models/deepseek_v4_flash_mtp/decode_mtp.py
@@ -140,6 +140,8 @@ def decode_mtp(
     mtp_norm_w: pl.Tensor[[D], pl.BF16],
     lm_head_weight: pl.Tensor[[VOCAB_PER_TP, D], pl.BF16],
     logit_row_indices: pl.Tensor[[MAX_LOGIT_ROWS], pl.INT32],
+    sampling_temperatures: pl.Tensor[[MAX_LOGIT_ROWS], pl.FP32],
+    sampling_seeds: pl.Tensor[[MAX_LOGIT_ROWS], pl.INT32],
     hidden_out: pl.Out[pl.Tensor[[T, D], pl.BF16]],
     next_pre_hc_hidden: pl.Out[pl.Tensor[[T, HC_MULT, D], pl.FP32]],
     logits: pl.Out[pl.Tensor[[MAX_LOGIT_ROWS, LM_HEAD_VOCAB], pl.FP32]],
@@ -208,7 +210,9 @@ def decode_mtp(
         hc_head(next_pre_hc_hidden, mtp_hc_head_fn, mtp_hc_head_scale, mtp_hc_head_base, x_head)
         rms_norm(x_head, mtp_norm_w, hidden_out)
         lm_head_with_sampling(
-            hidden_out, lm_head_weight, logit_row_indices, logits,
+            hidden_out, lm_head_weight, logit_row_indices,
+            sampling_temperatures, sampling_seeds, position_ids,
+            logits,
             sampled_ids,
             lm_head_hidden_window, lm_head_hidden_done,
             lm_head_logits_window, lm_head_logits_done,
@@ -277,6 +281,8 @@ def l2_decode_mtp(
     mtp_norm_w: pl.Tensor[[D], pl.BF16],
     lm_head_weight: pl.Tensor[[VOCAB_PER_TP, D], pl.BF16],
     logit_row_indices: pl.Tensor[[MAX_LOGIT_ROWS], pl.INT32],
+    sampling_temperatures: pl.Tensor[[MAX_LOGIT_ROWS], pl.FP32],
+    sampling_seeds: pl.Tensor[[MAX_LOGIT_ROWS], pl.INT32],
     hidden_out: pl.Out[pl.Tensor[[T, D], pl.BF16]],
     next_pre_hc_hidden: pl.Out[pl.Tensor[[T, HC_MULT, D], pl.FP32]],
     logits: pl.Out[pl.Tensor[[MAX_LOGIT_ROWS, LM_HEAD_VOCAB], pl.FP32]],
@@ -325,6 +331,7 @@ def l2_decode_mtp(
         shared_w1, shared_w1_scale, shared_w3, shared_w3_scale, shared_w2, shared_w2_scale,
         mtp_hc_head_fn, mtp_hc_head_scale, mtp_hc_head_base, mtp_norm_w,
         lm_head_weight, logit_row_indices,
+        sampling_temperatures, sampling_seeds,
         hidden_out, next_pre_hc_hidden, logits, sampled_ids,
         recv_meta, recv_x, recv_aux, recv_route,
         arrived, data_arrived, routed_y_buf, combine_arrived,
@@ -391,6 +398,8 @@ def l3_decode_mtp(
     mtp_hc_head_base: pl.Tensor[[N_RANKS, HC_MULT], pl.FP32],
     mtp_norm_w: pl.Tensor[[N_RANKS, D], pl.BF16],
     lm_head_weight: pl.Tensor[[N_RANKS, VOCAB_PER_TP, D], pl.BF16],
+    sampling_temperatures: pl.Tensor[[N_RANKS, MAX_LOGIT_ROWS], pl.FP32],
+    sampling_seeds: pl.Tensor[[N_RANKS, MAX_LOGIT_ROWS], pl.INT32],
     hidden_out: pl.Out[pl.Tensor[[N_RANKS, T, D], pl.BF16]],
     next_pre_hc_hidden: pl.Out[pl.Tensor[[N_RANKS, T, HC_MULT, D], pl.FP32]],
     logits: pl.Out[pl.Tensor[[N_RANKS, MAX_LOGIT_ROWS, LM_HEAD_VOCAB], pl.FP32]],
@@ -447,6 +456,7 @@ def l3_decode_mtp(
             shared_w2[r], shared_w2_scale[r],
             mtp_hc_head_fn[r], mtp_hc_head_scale[r], mtp_hc_head_base[r], mtp_norm_w[r],
             lm_head_weight[r], logit_row_indices[r],
+            sampling_temperatures[r], sampling_seeds[r],
             hidden_out[r], next_pre_hc_hidden[r], logits[r], sampled_ids[r],
             recv_meta, recv_x, recv_aux, recv_route,
             arrived, data_arrived, routed_y_buf, combine_arrived,
@@ -780,6 +790,18 @@ def build_tensor_specs(start_pos=DECODE_START_POS, num_tokens=T, ori_block_num=O
         resident="stacked",
     )
     specs.append(lm_head_spec)
+    specs.append(TensorSpec(
+        "sampling_temperatures",
+        [N_RANKS, MAX_LOGIT_ROWS],
+        torch.float32,
+        init_value=lambda: torch.zeros(N_RANKS, MAX_LOGIT_ROWS, dtype=torch.float32),
+    ))
+    specs.append(TensorSpec(
+        "sampling_seeds",
+        [N_RANKS, MAX_LOGIT_ROWS],
+        torch.int32,
+        init_value=lambda: torch.zeros(N_RANKS, MAX_LOGIT_ROWS, dtype=torch.int32),
+    ))
     hidden_out_spec = TensorSpec(
         "hidden_out", [N_RANKS, T, D], torch.bfloat16,
         is_output=True, resident="stacked",

--- a/models/deepseek_v4_flash_mtp/lm_head.py
+++ b/models/deepseek_v4_flash_mtp/lm_head.py
@@ -21,6 +21,7 @@ import pypto.language.distributed as pld
 from pypto.ir.distributed_compiled_program import DistributedConfig
 
 from config import DECODE_TOKENS, FLASH as M, FP32_NEG_INF
+from sample import sample
 
 
 T_DYN = pl.dynamic("LM_HEAD_T_DYN")
@@ -402,6 +403,9 @@ def lm_head_with_sampling(
     hidden_states: pl.Tensor[[T_DYN, D], pl.BF16],
     lm_head_weight: pl.Tensor[[VOCAB_PER_TP, D], pl.BF16],
     logit_row_indices: pl.Tensor[[MAX_LOGIT_ROWS], pl.INT32],
+    sampling_temperatures: pl.Tensor[[MAX_LOGIT_ROWS], pl.FP32],
+    sampling_seeds: pl.Tensor[[MAX_LOGIT_ROWS], pl.INT32],
+    sampling_positions: pl.Tensor[[MAX_LOGIT_ROWS], pl.INT32],
     logits: pl.Out[pl.Tensor[[MAX_LOGIT_ROWS, VOCAB], pl.FP32]],
     sampled_ids: pl.Out[pl.Tensor[[MAX_LOGIT_ROWS, SAMPLED_IDS_PAD], pl.INT32]],
     hidden_window: pld.DistributedTensor[[GROUP_LOGIT_ROWS, D], pl.BF16],
@@ -426,7 +430,13 @@ def lm_head_with_sampling(
         tp_rank,
         done_epoch,
     )
-    greedy_sample(logits, sampled_ids)
+    sample(
+        logits,
+        sampling_temperatures,
+        sampling_seeds,
+        sampling_positions,
+        sampled_ids,
+    )
     return logits, sampled_ids
 
 
@@ -435,6 +445,9 @@ def lm_head_with_sampling_test(
     hidden_states: pl.Tensor[[T_DYN, D], pl.BF16],
     lm_head_weight: pl.Tensor[[VOCAB_PER_TP, D], pl.BF16],
     logit_row_indices: pl.Tensor[[MAX_LOGIT_ROWS], pl.INT32],
+    sampling_temperatures: pl.Tensor[[MAX_LOGIT_ROWS], pl.FP32],
+    sampling_seeds: pl.Tensor[[MAX_LOGIT_ROWS], pl.INT32],
+    sampling_positions: pl.Tensor[[MAX_LOGIT_ROWS], pl.INT32],
     logits: pl.Out[pl.Tensor[[MAX_LOGIT_ROWS, VOCAB], pl.FP32]],
     sampled_ids: pl.Out[pl.Tensor[[MAX_LOGIT_ROWS, SAMPLED_IDS_PAD], pl.INT32]],
     hidden_window: pld.DistributedTensor[[GROUP_LOGIT_ROWS, D], pl.BF16],
@@ -450,6 +463,9 @@ def lm_head_with_sampling_test(
         hidden_states,
         lm_head_weight,
         logit_row_indices,
+        sampling_temperatures,
+        sampling_seeds,
+        sampling_positions,
         logits,
         sampled_ids,
         hidden_window,
@@ -466,6 +482,9 @@ def lm_head_with_sampling_test(
 def l3_lm_head(
     hidden_states: pl.Tensor[[WORLD_SIZE, TEST_TOKENS, D], pl.BF16],
     lm_head_weight: pl.Tensor[[WORLD_SIZE, VOCAB_PER_TP, D], pl.BF16],
+    sampling_temperatures: pl.Tensor[[WORLD_SIZE, MAX_LOGIT_ROWS], pl.FP32],
+    sampling_seeds: pl.Tensor[[WORLD_SIZE, MAX_LOGIT_ROWS], pl.INT32],
+    sampling_positions: pl.Tensor[[WORLD_SIZE, MAX_LOGIT_ROWS], pl.INT32],
     logits: pl.Out[pl.Tensor[[WORLD_SIZE, MAX_LOGIT_ROWS, VOCAB], pl.FP32]],
     sampled_ids: pl.Out[
         pl.Tensor[[WORLD_SIZE, MAX_LOGIT_ROWS, SAMPLED_IDS_PAD], pl.INT32]
@@ -485,7 +504,8 @@ def l3_lm_head(
         logits_window = pld.window(logits_window_buf, [MAX_LOGIT_ROWS, VOCAB], dtype=pl.FP32)
         logits_done = pld.window(logits_done_buf, [TP_SIZE, 1], dtype=pl.INT32)
         lm_head_with_sampling_test(
-            hidden_states[r], lm_head_weight[r], logit_row_indices[r], logits[r],
+            hidden_states[r], lm_head_weight[r], logit_row_indices[r],
+            sampling_temperatures[r], sampling_seeds[r], sampling_positions[r], logits[r],
             sampled_ids[r],
             hidden_window, hidden_done, logits_window, logits_done,
             r // TP_SIZE * TP_SIZE, r % TP_SIZE, DONE_VALUE, device=r,
@@ -552,6 +572,24 @@ def build_tensor_specs(num_tokens=TEST_TOKENS):
             torch.bfloat16,
             init_value=init_lm_head_weight,
             resident="stacked",
+        ),
+        TensorSpec(
+            "sampling_temperatures",
+            [WORLD_SIZE, MAX_LOGIT_ROWS],
+            torch.float32,
+            init_value=lambda: torch.zeros(WORLD_SIZE, MAX_LOGIT_ROWS, dtype=torch.float32),
+        ),
+        TensorSpec(
+            "sampling_seeds",
+            [WORLD_SIZE, MAX_LOGIT_ROWS],
+            torch.int32,
+            init_value=lambda: torch.zeros(WORLD_SIZE, MAX_LOGIT_ROWS, dtype=torch.int32),
+        ),
+        TensorSpec(
+            "sampling_positions",
+            [WORLD_SIZE, MAX_LOGIT_ROWS],
+            torch.int32,
+            init_value=lambda: torch.arange(MAX_LOGIT_ROWS, dtype=torch.int32).expand(WORLD_SIZE, -1).contiguous(),
         ),
         TensorSpec(
             "logits",

--- a/models/deepseek_v4_flash_mtp/sample.py
+++ b/models/deepseek_v4_flash_mtp/sample.py
@@ -1,0 +1,285 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""Greedy and counter-based Gumbel-max sampling for DeepSeek-V4 logits."""
+
+import pypto.language as pl
+
+from config import DECODE_TOKENS, FLASH as M, FP32_NEG_INF
+
+
+# model config
+VOCAB = M.vocab_size
+SAMPLE_ROWS = DECODE_TOKENS
+SAMPLED_IDS_PAD = 8
+
+# tiling
+SAMPLE_ROW_WIDTH_TILE = 256
+SAMPLE_BLOCK_ROWS_TILE = 8
+SAMPLE_GRID_ROWS = VOCAB // SAMPLE_ROW_WIDTH_TILE
+SAMPLE_FULL_BLOCKS = SAMPLE_GRID_ROWS // SAMPLE_BLOCK_ROWS_TILE
+SAMPLE_TAIL_ROWS = SAMPLE_GRID_ROWS % SAMPLE_BLOCK_ROWS_TILE
+SAMPLE_CANDIDATES_TILE = 512
+
+# sampling constants
+SAMPLING_EPS = 1e-5
+SAMPLING_EPS_INV = 100000.0
+RANDOM_KEY_MODULUS = 1073741824
+HASH_MULTIPLIER = 0x045D9F3B
+POSITION_MULTIPLIER = 65537
+UINT23_SCALE = 1.0 / 8388608.0
+
+
+@pl.jit.inline
+def _counter_gumbel(
+    block: pl.Scalar[pl.INDEX],
+    random_key: pl.Scalar[pl.INT32],
+):
+    """Generate one Gumbel-noise tile from a key and vocabulary counters."""
+    counter_zeros = pl.full([SAMPLE_BLOCK_ROWS_TILE, SAMPLE_ROW_WIDTH_TILE], dtype=pl.INT32, value=0)
+    column_ids = pl.arange(0, [1, SAMPLE_ROW_WIDTH_TILE], dtype=pl.INT32)
+    column_counters = pl.col_expand(counter_zeros, column_ids)
+    row_counters_pad = pl.full([SAMPLE_BLOCK_ROWS_TILE, SAMPLE_BLOCK_ROWS_TILE], dtype=pl.INT32, value=0)
+    for row in pl.range(SAMPLE_BLOCK_ROWS_TILE):
+        row_counter = pl.cast(row * SAMPLE_ROW_WIDTH_TILE, pl.INT32)
+        pl.write(row_counters_pad, [row, 0], row_counter)
+    row_counters = pl.row_max(row_counters_pad)
+    counters = pl.row_expand_add(column_counters, row_counters)
+    block_base = pl.cast(block * SAMPLE_BLOCK_ROWS_TILE * SAMPLE_ROW_WIDTH_TILE, pl.INT32)
+    counters = pl.add(counters, block_base)
+
+    key_zeros = pl.mul(column_ids, pl.cast(0, pl.INT32))
+    key_row = pl.add(key_zeros, random_key)
+    random_key_tile = pl.col_expand(counter_zeros, key_row)
+    positive_mask = pl.full([SAMPLE_BLOCK_ROWS_TILE, SAMPLE_ROW_WIDTH_TILE], dtype=pl.INT32, value=0x7FFFFFFF)
+    random_bits = pl.xor(counters, random_key_tile)
+    shifted = pl.shrs(random_bits, 16)
+    random_bits = pl.xor(random_bits, shifted)
+    random_bits = pl.mul(random_bits, pl.cast(HASH_MULTIPLIER, pl.INT32))
+    random_bits = pl.and_(random_bits, positive_mask)
+    shifted = pl.shrs(random_bits, 16)
+    random_bits = pl.xor(random_bits, shifted)
+    random_bits = pl.mul(random_bits, pl.cast(HASH_MULTIPLIER, pl.INT32))
+    random_bits = pl.and_(random_bits, positive_mask)
+    shifted = pl.shrs(random_bits, 16)
+    random_bits = pl.xor(random_bits, shifted)
+
+    uniform_bits = pl.shrs(random_bits, 8)
+    uniform_fp32 = pl.cast(uniform_bits, pl.FP32)
+    uniform_centered = pl.add(uniform_fp32, 0.5)
+    uniform = pl.mul(uniform_centered, UINT23_SCALE)
+    log_uniform = pl.log(uniform)
+    negative_log_uniform = pl.neg(log_uniform)
+    log_negative_log_uniform = pl.log(negative_log_uniform)
+    return pl.neg(log_negative_log_uniform)
+
+
+@pl.jit.inline
+def sample(
+    logits: pl.Tensor[[SAMPLE_ROWS, VOCAB], pl.FP32],
+    sampling_temperatures: pl.Tensor[[SAMPLE_ROWS], pl.FP32],
+    sampling_seeds: pl.Tensor[[SAMPLE_ROWS], pl.INT32],
+    sampling_positions: pl.Tensor[[SAMPLE_ROWS], pl.INT32],
+    sampled_ids: pl.Tensor[[SAMPLE_ROWS, SAMPLED_IDS_PAD], pl.INT32],
+):
+    """Sample each logits row with greedy or counter-based Gumbel-max."""
+    logits_grid = pl.reshape(logits, [SAMPLE_ROWS * SAMPLE_GRID_ROWS, SAMPLE_ROW_WIDTH_TILE])
+    for row in pl.spmd(SAMPLE_ROWS, name_hint="sample_gumbel_argmax"):
+        temperature = pl.read(sampling_temperatures, [row])
+        sampling_enabled = pl.cast(pl.mul(temperature, SAMPLING_EPS_INV), pl.INT32)
+        seed = pl.read(sampling_seeds, [row])
+        position = pl.read(sampling_positions, [row])
+        seed_index = pl.cast(seed, pl.INDEX)
+        position_index = pl.cast(position, pl.INDEX)
+        random_key_index = seed_index + position_index * POSITION_MULTIPLIER
+        random_key = pl.cast(random_key_index % RANDOM_KEY_MODULUS, pl.INT32)
+        row_base = row * SAMPLE_GRID_ROWS
+        candidate_maxima = pl.full([SAMPLE_BLOCK_ROWS_TILE, SAMPLE_CANDIDATES_TILE], dtype=pl.FP32, value=FP32_NEG_INF)
+        candidate_token_ids = pl.full([1, SAMPLE_CANDIDATES_TILE], dtype=pl.INT32, value=0)
+        for block in pl.range(SAMPLE_FULL_BLOCKS):
+            block_row = row_base + block * SAMPLE_BLOCK_ROWS_TILE
+            scores = logits_grid[
+                block_row : block_row + SAMPLE_BLOCK_ROWS_TILE,
+                0:SAMPLE_ROW_WIDTH_TILE,
+            ]
+            if sampling_enabled >= 1:
+                scaled_scores = pl.div(scores, temperature)
+                gumbel_noise = _counter_gumbel(block, random_key)
+                scores = pl.add(scaled_scores, gumbel_noise)
+            local_winners = pl.row_argmax(scores)
+            for lane in pl.range(SAMPLE_BLOCK_ROWS_TILE):
+                local_token = pl.read(local_winners, [lane, 0])
+                local_score = pl.read(scores, [lane, pl.cast(local_token, pl.INDEX)])
+                candidate = block * SAMPLE_BLOCK_ROWS_TILE + lane
+                block_token_base = block * SAMPLE_BLOCK_ROWS_TILE * SAMPLE_ROW_WIDTH_TILE
+                token_base = block_token_base + lane * SAMPLE_ROW_WIDTH_TILE
+                token_id = pl.cast(token_base, pl.INT32) + local_token
+                pl.write(candidate_maxima, [0, candidate], local_score)
+                pl.write(candidate_token_ids, [0, candidate], token_id)
+
+        tail_row = row_base + SAMPLE_FULL_BLOCKS * SAMPLE_BLOCK_ROWS_TILE
+        tail_scores = logits_grid[tail_row : tail_row + SAMPLE_TAIL_ROWS, 0:SAMPLE_ROW_WIDTH_TILE]
+        if sampling_enabled >= 1:
+            tail_scaled_scores = pl.div(tail_scores, temperature)
+            tail_gumbel_noise = _counter_gumbel(SAMPLE_FULL_BLOCKS, random_key)
+            tail_noise = tail_gumbel_noise[0:SAMPLE_TAIL_ROWS, 0:SAMPLE_ROW_WIDTH_TILE]
+            tail_scores = pl.add(tail_scaled_scores, tail_noise)
+        scores = pl.full([SAMPLE_BLOCK_ROWS_TILE, SAMPLE_ROW_WIDTH_TILE], dtype=pl.FP32, value=FP32_NEG_INF)
+        scores[0:SAMPLE_TAIL_ROWS, 0:SAMPLE_ROW_WIDTH_TILE] = tail_scores
+        for lane in pl.range(SAMPLE_TAIL_ROWS, SAMPLE_BLOCK_ROWS_TILE):
+            scores[lane : lane + 1, 0:SAMPLE_ROW_WIDTH_TILE] = tail_scores[0:1, 0:SAMPLE_ROW_WIDTH_TILE]
+        local_winners = pl.row_argmax(scores)
+        for lane in pl.range(SAMPLE_TAIL_ROWS):
+            local_token = pl.read(local_winners, [lane, 0])
+            local_score = pl.read(scores, [lane, pl.cast(local_token, pl.INDEX)])
+            candidate = SAMPLE_FULL_BLOCKS * SAMPLE_BLOCK_ROWS_TILE + lane
+            token_base = SAMPLE_FULL_BLOCKS * SAMPLE_BLOCK_ROWS_TILE * SAMPLE_ROW_WIDTH_TILE
+            token_id = pl.cast(token_base + lane * SAMPLE_ROW_WIDTH_TILE, pl.INT32) + local_token
+            pl.write(candidate_maxima, [0, candidate], local_score)
+            pl.write(candidate_token_ids, [0, candidate], token_id)
+
+        winning_candidate = pl.read(pl.row_argmax(candidate_maxima), [0, 0])
+        best_index = pl.read(candidate_token_ids, [0, pl.cast(winning_candidate, pl.INDEX)])
+
+        sampled_row = pl.create_tensor([1, SAMPLED_IDS_PAD], dtype=pl.INT32)
+        sampled_fill = pl.full([1, SAMPLED_IDS_PAD], dtype=pl.INT32, value=0)
+        sampled_row[:, :] = sampled_fill
+        pl.write(sampled_row, [0, 0], best_index)
+        sampled_ids[row : row + 1, :] = sampled_row
+    return sampled_ids
+
+
+@pl.jit
+def sample_test(
+    logits: pl.Tensor[[SAMPLE_ROWS, VOCAB], pl.FP32],
+    temperatures: pl.Tensor[[SAMPLE_ROWS], pl.FP32],
+    seeds: pl.Tensor[[SAMPLE_ROWS], pl.INT32],
+    positions: pl.Tensor[[SAMPLE_ROWS], pl.INT32],
+    sampled_ids: pl.Out[pl.Tensor[[SAMPLE_ROWS, SAMPLED_IDS_PAD], pl.INT32]],
+):
+    return sample(logits, temperatures, seeds, positions, sampled_ids)
+
+
+def _gumbel_noise(seed, position):
+    import numpy as np
+
+    counters = np.arange(VOCAB, dtype=np.uint32)
+    random_key = np.uint32((seed + position * POSITION_MULTIPLIER) % RANDOM_KEY_MODULUS)
+    random_bits = counters ^ random_key
+    random_bits ^= random_bits >> np.uint32(16)
+    random_bits *= np.uint32(HASH_MULTIPLIER)
+    random_bits &= np.uint32(0x7FFFFFFF)
+    random_bits ^= random_bits >> np.uint32(16)
+    random_bits *= np.uint32(HASH_MULTIPLIER)
+    random_bits &= np.uint32(0x7FFFFFFF)
+    random_bits ^= random_bits >> np.uint32(16)
+    uniform_bits = (random_bits >> np.uint32(8)).astype(np.float32)
+    uniform_centered = uniform_bits + np.float32(0.5)
+    uniform = uniform_centered * np.float32(UINT23_SCALE)
+    return -np.log(-np.log(uniform))
+
+
+def build_tensor_specs(sampling_temperature=None):
+    import torch
+
+    from golden import TensorSpec
+
+    def init_logits():
+        generator = torch.Generator().manual_seed(20260821)
+        logits = torch.randn(SAMPLE_ROWS, VOCAB, generator=generator, dtype=torch.float32)
+        logits[0, 7] = 20.0
+        if SAMPLE_ROWS > 4:
+            logits[4, 42] = 20.0
+        return logits
+
+    def repeat_rows(values, dtype):
+        repeats = (SAMPLE_ROWS + len(values) - 1) // len(values)
+        return torch.tensor(values, dtype=dtype).repeat(repeats)[:SAMPLE_ROWS]
+
+    return [
+        TensorSpec("logits", [SAMPLE_ROWS, VOCAB], torch.float32, init_value=init_logits),
+        TensorSpec(
+            "temperatures",
+            [SAMPLE_ROWS],
+            torch.float32,
+            init_value=lambda: (
+                repeat_rows([0.0, 0.3, 0.7, 1.0, 0.0, 0.5, 1.3, 2.0], torch.float32)
+                if sampling_temperature is None
+                else torch.full([SAMPLE_ROWS], sampling_temperature, dtype=torch.float32)
+            ),
+        ),
+        TensorSpec(
+            "seeds",
+            [SAMPLE_ROWS],
+            torch.int32,
+            init_value=lambda: repeat_rows([1, 7, 19, 1234, 42, 99, 2026, 65537], torch.int32),
+        ),
+        TensorSpec(
+            "positions",
+            [SAMPLE_ROWS],
+            torch.int32,
+            init_value=lambda: repeat_rows([0, 1, 17, 1024, 4, 55, 4096, 32767], torch.int32),
+        ),
+        TensorSpec("sampled_ids", [SAMPLE_ROWS, SAMPLED_IDS_PAD], torch.int32, is_output=True),
+    ]
+
+
+def golden_sample(tensors):
+    import torch
+
+    tensors["sampled_ids"].zero_()
+    for row in range(SAMPLE_ROWS):
+        logits = tensors["logits"][row].float()
+        temperature = float(tensors["temperatures"][row])
+        if temperature < SAMPLING_EPS:
+            selected = torch.argmax(logits)
+        else:
+            seed = int(tensors["seeds"][row])
+            position = int(tensors["positions"][row])
+            noise = torch.from_numpy(_gumbel_noise(seed, position))
+            selected = torch.argmax(logits / temperature + noise)
+        tensors["sampled_ids"][row, 0] = selected.to(torch.int32)
+
+
+if __name__ == "__main__":
+    import argparse
+
+    from golden import run_jit
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-p", "--platform", type=str, default="a2a3sim", choices=["a2a3", "a2a3sim", "a5", "a5sim"])
+    parser.add_argument("-d", "--device", type=int, default=0)
+    parser.add_argument("--compile-only", action="store_true", default=False)
+    parser.add_argument("--enable-l2-swimlane", action="store_true", default=False)
+    parser.add_argument("--temperature", type=float, default=None)
+    parser.add_argument("--save-data", action="store_true", default=False)
+    parser.add_argument("--golden-data", type=str, default=None)
+    args = parser.parse_args()
+    assert args.temperature is None or args.temperature >= 0.0, (
+        f"--temperature must be non-negative, got {args.temperature}"
+    )
+
+    result = run_jit(
+        fn=sample_test,
+        specs=build_tensor_specs(args.temperature),
+        golden_fn=golden_sample,
+        golden_data=args.golden_data,
+        save_data=args.save_data,
+        compile_only=args.compile_only,
+        runtime_cfg=dict(
+            platform=args.platform,
+            device_id=args.device,
+            enable_l2_swimlane=args.enable_l2_swimlane,
+        ),
+        rtol=0,
+        atol=0,
+    )
+    if not result.passed:
+        if result.error:
+            print(result.error)
+        raise SystemExit(1)


### PR DESCRIPTION
- Add per-row temperature sampling to the DeepSeek V4 Flash LM-head, decode, and fused MTP paths.
- Derive the sampling behavior from temperature alone: values below `1e-5` use greedy sampling; other values use counter-based Gumbel-max over the full vocabulary.
- Remove the explicit sampling-mode tensor from the kernel ABI and keep temperature, seed, and position as the sampling controls.
- Keep the sampler specialized to the active decode row count, with tiled full-vocabulary reduction and counter-based noise generation implemented as part of this PR.

Validation:
- `python -m pytest tests/golden -q`: 233 passed
- `pre-commit run --all-files`: passed
- Real NPU sampler golden, mixed greedy/temperature rows: `task_20260824_184538_140703910038`
- Real NPU below-threshold greedy check (`temperature=1e-6`): `task_20260824_184941_158483611084`