### PR TITLE
Docs: add a distributed programming guide and correct stale references

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -26,12 +26,13 @@ Files ending in `_draft.py` are works-in-progress and excluded from CI.
 - `docs/get-started/platforms.md` — simulator/device targets and CI coverage semantics
 - `docs/run-and-validate/golden-harness.md` — Golden Harness specs, execution, validation, and results
 - `docs/run-and-validate/save-and-replay.md` — frozen input/golden capture and replay
-- `docs/pypto-coding/pypto-coding-style.md` — **canonical** coding style: the two kernel forms (`@pl.jit` / `@pl.jit.inline` and `@pl.program` / `@pl.function`), `pl.at` scopes, four loop constructs (`pl.range`/`pl.parallel`/`pl.pipeline`/`pl.spmd`), vector / cube / mte ops, dynamic B/S shapes
+- `docs/pypto-coding/pypto-coding-style.md` — **canonical** coding style: the two kernel forms (`@pl.jit` / `@pl.jit.inline` and `@pl.program` / `@pl.function`), `pl.at` scopes, five loop constructs (`pl.range`/`pl.unroll`/`pl.parallel`/`pl.pipeline`/`pl.spmd`), scalar `pl.read`/`pl.write`, runtime `pl.scope`, vector / cube / mte ops, dynamic B/S shapes
 - `docs/run-and-validate/compile-runtime-workflow.md` — what `python <kernel>.py -p <platform>` does end-to-end (compile passes/codegen → input gen → golden → runtime → validate)
 - `docs/debug-and-tune/debugging.md` — debugging playbook: pypto/ptoas errors, `golden_data` replay, `runtime_dir` reuse, runtime-hang device logs, args-dump / dep-gen
 - `docs/debug-and-tune/performance-tuning.md` — L2 (inter-kernel) and L1/L0 (intra-kernel) tuning: swimlanes, PMU, buffer-occupancy / perf-hint reports
 - `docs/debug-and-tune/cce-incore-profiling.md` — on-device multi-core phase timestamps for fused CCE extern kernels: per-core capture, barrier diagnostics, and exact L2-reconciled partitions
 - `docs/debug-and-tune/precision-tuning.md` — keeping a kernel numerically faithful: `pl.cast` rounding modes vs torch, dtype alignment, fp32 intermediates / no double-cast, quant schemes, the `error_distribution` threshold sweep, and real-weight testing
+- `docs/pypto-coding/distributed-programming.md` — multi-card (L3) kernels: the `@pl.jit.host` driver, HCCL window buffers and `pld.DistributedTensor`, cross-rank `put`/`remote_store`/`remote_load`, and the notify/wait + epoch protocols
 - `docs/pypto-coding/cce-extern-kernel.md` — writing hand-written mixed (cube+vector) CCE kernels behind `pl.jit.extern`: the persistent-kernel runtime model, the tensors-first/scalars-last arg-packing trap, UB/`TPipe`, `SyncAll<false>` cross-core barriers, GM scalar coherency, and the on-device narrowing methodology
 
 ## External Dependencies

--- a/README.md
+++ b/README.md
@@ -47,9 +47,12 @@ flow (compile → input generation → golden → runtime → validation).
 
 Read [docs/pypto-coding/pypto-coding-style.md](docs/pypto-coding/pypto-coding-style.md) — it covers
 the two kernel forms (`@pl.jit` / `@pl.jit.inline` and `@pl.program` /
-`@pl.function`), `pl.at` scopes, the four loop constructs (`pl.range`,
-`pl.parallel`, `pl.pipeline`, `pl.spmd`), and the vector / cube / mte op
-set.
+`@pl.function`), `pl.at` scopes, the five loop constructs (`pl.range`,
+`pl.unroll`, `pl.parallel`, `pl.pipeline`, `pl.spmd`), runtime scopes
+(`pl.scope`), scalar access (`pl.read` / `pl.write`), and the vector / cube /
+mte op set. For a multi-card kernel, add
+[docs/pypto-coding/distributed-programming.md](docs/pypto-coding/distributed-programming.md)
+— window buffers, cross-rank data movement, and notify / wait.
 
 Existing kernels under `examples/intermediate/` are the best reference for
 single-stage patterns; `models/qwen3_14b/decode_fwd.py` shows a

--- a/docs/debug-and-tune/cube-tile-tuning.md
+++ b/docs/debug-and-tune/cube-tile-tuning.md
@@ -164,7 +164,10 @@ improve the running best beyond the noise band.
 
 - Use identical, seeded inputs for every candidate.
 - Revalidate numerical output for every shape; tiling must not change results.
-- Measure at least three times and compare medians, not the minimum.
+- Take every candidate's number from one `PYPTO_BENCH` run with the same
+  rounds / warmup, and compare the `mean=` field — repeating the whole script
+  to collect samples only re-pays for compile, input generation, and the torch
+  golden.
 - Use the chip swimlane and PMU data to confirm that the expected pipe changed.
 - Record compile failures as evidence: a `Mat buffer usage ... exceeds` error
   identifies L1, while a UB allocation error usually belongs to the vector
@@ -181,7 +184,7 @@ Before landing a tile change, confirm:
 - `Mat`, `Acc`, and `Vec` are within the exact build's constraints;
 - `Left`/`Right` percentages were not used as DSL-level targets;
 - K-contiguous transfers are not accidentally below the cache-line floor;
-- the end-to-end median improves outside normal noise;
+- the end-to-end mean wall time improves outside normal noise;
 - all numerical checks still pass; and
 - the code comment records the relevant constraint, not a transient benchmark
   story.

--- a/docs/debug-and-tune/dependency-and-scheduling.md
+++ b/docs/debug-and-tune/dependency-and-scheduling.md
@@ -135,10 +135,10 @@ Four opt-outs, from narrowest to widest. Each is an assertion the compiler
 
 | Construct | Scope of the claim | Used in this repo |
 |-----------|--------------------|-------------------|
-| `pl.at(..., no_dep_args=[t])` | One tensor, one task | `models/qwen3_14b/decode_layer_a8w8.py:669` |
+| `pl.at(..., no_dep_args=[t])` | One tensor, one task | the `gate_up_dual_proj` scope in `models/qwen3_14b/decode_layer_a8w8.py` |
 | `pl.no_dep(t)` at a call argument | One tensor, one task (`@pl.program` form) | — |
-| `pl.create_tensor(..., manual_dep=True)` | One tensor, its whole lifetime | `models/deepseek_v4_pro/moe.py:493` |
-| `with pl.manual_scope():` | Every task in the region | `models/qwen3_14b/decode_fwd.py:314` |
+| `pl.create_tensor(..., manual_dep=True)` | One tensor, its whole lifetime | `post_ffn` in `models/deepseek_v4_pro/moe.py` |
+| `with pl.manual_scope():` | Every task in the region | `_decode_layer` in `models/qwen3_14b/decode_fwd.py` |
 
 Prefer the narrowest one that expresses the claim. `manual_scope` says "I own
 the entire graph here" — inside it the runtime skips creator retention,
@@ -487,13 +487,14 @@ gate = pl.system.task_dummy(deps=[tid_a, tid_b])
 
 # 2. Delay by one hop: a real producer, plus a hop, before a non-critical
 #    consumer — so it stops resolving at the same instant as the critical one.
-#    models/deepseek_v4_flash_dspark/decode_swa.py:171
+#    decode_swa() in models/deepseek_v4_flash_dspark/decode_swa.py
 late_dep = pl.system.task_dummy(deps=[rms_tid])
 qkv_proj_rope(..., late_dep)
 
 # 3. Placeholder: a standalone entry has no fused-path producer to fence
 #    against, so an empty dummy satisfies the shared signature and is ready on
-#    submit.  models/deepseek_v4_flash_dspark/decode_indexer.py:428
+#    submit.  indexer_test() in
+#    models/deepseek_v4_flash_dspark/decode_indexer.py
 late_dep = pl.system.task_dummy(deps=[])
 ```
 
@@ -528,7 +529,7 @@ with non-deterministic indices — the signature of a race, not of a numerics
 bug. The live fix is a no-op self-copy that marks the parameter `inout` before
 the gather, so the writeback takes a WAW edge on it; `add_inout` is a
 param-level property, so one tile touch is enough. See the `kv_touch` scope in
-`models/deepseek_v4_pro/decode_sparse_attn.py:239` and its siblings in the
+`models/deepseek_v4_pro/decode_sparse_attn.py` and its siblings in the
 `_csa` variants.
 
 **A GM round-trip registered as `add_output`.** A GM tensor written by one task
@@ -544,8 +545,8 @@ sync timeout. Worth knowing when reading generated orchestration under
 comes from `deps=` and nothing else, for the tensor's whole lifetime. Removing
 one `deps=[tid]` to re-anchor a wait silently dropped the only edge ordering a
 cumsum before its consumer — no compile error, stale reads. The restored form
-is visible as the two-element dependency in
-`models/deepseek_v4_flash_dspark/moe.py:289`. Before cutting an explicit edge,
+is visible as the two-element dependency on the `dispatch_gather` scope of
+`models/deepseek_v4_flash_dspark/moe.py`. Before cutting an explicit edge,
 check whether any task it transitively orders reads a `manual_dep` tensor.
 
 **A conservative overlap that was not a dependency.** A `pl.range` loop whose

--- a/docs/debug-and-tune/index.md
+++ b/docs/debug-and-tune/index.md
@@ -43,7 +43,10 @@ source.
 - Save or replay one input set when comparing precision or performance.
 - Use the same platform, device topology, runtime configuration, and benchmark
   round count for every candidate.
-- Report the median of repeated measurements and retain the raw samples.
+- Collect repeats as rounds inside one process (`PYPTO_BENCH_ROUNDS`), not as
+  repeated invocations of the script, and report the `mean=` field of the
+  `[RUN] effective_us` line — the same convention as daily CI. Retain the raw
+  samples (`PYPTO_BENCH_RAW=1`).
 - Keep generated traces and build products under `build_output/`; do not commit
   them.
 - Remove diagnostic instrumentation and rerun validation before submitting a

--- a/docs/debug-and-tune/performance-tuning.md
+++ b/docs/debug-and-tune/performance-tuning.md
@@ -173,8 +173,8 @@ a dependency chain. Use `pl.parallel` whenever there is no carried state,
 and reserve `pl.range` for accumulators or stateful loops.
 
 ```python
-# decode_fwd.py: batch tile is independent — pl.parallel
-for b0 in pl.parallel(0, batch_padded, BATCH_TILE):
+# the batch tile is independent — pl.parallel
+for b0 in pl.parallel(0, BATCH, BATCH_TILE):
     ...
 ```
 
@@ -232,7 +232,7 @@ and vector on the right unit internally, removing the hand-off:
 
 ```python
 with pl.at(level=pl.Level.CORE_GROUP, name_hint="q_proj"):
-    for kb in pl.pipeline(0, input_proj_k_blocks, stage=2):
+    for kb in pl.pipeline(0, HIDDEN // K_STEP, stage=2):
         ...
         q_acc = pl.matmul_acc(q_acc, tile_a, tile_b)     # cube
     q_bf16 = pl.cast(q_acc, target_type=pl.BF16)         # vector
@@ -334,8 +334,8 @@ overhead is visible per iteration on the swimlane, replace the explicit
 `for ... in pl.parallel: with pl.at: ...` pattern with `pl.spmd`:
 
 ```python
-# qwen3_32b/decode.py: one AICPU dispatch fans out Q_OUT_BLOCKS blocks
-for qi in pl.spmd(Q_OUT_BLOCKS, name_hint="q_proj"):
+# qwen3_32b/decode.py: one AICPU dispatch fans out every q_proj block
+for qi in pl.spmd(HIDDEN // Q_OUT_TILE, name_hint="q_proj"):
     ...
 ```
 
@@ -416,12 +416,12 @@ loop body `stage` times for ping-pong buffering, so MTE2 (load) overlaps
 with cube/vec compute on alternating tiles.
 
 ```python
-# decode_fwd.py — stage=4 used for the largest input-proj K dim
-for kb in pl.pipeline(input_proj_k_blocks, stage=4):
+# stage=4 for the largest input-projection K dim
+for kb in pl.pipeline(HIDDEN // K_STEP, stage=4):
     ...
 
 # stage=2 is the common default
-for kb in pl.pipeline(0, hidden_blocks, stage=2):
+for kb in pl.pipeline(0, hidden // K_STEP, stage=2):
     ...
 ```
 

--- a/docs/examples/advanced.md
+++ b/docs/examples/advanced.md
@@ -59,6 +59,8 @@ validation, and sequential row handling within a core group.
 All-reduce is the only multi-device example. It uses distributed window
 buffers, remote tile loads, and notify/wait synchronization. The program is
 statically fixed at two ranks, and the CLI requires exactly two device IDs.
+[Distributed Programming](../pypto-coding/distributed-programming.md) is the
+reference for every construct it uses.
 
 Run it on two A2/A3 devices:
 

--- a/docs/pypto-coding/distributed-programming.md
+++ b/docs/pypto-coding/distributed-programming.md
@@ -1,0 +1,384 @@
+# Distributed Programming
+
+How a multi-card (L3) program is written in PyPTO-Lib: the host driver that
+launches one orchestration per rank, the HCCL **window buffers** those ranks
+address each other through, and the notify / wait protocol that orders the
+traffic.
+
+```python
+import pypto.language as pl
+import pypto.language.distributed as pld
+```
+
+`pld` is the only accepted alias for the distributed namespace, exactly as
+`pl` is for the core one.
+
+Read [PyPTO Coding Style](pypto-coding-style.md) first — everything there
+about kernel forms, `pl.at` scopes, and loops applies unchanged inside a rank.
+This page only adds what crosses the card boundary.
+
+---
+
+## 1. The shape of an L3 program
+
+Three layers, and each `@pl.jit.*` kind has exactly one job:
+
+| Layer | Decorator | Runs | Job |
+|---|---|---|---|
+| Host driver | `@pl.jit.host` | once, on the host | Allocate window buffers, loop over ranks, dispatch one orchestration per card |
+| Per-rank entry | `@pl.jit` | once per card | Ordinary orchestration — the whole model step for that rank |
+| Compute | `@pl.jit.inline` / `pl.at` / `pl.spmd` | on the cores | Kernels, including the comm ops |
+
+The host driver is what makes it distributed:
+
+```python
+@pl.jit.host
+def l3_allreduce(
+    inputs: pl.Tensor[[N_RANKS, 1, SIZE], pl.FP32],
+    outputs: pl.Out[pl.Tensor[[N_RANKS, 1, SIZE], pl.FP32]],
+):
+    data_buf = pld.alloc_window_buffer([1, SIZE], dtype=pl.FP32)
+    signal_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
+
+    for r in pl.range(pld.world_size()):
+        data = pld.window(data_buf, [1, SIZE], dtype=pl.FP32)
+        signal = pld.window(signal_buf, [N_RANKS, 1], dtype=pl.INT32)
+        allreduce(inputs[r], outputs[r], data, signal, r, device=r)
+```
+
+Three rules follow from that loop:
+
+- **Every host-driver tensor carries a leading rank axis** and is sliced
+  `x[r]` at the call. The per-rank entry sees an ordinary `[T, D]` tensor.
+- **`device=r` binds the call to a card.** It is a call-site kwarg on the
+  per-rank entry, not part of its signature.
+- **`pld.world_size()` is the trip count**, so one source serves EP2 / EP4 /
+  EP8 without an edit.
+
+A runnable version of exactly this is
+[`examples/advanced/allreduce.py`](../../examples/advanced/allreduce.py).
+
+---
+
+## 2. Window buffers and `DistributedTensor`
+
+A **window buffer** is a slot of HCCL symmetric memory: one
+`alloc_window_buffer` call reserves the *same* region on *every* rank. That
+symmetry is what makes `peer + offsets` addressing meaningful — an offset
+names the same place in every card's copy.
+
+Allocation is two-phase, and both phases live in the host driver:
+
+| Call | Where | What it does |
+|---|---|---|
+| `pld.alloc_window_buffer(shape, dtype=...)` | HOST orchestration **only** (`@pl.jit.host`) | Reserves the per-rank region. Rejected inside InCore. |
+| `pld.window(buf, shape, dtype=...)` | Same host driver, per rank | Types the region as a `DistributedTensor` view |
+
+Use the **shape + dtype** overload so the shape, element type, and byte size
+cannot drift apart. The canonical byte form
+(`alloc_window_buffer(n_bytes)`) is the escape hatch for one buffer backing
+several `window()` views of different shapes:
+
+```python
+# shape + dtype: the window() call below repeats the same two facts
+recv_x_buf = pld.alloc_window_buffer([N_LOCAL * RECV_MAX, D], dtype=pl.INT8)
+# byte form: only when one buffer backs several differently-shaped views
+scratch_buf = pld.alloc_window_buffer(N_LOCAL * RECV_MAX * D)
+```
+
+The view is passed into the rank kernel with a `pld.DistributedTensor`
+annotation, which mirrors `pl.Tensor`:
+
+```python
+@pl.jit.inline
+def dispatch(
+    x_norm_i8: pl.Tensor[[T, D], pl.INT8],                          # local
+    recv_x: pld.DistributedTensor[[N_LOCAL * RECV_MAX, D], pl.INT8],  # window
+    arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],           # signal
+    my_rank: pl.Scalar[pl.INT32],
+):
+```
+
+Two properties worth internalizing:
+
+- **Locally a window is just a tensor.** `recv_x[r0 : r0 + 1, :]`,
+  `pl.read(recv_meta, [src, e])`, and `pl.load` all work on it, and the
+  ordinary RAW edges apply to this rank's own writes. Only the *remote* side
+  needs a `pld` op.
+- **The buffer starts zeroed.** That is what lets a counter window be used as
+  `AtomicAdd` + `Ge(1)` without an init pass.
+
+### Lanes: make concurrent writers disjoint by construction
+
+Nothing serializes two peers writing the same window rows. Give every
+`(source, expert)` — or whatever the producing pair is — its own row range,
+computed the same way on both sides:
+
+```python
+# lane (loc_e, my_rank, slot) on peer=dst
+e_lane_base = loc_e * RECV_MAX + my_rank * MAX_PER_SRC
+row = e_lane_base + slot
+```
+
+A window is not a queue: there is no allocator, no bounds check against
+another rank, and a lane overrun silently corrupts a neighbour's rows.
+
+---
+
+## 3. Moving data
+
+Five ops, split by *who holds the data* and *which direction it goes*:
+
+| Op | Source | Destination | Use for |
+|---|---|---|---|
+| `pld.tensor.put(dst, peer, src, ...)` | local GM tensor | peer's window | Bulk rows already in GM — the default push |
+| `pld.tensor.get(dst, peer, src, ...)` | peer's window | local GM tensor | Bulk pull |
+| `pld.tile.remote_store(tile, target, peer, offsets)` | a tile on chip | peer's window | A value just computed, without a GM round-trip |
+| `pld.tile.remote_load(target, peer, offsets, shape)` | peer's window | a tile on chip | Pull straight into the consuming kernel |
+| `pld.tensor.remote_store(src, target, peer, offsets)` | local GM tensor | peer's window | Tensor-level form of the above |
+
+All of them take `peer` as a **global rank index**. For a sub-group (a TP
+group inside a larger world) address it as `group_base + local_index`.
+
+```python
+pld.tensor.put(                                   # GM -> peer GM, one token row
+    dst=recv_x, peer=dst, src=x_norm_i8,
+    dst_offsets=[row, 0], src_offsets=[t, 0], shape=[1, D],
+)
+pld.tile.remote_store(aux_tile, target=recv_aux, peer=dst, offsets=[row, 0])
+recv = pld.tile.remote_load(data, peer=peer, offsets=[0, 0], shape=[1, SIZE])
+```
+
+`dst_offsets` / `src_offsets` / `shape` are all-or-nothing: pass all three to
+narrow the transfer, or none to move the whole slice.
+
+**Combine instead of overwrite** with `atomic=pld.AtomicType.Add`, available
+on `put` and both `remote_store` forms. A BF16 destination is A2/A3 only; on
+A5 use an FP32 window and cast after the reduction.
+
+**Large transfers** need staging control. `put` / `get` move through a VEC
+staging tile, so a transfer wider than UB must be chunked:
+`chunk_rows=` / `chunk_cols=` size that tile and let the transfer
+auto-chunk through it, and `pipeline=True` (both chunk args required)
+double-buffers so a chunk is on the wire while the next one loads.
+
+```python
+pld.tensor.put(
+    dst=hidden_window, peer=peer, src=local_hidden_tail,
+    dst_offsets=[dst_row, 0], src_offsets=[src_row, 0], shape=[TAIL_ROWS, D],
+    chunk_rows=ROW_TILE, chunk_cols=D, pipeline=True,
+)
+```
+
+---
+
+## 4. Synchronization
+
+Data movement carries **no ordering of its own**. Every cross-rank
+dependency is a signal window plus a notify / wait pair.
+
+```python
+pld.system.notify(target=arrived, peer=dst, offsets=[my_rank, 0],
+                  value=1, op=pld.NotifyOp.AtomicAdd)   # bump my slot on peer
+pld.system.wait(signal=arrived, offsets=[src, 0],
+                expected=epoch, cmp=pld.WaitCmp.Ge)     # block on my local slot
+```
+
+Note the asymmetry: **`notify` writes a remote slot, `wait` reads the local
+one.** The conventional layout is a `[N_RANKS, 1]` INT32 window where row
+`s` is "what source `s` has told me".
+
+| Enum | Values | Pick |
+|---|---|---|
+| `pld.NotifyOp` | `AtomicAdd`, `Set` | `AtomicAdd` — see below |
+| `pld.WaitCmp` | `Ge`, `Eq` | `Ge` — pairs with `AtomicAdd` |
+
+### Use monotonic counters with an epoch, not set-and-clear
+
+A signal slot that is set to 1 and cleared has to be cleared by someone, and
+a late notify from the previous call lands in the next call's slot. Instead,
+never reset: each call bumps the counter by a fixed amount and waits for a
+threshold that grows with the call index.
+
+```python
+# 1-based call id; the window is monotonic so waits use `>= epoch`
+def dispatch(..., moe_epoch: pl.Scalar[pl.INT32]):
+    ...
+    pld.system.notify(target=arrived, peer=dst, offsets=[my_rank, 0],
+                      value=1, op=pld.NotifyOp.AtomicAdd)
+    pld.system.wait(signal=arrived, offsets=[src, 0],
+                    expected=moe_epoch, cmp=pld.WaitCmp.Ge)
+```
+
+`AtomicAdd` is order-independent, so a notify that arrives early or late
+cannot clobber anything — the count only has to *reach* the threshold. This
+is what lets one comm kernel be called once per layer with nothing to reset
+between layers.
+
+When the notify is folded into a fanned-out push (below), every block
+signals, so the threshold scales with it: `expected = epoch * n_blocks`.
+
+### One signal window per phase
+
+Two phases that can overlap need two windows. In the MoE dispatch the
+route-count metadata rides `arrived` and the bulk payload rides
+`data_arrived`, so a rank can start its cumsum on the metadata while the
+payload is still in flight. Sharing one window would serialize them.
+
+### Reusing a window across epochs needs a second counter
+
+A monotonic `ready` counter says "my data is there". It does *not* say the
+peer is finished reading the previous epoch's data out of that same region.
+Overwriting a window in a loop takes a **two-counter** protocol:
+
+```python
+epoch_value = pl.cast(comm_epoch + 1, pl.INT32)
+
+for peer in pl.range(CP_SIZE):                 # 1. peers read epoch n-1 out
+    if peer != my_rank:
+        pld.system.wait(signal=consumed, offsets=[peer, 0],
+                        expected=comm_epoch, cmp=pld.WaitCmp.Ge)
+
+for peer in pl.range(CP_SIZE):                 # 2. publish epoch n, announce
+    pld.tensor.put(dst=hidden_window, peer=peer, src=local_tail, ...)
+for peer in pl.range(CP_SIZE):
+    if peer != my_rank:
+        pld.system.notify(target=ready, peer=peer, offsets=[my_rank, 0],
+                          value=1, op=pld.NotifyOp.AtomicAdd)
+
+for seg in pl.range(NUM_SEGMENTS):             # 3. consume, then release
+    if owner != my_rank:
+        pld.system.wait(signal=ready, offsets=[owner, 0],
+                        expected=epoch_value, cmp=pld.WaitCmp.Ge)
+    ...                                        # read hidden_window locally
+for peer in pl.range(CP_SIZE):
+    if peer != my_rank:
+        pld.system.notify(target=consumed, peer=peer, offsets=[my_rank, 0],
+                          value=1, op=pld.NotifyOp.AtomicAdd)
+```
+
+The context-parallel prefill exchange in
+[`models/deepseek_v4_flash_mtp/prefill_cp_exchange.py`](../../models/deepseek_v4_flash_mtp/prefill_cp_exchange.py)
+is this protocol in full.
+
+### `defer_wait` — a wait that does not hold a core
+
+`pld.system.wait` spins on the device: the task occupies its core group until
+the condition holds. `pld.system.defer_wait(signal, offsets, expected,
+cmp=pld.WaitCmp.Ge)` instead leaves the task's TaskId incomplete and lets the
+core go. It never resumes the kernel, so everything after the condition must
+live in a dependent task.
+
+---
+
+## 5. Scheduling rules
+
+Comm is ordinary task-graph work, and the rules in
+[Dependencies and Scheduling](../debug-and-tune/dependency-and-scheduling.md)
+apply. Four that are specific to it:
+
+**Comm ops need an InCore scope.** `put` / `remote_store` / `notify` / `wait`
+must sit inside a `pl.at(level=pl.Level.CORE_GROUP, ...)` or a `pl.spmd`
+body. In orchestration the callee cannot be resolved.
+
+**Anchor a spinning wait.** A wait scope whose arguments create no dependency
+edge is ready at submit, so the scheduler dispatches it immediately and it
+spins holding a core group for the whole phase. Give it a `deps=` on the
+matching push, and read something the producer wrote so the edge is real:
+
+```python
+with pl.at(level=pl.Level.CORE_GROUP, name_hint="dispatch_wait",
+           deps=[_push_tid]) as _wait_tid:
+    _idx_anchor = pl.read(indices, [0, 0])      # anchor, not data
+    for src in pl.range(N_RANKS):
+        ...
+```
+
+**Keep the wait off the early-dispatch chain.** A speculatively dispatched
+wait reserves cores the push itself needs. Put `allow_early_resolve=False` on
+the scope that must not pre-empt the traffic, and split "notify" from "wait"
+so the notify can ride inside the push scope while the wait is a separate,
+`deps=`-anchored task.
+
+**Your own writes ride local edges.** A rank's `peer == my_rank` put is an
+ordinary local write to the window tensor, so the RAW edge already orders it
+against a later local read. The cross-rank wait covers only the *other*
+ranks' writes.
+
+Pass a TaskId across an inline boundary with `pl.Scalar[pl.TASK_ID]` when a
+later stage must fence against an earlier stage's traffic.
+
+### Visibility: `put` and `remote_store` are not equivalent
+
+A `notify` issued after a `pld.tensor.put` in program order on the same core
+is ordered behind it. `remote_store` is **non-draining**, and a local
+`PIPE_ALL` barrier is not a cross-rank DDR fence (`ptoas#872`) — so a peer
+that observed the notify has not necessarily observed the `remote_store`
+payload. Where the handshake must cover the payload, move it with `put`, or
+keep the notify in the same block that issued the stores and accept the
+program-order guarantee only.
+
+---
+
+## 6. Collectives
+
+`pld.tensor` also exposes `allgather`, `all_to_all`, `all_to_all_v`,
+`allreduce`, `reduce_scatter`, `broadcast`, and `barrier`, each taking a
+target window plus a signal window. **No kernel in this repository uses
+them**: every model builds its exchange from `put` / `remote_store` +
+notify / wait, because the pattern is fused into the surrounding compute
+(the notify rides inside the push scope, the gather is the consumer kernel)
+rather than standing alone as a collective. Reach for a collective only when
+the exchange really is a standalone whole-window operation, and verify its
+behaviour on the target before building on it.
+
+---
+
+## 7. Running and validating
+
+The harness compiles an L3 program when `compile_cfg` carries a
+`DistributedConfig`:
+
+```python
+from pypto.ir.distributed_compiled_program import DistributedConfig
+
+result = run_jit(
+    fn=l3_moe,                                  # the @pl.jit.host driver
+    specs=build_tensor_specs(),
+    golden_fn=golden_moe,
+    compile_cfg=dict(
+        distributed_config=DistributedConfig(device_ids=device_ids),
+    ),
+    runtime_cfg=dict(platform=args.platform),
+)
+```
+
+- **CLI**: distributed entries take `-d 0,1,...` (a comma-separated list),
+  not a single integer, and usually an `--ep` / `--tp` degree.
+- **CI**: declare the card count with a `# ci: devices=N` marker near the top
+  of the file; the real-NPU job borrows that many cards. See
+  [Platforms and Devices](../get-started/platforms.md).
+- **Specs**: every tensor keeps its leading rank axis, so a `TensorSpec` is
+  `[N_RANKS, ...]`. `resident="stacked"` uploads shard `i` to card `i` once
+  instead of per dispatch — see [`golden/spec.py`](../../golden/spec.py).
+- **Golden**: the reference is computed on the host over all ranks at once.
+  Write it so each rank's slice depends only on that rank's inputs where the
+  algorithm allows, which keeps the reference independent of the device's
+  packing order.
+
+Per-rank timing, start skew, and the fastest-rank convention are in
+[Performance Tuning](../debug-and-tune/performance-tuning.md#multi-card-l3-output).
+
+---
+
+## See also
+
+- [PyPTO Coding Style](pypto-coding-style.md) — kernel forms, scopes, loops.
+- [Dependencies and Scheduling](../debug-and-tune/dependency-and-scheduling.md)
+  — task edges, early dispatch, and why an unanchored wait costs a core.
+- [Ring Heap and Scope Stats](../debug-and-tune/ring-heap-and-scope-stats.md)
+  — the ring resources an L3 program's intermediates land in.
+- [`examples/advanced/allreduce.py`](../../examples/advanced/allreduce.py) —
+  the smallest complete L3 program.
+- [DeepSeek V4-Flash MTP](../models/deepseek_v4_flash_mtp.md) — the MoE
+  dispatch / combine and LM-head exchanges this page is drawn from.

--- a/docs/pypto-coding/index.md
+++ b/docs/pypto-coding/index.md
@@ -5,9 +5,13 @@ Use this chapter when writing or reviewing PyPTO-Lib kernels.
 - [PyPTO Coding Style](pypto-coding-style.md) is the canonical reference for
   kernel forms, scopes, loops, tensor operations, tiling, naming, and source
   layout.
+- [Distributed Programming](distributed-programming.md) covers multi-card (L3)
+  kernels: the host driver, HCCL window buffers, cross-rank data movement, and
+  the notify / wait protocols that order it.
 - [CCE Extern Kernel](cce-extern-kernel.md) covers hand-written mixed cube and
   vector kernels called through `pl.jit.extern`, including runtime, ABI,
   synchronization, and validation constraints.
 
-Start with the coding style for every kernel change. Use the extern-kernel page
-only when the implementation crosses from PyPTO into hand-written CCE code.
+Start with the coding style for every kernel change. Add the distributed page
+when the kernel spans more than one card. Use the extern-kernel page only when
+the implementation crosses from PyPTO into hand-written CCE code.

--- a/docs/pypto-coding/pypto-coding-style.md
+++ b/docs/pypto-coding/pypto-coding-style.md
@@ -70,7 +70,7 @@ class Qwen3Decode:
     @pl.function(type=pl.FunctionType.Opaque)
     def qwen3_decode(self, hidden_states: pl.Tensor[..., pl.BF16], ...):
         # orchestration code (loops, tensor allocation)
-        for b0 in pl.parallel(0, batch_padded, BATCH_TILE):
+        for b0 in pl.parallel(0, BATCH, BATCH_TILE):
             with pl.at(level=pl.Level.CORE_GROUP, name_hint="rmsnorm"):
                 # InCore region — vector / cube / mte ops
                 ...
@@ -137,7 +137,7 @@ sub-kernels.
 - **`pl.split(pl.SplitMode...)`** — split the region in half so the cube and
   vector units ping-pong on the two halves (cube on one half while vec runs
   the epilogue on the other). It applies **only to a mixed cube + vector
-  region** (§6); a pure-cube or pure-vector region has nothing to ping-pong.
+  region** (§7); a pure-cube or pure-vector region has nothing to ping-pong.
   The mode picks the axis:
   - `pl.SplitMode.NONE` — the default; no split.
   - `pl.SplitMode.UP_DOWN` — split vertically (rows / height halved).
@@ -150,7 +150,7 @@ sub-kernels.
 
 ```python
 # split form on a mixed region whose FP32 epilogue would blow the UB budget
-for ob in pl.spmd(N_BLOCKS, name_hint="gate_up_silu",
+for ob in pl.spmd(INTER // INTER_TILE, name_hint="gate_up_silu",
                   optimizations=[pl.split(pl.SplitMode.UP_DOWN)]):
     ...
 ```
@@ -160,7 +160,7 @@ for ob in pl.spmd(N_BLOCKS, name_hint="gate_up_silu",
 ## 2. Vector Ops
 
 Run on the vector unit, inside an InCore region (a `pl.at` block or a
-`pl.spmd` body — see §5). Vector ops are the standard tools for the cast /
+`pl.spmd` body — see §6). Vector ops are the standard tools for the cast /
 activation / norm epilogue around a matmul, and for small standalone
 reductions.
 
@@ -313,7 +313,7 @@ gathered = pl.gather(local_scores, dim=-1, index=topk_idx_tile)   # [B, K]
 ## 3. Cube Ops
 
 Matrix multiply primitives. They run on the cube unit, inside an InCore
-region (a `pl.at` block or a `pl.spmd` body — see §5), and produce FP32
+region (a `pl.at` block or a `pl.spmd` body — see §6), and produce FP32
 results by default (`out_dtype` may override).
 
 ### `pl.matmul(lhs, rhs, *, out_dtype=None, a_trans=False, b_trans=False)`
@@ -331,13 +331,12 @@ out = pl.matmul(tile_a, tile_b, out_dtype=pl.FP32, b_trans=True)
 
 Fused multiply-accumulate: `acc += lhs @ rhs`. Use this inside a K-loop to
 keep the partial sum on chip. The first iteration uses `pl.matmul`,
-subsequent iterations use `pl.matmul_acc`. The `acc` destination is
-allocated outside `pl.at` (see §4):
+subsequent iterations use `pl.matmul_acc` — the accumulator is the value
+`pl.matmul` returned, so nothing is allocated for it:
 
 ```python
-acc = pl.create_tensor([M, N], dtype=pl.FP32)
 with pl.at(level=pl.Level.CORE_GROUP, name_hint="kproj"):
-    for kb in pl.pipeline(0, K_BLOCKS, stage=2):
+    for kb in pl.pipeline(0, K // K_STEP, stage=2):
         k0 = kb * K_STEP
         tile_a = pl.slice(a, [M, K_STEP], [m0, k0])
         tile_b = pl.slice(b, [K_STEP, N], [k0, n0])
@@ -384,11 +383,11 @@ assembly, no `create_tensor` is needed.
 
 ```python
 # Multi-stage assembly: q_proj is built by per-tile assembles
-q_proj = pl.create_tensor([batch_padded, q_hidden], dtype=pl.BF16)
-for q0 in pl.parallel(0, q_hidden, Q_OUT_STEP):
+q_proj = pl.create_tensor([BATCH, Q_HIDDEN], dtype=pl.BF16)
+for q0 in pl.parallel(0, Q_HIDDEN, Q_OUT_STEP):
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="q_proj"):
         ...
-        q_proj = pl.assemble(q_proj, q_acc, [b0, q0])
+        q_proj = pl.assemble(q_proj, q_acc, [0, q0])
 ```
 
 ### `pl.slice` / `pl.assemble` — load/store at the `pl.at` boundary
@@ -430,9 +429,76 @@ flat = pl.reshape(q_chunk, [BATCH_TILE * H, D])
 
 ---
 
-## 5. Loops: `pl.range`, `pl.parallel`, `pl.pipeline`, `pl.spmd`
+## 5. Scalars: `pl.read` / `pl.write`
 
-PyPTO has four loop constructs. The choice between them is **semantic** —
+Vector and cube ops work on whole tiles. When the kernel needs **one value** —
+a routing index, a runtime row count, a slot cursor — read and write it
+directly.
+
+### `pl.read(src, offset)` / `pl.write(dst, offset, value)`
+
+`pl.read` returns a `pl.Scalar`; `pl.write` stores one. Both dispatch on the
+source kind: `src` / `dst` may be a **tensor** (GM) or a **tile** (UB), and
+`offset` is either an index list (one entry per dimension) or a single flat
+index. The explicit forms are `pl.tensor.read` / `pl.tensor.write` and
+`pl.tile.read` / `pl.tile.write`.
+
+```python
+eid = pl.read(indices, [t, k])                     # GM tensor element -> Scalar
+pl.write(recv_count_out, [e, 0], acc)              # Scalar -> GM tensor element
+pl.tile.write(meta_tile, [0, e], cursor[e])        # Scalar -> tile lane
+```
+
+A scalar read of a **tensor** is also legal in orchestration, and that is how
+a device-computed count becomes a host-side loop bound:
+
+```python
+for local_i in pl.parallel(N_LOCAL_EXPERTS):
+    n_rows = pl.read(recv_expert_count, [local_i, 0])   # a kernel wrote it
+```
+
+Cast to `pl.INDEX` before using a read value as an offset or a loop bound —
+the value comes back in its stored dtype (typically `INT32`):
+
+```python
+n = pl.cast(pl.read(recv_meta_local, [src, e]), pl.INDEX)
+for slot in pl.range(n):
+    ...
+```
+
+Keep scalar loops small. Each `pl.read` is a real memory access, so a
+per-element scalar loop over a tile-sized region is orders of magnitude
+slower than the vector op that does the same thing.
+
+### On-core scalar arrays: `pl.array`
+
+`pl.array.create(extent, dtype)` allocates a small array on the core's own
+stack — integer, BOOL, or `pl.TASK_ID` elements, and `extent` must be a
+compile-time constant. Index it with ordinary subscripts. Use it for
+bookkeeping that must not round-trip through GM: cursors, per-destination
+counters, or a list of TaskIds to fan a `deps=` in on.
+
+```python
+cursor = pl.array.create(N_RANKS * N_LOCAL, pl.INT32)
+for d in pl.range(N_RANKS):
+    for e in pl.range(N_LOCAL):
+        cursor[d * N_LOCAL + e] = 0
+...
+cursor[dst * N_LOCAL + loc_e] = cursor[dst * N_LOCAL + loc_e] + 1
+
+proj_tids = pl.array.create(O_GROUPS, pl.TASK_ID)   # orchestration: fan-in
+```
+
+Note the asymmetry with `pl.create_tensor`: an array is core-local and
+private to the block that created it, while a tensor created in orchestration
+is GM and shared. A `pl.create_tensor` **inside** a `pl.at` block yields a
+tile, not a GM tensor.
+
+---
+
+## 6. Loops: `pl.range`, `pl.unroll`, `pl.parallel`, `pl.pipeline`, `pl.spmd`
+
+PyPTO has five loop constructs. The choice between them is **semantic** —
 it tells the compiler what scheduling and codegen are valid.
 
 Each construct has a fixed placement relative to `pl.at`:
@@ -440,6 +506,7 @@ Each construct has a fixed placement relative to `pl.at`:
 | Construct | Outside `pl.at` (orchestration) | Inside `pl.at` (InCore) |
 |-----------|:-:|:-:|
 | `pl.range` | yes | yes |
+| `pl.unroll` | yes | yes |
 | `pl.parallel` | yes | no |
 | `pl.pipeline` | no | yes |
 | `pl.spmd` | yes (body is implicitly InCore) | no |
@@ -447,11 +514,12 @@ Each construct has a fixed placement relative to `pl.at`:
 `pl.parallel` distributes iterations across cores, so it must sit in
 orchestration. `pl.pipeline` software-pipelines stages within a single
 InCore region, so it must sit inside `pl.at`. `pl.range` is a plain
-sequential loop and is legal in either place. `pl.spmd` is a parallel SPMD
-loop that bundles its own InCore region — see below.
+sequential loop and is legal in either place; `pl.unroll` is the same loop
+unrolled at compile time. `pl.spmd` is a parallel SPMD loop that bundles its
+own InCore region — see below.
 
-`pl.range`, `pl.parallel`, and `pl.pipeline` share the same positional-arg
-shape, mirroring Python's `range`:
+`pl.range`, `pl.unroll`, `pl.parallel`, and `pl.pipeline` share the same
+positional-arg shape, mirroring Python's `range`:
 
 ```text
 pl.<loop>(stop)
@@ -466,8 +534,8 @@ Each argument may be either a Python `int` or a `pl.Scalar`.
 Iterations execute in strict order. Loop-carried dependencies are allowed.
 
 ```python
-for kb in pl.range(HIDDEN_BLOCKS):              # range [0, HIDDEN_BLOCKS)
-for kb in pl.range(1, hidden_blocks):           # range [1, hidden_blocks)
+for kb in pl.range(HIDDEN // K_STEP):           # range [0, HIDDEN // K_STEP)
+for kb in pl.range(1, hidden // K_STEP):        # range [1, hidden // K_STEP)
 for k0 in pl.range(0, HIDDEN, K_STEP):          # start, stop, step
 ```
 
@@ -479,6 +547,23 @@ for i, (acc,) in pl.range(N, init_values=(zero,)):
     acc = pl.add(acc, x[i])
 ```
 
+### `pl.unroll` — sequential, unrolled at compile time
+
+Same semantics as `pl.range` at run time; the parser emits `ForKind.Unroll`
+instead of `ForKind.Sequential`, so the body is replicated per iteration
+rather than looped. Use it for a short trip count whose body is small — the
+loop overhead and the per-iteration index math disappear — and keep
+`pl.range` for anything long enough that unrolling would bloat the kernel.
+
+`start`, `stop` and `step` must be compile-time constant integers, and
+`init_values=` is rejected — carry state with `pl.range` instead. The parser
+rejects both cases outright rather than failing later in the unroll pass.
+
+```python
+for kb in pl.unroll(1, K // K_STEP):          # replicated, no loop overhead
+    ...
+```
+
 ### `pl.parallel` — independent iterations
 
 Iterations are guaranteed independent — the compiler may split, reorder, or
@@ -487,7 +572,7 @@ schedule them across cores. Same arg shape and `init_values` support as
 
 ```python
 for b in pl.parallel(BATCH):                          # short form: extent only
-for b0 in pl.parallel(0, batch_padded, BATCH_TILE):   # start, stop, step
+for b0 in pl.parallel(0, BATCH, BATCH_TILE):          # start, stop, step
 ```
 
 ### `pl.pipeline` — software-pipelined sequential
@@ -500,9 +585,9 @@ ping-pong buffering; the outer trip count advances in strides of
 is not divisible by `stage`. Typical values are 2 or 4.
 
 ```python
-for kb in pl.pipeline(HIDDEN_BLOCKS, stage=2):
-for kb in pl.pipeline(2, HIDDEN_BLOCKS, stage=2):     # start at 2
-for kb in pl.pipeline(0, input_proj_k_blocks, stage=4):
+for kb in pl.pipeline(HIDDEN // K_STEP, stage=2):
+for kb in pl.pipeline(2, HIDDEN // K_STEP, stage=2):  # start at 2
+for kb in pl.pipeline(0, hidden // K_STEP, stage=4):
 ```
 
 `init_values=` is supported, with the same `(idx, (state...))` unpacking as
@@ -521,7 +606,7 @@ the iteration variable binds the per-block index (equivalent to
 `pl.tile.get_block_idx()`). No surrounding `pl.at` is needed or allowed:
 
 ```python
-for ob0 in pl.spmd(Q_SPMD_BLOCKS, name_hint="q_proj"):
+for ob0 in pl.spmd(Q_HIDDEN // (Q_OUT_STEP * 4), name_hint="q_proj"):
     # implicit InCore region — vector / cube / mte ops here
     for ob in pl.range(ob0 * 4, (ob0 + 1) * 4):
         q0 = ob * Q_OUT_STEP
@@ -545,7 +630,7 @@ Keyword args:
 
 ---
 
-## 6. Mixed Cube + Vector Within One `pl.at`
+## 7. Mixed Cube + Vector Within One `pl.at`
 
 A single `pl.at` region can contain both cube (matmul) and vector (cast,
 add, row_sum, …) ops. The compiler assigns each op to the appropriate unit
@@ -553,22 +638,19 @@ and pipelines cube/vec where possible. This is the standard pattern for a
 projection with cast/residual epilogue:
 
 ```python
-q_proj = pl.create_tensor([batch_padded, hidden], dtype=pl.BF16)
-for q0 in pl.parallel(0, hidden, Q_OUT_STEP):
-    q_acc = pl.create_tensor([BATCH_TILE, Q_OUT_STEP], dtype=pl.FP32)
+q_proj = pl.create_tensor([BATCH, Q_HIDDEN], dtype=pl.BF16)
+for q0 in pl.parallel(0, Q_HIDDEN, Q_OUT_STEP):
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="q_proj"):
-        for kb in pl.pipeline(0, input_proj_k_blocks, stage=2):
-            k0 = kb * INPUT_PROJ_K_STEP
-            tile_a = pl.slice(normed_tile,
-                              [BATCH_TILE, INPUT_PROJ_K_STEP], [0, k0])  # vec source
-            tile_b = pl.slice(wq,
-                              [INPUT_PROJ_K_STEP, Q_OUT_STEP], [k0, q0])  # cube right
+        for kb in pl.pipeline(0, HIDDEN // K_STEP, stage=2):
+            k0 = kb * K_STEP
+            tile_a = pl.slice(normed, [BATCH, K_STEP], [0, k0])    # vec src
+            tile_b = pl.slice(wq, [K_STEP, Q_OUT_STEP], [k0, q0])  # cube right
             if kb == 0:
                 q_acc = pl.matmul(tile_a, tile_b)              # cube
             else:
                 q_acc = pl.matmul_acc(q_acc, tile_a, tile_b)   # cube
         q_bf16 = pl.cast(q_acc, target_type=pl.BF16)           # vector
-        q_proj = pl.assemble(q_proj, q_bf16, [b0, q0])         # mte
+        q_proj = pl.assemble(q_proj, q_bf16, [0, q0])          # mte
 ```
 
 Larger fused regions (RMSNorm + projection + residual) follow the same
@@ -577,7 +659,70 @@ shape: a `pl.pipeline` matmul reduction, then the vector epilogue, then
 
 ---
 
-## 7. Dynamic Shapes (dynamic B / S)
+## 8. Runtime Scopes: `pl.scope`
+
+A **runtime scope** (`PTO2_SCOPE`) is an orchestration-level region that
+bounds two things at once: automatic dependency tracking, and the heap ring
+that the intermediates submitted inside it are allocated from. The runtime
+wraps an implicit top-level scope around every program, so writing scopes is
+a **tuning** decision, never a correctness requirement.
+
+### Automatic placement is the default
+
+With the default `auto_scope=True` the compiler inserts an AUTO scope around
+the function body and around **each `for` / `if` body**, including inside
+every `@pl.jit.inline` callee it splices in. That is convenient and blind: a
+model nested six levels deep puts everything past depth 3 on one ring, which
+then carries the whole program.
+
+### Placing them by hand
+
+Turn the automatic ones off on the enclosing function, then write the scopes:
+
+```python
+@pl.jit(auto_scope=False)            # also @pl.jit.inline(auto_scope=False)
+def decode_fwd(...):
+    with pl.scope():                 # one attention stage
+        attention_swa(...)
+    with pl.scope():                 # one MoE stage
+        moe(...)
+```
+
+Rules:
+
+- `pl.scope()` is legal only in orchestration code, never inside `pl.at`.
+- AUTO mode — plain `pl.scope()` — requires `auto_scope=False` on the
+  enclosing function. In the default mode the compiler owns AUTO placement
+  and a hand-written AUTO scope is rejected.
+- Only `@pl.jit`, `@pl.jit.inline`, `@pl.jit.host`, and `@pl.function` take
+  `auto_scope=`; `@pl.jit.incore` / `@pl.jit.opaque` outline into their own
+  kernels and reject it.
+- Nesting deeper than three levels buys nothing — ring 3 is a clamp.
+- A scope is a scheduling boundary too: the runtime drains its bookkeeping at
+  `scope_end`, so a scope around a handful of tasks costs more than it
+  reclaims.
+
+Ring selection, sizing, and how to measure a scope's peak occupancy are in
+[Ring Heap and Scope Stats](../debug-and-tune/ring-heap-and-scope-stats.md).
+
+### `MANUAL` is a dependency choice, not a ring choice
+
+`pl.scope(mode=pl.ScopeMode.MANUAL)` — spelled `pl.manual_scope()` — turns
+**off** the runtime's automatic dependency tracking for the whole region:
+inside it every ordering edge is one you declared with `deps=`. It is legal
+in either `auto_scope` mode, and an AUTO scope may not nest inside a MANUAL
+one.
+
+Prefer the narrowest opt-out that expresses the claim —
+`pl.create_tensor(..., manual_dep=True)` for one tensor,
+`pl.at(..., no_dep_args=[t])` for one tensor in one task — and note that
+`deps=` composes with automatic tracking, so it works in an AUTO scope
+without any opt-out at all. See
+[Dependencies and Scheduling](../debug-and-tune/dependency-and-scheduling.md).
+
+---
+
+## 9. Dynamic Shapes (dynamic B / S)
 
 `@pl.jit` / `@pl.jit.inline` kernels support dynamic batch (B) and sequence
 (S) dimensions via `pl.dynamic` symbolic dims — a single kernel can serve both
@@ -646,11 +791,12 @@ def compressor_test(x: pl.Tensor[[B_DYN, S_DYN, D], pl.BF16], ...):
 
 ### Dynamic loop bounds
 
-All four loop constructs accept dynamic bounds. `pl.spmd` accepts a single
-Scalar **or a composite dynamic expression** (`b_dim * HEAD_DIM // HEAD_TILE`)
-as the block count. When an SPMD loop folds several dims into one, **place the
-dynamic dim outermost** so every `//` and `%` divides by a compile-time
-constant — otherwise the hot loop needs a runtime division:
+`pl.range`, `pl.parallel`, `pl.pipeline` and `pl.spmd` accept dynamic bounds
+(`pl.unroll` does not — it unrolls a compile-time count). `pl.spmd` accepts a
+single Scalar **or a composite dynamic expression** (`b_dim * HEAD_DIM //
+HEAD_TILE`) as the block count. When an SPMD loop folds several dims into
+one, **place the dynamic dim outermost** so every `//` and `%` divides by a
+compile-time constant — otherwise the hot loop needs a runtime division:
 
 ```python
 BLOCKS_PER_OUTER = HEAD_COUNT * (D // D_CHUNK)        # compile-time
@@ -697,7 +843,7 @@ the old mode-specific wrapper is deleted.
 
 ---
 
-## 8. Naming and comment conventions
+## 10. Naming and comment conventions
 
 ### Name tile sizes, inline block counts
 

--- a/docs/run-and-validate/compile-runtime-workflow.md
+++ b/docs/run-and-validate/compile-runtime-workflow.md
@@ -327,13 +327,18 @@ for the output format, the multi-card breakdown, and what the number means.
 `golden.validation.validate_golden` compares each device output against
 the golden using `torch.allclose(rtol, atol)` by default. Override
 per-output with the `compare_fn={"out_name": custom_callable}` argument.
-`golden.validation` ships three ready-made comparators:
+`golden.validation` ships four ready-made gates:
 
 | Comparator | Use case |
 |------------|----------|
 | `topk_pair_compare(vals_name)` | Top-k index outputs whose ordering is implementation-dependent — checks the paired value tensor matches after sort, tolerating legal tie-break swaps. |
 | `ratio_allclose(atol, rtol, max_error_ratio=0.005)` | Quantized kernels where a small outlier fraction may exceed per-point `atol + rtol·|expected|`. NaN/Inf always fail. |
 | `ratio_reldiff(diff_thd, pct_thd, max_diff_hd=inf)` | cann-recipes-infer-style relative-diff check: per-point `rdiff > diff_thd` bad-point ratio capped by `pct_thd`, with optional single-point `max_diff_hd` cap. |
+| `mapped_pool_ratio_allclose(mapping_name, mapping_shape=…, block_size=…)` | A block-major paged pool (KV cache, compressor state) written through a slot mapping: allocator-mapped rows take the `ratio_allclose` check, every unmapped row must stay exactly equal to its golden snapshot, so a write outside the mapping fails. `leading_rank_axis=True` for a `[ranks, blocks, block_size, …]` pool. |
+
+A fifth helper, `error_distribution()`, is a **measurement** rather than a gate
+— it always passes and prints the error shape. See
+[Precision Tuning](../debug-and-tune/precision-tuning.md).
 
 Both ratio comparators also take `valid_rows` / `valid_axis` / `zero_tail`:
 `valid_rows=n` compares only the leading `n` entries along `valid_axis`

--- a/docs/run-and-validate/golden-harness.md
+++ b/docs/run-and-validate/golden-harness.md
@@ -116,6 +116,10 @@ torch.allclose(actual, expected, rtol=rtol, atol=atol)
 Choose tolerances from the numerical contract of the kernel, not simply to
 make a failing result pass. For output types that need a different correctness
 rule, pass a comparator for that output name through `compare_fn`.
+`golden.validation` ships four ready-made gates — `topk_pair_compare`,
+`ratio_allclose`, `ratio_reldiff`, and `mapped_pool_ratio_allclose` for a
+slot-mapped paged pool — plus the `error_distribution` measurement; see
+[Compile and Runtime Workflow](compile-runtime-workflow.md#5-validate).
 
 If neither `golden_fn` nor `golden_data` is provided, the runtime can still
 execute, but validation is explicitly reported as skipped. Such a run is not

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -75,6 +75,7 @@ nav:
   - PyPTO Coding:
       - Overview: pypto-coding/index.md
       - PyPTO coding style: pypto-coding/pypto-coding-style.md
+      - Distributed programming: pypto-coding/distributed-programming.md
       - CCE extern kernel: pypto-coding/cce-extern-kernel.md
   - Run and Validate:
       - Overview: run-and-validate/index.md


### PR DESCRIPTION
`pypto.language.distributed` had no page at all: 36 model and example
files import it and call `pld.window` / `alloc_window_buffer` / `notify`
/ `wait` / `put` 650-odd times, and the only prose about any of it was a
naming subsection at the end of the coding style. `pl.scope`, the scalar
`pl.read` / `pl.write` pair, and `pl.unroll` were in the same position --
load bearing in every model, absent from the canonical style reference.
Several pages had also drifted away from the tree they describe.

- Add pypto-coding/distributed-programming.md: the host-driver /
  per-rank / core layering, window buffers and `pld.DistributedTensor`,
  lane layout, the five data-movement ops with their staging and atomic
  options, notify/wait with monotonic counters and an epoch, the
  ready/consumed protocol for reusing a window, the scheduling rules
  (comm ops need an InCore scope, anchor a spinning wait, keep it off
  the early-dispatch chain), the put-vs-remote_store visibility
  difference, and how an L3 case is compiled and validated
- Record that the `pld.tensor` collectives exist but that no kernel here
  uses one, so a reader does not assume they are the supported path
- Give the style guide sections for scalar `pl.read` / `pl.write` plus
  `pl.array`, and for runtime `pl.scope` -- auto placement, hand
  placement under `auto_scope=False`, and MANUAL as a dependency choice
  rather than a ring choice
- Document `pl.unroll` as the fifth loop construct: 85 call sites, and
  the guide said PyPTO has four
- Inline the block counts in the style guide's own examples, which broke
  the naming rule the same file states, and drop the two dead
  `create_tensor` accumulators and the unbound `b0` from its matmul and
  mixed-region snippets
- Replace the `pl.spmd(Q_OUT_BLOCKS, ...)` snippet attributed to
  qwen3_32b/decode.py with the inlined block count the file actually
  has, and drop the `decode_fwd.py` attribution from two snippets built
  out of identifiers that exist nowhere in the tree
- List `mapped_pool_ratio_allclose` in the comparator table -- 67 call
  sites validate a slot-mapped paged pool with it, and the table claimed
  golden.validation ships three gates -- and name the four gates plus
  the `error_distribution` measurement on the Golden Harness page
- Report the `mean=` field from one `PYPTO_BENCH` run with fixed
  rounds/warmup instead of a median over repeated invocations, which is
  what daily CI records and what the in-process benchmark loop is for
- Anchor the dependency-and-scheduling source references on scope
  name_hints and function names rather than line numbers, one of which
  had already drifted by one line