### PR TITLE
Perf: fuse DeepSeek V4 SWA and HCA O projection reduce-scatter

### DIFF
--- a/models/deepseek_v4_flash_dspark/decode_swa.py
+++ b/models/deepseek_v4_flash_dspark/decode_swa.py
@@ -61,10 +61,9 @@ from decode_o_proj import (
     LOCAL_T,
     LOCAL_T_PAD,
     O_WINDOW_ROWS,
-    decode_o_proj,
+    decode_sharded_o_projection_reduce_scatter,
     decode_o_proj_tp1,
     o_group_a2a,
-    o_proj_reduce_scatter,
 )
 from decode_sparse_attn_swa import ATTN_K_TILE, PADDED_TOPK, T_PAD, sparse_attn_swa
 
@@ -219,17 +218,13 @@ def decode_swa(
     )
 
     attention_local_groups = pl.reshape(attention_local_flat, [LOCAL_O_GROUPS, GROUP_T_PAD, O_GROUP_IN])
-    o_partial = pl.create_tensor([GROUP_T_PAD, D], dtype=pl.FP32)
-    o_partial, projection_tid = decode_o_proj(
+    o_local = pl.create_tensor([LOCAL_T_PAD, D], dtype=pl.BF16)
+    o_local, o_signal = decode_sharded_o_projection_reduce_scatter(
         attention_local_groups,
         wo_a, wo_b, wo_b_scale,
-        local_t, o_partial,
-    )
-    o_local = pl.create_tensor([LOCAL_T_PAD, D], dtype=pl.BF16)
-    o_local, o_signal = o_proj_reduce_scatter(
-        o_partial, o_local,
+        local_t, o_local,
         o_window, o_signal,
-        group_base, tp_rank, local_t, projection_tid,
+        group_base, tp_rank,
     )
 
     attn_out = pl.create_tensor([t_dim, D], dtype=pl.BF16)


### PR DESCRIPTION
- Publish dequantized O-B tiles directly into ReduceScatter owner windows.
- Reuse the shared fused O projection and ReduceScatter path for SWA and HCA tensor-parallel outputs.
- Remove the intermediate FP32 projection buffer and separate projection/reduction boundary from both paths.
- Preserve TP1 paths and HCA compressed-cache dependencies.

SWA TP4 a2a3 max on fixed cards 0,1,2,3 with 20 rounds and 5 warmups: headline mean 4197.8 -> 3559.5 us (15.2% lower), fastest-rank mean 2912.0 -> 2084.9 us (28.4% lower), with kv_cache and x_out validation passing.

HCA TP4 max and subcapacity fresh-golden validation passed on fixed cards 0,1,2,3. compress_state, kv_cache, cmp_kv, and x_out all passed in both cases.
