### PR TITLE
Add: DeepSeek-V4 Flash serving contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,9 @@ jobs:
           pip install torch --index-url https://download.pytorch.org/whl/cpu
 
       - name: Run golden and DeepSeek contract tests
-        run: pytest tests/golden tests/contract/test_deepseek_v4_pro_*.py -v
+        run: >-
+          pytest tests/golden tests/contract/test_deepseek_v4_pro_*.py
+          tests/contract/test_deepseek_v4_flash_serving_contract.py -v
 
   detect-changes:
     runs-on: ubuntu-latest

--- a/docs/models/deepseek_v4_flash_mtp.md
+++ b/docs/models/deepseek_v4_flash_mtp.md
@@ -16,7 +16,7 @@ that every kernel imports as a bare sibling module.
 | Speculative decoding | MTP = 1 — one draft token verified against the previous one, so a decode step carries `S = 2` token rows per request |
 | Decode batch per card | 4 requests → 8 token rows per step (`DECODE_BATCH`, `DECODE_SEQ`) |
 | Decode context length | up to 16,384 positions, paged in 128-token pages (`max_position_embeddings`, `BLOCK_SIZE`) |
-| Prefill shape | one request of 128 tokens per program (`PREFILL_BATCH`, `PREFILL_SEQ`) |
+| Prefill shape | one request per rank partition, each with up to 8,192 active tokens per dispatch; the program walks the dynamic extent in 128-token tiles (`PREFILL_BATCH`, `PREFILL_SEQ`) |
 | Platform | Ascend A2/A3, single node |
 | Expert parallelism | `--ep 2/4/8`; the deployment point is EP 8, and each rank holds `256 / ep` routed experts |
 | LM-head parallelism | `--tp 2/4/8/16` vocab shards over DP row owners, `--tp <= --ep` |

--- a/models/deepseek_v4_flash_mtp/serving_contract.py
+++ b/models/deepseek_v4_flash_mtp/serving_contract.py
@@ -1,0 +1,70 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+"""Lightweight serving capabilities owned by the DeepSeek-V4 Flash kernels.
+
+This manifest exposes shape and scheduling constraints only.  The full external
+kernel ABI remains outside the scope of this module.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class DeepSeekV4FlashServingContract:
+    """Kernel limits and scheduling constraints consumed by serving runtimes."""
+
+    schema_version: str
+    prefill_tile_tokens: int
+    max_prefill_tokens_per_request: int
+    max_prefill_requests_per_partition: int
+    requires_homogeneous_prefill_decode: bool
+
+    def __post_init__(self) -> None:
+        if self.schema_version != "1":
+            raise ValueError(f"unsupported schema_version: {self.schema_version!r}")
+        if self.prefill_tile_tokens <= 0:
+            raise ValueError("prefill_tile_tokens must be positive")
+        if self.max_prefill_tokens_per_request < self.prefill_tile_tokens:
+            raise ValueError(
+                "max_prefill_tokens_per_request must cover one prefill tile"
+            )
+        if self.max_prefill_tokens_per_request % self.prefill_tile_tokens:
+            raise ValueError(
+                "max_prefill_tokens_per_request must be a multiple of prefill_tile_tokens"
+            )
+        if self.max_prefill_requests_per_partition <= 0:
+            raise ValueError("max_prefill_requests_per_partition must be positive")
+
+    def padded_prefill_tokens(self, active_tokens: int) -> int:
+        """Round one active dispatch extent to the kernel's internal tile."""
+        if isinstance(active_tokens, bool) or not isinstance(active_tokens, int):
+            raise TypeError(
+                f"active prefill tokens must be an int, got {active_tokens!r}"
+            )
+        if active_tokens <= 0:
+            raise ValueError("active prefill tokens must be positive")
+        if active_tokens > self.max_prefill_tokens_per_request:
+            raise ValueError(
+                f"active prefill tokens must not exceed "
+                f"{self.max_prefill_tokens_per_request}, got {active_tokens}"
+            )
+        tile = self.prefill_tile_tokens
+        return ((active_tokens + tile - 1) // tile) * tile
+
+
+DEEPSEEK_V4_FLASH_SERVING_CONTRACT = DeepSeekV4FlashServingContract(
+    schema_version="1",
+    prefill_tile_tokens=128,
+    max_prefill_tokens_per_request=8192,
+    max_prefill_requests_per_partition=1,
+    requires_homogeneous_prefill_decode=True,
+)

--- a/tests/contract/test_deepseek_v4_flash_serving_contract.py
+++ b/tests/contract/test_deepseek_v4_flash_serving_contract.py
@@ -1,0 +1,55 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+
+import pytest
+
+from models.deepseek_v4_flash_mtp import config
+from models.deepseek_v4_flash_mtp.serving_contract import (
+    DEEPSEEK_V4_FLASH_SERVING_CONTRACT as CONTRACT,
+)
+
+
+def test_deepseek_v4_flash_serving_capabilities() -> None:
+    assert CONTRACT.schema_version == "1"
+    assert CONTRACT.prefill_tile_tokens == 128
+    assert CONTRACT.max_prefill_tokens_per_request == 8192
+    assert CONTRACT.max_prefill_requests_per_partition == 1
+    assert CONTRACT.requires_homogeneous_prefill_decode is True
+
+
+@pytest.mark.parametrize(
+    ("active_tokens", "expected"),
+    [(1, 128), (128, 128), (129, 256), (8191, 8192), (8192, 8192)],
+)
+def test_deepseek_v4_flash_prefill_padding(
+    active_tokens: int,
+    expected: int,
+) -> None:
+    assert CONTRACT.padded_prefill_tokens(active_tokens) == expected
+
+
+@pytest.mark.parametrize("active_tokens", [0, -1, 8193])
+def test_deepseek_v4_flash_prefill_padding_rejects_invalid_extents(
+    active_tokens: int,
+) -> None:
+    with pytest.raises(ValueError):
+        CONTRACT.padded_prefill_tokens(active_tokens)
+
+
+@pytest.mark.parametrize("active_tokens", [True, 128.5, "128"])
+def test_deepseek_v4_flash_prefill_padding_rejects_non_integer_extents(
+    active_tokens: object,
+) -> None:
+    with pytest.raises(TypeError, match="must be an int"):
+        CONTRACT.padded_prefill_tokens(active_tokens)
+
+
+def test_deepseek_v4_flash_contract_matches_kernel_prefill_shape() -> None:
+    assert config.PREFILL_BATCH == CONTRACT.max_prefill_requests_per_partition
+    assert config.PREFILL_SEQ == CONTRACT.prefill_tile_tokens


### PR DESCRIPTION
- Add `models/deepseek_v4_flash_mtp/serving_contract.py`, a frozen
  dataclass declaring the kernel's prefill limits: a 128-token internal
  tile, at most 8192 active tokens per request per dispatch, one prefill
  request per rank partition, and no prefill/decode mixing within one
  dispatch.
- Validate the manifest at construction: schema version 1, a positive
  tile, and a per-request cap that is a positive multiple of that tile.
- Add `padded_prefill_tokens()`, rounding an active extent up to the tile
  and rejecting non-positive, over-cap, and non-integer inputs including
  `bool`, `float`, and `str`.
- Restate the prefill shape in `docs/models/deepseek_v4_flash_mtp.md` as
  one request per rank partition of up to 8192 active tokens, walked in
  128-token tiles.
- Run the new contract tests alongside the existing golden and
  DeepSeek-V4 Pro contract tests in CI.

The 8192 cap bounds a single prefill dispatch for one request, not the
model's context length; splitting a longer prompt across dispatches stays
with the serving side (hw-native-sys/pypto-serving#187). The module has
no import side effects and changes no kernel compute.