### PR TITLE
Add: dump DeepSeek V4 MoE expert load statistics

### DIFF
--- a/models/deepseek_v4_flash_mtp/decode_fwd.py
+++ b/models/deepseek_v4_flash_mtp/decode_fwd.py
@@ -96,6 +96,7 @@ from decode_prepare import (
 from moe import (
     AUX_PAD,
     IDX_PAD,
+    MOE_STATS_NUM_LAYERS,
     MOE_INTER,
     N_EXPERTS_GLOBAL,
     N_LOCAL,
@@ -306,8 +307,10 @@ def decode_fwd(
     lm_head_hidden_done: pld.DistributedTensor[[LM_HEAD_TP_SIZE, 1], pl.INT32],
     lm_head_logits_window: pld.DistributedTensor[[MAX_LOGIT_ROWS, LM_HEAD_VOCAB], pl.FP32],
     lm_head_logits_done: pld.DistributedTensor[[LM_HEAD_TP_SIZE, 1], pl.INT32],
+    moe_token_counts: pl.InOut[pl.Tensor[[MOE_STATS_NUM_LAYERS, N_LOCAL], pl.INT32]],
     num_tokens_per_owner: pl.Tensor[[N_RANKS], pl.INT32],
     my_rank: pl.Scalar[pl.INT32],
+    dump_moe_stats: pl.Scalar[pl.INT32],
 ) -> pl.Tensor[[T, D], pl.BF16]:
     swa_cos_profile: pl.Tensor[[1, MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16] = pl.slice(
         freqs_cos, [1, MAX_SEQ_LEN, ROPE_HEAD_DIM], [0, 0, 0]
@@ -436,8 +439,8 @@ def decode_fwd(
             shared_w2_l0, shared_w2_scale_l0,
             hidden,
             recv_meta, recv_x, recv_aux, recv_route, arrived, data_arrived,
-            routed_y_buf, combine_arrived,
-            pl.cast(0, pl.INT32), nt, my_rank, pl.cast(1, pl.INT32),
+            routed_y_buf, combine_arrived, moe_token_counts,
+            pl.cast(0, pl.INT32), nt, my_rank, pl.cast(1, pl.INT32), dump_moe_stats,
         )
     with pl.scope():
         attention_swa(
@@ -461,8 +464,8 @@ def decode_fwd(
             shared_w2_l1, shared_w2_scale_l1,
             hidden,
             recv_meta, recv_x, recv_aux, recv_route, arrived, data_arrived,
-            routed_y_buf, combine_arrived,
-            pl.cast(1, pl.INT32), nt, my_rank, pl.cast(2, pl.INT32),
+            routed_y_buf, combine_arrived, moe_token_counts,
+            pl.cast(1, pl.INT32), nt, my_rank, pl.cast(2, pl.INT32), dump_moe_stats,
         )
     for loop_i in pl.range(HCA_NUM_LAYERS):
         csa_layer: pl.Scalar[pl.INT32] = pl.cast(loop_i * 2 + 2, pl.INT32)
@@ -555,8 +558,8 @@ def decode_fwd(
                 shared_w2_csa, shared_w2_scale_csa,
                 hidden_mid,
                 recv_meta, recv_x, recv_aux, recv_route, arrived, data_arrived,
-                routed_y_buf, combine_arrived,
-                csa_layer, nt, my_rank, csa_moe_epoch,
+                routed_y_buf, combine_arrived, moe_token_counts,
+                csa_layer, nt, my_rank, csa_moe_epoch, dump_moe_stats,
             )
         hc_attn_fn_hca: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32] = pl.slice(hc_attn_fn, [MIX_HC, HC_DIM], [hca_layer * MIX_HC, 0])
         hc_attn_scale_hca: pl.Tensor[[3], pl.FP32] = pl.slice(hc_attn_scale, [3], [hca_layer * 3])
@@ -625,8 +628,8 @@ def decode_fwd(
                 shared_w2_hca, shared_w2_scale_hca,
                 hidden,
                 recv_meta, recv_x, recv_aux, recv_route, arrived, data_arrived,
-                routed_y_buf, combine_arrived,
-                hca_layer, nt, my_rank, hca_moe_epoch,
+                routed_y_buf, combine_arrived, moe_token_counts,
+                hca_layer, nt, my_rank, hca_moe_epoch, dump_moe_stats,
             )
     # FWD index (14), not CSA_LAST_LAYER (6): the *_last slices below index per-FWD-layer
     # stacked weights; csa-stacked weights use the literal (CSA_NUM_LAYERS-1).
@@ -716,8 +719,8 @@ def decode_fwd(
             shared_w2_last, shared_w2_scale_last,
             pre_hc_hidden_out,
             recv_meta, recv_x, recv_aux, recv_route, arrived, data_arrived,
-            routed_y_buf, combine_arrived,
-            csa_layer_last, nt, my_rank, last_moe_epoch,
+            routed_y_buf, combine_arrived, moe_token_counts,
+            csa_layer_last, nt, my_rank, last_moe_epoch, dump_moe_stats,
         )
     clear_moe_signals(pre_hc_hidden_out, arrived, data_arrived, combine_arrived)
     x_head: pl.Tensor[[T, D], pl.BF16] = pl.create_tensor([T, D], dtype=pl.BF16)
@@ -832,8 +835,10 @@ def l2_decode_fwd(
     lm_head_hidden_done: pld.DistributedTensor[[LM_HEAD_TP_SIZE, 1], pl.INT32],
     lm_head_logits_window: pld.DistributedTensor[[MAX_LOGIT_ROWS, LM_HEAD_VOCAB], pl.FP32],
     lm_head_logits_done: pld.DistributedTensor[[LM_HEAD_TP_SIZE, 1], pl.INT32],
+    moe_token_counts: pl.InOut[pl.Tensor[[MOE_STATS_NUM_LAYERS, N_LOCAL], pl.INT32]],
     num_tokens_per_owner: pl.Tensor[[N_RANKS], pl.INT32],
     my_rank: pl.Scalar[pl.INT32],
+    dump_moe_stats: pl.Scalar[pl.INT32],
 ) -> pl.Tensor[[T, D], pl.BF16]:
     ori_slot_mapping = pl.create_tensor([T], dtype=pl.INT64)
     swa_slot_mapping = pl.create_tensor([T], dtype=pl.INT64)
@@ -896,7 +901,8 @@ def l2_decode_fwd(
         recv_meta, recv_x, recv_aux, recv_route,
         arrived, data_arrived, routed_y_buf, combine_arrived,
         lm_head_hidden_window, lm_head_hidden_done, lm_head_logits_window, lm_head_logits_done,
-        num_tokens_per_owner, my_rank,
+        moe_token_counts,
+        num_tokens_per_owner, my_rank, dump_moe_stats,
     )
 
 
@@ -984,8 +990,12 @@ def l3_decode_fwd(
     sampled_ids: pl.Out[
         pl.Tensor[[N_RANKS, MAX_LOGIT_ROWS, SAMPLED_IDS_PAD], pl.INT32]
     ],
+    moe_token_counts: pl.InOut[
+        pl.Tensor[[N_RANKS, MOE_STATS_NUM_LAYERS, N_LOCAL], pl.INT32]
+    ],
     num_tokens_per_owner: pl.Tensor[[N_RANKS], pl.INT32],
     logit_row_indices: pl.Tensor[[N_RANKS, MAX_LOGIT_ROWS], pl.INT32],
+    dump_moe_stats: pl.Scalar[pl.INT32],
 ):
     recv_meta_buf = pld.alloc_window_buffer([N_RANKS, N_LOCAL], dtype=pl.INT32)
     # MoE and LM-head run sequentially, so they can share data storage; keep
@@ -1043,7 +1053,7 @@ def l3_decode_fwd(
             data_arrived, routed_y_buf, combine_arrived,
             lm_head_hidden_window, lm_head_hidden_done,
             lm_head_logits_window, lm_head_logits_done,
-            num_tokens_per_owner, r,
+            moe_token_counts[r], num_tokens_per_owner, r, dump_moe_stats,
             device=r,
         )
 
@@ -1718,7 +1728,7 @@ def build_tensor_specs(
     inner_state_block_num=CSA_INNER_STATE_BLOCK_NUM,
 ):
     import torch
-    from golden import TensorSpec
+    from golden import ScalarSpec, TensorSpec
 
     def init_lm_head_weight():
         shards = (torch.randn(LM_HEAD_TP_SIZE, VOCAB_PER_TP, D) / D ** 0.5).to(torch.bfloat16)
@@ -1803,6 +1813,11 @@ def build_tensor_specs(
         is_output=True,
     ))
     specs.append(TensorSpec(
+        "moe_token_counts",
+        [N_RANKS, MOE_STATS_NUM_LAYERS, N_LOCAL],
+        torch.int32,
+    ))
+    specs.append(TensorSpec(
         "num_tokens_per_owner",
         [N_RANKS],
         torch.int32,
@@ -1814,6 +1829,7 @@ def build_tensor_specs(
         torch.int32,
         init_value=init_logit_row_indices,
     ))
+    specs.append(ScalarSpec("dump_moe_stats", torch.int32, 1))
     return specs
 
 

--- a/models/deepseek_v4_flash_mtp/decode_fwd_mtp.py
+++ b/models/deepseek_v4_flash_mtp/decode_fwd_mtp.py
@@ -69,6 +69,7 @@ from decode_fwd import (
     MAX_LOGIT_ROWS,
     MAX_SEQ_LEN,
     MIX_HC,
+    MOE_STATS_NUM_LAYERS,
     MOE_INTER,
     N_CACHE_GROUPS,
     N_EXPERTS_GLOBAL,

--- a/models/deepseek_v4_flash_mtp/decode_fwd_mtp.py
+++ b/models/deepseek_v4_flash_mtp/decode_fwd_mtp.py
@@ -482,7 +482,9 @@ def l2_decode_fwd_mtp(
     mtp_lm_head_hidden_done: pld.DistributedTensor[[LM_HEAD_TP_SIZE, 1], pl.INT32],
     mtp_lm_head_logits_window: pld.DistributedTensor[[MAX_LOGIT_ROWS, LM_HEAD_VOCAB], pl.FP32],
     mtp_lm_head_logits_done: pld.DistributedTensor[[LM_HEAD_TP_SIZE, 1], pl.INT32],
+    moe_token_counts: pl.InOut[pl.Tensor[[MOE_STATS_NUM_LAYERS, N_LOCAL], pl.INT32]],
     rank: pl.Scalar[pl.INT32],
+    dump_moe_stats: pl.Scalar[pl.INT32],
     mtp_num_tokens: pl.Scalar[pl.INT32],
 ):
     swa_cos_profile: pl.Tensor[[1, MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16] = pl.slice(freqs_cos, [1, MAX_SEQ_LEN, ROPE_HEAD_DIM], [0, 0, 0])
@@ -558,7 +560,7 @@ def l2_decode_fwd_mtp(
         recv_meta, recv_x, recv_aux, recv_route,
         arrived, data_arrived, routed_y_buf, combine_arrived,
         lm_head_hidden_window, lm_head_hidden_done, lm_head_logits_window, lm_head_logits_done,
-        num_tokens_per_owner, rank,
+        moe_token_counts, num_tokens_per_owner, rank, dump_moe_stats,
     )
     verify_and_pack_mtp_tokens(
         input_ids, position_ids, sampled_ids,
@@ -607,7 +609,7 @@ def l2_decode_fwd_mtp(
         mtp_recv_meta, mtp_recv_x, mtp_recv_aux, mtp_recv_route,
         mtp_arrived, mtp_data_arrived, mtp_routed_y_buf, mtp_combine_arrived,
         mtp_lm_head_hidden_window, mtp_lm_head_hidden_done, mtp_lm_head_logits_window, mtp_lm_head_logits_done,
-        rank, mtp_num_tokens,
+        moe_token_counts, rank, dump_moe_stats, mtp_num_tokens,
     )
     # Commit the verified window and the next draft back to the persistent slot.
     advance_decode_device_state(
@@ -718,6 +720,9 @@ def l3_decode_fwd_mtp(
     hidden_out: pl.Out[pl.Tensor[[N_RANKS, T, D], pl.BF16]],
     logits: pl.Out[pl.Tensor[[N_RANKS, MAX_LOGIT_ROWS, LM_HEAD_VOCAB], pl.FP32]],
     sampled_ids: pl.Out[pl.Tensor[[N_RANKS, MAX_LOGIT_ROWS, SAMPLED_IDS_PAD], pl.INT32]],
+    moe_token_counts: pl.InOut[
+        pl.Tensor[[N_RANKS, MOE_STATS_NUM_LAYERS, N_LOCAL], pl.INT32]
+    ],
     num_tokens_per_owner: pl.Tensor[[N_RANKS], pl.INT32],
     logit_row_indices: pl.Tensor[[N_RANKS, MAX_LOGIT_ROWS], pl.INT32],
     mtp_tail_token_ids: pl.InOut[pl.Tensor[[N_RANKS, B], pl.INT64]],
@@ -785,6 +790,7 @@ def l3_decode_fwd_mtp(
     mtp_logits: pl.Out[pl.Tensor[[N_RANKS, MAX_LOGIT_ROWS, LM_HEAD_VOCAB], pl.FP32]],
     mtp_sampled_ids: pl.Out[pl.Tensor[[N_RANKS, MAX_LOGIT_ROWS, SAMPLED_IDS_PAD], pl.INT32]],
     mtp_logit_row_indices: pl.Tensor[[N_RANKS, MAX_LOGIT_ROWS], pl.INT32],
+    dump_moe_stats: pl.Scalar[pl.INT32],
     mtp_num_tokens: pl.Scalar[pl.INT32],
 ):
     recv_meta_buf = pld.alloc_window_buffer([N_RANKS, N_LOCAL], dtype=pl.INT32)
@@ -897,7 +903,8 @@ def l3_decode_fwd_mtp(
             mtp_arrived, mtp_data_arrived, mtp_routed_y_buf, mtp_combine_arrived,
             mtp_lm_head_hidden_window, mtp_lm_head_hidden_done, mtp_lm_head_logits_window,
             mtp_lm_head_logits_done,
-            rank, mtp_num_tokens,
+            moe_token_counts[rank],
+            rank, dump_moe_stats, mtp_num_tokens,
             device=rank,
         )
 
@@ -1073,7 +1080,9 @@ def build_tensor_specs(
         "freqs_cos",
         "freqs_sin",
         "lm_head_weight",
+        "moe_token_counts",
         "num_tokens",
+        "dump_moe_stats",
     }
     # Built on device from the main step's outputs, or built explicitly below.
     custom_mtp_names = {
@@ -1205,4 +1214,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-

--- a/models/deepseek_v4_flash_mtp/decode_layer.py
+++ b/models/deepseek_v4_flash_mtp/decode_layer.py
@@ -821,7 +821,7 @@ def build_tensor_specs(start_pos=DECODE_START_POS, layer_id=10):
     for spec in moe_specs:
         if not isinstance(spec, TensorSpec):
             continue
-        if spec.name in {"x_hc", "x_next"}:
+        if spec.name in {"x_hc", "x_next", "moe_token_counts"}:
             continue
         if spec.name == "tid2eid":
             def init_tid2eid():

--- a/models/deepseek_v4_flash_mtp/decode_layer.py
+++ b/models/deepseek_v4_flash_mtp/decode_layer.py
@@ -94,7 +94,7 @@ from moe import (
     build_tensor_specs as build_moe_tensor_specs,
     clear_moe_signals,
     golden_moe,
-    moe,
+    moe_legacy,
 )
 
 assert HCA_CMP_MAX_BLOCKS == CSA_CMP_MAX_BLOCKS
@@ -259,7 +259,7 @@ def decode_layer(
             x_attn,
         )
 
-    moe(
+    moe_legacy(
         x_attn,
         hc_ffn_fn, hc_ffn_scale, hc_ffn_base,
         norm_w, gate_w, gate_bias, tid2eid, input_ids,

--- a/models/deepseek_v4_flash_mtp/decode_mtp.py
+++ b/models/deepseek_v4_flash_mtp/decode_mtp.py
@@ -55,6 +55,7 @@ from moe import (
     HC_MULT,
     IDX_PAD,
     MIX_HC,
+    MOE_STATS_NUM_LAYERS,
     MOE_INTER,
     N_EXPERTS_GLOBAL,
     N_LOCAL,
@@ -158,7 +159,9 @@ def decode_mtp(
     lm_head_hidden_done: pld.DistributedTensor[[LM_HEAD_TP_SIZE, 1], pl.INT32],
     lm_head_logits_window: pld.DistributedTensor[[MAX_LOGIT_ROWS, LM_HEAD_VOCAB], pl.FP32],
     lm_head_logits_done: pld.DistributedTensor[[LM_HEAD_TP_SIZE, 1], pl.INT32],
+    moe_token_counts: pl.InOut[pl.Tensor[[MOE_STATS_NUM_LAYERS, N_LOCAL], pl.INT32]],
     my_rank: pl.Scalar[pl.INT32],
+    dump_moe_stats: pl.Scalar[pl.INT32],
     num_tokens: pl.Scalar[pl.INT32],
 ) -> pl.Tensor[[T, HC_MULT, D], pl.BF16]:
     projected_hidden = pl.create_tensor([T, HC_MULT, D], dtype=pl.FP32)
@@ -198,8 +201,9 @@ def decode_mtp(
             shared_w2, shared_w2_scale,
             next_pre_hc_hidden,
             recv_meta, recv_x, recv_aux, recv_route,
-            arrived, data_arrived, routed_y_buf, combine_arrived,
-            pl.cast(MTP_LAYER_ID, pl.INT32), num_tokens, my_rank, pl.cast(MTP_MOE_EPOCH, pl.INT32),
+            arrived, data_arrived, routed_y_buf, combine_arrived, moe_token_counts,
+            pl.cast(MTP_LAYER_ID, pl.INT32), num_tokens, my_rank,
+            pl.cast(MTP_MOE_EPOCH, pl.INT32), dump_moe_stats,
         )
 
     clear_moe_signals(next_pre_hc_hidden, arrived, data_arrived, combine_arrived)
@@ -293,7 +297,9 @@ def l2_decode_mtp(
     lm_head_hidden_done: pld.DistributedTensor[[LM_HEAD_TP_SIZE, 1], pl.INT32],
     lm_head_logits_window: pld.DistributedTensor[[MAX_LOGIT_ROWS, LM_HEAD_VOCAB], pl.FP32],
     lm_head_logits_done: pld.DistributedTensor[[LM_HEAD_TP_SIZE, 1], pl.INT32],
+    moe_token_counts: pl.InOut[pl.Tensor[[MOE_STATS_NUM_LAYERS, N_LOCAL], pl.INT32]],
     my_rank: pl.Scalar[pl.INT32],
+    dump_moe_stats: pl.Scalar[pl.INT32],
     num_tokens: pl.Scalar[pl.INT32],
 ) -> pl.Tensor[[T, HC_MULT, D], pl.BF16]:
     swa_cos_profile: pl.Tensor[[1, MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16] = pl.slice(
@@ -329,7 +335,8 @@ def l2_decode_mtp(
         recv_meta, recv_x, recv_aux, recv_route,
         arrived, data_arrived, routed_y_buf, combine_arrived,
         lm_head_hidden_window, lm_head_hidden_done, lm_head_logits_window, lm_head_logits_done,
-        my_rank, num_tokens,
+        moe_token_counts,
+        my_rank, dump_moe_stats, num_tokens,
     )
 
 
@@ -398,6 +405,10 @@ def l3_decode_mtp(
         pl.Tensor[[N_RANKS, MAX_LOGIT_ROWS, SAMPLED_IDS_PAD], pl.INT32]
     ],
     logit_row_indices: pl.Tensor[[N_RANKS, MAX_LOGIT_ROWS], pl.INT32],
+    moe_token_counts: pl.InOut[
+        pl.Tensor[[N_RANKS, MOE_STATS_NUM_LAYERS, N_LOCAL], pl.INT32]
+    ],
+    dump_moe_stats: pl.Scalar[pl.INT32],
     num_tokens: pl.Scalar[pl.INT32],
 ):
     recv_meta_buf = pld.alloc_window_buffer([N_RANKS, N_LOCAL], dtype=pl.INT32)
@@ -452,7 +463,7 @@ def l3_decode_mtp(
             arrived, data_arrived, routed_y_buf, combine_arrived,
             lm_head_hidden_window, lm_head_hidden_done,
             lm_head_logits_window, lm_head_logits_done,
-            r, num_tokens,
+            moe_token_counts[r], r, dump_moe_stats, num_tokens,
             device=r,
         )
 
@@ -807,6 +818,12 @@ def build_tensor_specs(start_pos=DECODE_START_POS, num_tokens=T, ori_block_num=O
         init_value=init_logit_row_indices,
     )
     specs.append(row_indices_spec)
+    specs.append(TensorSpec(
+        "moe_token_counts",
+        [N_RANKS, MOE_STATS_NUM_LAYERS, N_LOCAL],
+        torch.int32,
+    ))
+    specs.append(ScalarSpec("dump_moe_stats", torch.int32, 1))
     specs.append(ScalarSpec("num_tokens", torch.int32, num_tokens))
     return specs
 

--- a/models/deepseek_v4_flash_mtp/moe.py
+++ b/models/deepseek_v4_flash_mtp/moe.py
@@ -62,6 +62,8 @@ N_RANKS = EP_WORLD_SIZE
 N_EXPERTS_GLOBAL = M.n_routed_experts
 N_LOCAL = N_EXPERTS_GLOBAL // N_RANKS
 N_ROUTES = T * TOPK
+# Hidden-layer rows plus one MTP row for physical-expert token counts.
+MOE_STATS_NUM_LAYERS = M.num_hidden_layers + 1
 
 # recv_x/recv_aux laid out [expert, source, slot], flattened to
 # [N_LOCAL * RECV_MAX, D]. Lane (e, src, slot) flat row = e * RECV_MAX +
@@ -121,10 +123,12 @@ def dispatch(
     recv_route: pld.DistributedTensor[[N_LOCAL * RECV_MAX, IDX_PAD], pl.INT32],
     arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
     data_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
+    moe_token_counts: pl.InOut[pl.Tensor[[1, N_LOCAL], pl.INT32]],
     num_tokens: pl.Scalar[pl.INT32],
     my_rank: pl.Scalar[pl.INT32],
     # 1-based MoE call id; `arrived`/`data_arrived` are monotonic so waits use `>= moe_epoch`.
     moe_epoch: pl.Scalar[pl.INT32],
+    dump_moe_stats: pl.Scalar[pl.INT32],
 ):
     # Flat 2-D view kept outside the scope so it stays a tensor view, not a tile.
     recv_x_out_flat = pl.reshape(recv_x_out, [N_LOCAL * RECV_MAX, D])
@@ -194,6 +198,10 @@ def dispatch(
                 pl.write(recv_meta_local, [src, e], count)
                 acc = acc + count
             pl.write(recv_count_out, [e, 0], acc)
+            # Accumulate received token counts by physical expert.
+            if dump_moe_stats != 0:
+                previous = pl.read(moe_token_counts, [0, e])
+                pl.write(moe_token_counts, [0, e], previous + acc)
 
     # Move the bulk payload (x / aux / route) to each destination lane.
     # Split over LOCAL EXPERT INDEX (N_LOCAL blocks): block loc_e handles expert
@@ -439,12 +447,14 @@ def moe(
     data_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
     routed_y_buf: pld.DistributedTensor[[N_ROUTES, D], pl.BF16],
     combine_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
+    moe_token_counts: pl.InOut[pl.Tensor[[MOE_STATS_NUM_LAYERS, N_LOCAL], pl.INT32]],
     # scalars last: runtime TaskArgs forbids a tensor arg after a scalar arg.
     layer_id: pl.Scalar[pl.INT32],
     num_tokens: pl.Scalar[pl.INT32],
     my_rank: pl.Scalar[pl.INT32],
     # 1-based MoE call id for the shared flag windows (distinct from layer_id).
     moe_epoch: pl.Scalar[pl.INT32],
+    dump_moe_stats: pl.Scalar[pl.INT32],
 ) -> pl.Tensor[[T, HC_MULT, D], pl.FP32]:
     # Non-output intermediates allocate locally, in their producer's scope.
     x_mixed = pl.create_tensor([T, D], dtype=pl.BF16)
@@ -479,11 +489,14 @@ def moe(
     recv_r_route_out = pl.create_tensor([N_LOCAL, RECV_MAX], dtype=pl.INT32, manual_dep=True)
     recv_count_out = pl.create_tensor([N_LOCAL, 1], dtype=pl.INT32)
     recv_meta_local = pl.create_tensor([N_RANKS, N_LOCAL], dtype=pl.INT32, manual_dep=True)
+    moe_token_counts_row: pl.Tensor[[1, N_LOCAL], pl.INT32] = pl.slice(
+        moe_token_counts, [1, N_LOCAL], [layer_id, 0]
+    )
     dispatch_push_tid = dispatch(
         indices, x_norm_i8, x_norm_scale, weights,
         recv_x_out, recv_scale_out, recv_w_out, recv_r_route_out, recv_count_out, recv_meta_local,
         recv_meta, recv_x, recv_aux, recv_route, arrived, data_arrived,
-        num_tokens, my_rank, moe_epoch,
+        moe_token_counts_row, num_tokens, my_rank, moe_epoch, dump_moe_stats,
     )
 
     with pl.scope():
@@ -505,6 +518,58 @@ def moe(
 
         hc_post(ffn_out, x_hc, post_ffn, comb_ffn, x_next)
     return x_next
+
+
+@pl.jit.inline(auto_scope=False)
+def moe_legacy(
+    x_hc: pl.Tensor[[T, HC_MULT, D], pl.FP32],
+    hc_ffn_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
+    hc_ffn_scale: pl.Tensor[[3], pl.FP32],
+    hc_ffn_base: pl.Tensor[[MIX_HC], pl.FP32],
+    norm_w: pl.Tensor[[D], pl.BF16],
+    gate_w: pl.Tensor[[N_EXPERTS_GLOBAL, D], pl.FP32],
+    gate_bias: pl.Tensor[[N_EXPERTS_GLOBAL], pl.FP32],
+    tid2eid: pl.Tensor[[VOCAB, TOPK], pl.INT32],
+    input_ids: pl.Tensor[[T], pl.INT64],
+    routed_w1: pl.Tensor[[N_LOCAL, MOE_INTER, D], pl.INT8],
+    routed_w1_scale: pl.Tensor[[N_LOCAL, MOE_INTER], pl.FP32],
+    routed_w3: pl.Tensor[[N_LOCAL, MOE_INTER, D], pl.INT8],
+    routed_w3_scale: pl.Tensor[[N_LOCAL, MOE_INTER], pl.FP32],
+    routed_w2: pl.Tensor[[N_LOCAL, D, MOE_INTER], pl.INT8],
+    routed_w2_scale: pl.Tensor[[N_LOCAL, D], pl.FP32],
+    shared_w1: pl.Tensor[[MOE_INTER, D], pl.INT8],
+    shared_w1_scale: pl.Tensor[[MOE_INTER], pl.FP32],
+    shared_w3: pl.Tensor[[MOE_INTER, D], pl.INT8],
+    shared_w3_scale: pl.Tensor[[MOE_INTER], pl.FP32],
+    shared_w2: pl.Tensor[[D, MOE_INTER], pl.INT8],
+    shared_w2_scale: pl.Tensor[[D], pl.FP32],
+    x_next: pl.Out[pl.Tensor[[T, HC_MULT, D], pl.FP32]],
+    recv_meta: pld.DistributedTensor[[N_RANKS, N_LOCAL], pl.INT32],
+    recv_x: pld.DistributedTensor[[N_LOCAL * RECV_MAX, D], pl.INT8],
+    recv_aux: pld.DistributedTensor[[N_LOCAL * RECV_MAX, AUX_PAD], pl.FP32],
+    recv_route: pld.DistributedTensor[[N_LOCAL * RECV_MAX, IDX_PAD], pl.INT32],
+    arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
+    data_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
+    routed_y_buf: pld.DistributedTensor[[N_ROUTES, D], pl.BF16],
+    combine_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
+    layer_id: pl.Scalar[pl.INT32],
+    num_tokens: pl.Scalar[pl.INT32],
+    my_rank: pl.Scalar[pl.INT32],
+    moe_epoch: pl.Scalar[pl.INT32],
+) -> pl.Tensor[[T, HC_MULT, D], pl.FP32]:
+    """Compatibility path for callables that do not expose the fixed stats ABI."""
+    unused_counts = pl.create_tensor([MOE_STATS_NUM_LAYERS, N_LOCAL], dtype=pl.INT32)
+    return moe(
+        x_hc, hc_ffn_fn, hc_ffn_scale, hc_ffn_base,
+        norm_w, gate_w, gate_bias, tid2eid, input_ids,
+        routed_w1, routed_w1_scale, routed_w3, routed_w3_scale,
+        routed_w2, routed_w2_scale,
+        shared_w1, shared_w1_scale, shared_w3, shared_w3_scale,
+        shared_w2, shared_w2_scale, x_next,
+        recv_meta, recv_x, recv_aux, recv_route, arrived, data_arrived,
+        routed_y_buf, combine_arrived, unused_counts,
+        layer_id, num_tokens, my_rank, moe_epoch, pl.cast(0, pl.INT32),
+    )
 
 
 @pl.jit
@@ -542,12 +607,14 @@ def moe_test(
     data_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
     routed_y_buf: pld.DistributedTensor[[N_ROUTES, D], pl.BF16],
     combine_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
+    moe_token_counts: pl.InOut[pl.Tensor[[MOE_STATS_NUM_LAYERS, N_LOCAL], pl.INT32]],
     # scalars last: runtime TaskArgs forbids a tensor arg after a scalar arg.
     layer_id: pl.Scalar[pl.INT32],
     num_tokens: pl.Scalar[pl.INT32],
     my_rank: pl.Scalar[pl.INT32],
     # 1-based MoE call id; multi-layer callers increment it per reused window.
     moe_epoch: pl.Scalar[pl.INT32],
+    dump_moe_stats: pl.Scalar[pl.INT32],
 ) -> pl.Tensor[[T, HC_MULT, D], pl.FP32]:
     moe(
         x_hc, hc_ffn_fn, hc_ffn_scale, hc_ffn_base,
@@ -558,8 +625,8 @@ def moe_test(
         shared_w2, shared_w2_scale,
         x_next,
         recv_meta, recv_x, recv_aux, recv_route, arrived, data_arrived,
-        routed_y_buf, combine_arrived,
-        layer_id, num_tokens, my_rank, moe_epoch,
+        routed_y_buf, combine_arrived, moe_token_counts,
+        layer_id, num_tokens, my_rank, moe_epoch, dump_moe_stats,
     )
     clear_moe_signals(x_next, arrived, data_arrived, combine_arrived)
     return x_next
@@ -589,8 +656,12 @@ def l3_moe(
     shared_w2: pl.Tensor[[N_RANKS, D, MOE_INTER], pl.INT8],
     shared_w2_scale: pl.Tensor[[N_RANKS, D], pl.FP32],
     x_next: pl.Out[pl.Tensor[[N_RANKS, T, HC_MULT, D], pl.FP32]],
+    moe_token_counts: pl.InOut[
+        pl.Tensor[[N_RANKS, MOE_STATS_NUM_LAYERS, N_LOCAL], pl.INT32]
+    ],
     layer_id: pl.Scalar[pl.INT32],
     num_tokens: pl.Scalar[pl.INT32],
+    dump_moe_stats: pl.Scalar[pl.INT32],
 ):
     recv_meta_buf = pld.alloc_window_buffer([N_RANKS, N_LOCAL], dtype=pl.INT32)
     recv_x_buf = pld.alloc_window_buffer([N_LOCAL * RECV_MAX, D], dtype=pl.INT8)
@@ -619,8 +690,8 @@ def l3_moe(
             shared_w2[r], shared_w2_scale[r],
             x_next[r],
             recv_meta, recv_x, recv_aux, recv_route, arrived, data_arrived,
-            routed_y_buf, combine_arrived,
-            layer_id, num_tokens, r, pl.const(1, pl.INT32),
+            routed_y_buf, combine_arrived, moe_token_counts[r],
+            layer_id, num_tokens, r, pl.const(1, pl.INT32), dump_moe_stats,
             device=r,
         )
 
@@ -947,8 +1018,14 @@ def build_tensor_specs(layer_id=0, num_tokens=T, balanced_routing=False):
         TensorSpec("shared_w2",        [N_RANKS, D, MOE_INTER],          torch.int8,    init_value=lambda: sw2_i8),
         TensorSpec("shared_w2_scale",  [N_RANKS, D],                     torch.float32, init_value=lambda: sw2_s),
         TensorSpec("x_next",           [N_RANKS, T, HC_MULT, D],      torch.float32, is_output=True),
+        TensorSpec(
+            "moe_token_counts",
+            [N_RANKS, MOE_STATS_NUM_LAYERS, N_LOCAL],
+            torch.int32,
+        ),
         ScalarSpec("layer_id",         torch.int32,                      layer_id),
         ScalarSpec("num_tokens",       torch.int32,                      num_tokens),
+        ScalarSpec("dump_moe_stats",   torch.int32,                      1),
     ]
 
     # Keep the static weight parameters device-resident (child_memory), sharded

--- a/models/deepseek_v4_flash_mtp/prefill_cp_fwd_draft.py
+++ b/models/deepseek_v4_flash_mtp/prefill_cp_fwd_draft.py
@@ -112,7 +112,7 @@ from moe import (
     VOCAB,
     build_tensor_specs as build_moe_tensor_specs,
     clear_moe_signals,
-    moe,
+    moe_legacy,
 )
 from prefill_cp_swa import (
     BLOCK_ROWS,
@@ -545,7 +545,7 @@ def _fwd_moe_tail(
             )
         wave_out = pl.create_tensor([T, HC_MULT, D], dtype=pl.FP32, init_value=0.0)
         moe_epoch = moe_epoch_base + pl.cast(wave + 1, pl.INT32)
-        moe(
+        moe_legacy(
             x_moe_ready, hc_ffn_fn, hc_ffn_scale, hc_ffn_base,
             norm_w, gate_w, gate_bias, tid2eid, ids,
             routed_w1, routed_w1_scale, routed_w3, routed_w3_scale,

--- a/models/deepseek_v4_flash_mtp/prefill_cp_layer.py
+++ b/models/deepseek_v4_flash_mtp/prefill_cp_layer.py
@@ -45,7 +45,7 @@ from moe import (
     build_tensor_specs as build_moe_tensor_specs,
     clear_moe_signals,
     golden_moe,
-    moe,
+    moe_legacy,
 )
 from prefill_cp_swa import (
     CP_CHOICES,
@@ -362,7 +362,7 @@ def _prefill_layer_cp_moe_tail(
         wave_out = pl.create_tensor(
             [T, HC_MULT, D], dtype=pl.FP32, init_value=0.0
         )
-        moe(
+        moe_legacy(
             x_moe_ready, hc_ffn_fn, hc_ffn_scale, hc_ffn_base,
             norm_w, gate_w, gate_bias, tid2eid, ids,
             routed_w1, routed_w1_scale, routed_w3, routed_w3_scale,

--- a/models/deepseek_v4_flash_mtp/prefill_cp_layer.py
+++ b/models/deepseek_v4_flash_mtp/prefill_cp_layer.py
@@ -1940,7 +1940,7 @@ def _build_moe_specs(layer_id: int):
     for spec in moe_specs:
         if not isinstance(spec, TensorSpec):
             continue  # drop ScalarSpecs (layer_id, num_tokens)
-        if spec.name in {"x_hc", "x_next", "input_ids"}:
+        if spec.name in {"x_hc", "x_next", "input_ids", "moe_token_counts"}:
             continue
         moe_keep.append(spec)
     return moe_keep

--- a/models/deepseek_v4_flash_mtp/prefill_fwd.py
+++ b/models/deepseek_v4_flash_mtp/prefill_fwd.py
@@ -50,6 +50,7 @@ from moe import (
     N_LOCAL,
     N_RANKS,
     N_ROUTES,
+    MOE_STATS_NUM_LAYERS,
     RECV_MAX,
     T,
     TOPK,
@@ -335,8 +336,10 @@ def prefill_fwd(
     shared_w3_scale: pl.Tensor[[FWD_NUM_LAYERS * MOE_INTER], pl.FP32],
     shared_w2: pl.Tensor[[FWD_NUM_LAYERS * D, MOE_INTER], pl.INT8],
     shared_w2_scale: pl.Tensor[[FWD_NUM_LAYERS * D], pl.FP32],
+    moe_token_counts: pl.InOut[pl.Tensor[[MOE_STATS_NUM_LAYERS, N_LOCAL], pl.INT32]],
     num_tokens_per_owner: pl.Tensor[[N_RANKS], pl.INT32],
     my_rank: pl.Scalar[pl.INT32],
+    dump_moe_stats: pl.Scalar[pl.INT32],
 ) -> pl.Tensor[[FWD_TOKENS_DYN, D], pl.BF16]:
     swa_cos_profile: pl.Tensor[[1, MAX_SEQ_LEN, ROPE_HEAD_DIM], pl.BF16] = pl.slice(
         freqs_cos, [1, MAX_SEQ_LEN, ROPE_HEAD_DIM], [0, 0, 0]
@@ -462,8 +465,9 @@ def prefill_fwd(
                     shared_w2_l0, shared_w2_scale_l0,
                     hidden,
                     recv_meta, recv_x, recv_aux, recv_route, arrived, data_arrived,
-                    routed_y_buf, combine_arrived,
+                    routed_y_buf, combine_arrived, moe_token_counts,
                     pl.cast(0, pl.INT32), nt, my_rank, epoch_base + pl.cast(1, pl.INT32),
+                    dump_moe_stats,
                 )
 
             # ===================== layer 1 : swa =================================
@@ -524,8 +528,9 @@ def prefill_fwd(
                     shared_w2_l1, shared_w2_scale_l1,
                     hidden,
                     recv_meta, recv_x, recv_aux, recv_route, arrived, data_arrived,
-                    routed_y_buf, combine_arrived,
+                    routed_y_buf, combine_arrived, moe_token_counts,
                     pl.cast(1, pl.INT32), nt, my_rank, epoch_base + pl.cast(2, pl.INT32),
+                    dump_moe_stats,
                 )
 
             # ============ loop : csa (even) + hca (odd) pairs, layers 2..41 ======
@@ -620,8 +625,8 @@ def prefill_fwd(
                         shared_w2_csa, shared_w2_scale_csa,
                         hidden_mid,
                         recv_meta, recv_x, recv_aux, recv_route, arrived, data_arrived,
-                        routed_y_buf, combine_arrived,
-                        csa_layer, nt, my_rank, csa_moe_epoch,
+                        routed_y_buf, combine_arrived, moe_token_counts,
+                        csa_layer, nt, my_rank, csa_moe_epoch, dump_moe_stats,
                     )
 
                 # ---- hca attention weights (per-FWD by hca_layer, compact by loop_i) ----
@@ -691,8 +696,8 @@ def prefill_fwd(
                         shared_w2_hca, shared_w2_scale_hca,
                         hidden,
                         recv_meta, recv_x, recv_aux, recv_route, arrived, data_arrived,
-                        routed_y_buf, combine_arrived,
-                        hca_layer, nt, my_rank, hca_moe_epoch,
+                        routed_y_buf, combine_arrived, moe_token_counts,
+                        hca_layer, nt, my_rank, hca_moe_epoch, dump_moe_stats,
                     )
 
             # ================ layer 42 (FWD_LAST_LAYER) : csa -> x_out ===========
@@ -782,8 +787,8 @@ def prefill_fwd(
                     shared_w2_last, shared_w2_scale_last,
                     pre_hc_hidden_tile,
                     recv_meta, recv_x, recv_aux, recv_route, arrived, data_arrived,
-                    routed_y_buf, combine_arrived,
-                    csa_layer_last, nt, my_rank, last_moe_epoch,
+                    routed_y_buf, combine_arrived, moe_token_counts,
+                    csa_layer_last, nt, my_rank, last_moe_epoch, dump_moe_stats,
                 )
             x_head: pl.Tensor[[T, D], pl.BF16] = pl.create_tensor([T, D], dtype=pl.BF16)
             with pl.scope():
@@ -917,8 +922,12 @@ def l3_prefill_fwd(
     lm_head_weight: pl.Tensor[[N_RANKS, VOCAB_PER_TP, D], pl.BF16],
     hidden_out: pl.Out[pl.Tensor[[N_RANKS, FWD_TOKENS_DYN, D], pl.BF16]],
     logits: pl.Out[pl.Tensor[[N_RANKS, MAX_LOGIT_ROWS, LM_HEAD_VOCAB], pl.FP32]],
+    moe_token_counts: pl.InOut[
+        pl.Tensor[[N_RANKS, MOE_STATS_NUM_LAYERS, N_LOCAL], pl.INT32]
+    ],
     num_tokens_per_owner: pl.Tensor[[N_RANKS], pl.INT32],
     logit_row_indices: pl.Tensor[[N_RANKS, MAX_LOGIT_ROWS], pl.INT32],
+    dump_moe_stats: pl.Scalar[pl.INT32],
 ):
 
     x_hc.bind_dynamic(1, FWD_TOKENS_DYN)
@@ -991,7 +1000,8 @@ def l3_prefill_fwd(
             hc_ffn_scale[r], hc_ffn_base[r], norm_w[r], gate_w[r], gate_bias[r], tid2eid[r],
             routed_w1[r], routed_w1_scale[r], routed_w3[r], routed_w3_scale[r], routed_w2[r],
             routed_w2_scale[r], shared_w1[r], shared_w1_scale[r], shared_w3[r],
-            shared_w3_scale[r], shared_w2[r], shared_w2_scale[r], num_tokens_per_owner, r,
+            shared_w3_scale[r], shared_w2[r], shared_w2_scale[r], moe_token_counts[r],
+            num_tokens_per_owner, r, dump_moe_stats,
             device=r,
         )
 
@@ -1459,7 +1469,7 @@ def build_tensor_specs(
     active_ranks=N_RANKS,
 ):
     import torch
-    from golden import TensorSpec
+    from golden import ScalarSpec, TensorSpec
 
     def init_lm_head_weight():
         shards = (torch.randn(LM_HEAD_TP_SIZE, VOCAB_PER_TP, D) / D ** 0.5).to(torch.bfloat16)
@@ -1598,6 +1608,11 @@ def build_tensor_specs(
         is_output=True,
     ))
     specs.append(TensorSpec(
+        "moe_token_counts",
+        [N_RANKS, MOE_STATS_NUM_LAYERS, N_LOCAL],
+        torch.int32,
+    ))
+    specs.append(TensorSpec(
         "num_tokens_per_owner",
         [N_RANKS],
         torch.int32,
@@ -1609,6 +1624,7 @@ def build_tensor_specs(
         torch.int32,
         init_value=init_logit_row_indices,
     ))
+    specs.append(ScalarSpec("dump_moe_stats", torch.int32, 1))
     return specs
 
 

--- a/models/deepseek_v4_flash_mtp/prefill_layer.py
+++ b/models/deepseek_v4_flash_mtp/prefill_layer.py
@@ -43,7 +43,7 @@ from moe import (
     build_tensor_specs as build_moe_tensor_specs,
     clear_moe_signals,
     golden_moe,
-    moe,
+    moe_legacy,
 )
 from config import FLASH as MODEL_CONFIG, PREFILL_BATCH, PREFILL_SEQ
 from prefill_swa import (
@@ -311,7 +311,7 @@ def prefill_layer_core(
                 )
 
             x_next_tile = pl.create_tensor([TOK_TILE, HC_MULT, D], dtype=pl.FP32)
-            moe(
+            moe_legacy(
                 x_attn_tile,
                 hc_ffn_fn, hc_ffn_scale, hc_ffn_base,
                 norm_w, gate_w, gate_bias, tid2eid, input_ids_tile,

--- a/models/deepseek_v4_flash_mtp/prefill_layer.py
+++ b/models/deepseek_v4_flash_mtp/prefill_layer.py
@@ -848,7 +848,7 @@ def build_tensor_specs(layer_id=2):
 
     # MoE weight tensors (per rank). tid2eid keeps its hash-table init.
     for spec in build_moe_tensor_specs(layer_id=layer_id):
-        if not isinstance(spec, TensorSpec) or spec.name in {"x_hc", "x_next", "input_ids"}:
+        if not isinstance(spec, TensorSpec) or spec.name in {"x_hc", "x_next", "input_ids", "moe_token_counts"}:
             continue
         if spec.name == "tid2eid":
             def init_tid2eid(spec=spec):

--- a/models/deepseek_v4_flash_mtp/prefill_mtp.py
+++ b/models/deepseek_v4_flash_mtp/prefill_mtp.py
@@ -46,6 +46,7 @@ from moe import (
     HC_MULT,
     IDX_PAD,
     MIX_HC,
+    MOE_STATS_NUM_LAYERS,
     MOE_INTER,
     N_EXPERTS_GLOBAL,
     N_LOCAL,
@@ -180,7 +181,9 @@ def mtp_prefill_fwd(
     data_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
     routed_y_buf: pld.DistributedTensor[[N_ROUTES, D], pl.BF16],
     combine_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
+    moe_token_counts: pl.InOut[pl.Tensor[[MOE_STATS_NUM_LAYERS, N_LOCAL], pl.INT32]],
     my_rank: pl.Scalar[pl.INT32],
+    dump_moe_stats: pl.Scalar[pl.INT32],
     num_tokens: pl.Scalar[pl.INT32],
 ) -> pl.Tensor[[T, D], pl.BF16]:
     nt: pl.Scalar[pl.INT32] = num_tokens
@@ -233,8 +236,9 @@ def mtp_prefill_fwd(
             shared_w2, shared_w2_scale,
             pre_hc_hidden_out,
             recv_meta, recv_x, recv_aux, recv_route,
-            arrived, data_arrived, routed_y_buf, combine_arrived,
-            pl.cast(MTP_LAYER_ID, pl.INT32), nt, my_rank, pl.cast(MTP_MOE_EPOCH, pl.INT32),
+            arrived, data_arrived, routed_y_buf, combine_arrived, moe_token_counts,
+            pl.cast(MTP_LAYER_ID, pl.INT32), nt, my_rank,
+            pl.cast(MTP_MOE_EPOCH, pl.INT32), dump_moe_stats,
         )
 
     clear_moe_signals(pre_hc_hidden_out, arrived, data_arrived, combine_arrived)
@@ -306,6 +310,10 @@ def l3_mtp_prefill_fwd(
     pre_hc_hidden_out: pl.Out[pl.Tensor[[N_RANKS, T, HC_MULT, D], pl.FP32]],
     logits: pl.Out[pl.Tensor[[N_RANKS, MAX_LOGIT_ROWS, LM_HEAD_VOCAB], pl.FP32]],
     logit_row_indices: pl.Tensor[[N_RANKS, MAX_LOGIT_ROWS], pl.INT32],
+    moe_token_counts: pl.InOut[
+        pl.Tensor[[N_RANKS, MOE_STATS_NUM_LAYERS, N_LOCAL], pl.INT32]
+    ],
+    dump_moe_stats: pl.Scalar[pl.INT32],
     num_tokens: pl.Scalar[pl.INT32],
 ):
     recv_meta_buf = pld.alloc_window_buffer([N_RANKS, N_LOCAL], dtype=pl.INT32)
@@ -349,8 +357,8 @@ def l3_mtp_prefill_fwd(
             mtp_hc_head_fn[r], mtp_hc_head_scale[r], mtp_hc_head_base[r], mtp_norm_w[r],
             hidden_out[r], pre_hc_hidden_out[r],
             recv_meta, recv_x, recv_aux, recv_route, arrived, data_arrived,
-            routed_y_buf, combine_arrived,
-            r, num_tokens,
+            routed_y_buf, combine_arrived, moe_token_counts[r],
+            r, dump_moe_stats, num_tokens,
             device=r,
         )
 
@@ -608,6 +616,12 @@ def build_tensor_specs(
         init_value=init_logit_row_indices,
     )
     specs.append(row_indices_spec)
+    specs.append(TensorSpec(
+        "moe_token_counts",
+        [N_RANKS, MOE_STATS_NUM_LAYERS, N_LOCAL],
+        torch.int32,
+    ))
+    specs.append(ScalarSpec("dump_moe_stats", torch.int32, 1))
     specs.append(ScalarSpec("num_tokens", torch.int32, num_tokens))
     return specs
 


### PR DESCRIPTION
- Add a fixed per-layer physical-expert count tensor and runtime flag
  across prefill, decode, MTP, and fused MTP entry points
- Accumulate routed token counts after dispatch only when collection is
  enabled
- Keep standalone layer callables compatible through a disabled stats
  adapter