### PR TITLE
Refactor: type the syncall core_type as pl.KernelType

### DIFF
--- a/models/deepseek_v4_pro/hc_pre.py
+++ b/models/deepseek_v4_pro/hc_pre.py
@@ -125,7 +125,7 @@ def _hc_pre_syncall(
                     x_sq_row = pl.reshape(x_sq_sum, [1, T_TILE])
                     sq_part = pl.add(sq_part, x_sq_row)
                 sq_partials[rms_split : rms_split + 1, t0 : t0 + T_TILE] = sq_part
-        pl.system.syncall(core_type="mix")
+        pl.system.syncall(core_type=pl.KernelType.MIX)
 
         for aiv_id in pl.split_aiv(2, mode=pl.SplitMode.NONE):
             lane = core * 2 + aiv_id
@@ -145,7 +145,7 @@ def _hc_pre_syncall(
                         sq_partial = sq_partials[rms_split : rms_split + 1, rms_t0 : rms_t0 + T_TILE]
                         sq_total = pl.add(sq_total, sq_partial)
                     sq_sum_acc[0:1, rms_t0 : rms_t0 + T_TILE] = sq_total
-        pl.system.syncall(core_type="mix")
+        pl.system.syncall(core_type=pl.KernelType.MIX)
 
         for aiv_id in pl.split_aiv(2, mode=pl.SplitMode.NONE):
             lane = core * 2 + aiv_id

--- a/models/qwen3_14b/prefill_fwd.py
+++ b/models/qwen3_14b/prefill_fwd.py
@@ -632,7 +632,7 @@ def _attention_phase_window_full_single_block(
                     pl.slice(cur_li0, [Q_HEAD_BATCH_PAD, 1], [0, 0]),
                     [acc_li_row0, 0],
                 )
-        pl.system.syncall(core_type="mix")
+        pl.system.syncall(core_type=pl.KernelType.MIX)
 
         for final_work_id in pl.range(
             phase_core,


### PR DESCRIPTION
- pypto now types the cross-core sync keywords: pl.system.syncall
  takes core_type as a pl.KernelType member, and the bare "mix"
  string it used to accept emits a DeprecationWarning. Spell the
  three full-occupancy hard barriers as pl.KernelType.MIX.