### PR TITLE
Add: DeepSeek-V4 DSpark confidence head and CP draft flow

### DIFF
--- a/models/deepseek_v4_flash_dspark/dspark_attention.py
+++ b/models/deepseek_v4_flash_dspark/dspark_attention.py
@@ -28,11 +28,17 @@ from config import (
     KV_ORI_MAX_BLOCKS,
     TP,
 )
-from qkv_proj_rope import kv_proj_rope, materialize_rope_rows, q_proj_rope, rope_prepare
+from qkv_proj_rope import (
+    kv_proj_rope,
+    materialize_rope_rows_dynamic,
+    q_proj_rope,
+    rope_prepare,
+)
 
 
 # Dynamic shape variables.
 ORI_BLOCK_NUM_DYN = pl.dynamic("DSPARK_ATTENTION_ORI_BLOCK_NUM_DYN")
+KV_T_DYN = pl.dynamic("DSPARK_ATTENTION_KV_T_DYN")
 
 # model config
 B = DECODE_BATCH // TP
@@ -72,6 +78,7 @@ NEG_INF = -1.0e20
 @pl.jit.inline
 def dspark_attention(
     x: pl.Tensor[[T, D], pl.BF16],
+    kv_x: pl.Tensor[[KV_T_DYN, D], pl.BF16],
     wq_a: pl.Tensor[[D, Q_LORA], pl.BF16],
     wq_b: pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8],
     wq_b_scale: pl.Tensor[[H * HEAD_DIM], pl.FP32],
@@ -81,8 +88,9 @@ def dspark_attention(
     freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_DIM], pl.BF16],
     freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_DIM], pl.BF16],
     position_ids: pl.Tensor[[T], pl.INT32],
+    kv_position_ids: pl.Tensor[[KV_T_DYN], pl.INT32],
     kv_cache: pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
-    slot_mapping: pl.Tensor[[T], pl.INT64],
+    kv_slot_mapping: pl.Tensor[[KV_T_DYN], pl.INT64],
     swa_indices: pl.Tensor[[B, INDEX_WIDTH], pl.INT32],
     swa_lens: pl.Tensor[[B], pl.INT32],
     attn_sink: pl.Tensor[[H], pl.FP32],
@@ -91,9 +99,17 @@ def dspark_attention(
     wo_b_scale: pl.Tensor[[D], pl.FP32],
     x_out: pl.Tensor[[T, D], pl.BF16],
 ):
+    kv_tokens = pl.tensor.dim(kv_position_ids, 0)
     rope_cos_t = pl.create_tensor([T, ROPE_DIM], dtype=pl.BF16)
     rope_sin_t = pl.create_tensor([T, ROPE_DIM], dtype=pl.BF16)
-    materialize_rope_rows(freqs_cos, freqs_sin, position_ids, T, rope_cos_t, rope_sin_t)
+    for rope_t in pl.spmd(T, name_hint="dspark_q_rope_rows"):
+        rope_position = pl.cast(pl.read(position_ids, [rope_t]), pl.INDEX)
+        rope_cos_t[rope_t : rope_t + 1, :] = freqs_cos[
+            rope_position : rope_position + 1, :
+        ]
+        rope_sin_t[rope_t : rope_t + 1, :] = freqs_sin[
+            rope_position : rope_position + 1, :
+        ]
 
     rope_cos_il = pl.create_tensor([T, ROPE_DIM], dtype=pl.FP32)
     rope_sin_signed = pl.create_tensor([T, ROPE_DIM], dtype=pl.FP32)
@@ -109,10 +125,39 @@ def dspark_attention(
         q, qr, qr_scale,
     )
 
-    # Neutral fence: qr_proj and kv_proj share one input, nothing to defer behind.
+    kv_rope_cos_t = pl.create_tensor([kv_tokens, ROPE_DIM], dtype=pl.BF16)
+    kv_rope_sin_t = pl.create_tensor([kv_tokens, ROPE_DIM], dtype=pl.BF16)
+    materialize_rope_rows_dynamic(
+        freqs_cos,
+        freqs_sin,
+        kv_position_ids,
+        kv_rope_cos_t,
+        kv_rope_sin_t,
+    )
+    kv_rope_cos_il = pl.create_tensor([kv_tokens, ROPE_DIM], dtype=pl.FP32)
+    kv_rope_sin_signed = pl.create_tensor([kv_tokens, ROPE_DIM], dtype=pl.FP32)
+    kv_rope_swap_idx = pl.create_tensor([kv_tokens, ROPE_DIM], dtype=pl.INT32)
+    rope_prepare(
+        kv_rope_cos_t,
+        kv_rope_sin_t,
+        kv_rope_cos_il,
+        kv_rope_sin_signed,
+        kv_rope_swap_idx,
+    )
+
+    # Q remains on the local SP shard; KV covers the full TP-group token stream.
     late_dep = pl.system.task_dummy(deps=[])
-    kv = pl.create_tensor([T, HEAD_DIM], dtype=pl.BF16)
-    kv_proj_rope(x, wkv, gamma_ckv, rope_cos_il, rope_sin_signed, rope_swap_idx, kv, late_dep)
+    kv = pl.create_tensor([kv_tokens, HEAD_DIM], dtype=pl.BF16)
+    kv_proj_rope(
+        kv_x,
+        wkv,
+        gamma_ckv,
+        kv_rope_cos_il,
+        kv_rope_sin_signed,
+        kv_rope_swap_idx,
+        kv,
+        late_dep,
+    )
 
     # Commit the block's own KV and build the visible-length mask in one task; the
     # gather below reads those rows back through swa_indices.
@@ -120,8 +165,8 @@ def dspark_attention(
     kv_cache_flat = pl.reshape(kv_cache, [ori_block_num * BLOCK_SIZE, HEAD_DIM])
     sparse_bias = pl.create_tensor([B, INDEX_WIDTH], dtype=pl.FP32)
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="dspark_kv_commit_valid_bias"):
-        for write_t in pl.range(T):
-            write_row_i64 = pl.read(slot_mapping, [write_t])
+        for write_t in pl.range(kv_tokens):
+            write_row_i64 = pl.read(kv_slot_mapping, [write_t])
             if write_row_i64 >= 0:
                 write_row = pl.cast(write_row_i64, pl.INDEX)
                 kv_cache_flat[write_row : write_row + 1, 0:HEAD_DIM] = kv[write_t : write_t + 1, 0:HEAD_DIM]
@@ -331,8 +376,9 @@ def dspark_attention_test(
     kv_cache.bind_dynamic(0, ORI_BLOCK_NUM_DYN)
     return dspark_attention(
         x,
+        x,
         wq_a, wq_b, wq_b_scale, wkv, gamma_cq, gamma_ckv,
-        freqs_cos, freqs_sin, position_ids,
+        freqs_cos, freqs_sin, position_ids, position_ids,
         kv_cache, slot_mapping, swa_indices, swa_lens,
         attn_sink, wo_a, wo_b, wo_b_scale,
         x_out,

--- a/models/deepseek_v4_flash_dspark/dspark_context_kv.py
+++ b/models/deepseek_v4_flash_dspark/dspark_context_kv.py
@@ -28,7 +28,12 @@ from config import (
     PREFILL_SEQ,
     TP,
 )
-from qkv_proj_rope import kv_proj_rope, materialize_rope_rows, rope_prepare
+from qkv_proj_rope import (
+    kv_proj_rope,
+    materialize_rope_rows,
+    materialize_rope_rows_dynamic,
+    rope_prepare,
+)
 
 
 # Dynamic shape variables.
@@ -37,6 +42,7 @@ ORI_BLOCK_NUM_DYN = pl.dynamic("DSPARK_CONTEXT_KV_ORI_BLOCK_NUM_DYN")
 
 # The public DSpark program supports at most 16 requests with 7 draft rows.
 DSPARK_QUERY_TOKENS = 16 * 7
+DSPARK_CONTEXT_LAYERS = 3
 
 # model config
 D = M.hidden_size
@@ -57,14 +63,17 @@ def dspark_context_kv(
     freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_DIM], pl.BF16],
     freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_DIM], pl.BF16],
     position_ids: pl.Tensor[[T_DYN], pl.INT32],
-    slot_mapping: pl.Tensor[[T_DYN], pl.INT64],
+    slot_mapping: pl.Tensor[[DSPARK_CONTEXT_LAYERS, T_DYN], pl.INT64],
+    layer_index: pl.Scalar[pl.INT32],
     kv_cache: pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
 ):
-    t_dim = pl.tensor.dim(main_x, 0)
+    t_dim = pl.tensor.dim(position_ids, 0)
 
     rope_cos_t = pl.create_tensor([t_dim, ROPE_DIM], dtype=pl.BF16)
     rope_sin_t = pl.create_tensor([t_dim, ROPE_DIM], dtype=pl.BF16)
-    materialize_rope_rows(freqs_cos, freqs_sin, position_ids, t_dim, rope_cos_t, rope_sin_t)
+    materialize_rope_rows_dynamic(
+        freqs_cos, freqs_sin, position_ids, rope_cos_t, rope_sin_t
+    )
 
     rope_cos_il = pl.create_tensor([t_dim, ROPE_DIM], dtype=pl.FP32)
     rope_sin_signed = pl.create_tensor([t_dim, ROPE_DIM], dtype=pl.FP32)
@@ -80,7 +89,7 @@ def dspark_context_kv(
     kv_cache_flat = pl.reshape(kv_cache, [ori_block_num * BLOCK_SIZE, HEAD_DIM])
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="dspark_context_kv_scatter"):
         for write_t in pl.range(t_dim):
-            write_row_i64 = pl.read(slot_mapping, [write_t])
+            write_row_i64 = pl.read(slot_mapping, [layer_index, write_t])
             if write_row_i64 >= 0:
                 write_row = pl.cast(write_row_i64, pl.INDEX)
                 kv_cache_flat[write_row : write_row + 1, 0:HEAD_DIM] = kv[write_t : write_t + 1, 0:HEAD_DIM]
@@ -146,15 +155,23 @@ def dspark_context_kv_test(
     freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_DIM], pl.BF16],
     freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_DIM], pl.BF16],
     position_ids: pl.Tensor[[T_DYN], pl.INT32],
-    slot_mapping: pl.Tensor[[T_DYN], pl.INT64],
+    slot_mapping: pl.Tensor[[DSPARK_CONTEXT_LAYERS, T_DYN], pl.INT64],
     kv_cache: pl.InOut[pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
 ):
     main_x.bind_dynamic(0, T_DYN)
     position_ids.bind_dynamic(0, T_DYN)
-    slot_mapping.bind_dynamic(0, T_DYN)
+    slot_mapping.bind_dynamic(1, T_DYN)
     kv_cache.bind_dynamic(0, ORI_BLOCK_NUM_DYN)
     return dspark_context_kv(
-        main_x, wkv, gamma_ckv, freqs_cos, freqs_sin, position_ids, slot_mapping, kv_cache
+        main_x,
+        wkv,
+        gamma_ckv,
+        freqs_cos,
+        freqs_sin,
+        position_ids,
+        slot_mapping,
+        pl.const(0, pl.INT32),
+        kv_cache,
     )
 
 
@@ -179,7 +196,7 @@ def golden_dspark_context_kv(tensors):
 
     kv = torch.cat([kv_full[:, :NOPE_DIM], rotated.float()], dim=-1).to(torch.bfloat16)
     kv_cache_flat = tensors["kv_cache"].view(-1, HEAD_DIM)
-    slots = tensors["slot_mapping"]
+    slots = tensors["slot_mapping"][0]
     for token_idx in range(kv.shape[0]):
         cache_row = int(slots[token_idx].item())
         if cache_row >= 0:
@@ -212,9 +229,10 @@ def build_tensor_specs(batch, seq):
         return position_ids_from_starts(init_start_pos(), seq=seq).reshape(-1).contiguous()
 
     def init_slot_mapping():
-        return paged_slot_mapping(
+        slots = paged_slot_mapping(
             position_ids_from_starts(init_start_pos(), seq=seq), init_block_table(), block_size=BLOCK_SIZE
         ).reshape(-1).contiguous()
+        return slots.unsqueeze(0).expand(DSPARK_CONTEXT_LAYERS, -1).contiguous()
 
     def init_main_x():
         return torch.randn(t, D, dtype=torch.bfloat16) * 0.05
@@ -234,7 +252,12 @@ def build_tensor_specs(batch, seq):
         TensorSpec("freqs_cos", [MAX_SEQ_LEN, ROPE_DIM], torch.bfloat16, init_value=lambda: freqs_cos.clone()),
         TensorSpec("freqs_sin", [MAX_SEQ_LEN, ROPE_DIM], torch.bfloat16, init_value=lambda: freqs_sin.clone()),
         TensorSpec("position_ids", [t], torch.int32, init_value=init_position_ids),
-        TensorSpec("slot_mapping", [t], torch.int64, init_value=init_slot_mapping),
+        TensorSpec(
+            "slot_mapping",
+            [DSPARK_CONTEXT_LAYERS, t],
+            torch.int64,
+            init_value=init_slot_mapping,
+        ),
         TensorSpec(
             "kv_cache",
             [KV_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM],

--- a/models/deepseek_v4_flash_dspark/dspark_drafter.py
+++ b/models/deepseek_v4_flash_dspark/dspark_drafter.py
@@ -22,7 +22,6 @@ from config import (
     KV_ORI_BLOCK_NUM,
     KV_ORI_MAX_BLOCKS,
     MOE_TOKENS,
-    PREFILL_SEQ,
     PREFILL_TOKENS,
     TP,
 )
@@ -85,7 +84,10 @@ assert (
     * ((M.sliding_window + DSPARK_QUERY_WIDTH + BLOCK_SIZE - 1) // BLOCK_SIZE)
     <= KV_ORI_BLOCK_NUM
 )
-assert PREFILL_SEQ + DSPARK_QUERY_WIDTH <= KV_ORI_MAX_BLOCKS * BLOCK_SIZE
+assert (
+    DSPARK_GROUP_TOKEN_CAP // DSPARK_CP_SIZE + DSPARK_QUERY_WIDTH
+    <= KV_ORI_MAX_BLOCKS * BLOCK_SIZE
+)
 
 # model config
 T = DSPARK_MOE_TOKENS
@@ -902,7 +904,14 @@ def _block_tables(batch):
     return tables
 
 
-def _context_slots(tables, positions, tokens_per_request, valid_counts=None):
+def _context_slots(
+    tables,
+    positions,
+    request_ids,
+    *,
+    valid_mask=None,
+    first_cached_positions=None,
+):
     import torch
 
     slots = torch.full(
@@ -913,11 +922,15 @@ def _context_slots(tables, positions, tokens_per_request, valid_counts=None):
     for rank in range(N_RANKS):
         for layer in range(DSPARK_DRAFT_LAYERS):
             for token in range(positions.shape[1]):
-                request = token // tokens_per_request
-                request_offset = token % tokens_per_request
-                if valid_counts is not None and request_offset >= int(valid_counts[request]):
+                request = int(request_ids[token])
+                if valid_mask is not None and not bool(valid_mask[token]):
                     continue
                 position = int(positions[rank, token])
+                if (
+                    first_cached_positions is not None
+                    and position < int(first_cached_positions[request])
+                ):
+                    continue
                 physical_block = int(tables[rank, layer, request, position // BLOCK_SIZE])
                 slots[rank, layer, token] = physical_block * BLOCK_SIZE + position % BLOCK_SIZE
     return slots
@@ -942,26 +955,38 @@ def build_tensor_specs(batch, *, mode="decode"):
         raise ValueError(f"unsupported DSpark mode {mode!r}; expected 'decode' or 'prefill'")
 
     if mode == "decode":
-        target_seq = DECODE_SEQ
-        context_seq = DECODE_SEQ
+        local_context_tokens = batch * DECODE_SEQ
         positions = _anchor_position_set(batch).unsqueeze(0).expand(N_RANKS, -1).contiguous()
         valid_pattern = torch.tensor([1, 4, 7, 2, 5, 8, 3, 6], dtype=torch.int32)
         valid_counts = valid_pattern.repeat((batch + valid_pattern.numel() - 1) // valid_pattern.numel())[:batch]
-        context_positions = torch.zeros(N_RANKS, batch * context_seq, dtype=torch.int32)
+        context_request_ids = torch.arange(batch, dtype=torch.int64).repeat_interleave(DECODE_SEQ)
+        context_offsets = torch.arange(DECODE_SEQ, dtype=torch.int32).repeat(batch)
+        valid_mask = context_offsets < valid_counts.repeat_interleave(DECODE_SEQ)
+        context_positions = torch.zeros(N_RANKS, local_context_tokens, dtype=torch.int32)
         for request in range(batch):
             valid_count = int(valid_counts[request])
             context_start = int(positions[0, request]) - valid_count + 1
             context_positions[
                 :,
-                request * context_seq : request * context_seq + valid_count,
+                request * DECODE_SEQ : request * DECODE_SEQ + valid_count,
             ] = torch.arange(context_start, context_start + valid_count, dtype=torch.int32)
+        first_cached_positions = None
     else:
-        target_seq = PREFILL_SEQ
-        context_seq = PREFILL_SEQ
-        valid_counts = None
-        position_row = torch.arange(PREFILL_SEQ, dtype=torch.int32)
-        context_positions = position_row.repeat(batch).unsqueeze(0).expand(N_RANKS, -1).contiguous()
-        positions = torch.full((N_RANKS, batch), PREFILL_SEQ - 1, dtype=torch.int32)
+        local_context_tokens = PREFILL_TOKENS // DSPARK_CP_SIZE
+        request_counts = torch.full(
+            (batch,), local_context_tokens // batch, dtype=torch.int32
+        )
+        request_counts[: local_context_tokens % batch] += 1
+        context_request_ids = torch.arange(batch, dtype=torch.int64).repeat_interleave(
+            request_counts.to(torch.int64)
+        )
+        context_offsets = torch.cat(
+            [torch.arange(int(count), dtype=torch.int32) for count in request_counts]
+        )
+        context_positions = context_offsets.unsqueeze(0).expand(N_RANKS, -1).contiguous()
+        positions = (request_counts - 1).unsqueeze(0).expand(N_RANKS, -1).contiguous()
+        valid_mask = None
+        first_cached_positions = torch.clamp(request_counts - WIN, min=0)
     if int(context_positions.min()) < 0 or int(context_positions.max()) >= ORI_MAX_BLOCKS * BLOCK_SIZE:
         raise ValueError("DSpark context positions exceed the logical KV block table")
     if int((positions + DSPARK_QUERY_WIDTH).max()) >= ORI_MAX_BLOCKS * BLOCK_SIZE:
@@ -969,14 +994,20 @@ def build_tensor_specs(batch, *, mode="decode"):
     tables = _block_tables(batch)
     if int(tables.min()) < 0 or int(tables.max()) >= ORI_BLOCK_NUM:
         raise ValueError("DSpark block table references a physical KV block outside the cache")
-    context_slots = _context_slots(tables, context_positions, context_seq, valid_counts)
+    context_slots = _context_slots(
+        tables,
+        context_positions,
+        context_request_ids,
+        valid_mask=valid_mask,
+        first_cached_positions=first_cached_positions,
+    )
     context_group_positions = torch.empty(
-        N_RANKS, DSPARK_CP_SIZE * batch * context_seq, dtype=torch.int32
+        N_RANKS, DSPARK_CP_SIZE * local_context_tokens, dtype=torch.int32
     )
     context_group_slots = torch.empty(
         N_RANKS,
         DSPARK_DRAFT_LAYERS,
-        DSPARK_CP_SIZE * batch * context_seq,
+        DSPARK_CP_SIZE * local_context_tokens,
         dtype=torch.int64,
     )
     query_positions_local = torch.zeros(N_RANKS, T_QUERY, dtype=torch.int32)
@@ -1033,16 +1064,16 @@ def build_tensor_specs(batch, *, mode="decode"):
     routes = routes.reshape(N_RANKS, DSPARK_DRAFT_LAYERS * VOCAB, TOPK).contiguous()
 
     def init_target_hidden():
-        values = torch.zeros(N_RANKS, batch * target_seq, MAIN_IN, dtype=torch.bfloat16)
+        values = torch.zeros(N_RANKS, local_context_tokens, MAIN_IN, dtype=torch.bfloat16)
         columns = torch.arange(D, dtype=torch.float32)
         base = ((columns % 31) - 15) * 0.002
         for rank in range(N_RANKS):
-            for request in range(batch):
-                for offset in range(target_seq):
-                    row = request * target_seq + offset
-                    values[rank, row, :D] = (
-                        base + 0.01 * (rank + request + 1) + 0.001 * offset
-                    ).to(torch.bfloat16)
+            for row in range(local_context_tokens):
+                request = int(context_request_ids[row])
+                offset = int(context_offsets[row])
+                values[rank, row, :D] = (
+                    base + 0.01 * (rank + request + 1) + 0.001 * offset
+                ).to(torch.bfloat16)
         return values
 
     def init_main_proj_weight():
@@ -1102,7 +1133,7 @@ def build_tensor_specs(batch, *, mode="decode"):
         return cache
 
     specs = [
-        ranked("target_hidden", [batch * target_seq, MAIN_IN], torch.bfloat16, init_value=init_target_hidden),
+        ranked("target_hidden", [local_context_tokens, MAIN_IN], torch.bfloat16, init_value=init_target_hidden),
         TensorSpec(
             "initial_hidden",
             [N_RANKS, DSPARK_MAX_BATCH * DSPARK_QUERY_PAD, HC_MULT, D],
@@ -1128,13 +1159,13 @@ def build_tensor_specs(batch, *, mode="decode"):
         ranked("embedding_weight", [VOCAB, D], torch.bfloat16, init_value=init_embedding_weight, resident=True),
         ranked(
             "context_group_position_ids",
-            [DSPARK_CP_SIZE * batch * context_seq],
+            [DSPARK_CP_SIZE * local_context_tokens],
             torch.int32,
             init_value=lambda: context_group_positions,
         ),
         ranked(
             "context_group_slot_mapping",
-            [DSPARK_DRAFT_LAYERS, DSPARK_CP_SIZE * batch * context_seq],
+            [DSPARK_DRAFT_LAYERS, DSPARK_CP_SIZE * local_context_tokens],
             torch.int64,
             init_value=lambda: context_group_slots,
         ),
@@ -1366,7 +1397,7 @@ def golden_dspark_drafter(tensors):
 
 if __name__ == "__main__":
     import argparse
-    from golden import run_jit
+    from golden import ratio_allclose, run_jit
 
     parser = argparse.ArgumentParser(description="Validate the multi-rank DeepSeek V4 DSpark drafter.")
     parser.add_argument("--batch", type=int, choices=DSPARK_SUPPORTED_BATCHES, default=4)
@@ -1395,6 +1426,9 @@ if __name__ == "__main__":
         ),
         rtol=1e-3,
         atol=1e-3,
+        compare_fn={
+            "kv_caches": ratio_allclose(atol=1e-4, rtol=1.0 / 128),
+        },
     )
     if not result.passed:
         if result.error:

--- a/models/deepseek_v4_flash_dspark/dspark_drafter.py
+++ b/models/deepseek_v4_flash_dspark/dspark_drafter.py
@@ -17,11 +17,13 @@ from config import (
     BLOCK_SIZE,
     DECODE_BATCH,
     DECODE_SEQ,
+    DECODE_TOKENS,
     FLASH as M,
     KV_ORI_BLOCK_NUM,
     KV_ORI_MAX_BLOCKS,
     MOE_TOKENS,
     PREFILL_SEQ,
+    PREFILL_TOKENS,
     TP,
 )
 from dspark_attention import dspark_attention
@@ -51,6 +53,8 @@ B_DYN = pl.dynamic("DSPARK_BACKBONE_B_DYN")
 PREPARE_T_MAIN_DYN = pl.dynamic("DSPARK_PREPARE_T_MAIN_DYN")
 PREPARE_B_DYN = pl.dynamic("DSPARK_PREPARE_B_DYN")
 METADATA_B_DYN = pl.dynamic("DSPARK_METADATA_B_DYN")
+CP_LOCAL_T_DYN = pl.dynamic("DSPARK_CP_LOCAL_T_DYN")
+CP_CONTEXT_T_DYN = pl.dynamic("DSPARK_CP_CONTEXT_T_DYN")
 
 # DSpark program contract.
 DSPARK_DRAFT_LAYERS = 3
@@ -62,6 +66,10 @@ DSPARK_MAX_BATCH = max(DSPARK_SUPPORTED_BATCHES)
 DSPARK_QUERY_TOKENS = DSPARK_MAX_BATCH * DSPARK_QUERY_WIDTH
 DSPARK_MOE_TOKENS = DSPARK_MAX_BATCH * DSPARK_QUERY_PAD
 DSPARK_SWA_INDEX_WIDTH = (M.sliding_window + DSPARK_QUERY_WIDTH + 63) // 64 * 64
+DSPARK_CP_SIZE = min(TP, N_RANKS)
+DSPARK_GROUP_TOKEN_CAP = max(DECODE_TOKENS, PREFILL_TOKENS)
+DSPARK_COMM_ROW_TILE = 8
+DSPARK_READBACK_ROW_TILE = 16
 
 assert DECODE_SEQ == 1 + DSPARK_QUERY_WIDTH
 assert DSPARK_QUERY_WIDTH < DSPARK_QUERY_PAD
@@ -69,9 +77,13 @@ assert DSPARK_MAX_BATCH == DECODE_BATCH // TP
 assert DSPARK_MOE_TOKENS == MOE_TOKENS
 assert DSPARK_NOISE_TOKEN_ID < M.vocab_size
 assert DSPARK_SWA_INDEX_WIDTH >= M.sliding_window + DSPARK_QUERY_WIDTH
-assert KV_ORI_BLOCK_NUM % DSPARK_MAX_BATCH == 0
-assert PREFILL_SEQ + DSPARK_QUERY_WIDTH <= (
-    KV_ORI_BLOCK_NUM // DSPARK_MAX_BATCH * BLOCK_SIZE
+assert N_RANKS % DSPARK_CP_SIZE == 0
+assert DSPARK_CP_SIZE * DSPARK_QUERY_TOKENS <= DSPARK_GROUP_TOKEN_CAP
+assert (
+    DSPARK_CP_SIZE
+    * DSPARK_MAX_BATCH
+    * ((M.sliding_window + DSPARK_QUERY_WIDTH + BLOCK_SIZE - 1) // BLOCK_SIZE)
+    <= KV_ORI_BLOCK_NUM
 )
 assert PREFILL_SEQ + DSPARK_QUERY_WIDTH <= KV_ORI_MAX_BLOCKS * BLOCK_SIZE
 
@@ -100,6 +112,99 @@ PAD_D_TILE = 512
 # Three draft layers plus their MoE communication graph exceed the runtime's
 # default per-ring heap. Match the established large-model harness allocation.
 _DSPARK_RING_HEAP = (4 * 1024 * 1024 * 1024,) * 4
+
+
+@pl.jit.inline
+def dspark_cp_barrier(
+    signal: pld.DistributedTensor[[DSPARK_CP_SIZE, 1], pl.INT32],
+    group_base: pl.Scalar[pl.INT32],
+    cp_rank: pl.Scalar[pl.INT32],
+    expected: pl.Scalar[pl.INT32],
+):
+    """Synchronize one contiguous TP group used as DSpark context parallelism."""
+    for peer_cp in pl.range(DSPARK_CP_SIZE):
+        if peer_cp != cp_rank:
+            pld.system.notify(
+                target=signal,
+                peer=group_base + peer_cp,
+                offsets=[cp_rank, 0],
+                value=1,
+                op=pld.NotifyOp.AtomicAdd,
+            )
+    for source_cp in pl.range(DSPARK_CP_SIZE):
+        if source_cp != cp_rank:
+            pld.system.wait(
+                signal=signal,
+                offsets=[source_cp, 0],
+                expected=expected,
+                cmp=pld.WaitCmp.Ge,
+            )
+    return signal
+
+
+@pl.jit.inline
+def reset_dspark_cp_signal(
+    signal: pld.DistributedTensor[[DSPARK_CP_SIZE, 1], pl.INT32],
+    group_base: pl.Scalar[pl.INT32],
+    cp_rank: pl.Scalar[pl.INT32],
+):
+    """Reset the two barrier credits before reusing a DSpark CP signal."""
+    reset_value = pl.cast(-2, pl.INT32)
+    self_rank = group_base + cp_rank
+    for source_cp in pl.range(DSPARK_CP_SIZE):
+        if source_cp != cp_rank:
+            pld.system.notify(
+                target=signal,
+                peer=self_rank,
+                offsets=[source_cp, 0],
+                value=reset_value,
+                op=pld.NotifyOp.AtomicAdd,
+            )
+    return signal
+
+
+@pl.jit.inline(auto_scope=False)
+def dspark_cp_allgather_hidden(
+    hidden_local: pl.Tensor[[CP_LOCAL_T_DYN, D], pl.BF16],
+    hidden_group: pl.Tensor[[CP_CONTEXT_T_DYN, D], pl.BF16],
+    gather_window: pld.DistributedTensor[[DSPARK_GROUP_TOKEN_CAP, D], pl.BF16],
+    gather_signal: pld.DistributedTensor[[DSPARK_CP_SIZE, 1], pl.INT32],
+    group_base: pl.Scalar[pl.INT32],
+    cp_rank: pl.Scalar[pl.INT32],
+):
+    """Gather equal-sized local SP hidden rows in rank-major order."""
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="dspark_cp_allgather_hidden"):
+        local_rows = pl.tensor.dim(hidden_local, 0)
+        group_rows = DSPARK_CP_SIZE * local_rows
+        local_t = pl.cast(local_rows, pl.INT32)
+        target_row = cp_rank * local_t
+        for peer_cp in pl.range(DSPARK_CP_SIZE):
+            pld.tensor.put(
+                dst=gather_window,
+                peer=group_base + peer_cp,
+                src=hidden_local,
+                dst_offsets=[target_row, 0],
+                src_offsets=[0, 0],
+                shape=[local_t, D],
+                chunk_rows=DSPARK_COMM_ROW_TILE,
+                chunk_cols=D,
+            )
+        gather_signal = dspark_cp_barrier(
+            gather_signal, group_base, cp_rank, pl.cast(1, pl.INT32)
+        )
+        full_rows = (group_rows // DSPARK_READBACK_ROW_TILE) * DSPARK_READBACK_ROW_TILE
+        for row in pl.range(0, full_rows, DSPARK_READBACK_ROW_TILE):
+            hidden_group[row : row + DSPARK_READBACK_ROW_TILE, :] = gather_window[
+                row : row + DSPARK_READBACK_ROW_TILE, :
+            ]
+        for row in pl.range(full_rows, group_rows):
+            hidden_group[row : row + 1, :] = gather_window[row : row + 1, :]
+        gather_signal = dspark_cp_barrier(
+            gather_signal, group_base, cp_rank, pl.cast(2, pl.INT32)
+        )
+        gather_signal = reset_dspark_cp_signal(gather_signal, group_base, cp_rank)
+    return hidden_group, gather_signal
+
 
 @pl.jit.inline
 def prepare_dspark_inputs(
@@ -224,8 +329,9 @@ def draft_layer(
     freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_DIM], pl.BF16],
     freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_DIM], pl.BF16],
     query_positions: pl.Tensor[[T_QUERY], pl.INT32],
+    query_group_positions: pl.Tensor[[DSPARK_CP_SIZE * T_QUERY], pl.INT32],
     kv_cache: pl.Tensor[[KV_ORI_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
-    query_slot_mapping: pl.Tensor[[T_QUERY], pl.INT64],
+    query_group_slot_mapping: pl.Tensor[[DSPARK_CP_SIZE * T_QUERY], pl.INT64],
     swa_indices: pl.Tensor[[DSPARK_MAX_BATCH, DSPARK_SWA_INDEX_WIDTH], pl.INT32],
     swa_lens: pl.Tensor[[DSPARK_MAX_BATCH], pl.INT32],
     attn_sink: pl.Tensor[[DSPARK_DRAFT_LAYERS * H], pl.FP32],
@@ -253,6 +359,10 @@ def draft_layer(
     shared_w2: pl.Tensor[[DSPARK_DRAFT_LAYERS * D, MOE_INTER], pl.INT8],
     shared_w2_scale: pl.Tensor[[DSPARK_DRAFT_LAYERS * D], pl.FP32],
     output_hc: pl.Tensor[[T, HC_MULT, D], pl.FP32],
+    hidden_gather_window: pld.DistributedTensor[[DSPARK_GROUP_TOKEN_CAP, D], pl.BF16],
+    hidden_gather_signal: pld.DistributedTensor[[DSPARK_CP_SIZE, 1], pl.INT32],
+    group_base: pl.Scalar[pl.INT32],
+    cp_rank: pl.Scalar[pl.INT32],
     recv_meta: pld.DistributedTensor[[N_RANKS, N_LOCAL], pl.INT32],
     recv_x: pld.DistributedTensor[[N_LOCAL * RECV_MAX, D], pl.INT8],
     recv_aux: pld.DistributedTensor[[N_LOCAL * RECV_MAX, AUX_PAD], pl.FP32],
@@ -320,12 +430,22 @@ def draft_layer(
         [0, 0],
     )
     rms_norm(query_mixed_active, layer_attn_norm_w, query_normed)
+    query_group = pl.create_tensor([DSPARK_CP_SIZE * T_QUERY, D], dtype=pl.BF16)
+    query_group, hidden_gather_signal = dspark_cp_allgather_hidden(
+        query_normed,
+        query_group,
+        hidden_gather_window,
+        hidden_gather_signal,
+        group_base,
+        cp_rank,
+    )
     attention_output = pl.create_tensor([T_QUERY, D], dtype=pl.BF16)
     dspark_attention(
         query_normed,
+        query_group,
         layer_wq_a, layer_wq_b, layer_wq_b_scale, layer_wkv, layer_gamma_cq, layer_gamma_ckv,
-        freqs_cos, freqs_sin, query_positions,
-        kv_cache, query_slot_mapping, swa_indices, swa_lens,
+        freqs_cos, freqs_sin, query_positions, query_group_positions,
+        kv_cache, query_group_slot_mapping, swa_indices, swa_lens,
         layer_attn_sink, layer_wo_a, layer_wo_b, layer_wo_b_scale,
         attention_output,
     )
@@ -360,7 +480,7 @@ def draft_layer(
         arrived, data_arrived, routed_y_buf, combine_arrived,
         layer_id, active_tokens, my_rank, moe_epoch,
     )
-    return output_hc
+    return output_hc, hidden_gather_signal
 
 @pl.jit
 def dspark_drafter(
@@ -371,12 +491,18 @@ def dspark_drafter(
     last_sampled: pl.Tensor[[B_DYN], pl.INT64],
     next_prefill_tokens: pl.Tensor[[B_DYN], pl.INT64],
     embedding_weight: pl.Tensor[[VOCAB, D], pl.BF16],
-    context_position_ids: pl.Tensor[[T_MAIN_DYN], pl.INT32],
-    context_slot_mapping: pl.Tensor[[DSPARK_DRAFT_LAYERS, T_MAIN_DYN], pl.INT64],
+    context_group_position_ids: pl.Tensor[[CP_CONTEXT_T_DYN], pl.INT32],
+    context_group_slot_mapping: pl.Tensor[
+        [DSPARK_DRAFT_LAYERS, CP_CONTEXT_T_DYN], pl.INT64
+    ],
     anchor_positions: pl.Tensor[[B_DYN], pl.INT32],
     block_tables: pl.Tensor[
         [DSPARK_DRAFT_LAYERS, B_DYN, ORI_MAX_BLOCKS],
         pl.INT32,
+    ],
+    query_group_position_ids: pl.Tensor[[DSPARK_CP_SIZE * T_QUERY], pl.INT32],
+    query_group_slot_mapping: pl.Tensor[
+        [DSPARK_DRAFT_LAYERS, DSPARK_CP_SIZE * T_QUERY], pl.INT64
     ],
     freqs_cos: pl.Tensor[[MAX_SEQ_LEN, ROPE_DIM], pl.BF16],
     freqs_sin: pl.Tensor[[MAX_SEQ_LEN, ROPE_DIM], pl.BF16],
@@ -424,6 +550,8 @@ def dspark_drafter(
         pl.Tensor[[DSPARK_DRAFT_LAYERS, T, HC_MULT, D], pl.FP32]
     ],
     head_hidden: pl.Out[pl.Tensor[[B_DYN, DSPARK_QUERY_WIDTH, D], pl.BF16]],
+    hidden_gather_window: pld.DistributedTensor[[DSPARK_GROUP_TOKEN_CAP, D], pl.BF16],
+    hidden_gather_signal: pld.DistributedTensor[[DSPARK_CP_SIZE, 1], pl.INT32],
     recv_meta: pld.DistributedTensor[[N_RANKS, N_LOCAL], pl.INT32],
     recv_x: pld.DistributedTensor[[N_LOCAL * RECV_MAX, D], pl.INT8],
     recv_aux: pld.DistributedTensor[[N_LOCAL * RECV_MAX, AUX_PAD], pl.FP32],
@@ -432,11 +560,13 @@ def dspark_drafter(
     data_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
     routed_y_buf: pld.DistributedTensor[[N_ROUTES, D], pl.BF16],
     combine_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
+    group_base: pl.Scalar[pl.INT32],
+    cp_rank: pl.Scalar[pl.INT32],
     my_rank: pl.Scalar[pl.INT32],
 ):
     target_hidden.bind_dynamic(0, T_MAIN_DYN)
-    context_position_ids.bind_dynamic(0, T_MAIN_DYN)
-    context_slot_mapping.bind_dynamic(1, T_MAIN_DYN)
+    context_group_position_ids.bind_dynamic(0, CP_CONTEXT_T_DYN)
+    context_group_slot_mapping.bind_dynamic(1, CP_CONTEXT_T_DYN)
     num_sampled.bind_dynamic(0, B_DYN)
     last_sampled.bind_dynamic(0, B_DYN)
     next_prefill_tokens.bind_dynamic(0, B_DYN)
@@ -471,26 +601,27 @@ def dspark_drafter(
         query_token_ids,
         hidden_0_flat,
     )
-    context_slots_0 = pl.create_tensor([target_tokens], dtype=pl.INT64)
-    context_slots_1 = pl.create_tensor([target_tokens], dtype=pl.INT64)
-    context_slots_2 = pl.create_tensor([target_tokens], dtype=pl.INT64)
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="dspark_context_slots"):
-        for token in pl.range(target_tokens):
-            pl.write(context_slots_0, [token], pl.read(context_slot_mapping, [0, token]))
-            pl.write(context_slots_1, [token], pl.read(context_slot_mapping, [1, token]))
-            pl.write(context_slots_2, [token], pl.read(context_slot_mapping, [2, token]))
-
-    dspark_context_kv(
-        main_x, wkv_0, gamma_ckv_0, freqs_cos, freqs_sin,
-        context_position_ids, context_slots_0, kv_cache_0,
+    group_context_tokens = pl.tensor.dim(context_group_position_ids, 0)
+    group_main_x = pl.create_tensor([group_context_tokens, D], dtype=pl.BF16)
+    group_main_x, hidden_gather_signal = dspark_cp_allgather_hidden(
+        main_x,
+        group_main_x,
+        hidden_gather_window,
+        hidden_gather_signal,
+        group_base,
+        cp_rank,
     )
     dspark_context_kv(
-        main_x, wkv_1, gamma_ckv_1, freqs_cos, freqs_sin,
-        context_position_ids, context_slots_1, kv_cache_1,
+        group_main_x, wkv_0, gamma_ckv_0, freqs_cos, freqs_sin,
+        context_group_position_ids, context_group_slot_mapping, pl.const(0, pl.INT32), kv_cache_0,
     )
     dspark_context_kv(
-        main_x, wkv_2, gamma_ckv_2, freqs_cos, freqs_sin,
-        context_position_ids, context_slots_2, kv_cache_2,
+        group_main_x, wkv_1, gamma_ckv_1, freqs_cos, freqs_sin,
+        context_group_position_ids, context_group_slot_mapping, pl.const(1, pl.INT32), kv_cache_1,
+    )
+    dspark_context_kv(
+        group_main_x, wkv_2, gamma_ckv_2, freqs_cos, freqs_sin,
+        context_group_position_ids, context_group_slot_mapping, pl.const(2, pl.INT32), kv_cache_2,
     )
 
     query_slot_mapping = pl.create_tensor([DSPARK_DRAFT_LAYERS, T_QUERY], dtype=pl.INT64)
@@ -513,9 +644,6 @@ def dspark_drafter(
         swa_lens,
         query_positions,
     )
-    query_slot_mapping_0 = query_slot_mapping[0]
-    query_slot_mapping_1 = query_slot_mapping[1]
-    query_slot_mapping_2 = query_slot_mapping[2]
     swa_indices_0 = swa_indices[0]
     swa_indices_1 = swa_indices[1]
     swa_indices_2 = swa_indices[2]
@@ -523,12 +651,12 @@ def dspark_drafter(
     swa_lens_1 = swa_lens[1]
     swa_lens_2 = swa_lens[2]
     hidden_1 = intermediate_hidden[0]
-    draft_layer(
+    hidden_1, hidden_gather_signal = draft_layer(
         initial_hidden, pl.const(0, pl.INT32),
         hc_attn_fn, hc_attn_scale, hc_attn_base,
         attn_norm_w, wq_a, wq_b, wq_b_scale, wkv, gamma_cq, gamma_ckv,
-        freqs_cos, freqs_sin, query_positions,
-        kv_cache_0, query_slot_mapping_0, swa_indices_0, swa_lens_0,
+        freqs_cos, freqs_sin, query_positions, query_group_position_ids,
+        kv_cache_0, query_group_slot_mapping[0], swa_indices_0, swa_lens_0,
         attn_sink, wo_a, wo_b, wo_b_scale,
         hc_ffn_fn, hc_ffn_scale, hc_ffn_base, ffn_norm_w,
         gate_w, gate_bias, tid2eid, query_token_ids,
@@ -536,18 +664,18 @@ def dspark_drafter(
         routed_w2, routed_w2_scale,
         shared_w1, shared_w1_scale, shared_w3, shared_w3_scale,
         shared_w2, shared_w2_scale,
-        hidden_1,
+        hidden_1, hidden_gather_window, hidden_gather_signal, group_base, cp_rank,
         recv_meta, recv_x, recv_aux, recv_route, arrived, data_arrived, routed_y_buf, combine_arrived,
         pl.const(40, pl.INT32), pl.cast(active_tokens, pl.INT32), my_rank, pl.const(1, pl.INT32),
     )
 
     hidden_2 = intermediate_hidden[1]
-    draft_layer(
+    hidden_2, hidden_gather_signal = draft_layer(
         hidden_1, pl.const(1, pl.INT32),
         hc_attn_fn, hc_attn_scale, hc_attn_base,
         attn_norm_w, wq_a, wq_b, wq_b_scale, wkv, gamma_cq, gamma_ckv,
-        freqs_cos, freqs_sin, query_positions,
-        kv_cache_1, query_slot_mapping_1, swa_indices_1, swa_lens_1,
+        freqs_cos, freqs_sin, query_positions, query_group_position_ids,
+        kv_cache_1, query_group_slot_mapping[1], swa_indices_1, swa_lens_1,
         attn_sink, wo_a, wo_b, wo_b_scale,
         hc_ffn_fn, hc_ffn_scale, hc_ffn_base, ffn_norm_w,
         gate_w, gate_bias, tid2eid, query_token_ids,
@@ -555,18 +683,18 @@ def dspark_drafter(
         routed_w2, routed_w2_scale,
         shared_w1, shared_w1_scale, shared_w3, shared_w3_scale,
         shared_w2, shared_w2_scale,
-        hidden_2,
+        hidden_2, hidden_gather_window, hidden_gather_signal, group_base, cp_rank,
         recv_meta, recv_x, recv_aux, recv_route, arrived, data_arrived, routed_y_buf, combine_arrived,
         pl.const(41, pl.INT32), pl.cast(active_tokens, pl.INT32), my_rank, pl.const(2, pl.INT32),
     )
 
     hidden_3 = intermediate_hidden[2]
-    draft_layer(
+    hidden_3, hidden_gather_signal = draft_layer(
         hidden_2, pl.const(2, pl.INT32),
         hc_attn_fn, hc_attn_scale, hc_attn_base,
         attn_norm_w, wq_a, wq_b, wq_b_scale, wkv, gamma_cq, gamma_ckv,
-        freqs_cos, freqs_sin, query_positions,
-        kv_cache_2, query_slot_mapping_2, swa_indices_2, swa_lens_2,
+        freqs_cos, freqs_sin, query_positions, query_group_position_ids,
+        kv_cache_2, query_group_slot_mapping[2], swa_indices_2, swa_lens_2,
         attn_sink, wo_a, wo_b, wo_b_scale,
         hc_ffn_fn, hc_ffn_scale, hc_ffn_base, ffn_norm_w,
         gate_w, gate_bias, tid2eid, query_token_ids,
@@ -574,7 +702,7 @@ def dspark_drafter(
         routed_w2, routed_w2_scale,
         shared_w1, shared_w1_scale, shared_w3, shared_w3_scale,
         shared_w2, shared_w2_scale,
-        hidden_3,
+        hidden_3, hidden_gather_window, hidden_gather_signal, group_base, cp_rank,
         recv_meta, recv_x, recv_aux, recv_route, arrived, data_arrived, routed_y_buf, combine_arrived,
         pl.const(42, pl.INT32), pl.cast(active_tokens, pl.INT32), my_rank, pl.const(3, pl.INT32),
     )
@@ -609,10 +737,18 @@ def l3_dspark_drafter(
     last_sampled: pl.Tensor[[N_RANKS, B_DYN], pl.INT64],
     next_prefill_tokens: pl.Tensor[[N_RANKS, B_DYN], pl.INT64],
     embedding_weight: pl.Tensor[[N_RANKS, VOCAB, D], pl.BF16],
-    context_position_ids: pl.Tensor[[N_RANKS, T_MAIN_DYN], pl.INT32],
-    context_slot_mapping: pl.Tensor[[N_RANKS, DSPARK_DRAFT_LAYERS, T_MAIN_DYN], pl.INT64],
+    context_group_position_ids: pl.Tensor[[N_RANKS, CP_CONTEXT_T_DYN], pl.INT32],
+    context_group_slot_mapping: pl.Tensor[
+        [N_RANKS, DSPARK_DRAFT_LAYERS, CP_CONTEXT_T_DYN], pl.INT64
+    ],
     anchor_positions: pl.Tensor[[N_RANKS, B_DYN], pl.INT32],
     block_tables: pl.Tensor[[N_RANKS, DSPARK_DRAFT_LAYERS, B_DYN, ORI_MAX_BLOCKS], pl.INT32],
+    query_group_position_ids: pl.Tensor[
+        [N_RANKS, DSPARK_CP_SIZE * T_QUERY], pl.INT32
+    ],
+    query_group_slot_mapping: pl.Tensor[
+        [N_RANKS, DSPARK_DRAFT_LAYERS, DSPARK_CP_SIZE * T_QUERY], pl.INT64
+    ],
     freqs_cos: pl.Tensor[[N_RANKS, MAX_SEQ_LEN, ROPE_DIM], pl.BF16],
     freqs_sin: pl.Tensor[[N_RANKS, MAX_SEQ_LEN, ROPE_DIM], pl.BF16],
     hc_attn_fn: pl.Tensor[[N_RANKS, DSPARK_DRAFT_LAYERS * MIX_HC, HC_DIM], pl.FP32],
@@ -657,8 +793,8 @@ def l3_dspark_drafter(
     head_hidden: pl.Out[pl.Tensor[[N_RANKS, B_DYN, DSPARK_QUERY_WIDTH, D], pl.BF16]],
 ):
     target_hidden.bind_dynamic(1, T_MAIN_DYN)
-    context_position_ids.bind_dynamic(1, T_MAIN_DYN)
-    context_slot_mapping.bind_dynamic(2, T_MAIN_DYN)
+    context_group_position_ids.bind_dynamic(1, CP_CONTEXT_T_DYN)
+    context_group_slot_mapping.bind_dynamic(2, CP_CONTEXT_T_DYN)
     num_sampled.bind_dynamic(1, B_DYN)
     last_sampled.bind_dynamic(1, B_DYN)
     next_prefill_tokens.bind_dynamic(1, B_DYN)
@@ -666,6 +802,12 @@ def l3_dspark_drafter(
     block_tables.bind_dynamic(2, B_DYN)
     head_hidden.bind_dynamic(1, B_DYN)
 
+    hidden_gather_window_buf = pld.alloc_window_buffer(
+        [DSPARK_GROUP_TOKEN_CAP, D], dtype=pl.BF16
+    )
+    hidden_gather_signal_buf = pld.alloc_window_buffer(
+        [DSPARK_CP_SIZE, 1], dtype=pl.INT32
+    )
     recv_meta_buf = pld.alloc_window_buffer([N_RANKS, N_LOCAL], dtype=pl.INT32)
     recv_x_buf = pld.alloc_window_buffer([N_LOCAL * RECV_MAX, D], dtype=pl.INT8)
     recv_aux_buf = pld.alloc_window_buffer([N_LOCAL * RECV_MAX, AUX_PAD], dtype=pl.FP32)
@@ -676,6 +818,12 @@ def l3_dspark_drafter(
     combine_arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
 
     for rank in pl.range(pld.world_size()):
+        hidden_gather_window = pld.window(
+            hidden_gather_window_buf, [DSPARK_GROUP_TOKEN_CAP, D], dtype=pl.BF16
+        )
+        hidden_gather_signal = pld.window(
+            hidden_gather_signal_buf, [DSPARK_CP_SIZE, 1], dtype=pl.INT32
+        )
         recv_meta = pld.window(recv_meta_buf, [N_RANKS, N_LOCAL], dtype=pl.INT32)
         recv_x = pld.window(recv_x_buf, [N_LOCAL * RECV_MAX, D], dtype=pl.INT8)
         recv_aux = pld.window(recv_aux_buf, [N_LOCAL * RECV_MAX, AUX_PAD], dtype=pl.FP32)
@@ -688,7 +836,9 @@ def l3_dspark_drafter(
             target_hidden[rank], main_proj_weight[rank], main_norm_weight[rank],
             num_sampled[rank], last_sampled[rank], next_prefill_tokens[rank],
             embedding_weight[rank],
-            context_position_ids[rank], context_slot_mapping[rank], anchor_positions[rank], block_tables[rank],
+            context_group_position_ids[rank], context_group_slot_mapping[rank],
+            anchor_positions[rank], block_tables[rank],
+            query_group_position_ids[rank], query_group_slot_mapping[rank],
             freqs_cos[rank], freqs_sin[rank],
             hc_attn_fn[rank], hc_attn_scale[rank], hc_attn_base[rank], attn_norm_w[rank],
             wq_a[rank], wq_b[rank], wq_b_scale[rank], wkv[rank], gamma_cq[rank], gamma_ckv[rank],
@@ -701,7 +851,9 @@ def l3_dspark_drafter(
             shared_w2[rank], shared_w2_scale[rank],
             hc_head_fn[rank], hc_head_scale[rank], hc_head_base[rank], initial_hidden[rank],
             intermediate_hidden[rank], head_hidden[rank],
+            hidden_gather_window, hidden_gather_signal,
             recv_meta, recv_x, recv_aux, recv_route, arrived, data_arrived, routed_y_buf, combine_arrived,
+            rank // DSPARK_CP_SIZE * DSPARK_CP_SIZE, rank % DSPARK_CP_SIZE,
             rank,
             device=rank,
         )
@@ -732,12 +884,20 @@ def _block_tables(batch):
 
     logical = torch.arange(ORI_MAX_BLOCKS, dtype=torch.int32)
     tables = torch.empty(N_RANKS, DSPARK_DRAFT_LAYERS, batch, ORI_MAX_BLOCKS, dtype=torch.int32)
+    blocks_per_request = ORI_BLOCK_NUM // (DSPARK_CP_SIZE * batch)
+    required_blocks = (WIN + DSPARK_QUERY_WIDTH + BLOCK_SIZE - 1) // BLOCK_SIZE
+    if blocks_per_request < required_blocks:
+        raise ValueError(
+            "DSpark fixture KV cache cannot assign a sliding-window ring to every CP request"
+        )
     for rank in range(N_RANKS):
+        cp_rank = rank % DSPARK_CP_SIZE
         for layer in range(DSPARK_DRAFT_LAYERS):
             for request in range(batch):
-                request_base = request * (ORI_BLOCK_NUM // DSPARK_MAX_BATCH)
-                ring_offset = rank * 3 + layer * 7
-                request_block = (logical + ring_offset) % (ORI_BLOCK_NUM // DSPARK_MAX_BATCH)
+                group_request = cp_rank * batch + request
+                request_base = group_request * blocks_per_request
+                ring_offset = layer * 7
+                request_block = (logical + ring_offset) % blocks_per_request
                 tables[rank, layer, request] = request_base + request_block
     return tables
 
@@ -810,14 +970,59 @@ def build_tensor_specs(batch, *, mode="decode"):
     if int(tables.min()) < 0 or int(tables.max()) >= ORI_BLOCK_NUM:
         raise ValueError("DSpark block table references a physical KV block outside the cache")
     context_slots = _context_slots(tables, context_positions, context_seq, valid_counts)
-    last_sampled = torch.arange(1, batch + 1, dtype=torch.int64)
-    last_sampled = last_sampled.unsqueeze(0).expand(N_RANKS, -1).contiguous()
-    next_prefill_tokens = torch.arange(
-        DSPARK_MAX_BATCH + 1,
-        DSPARK_MAX_BATCH + batch + 1,
+    context_group_positions = torch.empty(
+        N_RANKS, DSPARK_CP_SIZE * batch * context_seq, dtype=torch.int32
+    )
+    context_group_slots = torch.empty(
+        N_RANKS,
+        DSPARK_DRAFT_LAYERS,
+        DSPARK_CP_SIZE * batch * context_seq,
         dtype=torch.int64,
     )
-    next_prefill_tokens = next_prefill_tokens.unsqueeze(0).expand(N_RANKS, -1).contiguous()
+    query_positions_local = torch.zeros(N_RANKS, T_QUERY, dtype=torch.int32)
+    query_slots_local = torch.full(
+        (N_RANKS, DSPARK_DRAFT_LAYERS, T_QUERY), -1, dtype=torch.int64
+    )
+    for rank in range(N_RANKS):
+        group_base = rank // DSPARK_CP_SIZE * DSPARK_CP_SIZE
+        group_slice = slice(group_base, group_base + DSPARK_CP_SIZE)
+        context_group_positions[rank] = context_positions[group_slice].reshape(-1)
+        context_group_slots[rank] = context_slots[group_slice].permute(1, 0, 2).reshape(
+            DSPARK_DRAFT_LAYERS, -1
+        )
+        for request in range(batch):
+            anchor = int(positions[rank, request])
+            for offset in range(DSPARK_QUERY_WIDTH):
+                token = request * DSPARK_QUERY_WIDTH + offset
+                query_position = anchor + 1 + offset
+                query_positions_local[rank, token] = query_position
+                for layer in range(DSPARK_DRAFT_LAYERS):
+                    physical_block = int(
+                        tables[rank, layer, request, query_position // BLOCK_SIZE]
+                    )
+                    query_slots_local[rank, layer, token] = (
+                        physical_block * BLOCK_SIZE + query_position % BLOCK_SIZE
+                    )
+    query_group_positions = torch.empty(
+        N_RANKS, DSPARK_CP_SIZE * T_QUERY, dtype=torch.int32
+    )
+    query_group_slots = torch.empty(
+        N_RANKS,
+        DSPARK_DRAFT_LAYERS,
+        DSPARK_CP_SIZE * T_QUERY,
+        dtype=torch.int64,
+    )
+    for rank in range(N_RANKS):
+        group_base = rank // DSPARK_CP_SIZE * DSPARK_CP_SIZE
+        group_slice = slice(group_base, group_base + DSPARK_CP_SIZE)
+        query_group_positions[rank] = query_positions_local[group_slice].reshape(-1)
+        query_group_slots[rank] = query_slots_local[group_slice].permute(1, 0, 2).reshape(
+            DSPARK_DRAFT_LAYERS, -1
+        )
+    request_ids = torch.arange(batch, dtype=torch.int64).unsqueeze(0)
+    owner_ids = torch.arange(N_RANKS, dtype=torch.int64).unsqueeze(1)
+    last_sampled = owner_ids * batch + request_ids + 1
+    next_prefill_tokens = N_RANKS * batch + owner_ids * batch + request_ids + 1
     num_sampled = torch.full(
         (N_RANKS, batch),
         1 if mode == "decode" else 0,
@@ -851,13 +1056,19 @@ def build_tensor_specs(batch, *, mode="decode"):
         columns = torch.arange(D, dtype=torch.float32)
         base = ((columns % 29) - 14) * 0.002
         for rank in range(N_RANKS):
-            weight[rank, 0] = (base + 0.005 * rank).to(torch.bfloat16)
-            weight[rank, DSPARK_NOISE_TOKEN_ID] = (base + 0.03 + 0.005 * rank).to(torch.bfloat16)
-            for request in range(batch):
-                last_token = int(last_sampled[rank, request])
-                next_token = int(next_prefill_tokens[rank, request])
-                weight[rank, last_token] = (base + 0.01 * (request + 1) + 0.005 * rank).to(torch.bfloat16)
-                weight[rank, next_token] = (base + 0.02 * (request + 1) + 0.005 * rank).to(torch.bfloat16)
+            weight[rank, 0] = base.to(torch.bfloat16)
+            weight[rank, DSPARK_NOISE_TOKEN_ID] = (base + 0.03).to(torch.bfloat16)
+            for owner_rank in range(N_RANKS):
+                for request in range(batch):
+                    owner_offset = 0.005 * owner_rank
+                    last_token = int(last_sampled[owner_rank, request])
+                    next_token = int(next_prefill_tokens[owner_rank, request])
+                    weight[rank, last_token] = (
+                        base + 0.01 * (request + 1) + owner_offset
+                    ).to(torch.bfloat16)
+                    weight[rank, next_token] = (
+                        base + 0.02 * (request + 1) + owner_offset
+                    ).to(torch.bfloat16)
         return weight
 
     def init_wkv():
@@ -885,7 +1096,9 @@ def build_tensor_specs(batch, *, mode="decode"):
         )
         for rank in range(N_RANKS):
             for layer in range(DSPARK_DRAFT_LAYERS):
-                cache[rank, layer].fill_(layer + 1 + rank * 0.25)
+                cache[rank, layer].fill_(
+                    layer + 1 + (rank // DSPARK_CP_SIZE) * 0.25
+                )
         return cache
 
     specs = [
@@ -914,19 +1127,31 @@ def build_tensor_specs(batch, *, mode="decode"):
         ),
         ranked("embedding_weight", [VOCAB, D], torch.bfloat16, init_value=init_embedding_weight, resident=True),
         ranked(
-            "context_position_ids",
-            [batch * context_seq],
+            "context_group_position_ids",
+            [DSPARK_CP_SIZE * batch * context_seq],
             torch.int32,
-            init_value=lambda: context_positions,
+            init_value=lambda: context_group_positions,
         ),
         ranked(
-            "context_slot_mapping",
-            [DSPARK_DRAFT_LAYERS, batch * context_seq],
+            "context_group_slot_mapping",
+            [DSPARK_DRAFT_LAYERS, DSPARK_CP_SIZE * batch * context_seq],
             torch.int64,
-            init_value=lambda: context_slots,
+            init_value=lambda: context_group_slots,
         ),
         ranked("anchor_positions", [batch], torch.int32, init_value=lambda: positions),
         ranked("block_tables", [DSPARK_DRAFT_LAYERS, batch, ORI_MAX_BLOCKS], torch.int32, init_value=lambda: tables),
+        ranked(
+            "query_group_position_ids",
+            [DSPARK_CP_SIZE * T_QUERY],
+            torch.int32,
+            init_value=lambda: query_group_positions,
+        ),
+        ranked(
+            "query_group_slot_mapping",
+            [DSPARK_DRAFT_LAYERS, DSPARK_CP_SIZE * T_QUERY],
+            torch.int64,
+            init_value=lambda: query_group_slots,
+        ),
         ranked("freqs_cos", [MAX_SEQ_LEN, ROPE_DIM], torch.bfloat16, init_value=1, resident=True),
         ranked("freqs_sin", [MAX_SEQ_LEN, ROPE_DIM], torch.bfloat16, resident=True),
     ]
@@ -1043,14 +1268,29 @@ def golden_dspark_drafter(tensors):
     tensors["intermediate_hidden"].zero_()
     positions = tensors["anchor_positions"]
     tables = tensors["block_tables"]
-    context_slots = tensors["context_slot_mapping"]
+    group_context_slots = tensors["context_group_slot_mapping"]
+    local_context_tokens = tensors["target_hidden"].shape[1]
+    context_slots = torch.empty(
+        N_RANKS,
+        DSPARK_DRAFT_LAYERS,
+        local_context_tokens,
+        dtype=torch.int64,
+    )
+    for rank in range(N_RANKS):
+        cp_rank = rank % DSPARK_CP_SIZE
+        start = cp_rank * local_context_tokens
+        context_slots[rank] = group_context_slots[
+            rank, :, start : start + local_context_tokens
+        ]
     selected_anchor_ids = torch.where(
         tensors["num_sampled"] > 0,
         tensors["last_sampled"],
         tensors["next_prefill_tokens"],
     )
+    main_x_by_rank = []
+    hidden_by_rank = []
     for rank in range(N_RANKS):
-        main_x = rms_norm(tensors["target_hidden"][rank, :, :D])
+        main_x_by_rank.append(rms_norm(tensors["target_hidden"][rank, :, :D]))
         query_ids = torch.zeros(DSPARK_MAX_BATCH * DSPARK_QUERY_PAD, dtype=torch.int64)
         for request in range(positions.shape[1]):
             row = request * DSPARK_QUERY_WIDTH
@@ -1059,13 +1299,16 @@ def golden_dspark_drafter(tensors):
         query_hidden = tensors["embedding_weight"][rank].index_select(0, query_ids)
         hidden = query_hidden.float().unsqueeze(1).expand(-1, HC_MULT, -1).contiguous()
         tensors["initial_hidden"][rank] = hidden
+        hidden_by_rank.append(hidden)
 
-        for layer in range(DSPARK_DRAFT_LAYERS):
-            cache = tensors["kv_caches"][rank, layer].view(-1, HEAD_DIM)
-            layer_context_slots = context_slots[rank, layer]
-            valid_context = layer_context_slots >= 0
-            valid_context_slots = layer_context_slots[valid_context].long()
-            cache[valid_context_slots] = project_kv(main_x[valid_context])
+    active_tokens = positions.shape[1] * DSPARK_QUERY_WIDTH
+    for layer in range(DSPARK_DRAFT_LAYERS):
+        layer_state = []
+        query_slots_by_rank = []
+        for rank in range(N_RANKS):
+            mixed, post, combine = hc_pre_zero_function(hidden_by_rank[rank])
+            query_normed = rms_norm(mixed[: DSPARK_MAX_BATCH * DSPARK_QUERY_WIDTH])
+            layer_state.append((post, combine, query_normed))
             query_slots = []
             for request in range(positions.shape[1]):
                 anchor = int(positions[rank, request])
@@ -1073,10 +1316,27 @@ def golden_dspark_drafter(tensors):
                     position = anchor + offset
                     physical_block = int(tables[rank, layer, request, position // BLOCK_SIZE])
                     query_slots.append(physical_block * BLOCK_SIZE + position % BLOCK_SIZE)
-            mixed, post, combine = hc_pre_zero_function(hidden)
-            query_normed = rms_norm(mixed[: DSPARK_MAX_BATCH * DSPARK_QUERY_WIDTH])
-            active_tokens = positions.shape[1] * DSPARK_QUERY_WIDTH
-            cache[torch.tensor(query_slots, dtype=torch.int64)] = project_kv(query_normed[:active_tokens])
+            query_slots_by_rank.append(torch.tensor(query_slots, dtype=torch.int64))
+
+        for rank in range(N_RANKS):
+            cache = tensors["kv_caches"][rank, layer].view(-1, HEAD_DIM)
+            group_base = rank // DSPARK_CP_SIZE * DSPARK_CP_SIZE
+            for source_rank in range(group_base, group_base + DSPARK_CP_SIZE):
+                layer_context_slots = context_slots[source_rank, layer]
+                valid_context = layer_context_slots >= 0
+                valid_context_slots = layer_context_slots[valid_context].long()
+                cache[valid_context_slots] = project_kv(
+                    main_x_by_rank[source_rank][valid_context]
+                )
+                query_normed = layer_state[source_rank][2]
+                cache[query_slots_by_rank[source_rank]] = project_kv(
+                    query_normed[:active_tokens]
+                )
+
+        next_hidden_by_rank = []
+        for rank in range(N_RANKS):
+            hidden = hidden_by_rank[rank]
+            post, combine, _ = layer_state[rank]
             attention_hidden = hc_post_zero_output(
                 hidden[: DSPARK_MAX_BATCH * DSPARK_QUERY_WIDTH],
                 post[: DSPARK_MAX_BATCH * DSPARK_QUERY_WIDTH],
@@ -1089,7 +1349,11 @@ def golden_dspark_drafter(tensors):
             _, moe_post, moe_combine = hc_pre_zero_function(padded_attention)
             hidden = hc_post_zero_output(padded_attention, moe_post, moe_combine)
             tensors["intermediate_hidden"][rank, layer] = hidden
+            next_hidden_by_rank.append(hidden)
+        hidden_by_rank = next_hidden_by_rank
 
+    for rank in range(N_RANKS):
+        hidden = hidden_by_rank[rank]
         active = hidden[: positions.shape[1] * DSPARK_QUERY_WIDTH]
         head_pre = torch.full((active.shape[0], HC_MULT), 0.5 + M.hc_eps, dtype=torch.float32)
         head = active[:, 0] * head_pre[:, 0:1]

--- a/models/deepseek_v4_flash_dspark/dspark_markov.py
+++ b/models/deepseek_v4_flash_dspark/dspark_markov.py
@@ -6,11 +6,22 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-"""Compose the shared target LM head and rank-256 sequential Markov sampler."""
+"""Compose the target LM head with sequential Markov sampling and confidence."""
 
 import pypto.language as pl
+import pypto.language.distributed as pld
+from pypto.ir.distributed_compiled_program import DistributedConfig
 
 from config import FLASH as M
+from lm_head import (
+    DONE_VALUE,
+    GROUP_LOGIT_ROWS,
+    MAX_LOGIT_ROWS,
+    TP_SIZE,
+    VOCAB_PER_TP,
+    WORLD_SIZE,
+    lm_head,
+)
 from markov_head import markov_head
 
 
@@ -39,6 +50,7 @@ LM_N_TILE = 128
 LM_K_TILE = 256
 MARKOV_M_TILE = DSPARK_MAX_BATCH
 MARKOV_ID_PAD = 8
+CONFIDENCE_PAD = 8
 GREEDY_VOCAB_CHUNK = 256
 GREEDY_NUM_CHUNKS = VOCAB // GREEDY_VOCAB_CHUNK
 GREEDY_CHUNK_PAD = 512
@@ -50,17 +62,17 @@ assert D % LM_K_TILE == 0
 assert VOCAB % LM_N_TILE == 0
 assert VOCAB % GREEDY_VOCAB_CHUNK == 0
 assert GREEDY_NUM_CHUNKS <= GREEDY_CHUNK_PAD
+assert CONFIDENCE_PAD * 4 == 32
 # Base-logit row tiling must exactly cover every supported padded batch.
 for _batch in DSPARK_SUPPORTED_BATCHES:
     assert (_batch * DSPARK_QUERY_PAD) % LM_M_TILE == 0
 
 
 @pl.jit.inline
-def compute_base_logits(
+def normalize_head_hidden(
     head_hidden: pl.Tensor[[B_DYN, DSPARK_QUERY_WIDTH, D], pl.BF16],
     final_norm_weight: pl.Tensor[[D], pl.BF16],
-    lm_head_weight: pl.Tensor[[VOCAB, D], pl.BF16],
-    base_logits: pl.Tensor[[DSPARK_MOE_TOKENS, VOCAB], pl.FP32],
+    normalized: pl.Tensor[[DSPARK_MOE_TOKENS, D], pl.BF16],
 ):
     batch = pl.tensor.dim(head_hidden, 0)
     active_tokens = batch * DSPARK_QUERY_WIDTH
@@ -90,7 +102,6 @@ def compute_base_logits(
     # Keep this normalization local. Passing a dynamically sized temporary to
     # the generic rms_norm inline kernel loses its inferred tensor metadata
     # during JIT specialization.
-    normalized = pl.create_tensor([DSPARK_MOE_TOKENS, D], dtype=pl.BF16)
     with pl.spmd(
         padded_tokens // RMS_M_TILE,
         name_hint="dspark_final_norm",
@@ -152,6 +163,24 @@ def compute_base_logits(
                 target_type=pl.BF16,
                 mode="rint",
             )
+    return final_norm_tid
+
+
+@pl.jit.inline
+def compute_base_logits(
+    head_hidden: pl.Tensor[[B_DYN, DSPARK_QUERY_WIDTH, D], pl.BF16],
+    final_norm_weight: pl.Tensor[[D], pl.BF16],
+    lm_head_weight: pl.Tensor[[VOCAB, D], pl.BF16],
+    base_logits: pl.Tensor[[DSPARK_MOE_TOKENS, VOCAB], pl.FP32],
+):
+    batch = pl.tensor.dim(head_hidden, 0)
+    padded_tokens = batch * DSPARK_QUERY_PAD
+    normalized = pl.create_tensor([DSPARK_MOE_TOKENS, D], dtype=pl.BF16)
+    final_norm_tid = normalize_head_hidden(
+        head_hidden,
+        final_norm_weight,
+        normalized,
+    )
     row_blocks = padded_tokens // LM_M_TILE
     vocab_blocks = VOCAB // LM_N_TILE
     with pl.spmd(
@@ -207,13 +236,16 @@ def compute_base_logits(
 
 @pl.jit.inline
 def greedy_markov_step(
-    base_logits: pl.Tensor[[DSPARK_MOE_TOKENS, VOCAB], pl.FP32],
+    head_hidden: pl.Tensor[[B_DYN, DSPARK_QUERY_WIDTH, D], pl.BF16],
+    base_logits: pl.Tensor,
     num_sampled: pl.Tensor[[B_DYN], pl.INT32],
     last_sampled: pl.Tensor[[B_DYN], pl.INT64],
     next_prefill_tokens: pl.Tensor[[B_DYN], pl.INT64],
     markov_w1: pl.Tensor[[VOCAB, DSPARK_MARKOV_RANK], pl.BF16],
     markov_w2: pl.Tensor[[VOCAB, DSPARK_MARKOV_RANK], pl.BF16],
+    confidence_head_weight: pl.Tensor[[1, D + DSPARK_MARKOV_RANK], pl.FP32],
     draft_token_scratch: pl.Tensor[[MARKOV_M_TILE, MARKOV_ID_PAD], pl.INT32],
+    confidence_scratch: pl.Tensor[[DSPARK_QUERY_WIDTH, MARKOV_M_TILE], pl.FP32],
     base_logits_ready_tid: pl.Scalar[pl.TASK_ID],
     start_tid: pl.Scalar[pl.TASK_ID],
     step: pl.Scalar[pl.INT32],
@@ -240,7 +272,12 @@ def greedy_markov_step(
 
     markov_bias = pl.create_tensor([batch, VOCAB], dtype=pl.FP32)
     markov_embedding = pl.create_tensor([batch, DSPARK_MARKOV_RANK], dtype=pl.BF16)
-    markov_bias, markov_embedding = markov_head(
+    (
+        markov_bias,
+        markov_embedding,
+        markov_embedding_tid,
+        markov_logits_tid,
+    ) = markov_head(
         previous_token_ids,
         markov_w1,
         markov_w2,
@@ -248,10 +285,75 @@ def greedy_markov_step(
         markov_embedding,
     )
 
+    confidence_blocks = (batch + CONFIDENCE_PAD - 1) // CONFIDENCE_PAD
+    with pl.spmd(
+        confidence_blocks,
+        name_hint="dspark_confidence_head",
+        deps=[markov_embedding_tid],
+    ) as confidence_tid:
+        confidence_block = pl.tile.get_block_idx()
+        request_base = confidence_block * CONFIDENCE_PAD
+        valid_rows = pl.min(CONFIDENCE_PAD, batch - request_base)
+        confidence_logit = pl.full(
+            [1, CONFIDENCE_PAD],
+            dtype=pl.FP32,
+            value=0.0,
+        )
+        for hidden_block in pl.range(D // HIDDEN_TILE):
+            hidden_offset = hidden_block * HIDDEN_TILE
+            hidden_bf16 = pl.reshape(
+                pl.slice(
+                    head_hidden,
+                    [CONFIDENCE_PAD, 1, HIDDEN_TILE],
+                    [request_base, step, hidden_offset],
+                    valid_shape=[valid_rows, 1, HIDDEN_TILE],
+                ),
+                [CONFIDENCE_PAD, HIDDEN_TILE],
+            )
+            hidden_fp32 = pl.cast(hidden_bf16, target_type=pl.FP32)
+            hidden_weight = confidence_head_weight[
+                0:1,
+                hidden_offset : hidden_offset + HIDDEN_TILE,
+            ]
+            confidence_logit = pl.add(
+                confidence_logit,
+                pl.reshape(
+                    pl.row_sum(
+                        pl.col_expand_mul(hidden_fp32, hidden_weight)
+                    ),
+                    [1, CONFIDENCE_PAD],
+                ),
+            )
+        markov_bf16 = pl.slice(
+            markov_embedding,
+            [CONFIDENCE_PAD, DSPARK_MARKOV_RANK],
+            [request_base, 0],
+            valid_shape=[valid_rows, DSPARK_MARKOV_RANK],
+        )
+        markov_fp32 = pl.cast(markov_bf16, target_type=pl.FP32)
+        markov_weight = confidence_head_weight[
+            0:1,
+            D : D + DSPARK_MARKOV_RANK,
+        ]
+        confidence_logit = pl.add(
+            confidence_logit,
+            pl.reshape(
+                pl.row_sum(pl.col_expand_mul(markov_fp32, markov_weight)),
+                [1, CONFIDENCE_PAD],
+            ),
+        )
+        confidence_prob = pl.recip(
+            pl.add(pl.exp(pl.neg(confidence_logit)), 1.0)
+        )
+        confidence_scratch[
+            step : step + 1,
+            request_base : request_base + CONFIDENCE_PAD,
+        ] = confidence_prob
+
     with pl.spmd(
         MARKOV_M_TILE,
         name_hint="dspark_markov_greedy",
-        deps=[base_logits_ready_tid, previous_tokens_tid],
+        deps=[base_logits_ready_tid, confidence_tid, markov_logits_tid],
     ) as greedy_tid:
         request = pl.tile.get_block_idx()
         if request < batch:
@@ -328,37 +430,28 @@ def greedy_markov_step(
     return greedy_tid
 
 
-@pl.jit
-def markov_sample(
+@pl.jit.inline
+def sample_from_base_logits(
     head_hidden: pl.Tensor[[B_DYN, DSPARK_QUERY_WIDTH, D], pl.BF16],
-    final_norm_weight: pl.Tensor[[D], pl.BF16],
-    lm_head_weight: pl.Tensor[[VOCAB, D], pl.BF16],
+    base_logits: pl.Tensor,
     num_sampled: pl.Tensor[[B_DYN], pl.INT32],
     last_sampled: pl.Tensor[[B_DYN], pl.INT64],
     next_prefill_tokens: pl.Tensor[[B_DYN], pl.INT64],
     markov_w1: pl.Tensor[[VOCAB, DSPARK_MARKOV_RANK], pl.BF16],
     markov_w2: pl.Tensor[[VOCAB, DSPARK_MARKOV_RANK], pl.BF16],
-    draft_token_ids: pl.Out[pl.Tensor[[B_DYN, DSPARK_QUERY_WIDTH], pl.INT32]],
+    confidence_head_weight: pl.Tensor[[1, D + DSPARK_MARKOV_RANK], pl.FP32],
+    draft_token_ids: pl.Tensor[[B_DYN, DSPARK_QUERY_WIDTH], pl.INT32],
+    confidence_probs: pl.Tensor[[B_DYN, DSPARK_QUERY_WIDTH], pl.FP32],
+    base_logits_ready_tid: pl.Scalar[pl.TASK_ID],
 ):
-    head_hidden.bind_dynamic(0, B_DYN)
-    num_sampled.bind_dynamic(0, B_DYN)
-    last_sampled.bind_dynamic(0, B_DYN)
-    next_prefill_tokens.bind_dynamic(0, B_DYN)
-    draft_token_ids.bind_dynamic(0, B_DYN)
     batch = pl.tensor.dim(num_sampled, 0)
-    base_logits = pl.create_tensor(
-        [DSPARK_MOE_TOKENS, VOCAB],
-        dtype=pl.FP32,
-    )
-    base_logits_tid = compute_base_logits(
-        head_hidden,
-        final_norm_weight,
-        lm_head_weight,
-        base_logits,
-    )
     draft_token_scratch = pl.create_tensor(
         [MARKOV_M_TILE, MARKOV_ID_PAD],
         dtype=pl.INT32,
+    )
+    confidence_scratch = pl.create_tensor(
+        [DSPARK_QUERY_WIDTH, MARKOV_M_TILE],
+        dtype=pl.FP32,
     )
     with pl.spmd(
         batch,
@@ -370,46 +463,46 @@ def markov_sample(
             0:MARKOV_ID_PAD,
         ] = pl.full([1, MARKOV_ID_PAD], dtype=pl.INT32, value=0)
     step_0_tid = greedy_markov_step(
-        base_logits, num_sampled, last_sampled, next_prefill_tokens,
-        markov_w1, markov_w2,
-        draft_token_scratch,
-        base_logits_tid, token_scratch_zero_tid, pl.cast(0, pl.INT32)
+        head_hidden, base_logits, num_sampled, last_sampled, next_prefill_tokens,
+        markov_w1, markov_w2, confidence_head_weight,
+        draft_token_scratch, confidence_scratch,
+        base_logits_ready_tid, token_scratch_zero_tid, pl.cast(0, pl.INT32)
     )
     step_1_tid = greedy_markov_step(
-        base_logits, num_sampled, last_sampled, next_prefill_tokens,
-        markov_w1, markov_w2,
-        draft_token_scratch,
-        base_logits_tid, step_0_tid, pl.cast(1, pl.INT32)
+        head_hidden, base_logits, num_sampled, last_sampled, next_prefill_tokens,
+        markov_w1, markov_w2, confidence_head_weight,
+        draft_token_scratch, confidence_scratch,
+        base_logits_ready_tid, step_0_tid, pl.cast(1, pl.INT32)
     )
     step_2_tid = greedy_markov_step(
-        base_logits, num_sampled, last_sampled, next_prefill_tokens,
-        markov_w1, markov_w2,
-        draft_token_scratch,
-        base_logits_tid, step_1_tid, pl.cast(2, pl.INT32)
+        head_hidden, base_logits, num_sampled, last_sampled, next_prefill_tokens,
+        markov_w1, markov_w2, confidence_head_weight,
+        draft_token_scratch, confidence_scratch,
+        base_logits_ready_tid, step_1_tid, pl.cast(2, pl.INT32)
     )
     step_3_tid = greedy_markov_step(
-        base_logits, num_sampled, last_sampled, next_prefill_tokens,
-        markov_w1, markov_w2,
-        draft_token_scratch,
-        base_logits_tid, step_2_tid, pl.cast(3, pl.INT32)
+        head_hidden, base_logits, num_sampled, last_sampled, next_prefill_tokens,
+        markov_w1, markov_w2, confidence_head_weight,
+        draft_token_scratch, confidence_scratch,
+        base_logits_ready_tid, step_2_tid, pl.cast(3, pl.INT32)
     )
     step_4_tid = greedy_markov_step(
-        base_logits, num_sampled, last_sampled, next_prefill_tokens,
-        markov_w1, markov_w2,
-        draft_token_scratch,
-        base_logits_tid, step_3_tid, pl.cast(4, pl.INT32)
+        head_hidden, base_logits, num_sampled, last_sampled, next_prefill_tokens,
+        markov_w1, markov_w2, confidence_head_weight,
+        draft_token_scratch, confidence_scratch,
+        base_logits_ready_tid, step_3_tid, pl.cast(4, pl.INT32)
     )
     step_5_tid = greedy_markov_step(
-        base_logits, num_sampled, last_sampled, next_prefill_tokens,
-        markov_w1, markov_w2,
-        draft_token_scratch,
-        base_logits_tid, step_4_tid, pl.cast(5, pl.INT32)
+        head_hidden, base_logits, num_sampled, last_sampled, next_prefill_tokens,
+        markov_w1, markov_w2, confidence_head_weight,
+        draft_token_scratch, confidence_scratch,
+        base_logits_ready_tid, step_4_tid, pl.cast(5, pl.INT32)
     )
     step_6_tid = greedy_markov_step(
-        base_logits, num_sampled, last_sampled, next_prefill_tokens,
-        markov_w1, markov_w2,
-        draft_token_scratch,
-        base_logits_tid, step_5_tid, pl.cast(6, pl.INT32)
+        head_hidden, base_logits, num_sampled, last_sampled, next_prefill_tokens,
+        markov_w1, markov_w2, confidence_head_weight,
+        draft_token_scratch, confidence_scratch,
+        base_logits_ready_tid, step_5_tid, pl.cast(6, pl.INT32)
     )
     with pl.at(
         level=pl.Level.CORE_GROUP,
@@ -423,10 +516,191 @@ def markov_sample(
                     [request, output_step],
                     pl.read(draft_token_scratch, [request, output_step]),
                 )
-    return draft_token_ids
+                pl.write(
+                    confidence_probs,
+                    [request, output_step],
+                    pl.read(confidence_scratch, [output_step, request]),
+                )
+    return draft_token_ids, confidence_probs
 
 
-def build_tensor_specs(batch: int):
+@pl.jit
+def markov_sample(
+    head_hidden: pl.Tensor[[B_DYN, DSPARK_QUERY_WIDTH, D], pl.BF16],
+    final_norm_weight: pl.Tensor[[D], pl.BF16],
+    lm_head_weight: pl.Tensor[[VOCAB, D], pl.BF16],
+    num_sampled: pl.Tensor[[B_DYN], pl.INT32],
+    last_sampled: pl.Tensor[[B_DYN], pl.INT64],
+    next_prefill_tokens: pl.Tensor[[B_DYN], pl.INT64],
+    markov_w1: pl.Tensor[[VOCAB, DSPARK_MARKOV_RANK], pl.BF16],
+    markov_w2: pl.Tensor[[VOCAB, DSPARK_MARKOV_RANK], pl.BF16],
+    confidence_head_weight: pl.Tensor[[1, D + DSPARK_MARKOV_RANK], pl.FP32],
+    draft_token_ids: pl.Out[pl.Tensor[[B_DYN, DSPARK_QUERY_WIDTH], pl.INT32]],
+    confidence_probs: pl.Out[pl.Tensor[[B_DYN, DSPARK_QUERY_WIDTH], pl.FP32]],
+):
+    head_hidden.bind_dynamic(0, B_DYN)
+    num_sampled.bind_dynamic(0, B_DYN)
+    last_sampled.bind_dynamic(0, B_DYN)
+    next_prefill_tokens.bind_dynamic(0, B_DYN)
+    draft_token_ids.bind_dynamic(0, B_DYN)
+    confidence_probs.bind_dynamic(0, B_DYN)
+    base_logits = pl.create_tensor(
+        [DSPARK_MOE_TOKENS, VOCAB],
+        dtype=pl.FP32,
+    )
+    base_logits_tid = compute_base_logits(
+        head_hidden,
+        final_norm_weight,
+        lm_head_weight,
+        base_logits,
+    )
+    return sample_from_base_logits(
+        head_hidden,
+        base_logits,
+        num_sampled,
+        last_sampled,
+        next_prefill_tokens,
+        markov_w1,
+        markov_w2,
+        confidence_head_weight,
+        draft_token_ids,
+        confidence_probs,
+        base_logits_tid,
+    )
+
+
+@pl.jit
+def l2_distributed_markov_sample(
+    head_hidden: pl.Tensor[[B_DYN, DSPARK_QUERY_WIDTH, D], pl.BF16],
+    final_norm_weight: pl.Tensor[[D], pl.BF16],
+    lm_head_weight: pl.Tensor[[VOCAB_PER_TP, D], pl.BF16],
+    logit_row_indices: pl.Tensor[[MAX_LOGIT_ROWS], pl.INT32],
+    num_sampled: pl.Tensor[[B_DYN], pl.INT32],
+    last_sampled: pl.Tensor[[B_DYN], pl.INT64],
+    next_prefill_tokens: pl.Tensor[[B_DYN], pl.INT64],
+    markov_w1: pl.Tensor[[VOCAB, DSPARK_MARKOV_RANK], pl.BF16],
+    markov_w2: pl.Tensor[[VOCAB, DSPARK_MARKOV_RANK], pl.BF16],
+    confidence_head_weight: pl.Tensor[[1, D + DSPARK_MARKOV_RANK], pl.FP32],
+    draft_token_ids: pl.Out[pl.Tensor[[B_DYN, DSPARK_QUERY_WIDTH], pl.INT32]],
+    confidence_probs: pl.Out[pl.Tensor[[B_DYN, DSPARK_QUERY_WIDTH], pl.FP32]],
+    hidden_window: pld.DistributedTensor[[GROUP_LOGIT_ROWS, D], pl.BF16],
+    hidden_done: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
+    logits_window: pld.DistributedTensor[[MAX_LOGIT_ROWS * VOCAB], pl.FP32],
+    logits_done: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
+    group_base: pl.Scalar[pl.INT32],
+    tp_rank: pl.Scalar[pl.INT32],
+):
+    head_hidden.bind_dynamic(0, B_DYN)
+    num_sampled.bind_dynamic(0, B_DYN)
+    last_sampled.bind_dynamic(0, B_DYN)
+    next_prefill_tokens.bind_dynamic(0, B_DYN)
+    draft_token_ids.bind_dynamic(0, B_DYN)
+    confidence_probs.bind_dynamic(0, B_DYN)
+    normalized = pl.create_tensor([DSPARK_MOE_TOKENS, D], dtype=pl.BF16)
+    final_norm_tid = normalize_head_hidden(
+        head_hidden,
+        final_norm_weight,
+        normalized,
+    )
+    base_logits = pl.create_tensor([MAX_LOGIT_ROWS, VOCAB], dtype=pl.FP32)
+    base_logits, base_logits_tid = lm_head(
+        normalized,
+        lm_head_weight,
+        logit_row_indices,
+        base_logits,
+        hidden_window,
+        hidden_done,
+        logits_window,
+        logits_done,
+        group_base,
+        tp_rank,
+        DONE_VALUE,
+        final_norm_tid,
+    )
+    return sample_from_base_logits(
+        head_hidden,
+        base_logits,
+        num_sampled,
+        last_sampled,
+        next_prefill_tokens,
+        markov_w1,
+        markov_w2,
+        confidence_head_weight,
+        draft_token_ids,
+        confidence_probs,
+        base_logits_tid,
+    )
+
+
+@pl.jit.host
+def l3_distributed_markov_sample(
+    head_hidden: pl.Tensor[[WORLD_SIZE, B_DYN, DSPARK_QUERY_WIDTH, D], pl.BF16],
+    final_norm_weight: pl.Tensor[[WORLD_SIZE, D], pl.BF16],
+    lm_head_weight: pl.Tensor[[WORLD_SIZE, VOCAB_PER_TP, D], pl.BF16],
+    logit_row_indices: pl.Tensor[[WORLD_SIZE, MAX_LOGIT_ROWS], pl.INT32],
+    num_sampled: pl.Tensor[[WORLD_SIZE, B_DYN], pl.INT32],
+    last_sampled: pl.Tensor[[WORLD_SIZE, B_DYN], pl.INT64],
+    next_prefill_tokens: pl.Tensor[[WORLD_SIZE, B_DYN], pl.INT64],
+    markov_w1: pl.Tensor[[WORLD_SIZE, VOCAB, DSPARK_MARKOV_RANK], pl.BF16],
+    markov_w2: pl.Tensor[[WORLD_SIZE, VOCAB, DSPARK_MARKOV_RANK], pl.BF16],
+    confidence_head_weight: pl.Tensor[
+        [WORLD_SIZE, 1, D + DSPARK_MARKOV_RANK], pl.FP32
+    ],
+    draft_token_ids: pl.Out[
+        pl.Tensor[[WORLD_SIZE, B_DYN, DSPARK_QUERY_WIDTH], pl.INT32]
+    ],
+    confidence_probs: pl.Out[
+        pl.Tensor[[WORLD_SIZE, B_DYN, DSPARK_QUERY_WIDTH], pl.FP32]
+    ],
+):
+    head_hidden.bind_dynamic(1, B_DYN)
+    num_sampled.bind_dynamic(1, B_DYN)
+    last_sampled.bind_dynamic(1, B_DYN)
+    next_prefill_tokens.bind_dynamic(1, B_DYN)
+    draft_token_ids.bind_dynamic(1, B_DYN)
+    confidence_probs.bind_dynamic(1, B_DYN)
+    hidden_window_buf = pld.alloc_window_buffer(GROUP_LOGIT_ROWS * D * 2)
+    logits_window_buf = pld.alloc_window_buffer(MAX_LOGIT_ROWS * VOCAB * 4)
+    hidden_done_buf = pld.alloc_window_buffer(TP_SIZE * 4)
+    logits_done_buf = pld.alloc_window_buffer(TP_SIZE * 4)
+
+    for rank in pl.range(pld.world_size()):
+        hidden_window = pld.window(
+            hidden_window_buf,
+            [GROUP_LOGIT_ROWS, D],
+            dtype=pl.BF16,
+        )
+        logits_window = pld.window(
+            logits_window_buf,
+            [MAX_LOGIT_ROWS * VOCAB],
+            dtype=pl.FP32,
+        )
+        hidden_done = pld.window(hidden_done_buf, [TP_SIZE, 1], dtype=pl.INT32)
+        logits_done = pld.window(logits_done_buf, [TP_SIZE, 1], dtype=pl.INT32)
+        l2_distributed_markov_sample(
+            head_hidden[rank],
+            final_norm_weight[rank],
+            lm_head_weight[rank],
+            logit_row_indices[rank],
+            num_sampled[rank],
+            last_sampled[rank],
+            next_prefill_tokens[rank],
+            markov_w1[rank],
+            markov_w2[rank],
+            confidence_head_weight[rank],
+            draft_token_ids[rank],
+            confidence_probs[rank],
+            hidden_window,
+            hidden_done,
+            logits_window,
+            logits_done,
+            rank // TP_SIZE * TP_SIZE,
+            rank % TP_SIZE,
+            device=rank,
+        )
+
+
+def build_tensor_specs(batch: int, *, distributed: bool = False):
     """Build a deterministic nonzero Markov validation case."""
     import torch
     from golden import TensorSpec
@@ -434,7 +708,37 @@ def build_tensor_specs(batch: int):
     if batch not in DSPARK_SUPPORTED_BATCHES:
         raise ValueError(f"unsupported DSpark batch {batch}; expected one of {DSPARK_SUPPORTED_BATCHES}")
 
+    def init_head_hidden():
+        hidden = torch.ones(batch, DSPARK_QUERY_WIDTH, D, dtype=torch.bfloat16)
+        request_delta = torch.arange(batch, dtype=torch.float32).view(batch, 1) / 64.0
+        step_delta = torch.arange(DSPARK_QUERY_WIDTH, dtype=torch.float32).view(1, -1) / 32.0
+        hidden[:, :, 0] = (0.25 + request_delta + step_delta).to(torch.bfloat16)
+        if distributed:
+            # TP ranks share one request batch; DP groups own different context.
+            rank_hidden = []
+            for rank in range(WORLD_SIZE):
+                group_hidden = hidden.clone()
+                group_hidden[:, :, 1] = 1.0 + (rank // TP_SIZE) / 8.0
+                rank_hidden.append(group_hidden)
+            return torch.stack(rank_hidden)
+        return hidden
+
     def init_lm_head_weight():
+        if distributed:
+            weight = torch.zeros(
+                WORLD_SIZE,
+                VOCAB_PER_TP,
+                D,
+                dtype=torch.bfloat16,
+            )
+            for rank in range(WORLD_SIZE):
+                if rank % TP_SIZE == 0:
+                    dp_group = rank // TP_SIZE
+                    # Rows 4-7 have no Markov bias. Give each DP group a
+                    # different base-logit winner that stays above the +/-4 bias.
+                    group_token = 4 + dp_group % 4
+                    weight[rank, group_token, :LM_K_TILE] = 8.0 / LM_K_TILE
+            return weight
         weight = torch.zeros(VOCAB, D, dtype=torch.bfloat16)
         weight[0, :LM_K_TILE] = 1.0 / LM_K_TILE
         return weight
@@ -459,32 +763,127 @@ def build_tensor_specs(batch: int):
         weight[1, 0] = 4.0
         return weight
 
-    return [
-        TensorSpec("head_hidden", [batch, DSPARK_QUERY_WIDTH, D], torch.bfloat16, init_value=1),
-        TensorSpec("final_norm_weight", [D], torch.bfloat16, init_value=1),
-        TensorSpec("lm_head_weight", [VOCAB, D], torch.bfloat16, init_value=init_lm_head_weight),
+    def init_confidence_head_weight():
+        weight = torch.zeros(1, D + DSPARK_MARKOV_RANK, dtype=torch.float32)
+        weight[0, 0] = 0.75
+        weight[0, 1] = -0.25
+        weight[0, D] = 0.5
+        return weight
+
+    def replicate(init_fn):
+        value = init_fn()
+        if distributed:
+            return torch.stack([value] * WORLD_SIZE)
+        return value
+
+    def with_world(*shape):
+        if distributed:
+            return [WORLD_SIZE, *shape]
+        return list(shape)
+
+    specs = [
+        TensorSpec(
+            "head_hidden",
+            with_world(batch, DSPARK_QUERY_WIDTH, D),
+            torch.bfloat16,
+            init_value=init_head_hidden,
+        ),
+        TensorSpec(
+            "final_norm_weight",
+            with_world(D),
+            torch.bfloat16,
+            init_value=lambda: replicate(
+                lambda: torch.ones(D, dtype=torch.bfloat16)
+            ),
+        ),
+        TensorSpec(
+            "lm_head_weight",
+            [WORLD_SIZE, VOCAB_PER_TP, D] if distributed else [VOCAB, D],
+            torch.bfloat16,
+            init_value=init_lm_head_weight,
+            **({"resident": "stacked"} if distributed else {}),
+        ),
+    ]
+    if distributed:
+        active_tokens = batch * DSPARK_QUERY_WIDTH
+
+        def init_logit_row_indices():
+            indices = torch.full(
+                (WORLD_SIZE, MAX_LOGIT_ROWS),
+                -1,
+                dtype=torch.int32,
+            )
+            indices[:, :active_tokens] = torch.arange(
+                active_tokens,
+                dtype=torch.int32,
+            )
+            return indices
+
+        specs.append(
+            TensorSpec(
+                "logit_row_indices",
+                [WORLD_SIZE, MAX_LOGIT_ROWS],
+                torch.int32,
+                init_value=init_logit_row_indices,
+            )
+        )
+
+    specs.extend([
         TensorSpec(
             "num_sampled",
-            [batch],
+            with_world(batch),
             torch.int32,
-            init_value=lambda: torch.arange(batch, dtype=torch.int32) % 2,
+            init_value=lambda: replicate(
+                lambda: torch.arange(batch, dtype=torch.int32) % 2
+            ),
         ),
-        TensorSpec("last_sampled", [batch], torch.int64, init_value=init_last_sampled),
+        TensorSpec(
+            "last_sampled",
+            with_world(batch),
+            torch.int64,
+            init_value=lambda: replicate(init_last_sampled),
+        ),
         TensorSpec(
             "next_prefill_tokens",
-            [batch],
+            with_world(batch),
             torch.int64,
-            init_value=init_next_prefill_tokens,
+            init_value=lambda: replicate(init_next_prefill_tokens),
         ),
-        TensorSpec("markov_w1", [VOCAB, DSPARK_MARKOV_RANK], torch.bfloat16, init_value=init_markov_w1),
-        TensorSpec("markov_w2", [VOCAB, DSPARK_MARKOV_RANK], torch.bfloat16, init_value=init_markov_w2),
+        TensorSpec(
+            "markov_w1",
+            with_world(VOCAB, DSPARK_MARKOV_RANK),
+            torch.bfloat16,
+            init_value=lambda: replicate(init_markov_w1),
+            **({"resident": "stacked"} if distributed else {}),
+        ),
+        TensorSpec(
+            "markov_w2",
+            with_world(VOCAB, DSPARK_MARKOV_RANK),
+            torch.bfloat16,
+            init_value=lambda: replicate(init_markov_w2),
+            **({"resident": "stacked"} if distributed else {}),
+        ),
+        TensorSpec(
+            "confidence_head_weight",
+            with_world(1, D + DSPARK_MARKOV_RANK),
+            torch.float32,
+            init_value=lambda: replicate(init_confidence_head_weight),
+            **({"resident": "stacked"} if distributed else {}),
+        ),
         TensorSpec(
             "draft_token_ids",
-            [batch, DSPARK_QUERY_WIDTH],
+            with_world(batch, DSPARK_QUERY_WIDTH),
             torch.int32,
             is_output=True,
         ),
-    ]
+        TensorSpec(
+            "confidence_probs",
+            with_world(batch, DSPARK_QUERY_WIDTH),
+            torch.float32,
+            is_output=True,
+        ),
+    ])
+    return specs
 
 
 def golden_nonzero_markov(tensors):
@@ -510,6 +909,14 @@ def golden_nonzero_markov(tensors):
     ).long()
     for step in range(DSPARK_QUERY_WIDTH):
         embedding = tensors["markov_w1"].float().index_select(0, previous)
+        confidence_input = torch.cat(
+            [hidden_fp32[:, step], embedding],
+            dim=-1,
+        )
+        confidence_logits = confidence_input.matmul(
+            tensors["confidence_head_weight"].float().t()
+        ).squeeze(-1)
+        tensors["confidence_probs"][:, step] = torch.sigmoid(confidence_logits)
         markov_bias = embedding.matmul(
             tensors["markov_w2"][:validation_support].float().t()
         )
@@ -519,6 +926,35 @@ def golden_nonzero_markov(tensors):
         tensors["draft_token_ids"][:, step] = previous.to(torch.int32)
 
 
+def golden_distributed_markov(tensors):
+    """Apply the single-rank golden to every DP-owned TP-group result."""
+    import torch
+
+    for rank in range(WORLD_SIZE):
+        group_base = rank // TP_SIZE * TP_SIZE
+        full_lm_head_weight = torch.cat(
+            [
+                tensors["lm_head_weight"][group_base + tp_rank]
+                for tp_rank in range(TP_SIZE)
+            ],
+            dim=0,
+        )
+        rank_tensors = {
+            "head_hidden": tensors["head_hidden"][rank],
+            "final_norm_weight": tensors["final_norm_weight"][rank],
+            "lm_head_weight": full_lm_head_weight,
+            "num_sampled": tensors["num_sampled"][rank],
+            "last_sampled": tensors["last_sampled"][rank],
+            "next_prefill_tokens": tensors["next_prefill_tokens"][rank],
+            "markov_w1": tensors["markov_w1"][rank],
+            "markov_w2": tensors["markov_w2"][rank],
+            "confidence_head_weight": tensors["confidence_head_weight"][rank],
+            "draft_token_ids": tensors["draft_token_ids"][rank],
+            "confidence_probs": tensors["confidence_probs"][rank],
+        }
+        golden_nonzero_markov(rank_tensors)
+
+
 if __name__ == "__main__":
     import argparse
     from golden import run_jit
@@ -526,17 +962,38 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Validate the DeepSeek V4 DSpark Markov sampler.")
     parser.add_argument("--batch", type=int, choices=DSPARK_SUPPORTED_BATCHES, default=4)
     parser.add_argument("-p", "--platform", default="a2a3", choices=["a2a3", "a2a3sim"])
-    parser.add_argument("-d", "--device", type=int, default=0)
+    parser.add_argument("--distributed", action="store_true")
+    parser.add_argument("--tp", type=int, default=TP_SIZE, choices=[2, 4, 8, 16])
+    parser.add_argument("--dp", type=int, default=1, choices=[1, 2, 4, 8, 16])
+    parser.add_argument("-d", "--device", default="0")
     parser.add_argument("--compile-only", action="store_true")
     parser.add_argument("--dump-passes", action="store_true")
     args = parser.parse_args()
 
+    assert args.tp == TP_SIZE
+    assert args.dp * args.tp == WORLD_SIZE
+    compile_cfg = dict(dump_passes=args.dump_passes)
+    runtime_cfg = dict(platform=args.platform)
+    fn = markov_sample
+    golden_fn = golden_nonzero_markov
+    if args.distributed:
+        device_ids = [int(device) for device in args.device.split(",")]
+        assert len(device_ids) >= WORLD_SIZE
+        fn = l3_distributed_markov_sample
+        golden_fn = golden_distributed_markov
+        compile_cfg["distributed_config"] = DistributedConfig(
+            device_ids=device_ids[:WORLD_SIZE],
+            num_sub_workers=0,
+        )
+    else:
+        runtime_cfg["device_id"] = int(args.device)
+
     result = run_jit(
-        fn=markov_sample,
-        specs=build_tensor_specs(args.batch),
-        golden_fn=golden_nonzero_markov,
-        compile_cfg=dict(dump_passes=args.dump_passes),
-        runtime_cfg=dict(platform=args.platform, device_id=args.device),
+        fn=fn,
+        specs=build_tensor_specs(args.batch, distributed=args.distributed),
+        golden_fn=golden_fn,
+        compile_cfg=compile_cfg,
+        runtime_cfg=runtime_cfg,
         rtol=2e-3,
         atol=2e-3,
         compile_only=args.compile_only,

--- a/models/deepseek_v4_flash_dspark/dspark_markov.py
+++ b/models/deepseek_v4_flash_dspark/dspark_markov.py
@@ -714,11 +714,14 @@ def build_tensor_specs(batch: int, *, distributed: bool = False):
         step_delta = torch.arange(DSPARK_QUERY_WIDTH, dtype=torch.float32).view(1, -1) / 32.0
         hidden[:, :, 0] = (0.25 + request_delta + step_delta).to(torch.bfloat16)
         if distributed:
-            # TP ranks share one request batch; DP groups own different context.
+            # Every TP rank owns a distinct SP request slice. A rank-specific
+            # one-hot feature makes the fused SP-gather/TP-vocab path observable.
             rank_hidden = []
             for rank in range(WORLD_SIZE):
                 group_hidden = hidden.clone()
                 group_hidden[:, :, 1] = 1.0 + (rank // TP_SIZE) / 8.0
+                group_hidden[:, :, 2 : 2 + TP_SIZE] = 0.0
+                group_hidden[:, :, 2 + rank % TP_SIZE] = 1.0
                 rank_hidden.append(group_hidden)
             return torch.stack(rank_hidden)
         return hidden
@@ -733,11 +736,10 @@ def build_tensor_specs(batch: int, *, distributed: bool = False):
             )
             for rank in range(WORLD_SIZE):
                 if rank % TP_SIZE == 0:
-                    dp_group = rank // TP_SIZE
-                    # Rows 4-7 have no Markov bias. Give each DP group a
-                    # different base-logit winner that stays above the +/-4 bias.
-                    group_token = 4 + dp_group % 4
-                    weight[rank, group_token, :LM_K_TILE] = 8.0 / LM_K_TILE
+                    # Rows 4+owner_tp have no Markov bias. Distinct winners for
+                    # the SP owners prove their hidden rows are not duplicated.
+                    for owner_tp in range(TP_SIZE):
+                        weight[rank, 4 + owner_tp, 2 + owner_tp] = 8.0
             return weight
         weight = torch.zeros(VOCAB, D, dtype=torch.bfloat16)
         weight[0, :LM_K_TILE] = 1.0 / LM_K_TILE

--- a/models/deepseek_v4_flash_dspark/lm_head.py
+++ b/models/deepseek_v4_flash_dspark/lm_head.py
@@ -68,17 +68,16 @@ GREEDY_ROW_WIDTH = 808
 GREEDY_BLOCK_ROWS = 8
 SAMPLED_IDS_PAD = 8
 FUSED_LM_HEAD_CORES = 24
-# AIV lanes per AICore: the fused kernel splits each row block's accumulator
-# across the two lanes, and each lane pushes a contiguous half of one owner's
-# rows.
-AIV_LANES = 2
-LANE_ROWS = MM_ROW_TILE // AIV_LANES
 VOCAB_TAIL = VOCAB_PER_TP % FUSED_VOCAB_TILE
 VOCAB_FULL_TILES = VOCAB_PER_TP // FUSED_VOCAB_TILE
 LOGITS_COMM_TAIL = VOCAB_PER_TP % LOGITS_COMM_TILE
 N_LOGITS_COMM_TILES = VOCAB_PER_TP // LOGITS_COMM_TILE
 LOGITS_COMM_BLOCKS = min(FUSED_LM_HEAD_CORES, N_LOGITS_COMM_TILES + (1 if LOGITS_COMM_TAIL != 0 else 0))
+LOGITS_OWNER_ROW_BLOCKS = MAX_LOGIT_ROWS // LOGITS_GATHER_ROW_TILE
 LOGITS_TAIL_BLOCK = N_LOGITS_COMM_TILES % LOGITS_COMM_BLOCKS
+LOGITS_FLAT_PUT_TILE = 16384
+LOGITS_FLAT_PUT_TILES = VOCAB_PER_TP // LOGITS_FLAT_PUT_TILE
+LOGITS_FLAT_PUT_TAIL = VOCAB_PER_TP % LOGITS_FLAT_PUT_TILE
 GREEDY_GRID_ROWS = VOCAB // GREEDY_ROW_WIDTH
 GREEDY_BLOCK_SPAN = GREEDY_BLOCK_ROWS * GREEDY_ROW_WIDTH
 # 2^30: above every vocab id, clear of int32 overflow once a block base is added.
@@ -91,7 +90,7 @@ os.environ.setdefault("PTO2_RING_HEAP", "1073741824")
 
 assert MAX_LOGIT_ROWS % MM_ROW_TILE == 0, "each row block must be one owner's rows"
 assert MAX_LOGIT_ROWS % PUSH_ROW_TILE == 0, "row block must cover whole rows"
-assert TP_SIZE % AIV_LANES == 0, "owners must divide evenly across the AIV lanes"
+assert MAX_LOGIT_ROWS % LOGITS_GATHER_ROW_TILE == 0, "logits row blocks must cover whole rows"
 assert GREEDY_BLOCK_ROWS * 4 % 32 == 0, "reduction result must clear the 32 B column floor"
 assert GREEDY_ROW_WIDTH * 4 % 32 == 0, "block row must clear the 32 B row floor"
 assert VOCAB < GREEDY_INDEX_SENTINEL, "sentinel must lose every row_min against a real id"
@@ -105,12 +104,16 @@ def lm_head(
     logits: pl.Tensor[[MAX_LOGIT_ROWS, VOCAB], pl.FP32],
     hidden_window: pld.DistributedTensor[[GROUP_LOGIT_ROWS, D], pl.BF16],
     hidden_done: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
-    logits_window: pld.DistributedTensor[[MAX_LOGIT_ROWS, VOCAB], pl.FP32],
+    logits_window: pld.DistributedTensor[[MAX_LOGIT_ROWS * VOCAB], pl.FP32],
     logits_done: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
     group_base: pl.Scalar[pl.INT32],
     tp_rank: pl.Scalar[pl.INT32],
     done_epoch: pl.Scalar[pl.INT32],
-) -> pl.Tensor[[MAX_LOGIT_ROWS, VOCAB], pl.FP32]:
+    hidden_ready_tid: pl.Scalar[pl.TASK_ID],
+) -> tuple[
+    pl.Tensor[[MAX_LOGIT_ROWS, VOCAB], pl.FP32],
+    pl.Scalar[pl.TASK_ID],
+]:
     # Scratch is allocated just outside the scope that first writes it: a
     # create_tensor inside a pl.at yields a tile, not a GM tensor view.
     selected_hidden = pl.create_tensor([MAX_LOGIT_ROWS, D], dtype=pl.BF16)
@@ -123,7 +126,12 @@ def lm_head(
     # counts (512 -> 32 per card) to the MTP fixture's scale; the earlier
     # per-row form stalled lm_head_dispatch_gather on persistent re-dispatch
     # (SCHEDULER_TIMEOUT S1 with the gather task's core never exiting).
-    for blk in pl.spmd(MAX_LOGIT_ROWS // PUSH_ROW_TILE, name_hint="lm_head_dispatch_push"):
+    with pl.spmd(
+        MAX_LOGIT_ROWS // PUSH_ROW_TILE,
+        name_hint="lm_head_dispatch_push",
+        deps=[hidden_ready_tid],
+    ) as _dispatch_push_tid:
+        blk = pl.tile.get_block_idx()
         r0 = blk * PUSH_ROW_TILE
         hidden_rows = pl.tensor.dim(hidden_states, 0)
         for i in pl.range(PUSH_ROW_TILE):
@@ -160,11 +168,12 @@ def lm_head(
                     op=pld.NotifyOp.AtomicAdd,
                 )
 
-    # Barrier on the group's publishes. The hidden_states read is an anchor, not
-    # data: it deps this task on the hidden-state producer so the wait runs
-    # alongside our own push instead of trailing it.
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="lm_head_dispatch_wait") as _dwait_tid:
-        _hidden_anchor = pl.read(hidden_states, [0, 0])
+    # Start the wait after this rank has published. Signal credits persist until
+    # the final clear, so peer notifies may safely arrive before this task starts;
+    # anchoring avoids an idle wait occupying a core group while the push is pending.
+    with pl.at(
+        level=pl.Level.CORE_GROUP, name_hint="lm_head_dispatch_wait", deps=[_dispatch_push_tid]
+    ) as _dwait_tid:
         for owner_tp in pl.range(TP_SIZE):
             if owner_tp != tp_rank:
                 pld.system.wait(
@@ -180,7 +189,7 @@ def lm_head(
     with pl.spmd(
         (GROUP_LOGIT_ROWS // HIDDEN_GATHER_ROW_TILE) * (D // HIDDEN_GATHER_TILE),
         name_hint="lm_head_dispatch_gather",
-        deps=[_dwait_tid],
+        deps=[_dwait_tid, _dispatch_push_tid],
     ) as _dgather_tid:
         gblock = pl.tile.get_block_idx()
         gk0 = (gblock % (D // HIDDEN_GATHER_TILE)) * HIDDEN_GATHER_TILE
@@ -189,21 +198,16 @@ def lm_head(
             gr0 : gr0 + HIDDEN_GATHER_ROW_TILE, gk0 : gk0 + HIDDEN_GATHER_TILE
         ]
 
-    # Fused cube+comm kernel: matmul one [MM_ROW_TILE, FUSED_VOCAB_TILE] tile,
-    # carry the accumulator across the C->V edge with pl.aiv_shard, and
-    # remote_store each lane's row half to its owner's window while the cube
-    # projects the next tile. No GM staging: every row block is one owner's
-    # rows, so each lane's shard is already the exact rows it pushes.
-    #
-    # The ragged last tile gets its own narrow matmul; its accumulator is
-    # already VOCAB_TAIL wide, so the push stays a whole-shard write.
+    # Keep the rank-local vocabulary shard in GM before publishing it. The
+    # current PyPTO pin exposes tensor.put for a Tensor source, but does not
+    # expose a high-level Tensor form of tile.remote_store for aiv_shard output.
+    logits_shards = pl.create_tensor([GROUP_LOGIT_ROWS, VOCAB_PER_TP], dtype=pl.FP32)
     with pl.spmd(
         FUSED_LM_HEAD_CORES,
-        name_hint="lm_head_matmul_push",
-        optimizations=[pl.cross_core_slot(slot_num=2)],
-    ) as _push_tid:
+        name_hint="lm_head_matmul",
+        deps=[_dgather_tid],
+    ) as _matmul_tid:
         lm_core = pl.tile.get_block_idx()
-        vocab_base = tp_rank * VOCAB_PER_TP
         for mm_ob in pl.range(lm_core, VOCAB_FULL_TILES, FUSED_LM_HEAD_CORES):
             mm_o0 = mm_ob * FUSED_VOCAB_TILE
             for mm_rb in pl.range(GROUP_LOGIT_ROWS // MM_ROW_TILE):
@@ -216,21 +220,11 @@ def lm_head(
                     mm_hidden_tile = owner_hiddens[mm_r0 : mm_r0 + MM_ROW_TILE, mm_k0 : mm_k0 + FUSED_K_TILE]
                     mm_weight_tile = lm_head_weight[mm_o0 : mm_o0 + FUSED_VOCAB_TILE, mm_k0 : mm_k0 + FUSED_K_TILE]
                     mm_acc = pl.matmul_acc(mm_acc, mm_hidden_tile, mm_weight_tile, b_trans=True)
+                logits_shards[
+                    mm_r0 : mm_r0 + MM_ROW_TILE,
+                    mm_o0 : mm_o0 + FUSED_VOCAB_TILE,
+                ] = mm_acc
 
-                # The block is one owner's rows; the two lanes push its two
-                # contiguous halves straight to that owner's window.
-                for aiv_id in pl.split_aiv(AIV_LANES, mode=pl.SplitMode.UP_DOWN):
-                    mm_shard = pl.aiv_shard(mm_acc)
-                    owner_tp = mm_rb // (MAX_LOGIT_ROWS // MM_ROW_TILE)
-                    owner_r0 = (mm_rb % (MAX_LOGIT_ROWS // MM_ROW_TILE)) * MM_ROW_TILE + aiv_id * LANE_ROWS
-                    pld.tensor.remote_store(
-                        mm_shard, logits_window, group_base + owner_tp,
-                        [owner_r0, vocab_base + mm_o0],
-                    )
-
-        # Ragged tail: its own matmul on one block; the accumulator is already
-        # VOCAB_TAIL wide. Hoisted out of the strided loop: a dynamic branch
-        # would give the accumulator two static shapes across the C->V edge.
         if VOCAB_TAIL != 0:
             if lm_core == VOCAB_FULL_TILES % FUSED_LM_HEAD_CORES:
                 mm_tail_o0 = VOCAB_FULL_TILES * FUSED_VOCAB_TILE
@@ -249,29 +243,58 @@ def lm_head(
                             tail_k0 : tail_k0 + FUSED_K_TILE,
                         ]
                         tail_acc = pl.matmul_acc(tail_acc, tail_hidden_tile, tail_weight_tile, b_trans=True)
+                    logits_shards[
+                        tail_r0 : tail_r0 + MM_ROW_TILE,
+                        mm_tail_o0 : mm_tail_o0 + VOCAB_TAIL,
+                    ] = tail_acc
 
-                    for aiv_id in pl.split_aiv(AIV_LANES, mode=pl.SplitMode.UP_DOWN):
-                        tail_shard = pl.aiv_shard(tail_acc)
-                        owner_tp = tail_rb // (MAX_LOGIT_ROWS // MM_ROW_TILE)
-                        owner_r0 = (tail_rb % (MAX_LOGIT_ROWS // MM_ROW_TILE)) * MM_ROW_TILE + aiv_id * LANE_ROWS
-                        pld.tensor.remote_store(
-                            tail_shard, logits_window, group_base + owner_tp,
-                            [owner_r0, vocab_base + mm_tail_o0],
-                        )
-
-        # Notify folded into the push: each block signals every peer after its own
-        # stores, so a peer sees FUSED_LM_HEAD_CORES notifies per source per epoch.
-        for aiv_id in pl.split_aiv(AIV_LANES, mode=pl.SplitMode.NONE):
-            for notify_pair in pl.range(TP_SIZE // AIV_LANES):
-                owner_tp = notify_pair * AIV_LANES + aiv_id
-                if owner_tp != tp_rank:
-                    pld.system.notify(
-                        target=logits_done,
+    # Flatten TP logits communication views.
+    logits_shards_flat = pl.reshape(logits_shards, [GROUP_LOGIT_ROWS * VOCAB_PER_TP])
+    with pl.spmd(
+        LOGITS_OWNER_ROW_BLOCKS,
+        name_hint="lm_head_combine_push",
+        deps=[_matmul_tid],
+    ) as _push_tid:
+        row_block = pl.tile.get_block_idx()
+        row_offset = row_block * LOGITS_GATHER_ROW_TILE
+        vocab_base = tp_rank * VOCAB_PER_TP
+        for owner_tp in pl.range(TP_SIZE):
+            source_row_base = owner_tp * MAX_LOGIT_ROWS
+            for row_lane in pl.unroll(8):
+                row = row_offset + row_lane
+                dst_row_base = row * VOCAB + vocab_base
+                src_row_base = (source_row_base + row) * VOCAB_PER_TP
+                for output_block in pl.range(LOGITS_FLAT_PUT_TILES):
+                    output_offset = output_block * LOGITS_FLAT_PUT_TILE
+                    pld.tensor.put(
+                        dst=logits_window,
                         peer=group_base + owner_tp,
-                        offsets=[tp_rank, 0],
-                        value=1,
-                        op=pld.NotifyOp.AtomicAdd,
+                        src=logits_shards_flat,
+                        dst_offsets=[dst_row_base + output_offset],
+                        src_offsets=[src_row_base + output_offset],
+                        shape=[LOGITS_FLAT_PUT_TILE],
                     )
+
+                if LOGITS_FLAT_PUT_TAIL != 0:
+                    tail_offset = LOGITS_FLAT_PUT_TILES * LOGITS_FLAT_PUT_TILE
+                    pld.tensor.put(
+                        dst=logits_window,
+                        peer=group_base + owner_tp,
+                        src=logits_shards_flat,
+                        dst_offsets=[dst_row_base + tail_offset],
+                        src_offsets=[src_row_base + tail_offset],
+                        shape=[LOGITS_FLAT_PUT_TAIL],
+                    )
+
+        for owner_tp in pl.range(TP_SIZE):
+            if owner_tp != tp_rank:
+                pld.system.notify(
+                    target=logits_done,
+                    peer=group_base + owner_tp,
+                    offsets=[tp_rank, 0],
+                    value=1,
+                    op=pld.NotifyOp.AtomicAdd,
+                )
 
     # Wait only (the notify rides inside the push). deps on the push scope so the
     # wait runs alongside our own push; an unanchored wait dispatches immediately
@@ -284,7 +307,7 @@ def lm_head(
                 pld.system.wait(
                     signal=logits_done,
                     offsets=[src_tp, 0],
-                    expected=pl.cast(done_epoch * FUSED_LM_HEAD_CORES, pl.INT32),
+                    expected=pl.cast(done_epoch * LOGITS_OWNER_ROW_BLOCKS, pl.INT32),
                     cmp=pld.WaitCmp.Ge,
                 )
 
@@ -300,29 +323,38 @@ def lm_head(
                 o0 = ob * LOGITS_COMM_TILE
                 lo = src_vocab_base + o0
                 for gr in pl.range(0, MAX_LOGIT_ROWS, LOGITS_GATHER_ROW_TILE):
-                    logits[gr : gr + LOGITS_GATHER_ROW_TILE, lo : lo + LOGITS_COMM_TILE] = logits_window[
-                        gr : gr + LOGITS_GATHER_ROW_TILE, lo : lo + LOGITS_COMM_TILE
-                    ]
+                    for row_lane in pl.unroll(8):
+                        row = gr + row_lane
+                        flat_offset = row * VOCAB + lo
+                        flat_logits = pl.load(logits_window, [flat_offset], [LOGITS_COMM_TILE])
+                        logits_row = pl.reshape(flat_logits, [1, LOGITS_COMM_TILE])
+                        pl.store(logits_row, [row, lo], logits)
 
             if LOGITS_COMM_TAIL != 0:
                 if gblk == LOGITS_TAIL_BLOCK:
                     tail_o0 = N_LOGITS_COMM_TILES * LOGITS_COMM_TILE
                     tl = src_vocab_base + tail_o0
                     for tr in pl.range(0, MAX_LOGIT_ROWS, LOGITS_GATHER_ROW_TILE):
-                        logits[tr : tr + LOGITS_GATHER_ROW_TILE, tl : tl + LOGITS_COMM_TAIL] = logits_window[
-                            tr : tr + LOGITS_GATHER_ROW_TILE, tl : tl + LOGITS_COMM_TAIL
-                        ]
+                        for tail_lane in pl.unroll(8):
+                            tail_row = tr + tail_lane
+                            tail_flat_offset = tail_row * VOCAB + tl
+                            flat_tail = pl.load(logits_window, [tail_flat_offset], [LOGITS_COMM_TAIL])
+                            tail_logits_row = pl.reshape(flat_tail, [1, LOGITS_COMM_TAIL])
+                            pl.store(tail_logits_row, [tail_row, tl], logits)
 
     # Every local wait has observed all current-round peer notifies before the
     # logits gather can complete. Clear only this rank's counters so a retained
     # CommDomain can safely reuse the fixed done_epoch on the next forward.
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="lm_head_signal_clear"):
-        _completion_anchor = pl.read(logits, [0, 0])
+    with pl.at(
+        level=pl.Level.CORE_GROUP,
+        name_hint="lm_head_signal_clear",
+        deps=[_gather_tid],
+    ) as _clear_tid:
         zero = pl.cast(0, pl.INT32)
         for src_tp in pl.range(TP_SIZE):
             pl.write(hidden_done, [src_tp, 0], zero)
             pl.write(logits_done, [src_tp, 0], zero)
-    return logits
+    return logits, _clear_tid
 
 
 @pl.jit
@@ -333,16 +365,21 @@ def l2_lm_head(
     logits: pl.Out[pl.Tensor[[MAX_LOGIT_ROWS, VOCAB], pl.FP32]],
     hidden_window: pld.DistributedTensor[[GROUP_LOGIT_ROWS, D], pl.BF16],
     hidden_done: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
-    logits_window: pld.DistributedTensor[[MAX_LOGIT_ROWS, VOCAB], pl.FP32],
+    logits_window: pld.DistributedTensor[[MAX_LOGIT_ROWS * VOCAB], pl.FP32],
     logits_done: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
     group_base: pl.Scalar[pl.INT32],
     tp_rank: pl.Scalar[pl.INT32],
     done_epoch: pl.Scalar[pl.INT32],
 ) -> pl.Tensor[[MAX_LOGIT_ROWS, VOCAB], pl.FP32]:
+    with pl.at(
+        level=pl.Level.CORE_GROUP,
+        name_hint="lm_head_input_ready",
+    ) as hidden_ready_tid:
+        _input_anchor = pl.read(hidden_states, [0, 0])
     lm_head(
         hidden_states, lm_head_weight, logit_row_indices, logits,
         hidden_window, hidden_done, logits_window, logits_done,
-        group_base, tp_rank, done_epoch,
+        group_base, tp_rank, done_epoch, hidden_ready_tid,
     )
     return logits
 
@@ -421,7 +458,7 @@ def l3_lm_head(
     for r in pl.range(pld.world_size()):
         hidden_window = pld.window(hidden_window_buf, [GROUP_LOGIT_ROWS, D], dtype=pl.BF16)
         hidden_done = pld.window(hidden_done_buf, [TP_SIZE, 1], dtype=pl.INT32)
-        logits_window = pld.window(logits_window_buf, [MAX_LOGIT_ROWS, VOCAB], dtype=pl.FP32)
+        logits_window = pld.window(logits_window_buf, [MAX_LOGIT_ROWS * VOCAB], dtype=pl.FP32)
         logits_done = pld.window(logits_done_buf, [TP_SIZE, 1], dtype=pl.INT32)
         l2_lm_head(
             hidden_states[r], lm_head_weight[r], logit_row_indices[r], logits[r],

--- a/models/deepseek_v4_flash_dspark/markov_head.py
+++ b/models/deepseek_v4_flash_dspark/markov_head.py
@@ -37,7 +37,12 @@ def markov_head(
     t_dim = pl.tensor.dim(token_ids, 0)
     t_linear = ((t_dim + T_TILE - 1) // T_TILE) * T_TILE
 
-    for token_idx in pl.spmd(t_dim, name_hint="markov_embedding", allow_early_resolve=True):
+    with pl.spmd(
+        t_dim,
+        name_hint="markov_embedding",
+        allow_early_resolve=True,
+    ) as embedding_tid:
+        token_idx = pl.tile.get_block_idx()
         token_id = pl.read(token_ids, [token_idx])
         token_row = pl.cast(token_id, target_type=pl.INDEX)
         markov_embed[token_idx : token_idx + 1, 0:MARKOV_RANK] = markov_w1[
@@ -46,7 +51,12 @@ def markov_head(
 
     vocab_dim = pl.tensor.dim(markov_w2, 0)
     work_items = (t_linear // T_TILE) * (vocab_dim // VOCAB_TILE)
-    for block in pl.spmd(SPMD_BLOCKS, name_hint="markov_logits"):
+    with pl.spmd(
+        SPMD_BLOCKS,
+        name_hint="markov_logits",
+        deps=[embedding_tid],
+    ) as logits_tid:
+        block = pl.tile.get_block_idx()
         for work_idx in pl.range(block, work_items, SPMD_BLOCKS):
             t0 = (work_idx // (vocab_dim // VOCAB_TILE)) * T_TILE
             vocab0 = (work_idx % (vocab_dim // VOCAB_TILE)) * VOCAB_TILE
@@ -59,7 +69,7 @@ def markov_head(
             logits_valid = pl.set_validshape(logits_tile, valid_rows, VOCAB_TILE)
             logits_bias[t0 : t0 + T_TILE, vocab0 : vocab0 + VOCAB_TILE] = logits_valid
 
-    return logits_bias, markov_embed
+    return logits_bias, markov_embed, embedding_tid, logits_tid
 
 
 @pl.jit
@@ -76,7 +86,14 @@ def markov_head_test(
     logits_bias.bind_dynamic(0, T_DYN)
     logits_bias.bind_dynamic(1, VOCAB_DYN)
     markov_embed.bind_dynamic(0, T_DYN)
-    return markov_head(token_ids, markov_w1, markov_w2, logits_bias, markov_embed)
+    logits_bias, markov_embed, _, _ = markov_head(
+        token_ids,
+        markov_w1,
+        markov_w2,
+        logits_bias,
+        markov_embed,
+    )
+    return logits_bias, markov_embed
 
 
 def golden_markov_head(tensors):


### PR DESCRIPTION
- Project head_hidden[B, 7, D] through the shared LM head with the
  weights sharded by vocabulary across the TP group (32320 rows per
  rank at TP4), exchange the hidden and logit rows inside the group,
  and take the greedy token globally across all vocabulary shards.
- Keep the seven-step sequential Markov dependency: the token sampled
  at step k supplies the Markov embedding used at step k + 1.
- Add the bias-free FP32 confidence projection over head_hidden and the
  previous-token Markov embedding with a sigmoid, and return
  confidence_probs[B, 7] next to draft_token_ids[B, 7].
- Flatten the lm_head logits window into a 1-D put buffer, replace the
  AIV lane split with LOGITS_GATHER_ROW_TILE row blocks, and thread a
  hidden_ready task id through so the dispatch push deps on its
  producer instead of re-reading hidden_states as an anchor.
- Return the markov_head embedding and logits task ids so the sampler
  chains its spmd scopes explicitly.
- Run the three-layer drafter context-parallel over min(TP, N_RANKS)
  ranks: token-shard the hidden stream, gather the group hidden and
  context rows only at the attention/KV boundary through a window plus
  a notify/wait CP barrier, and keep query outputs rank-local.
- Derive context capacity from DECODE_TOKENS / PREFILL_TOKENS instead
  of a fixed PREFILL_SEQ, spread the prefill context rows over the CP
  group, and drop context positions that already fell out of the
  drafter's sliding window so no write lands outside the physical KV
  cache.
- Assert the CP block budget against KV_ORI_BLOCK_NUM and the per-rank
  context span against KV_ORI_MAX_BLOCKS, and compare kv_caches with
  ratio_allclose(atol=1e-4, rtol=1/128).
- Extend the distributed golden fixtures to cover TP ownership,
  vocabulary offsets, token ids and confidence output.

The contract stays three draft layers, draft width 7 with
[anchor, noise x 6], Markov rank 256, and local batches in
{4, 8, 12, 16}. The serving-side policy that consumes the confidence
scores - survival products, adaptive verification budgets, per-request
speculative lengths, target-model KV updates - is not part of this
change and stays tracked by #905.
