### PR TITLE
Fix: cap nanobind below 3.0 in the CI setup

### DIFF
--- a/.github/actions/setup-ci-job/action.yml
+++ b/.github/actions/setup-ci-job/action.yml
@@ -549,7 +549,15 @@ runs:
         # releases of scikit-build-core before reporting it, burying the real
         # message ("no matching distribution for packaging") under a wall of
         # version lists. pyproject already requires >=0.10.0.
-        pip install 'scikit-build-core>=0.10' nanobind cmake ninja
+        # nanobind is capped below 3.0 to match pypto's own build requirement.
+        # It has to be pinned here rather than inherited: the pypto build below
+        # passes --no-build-isolation, so the extension is compiled against this
+        # install and pypto's [build-system] requires is never consulted.
+        # nanobind 3.0 stopped binding a null holder to a parameter typed after a
+        # bound class, which is what pypto's TileView uses for `start_offset`, so
+        # `ir.TileView()` no longer matches its own all-defaulted overload and
+        # every `pl.Tile` annotation fails to parse.
+        pip install 'scikit-build-core>=0.10' 'nanobind<3' cmake ninja
         # torch BEFORE pypto is built. pypto declares torch>=2.0.0, and if it is
         # not installed yet pip resolves that from the default index, where the
         # aarch64 wheel now drags ~1.5 GB of CUDA onto an Ascend host. Under
@@ -609,7 +617,7 @@ runs:
       working-directory: ${{ inputs.checkout-path }}
       run: |
         source activate.sh
-        pip install nanobind
+        pip install 'nanobind<3'  # same cap as the build step above
         # torch is installed in the build step above, before pypto is resolved.
 
     - name: Show ccache stats (after)


### PR DESCRIPTION
- Cap nanobind at `nanobind<3` in the setup action's build-step
  `pip install`, next to scikit-build-core, cmake and ninja.
- Cap the later standalone `pip install nanobind` the same way, and
  comment both with the incompatibility and why the cap cannot be
  inherited from pypto.

nanobind 3.0.0, released between 2026-08-21 and 2026-08-24, stopped
binding a null holder to a parameter typed after a bound class. pypto's
`TileView` uses one for `start_offset`, so `ir.TileView()` no longer
matches its own all-defaulted overload, and pypto's type resolver makes
that call for every `pl.Tile` annotation — every model example here fails
while parsing its first kernel. The cap has to live in this repository:
the build step passes `--no-build-isolation`, so the pypto extension is
compiled against the nanobind this action installs and pypto's own
`[build-system] requires` (capped by hw-native-sys/pypto#2492) is never
consulted. hw-native-sys/pypto#2493 tracks the wider problem that build
inputs across both repositories are unbounded, so the same class of
outage can arrive next from scikit-build-core, cmake or ninja.