### PR TITLE
Refactor: defer DeepSeek V4 MTP communication waits

### DIFF
--- a/models/deepseek_v4_flash_mtp/lm_head.py
+++ b/models/deepseek_v4_flash_mtp/lm_head.py
@@ -162,14 +162,10 @@ def lm_head(
                     op=pld.NotifyOp.AtomicAdd,
                 )
 
-    # Barrier on the group's publishes. The hidden_states read is an anchor, not
-    # data: it deps this task on the hidden-state producer so the wait runs
-    # alongside our own push instead of trailing it.
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="lm_head_dispatch_wait") as _dwait_tid:
-        _hidden_anchor = pl.read(hidden_states, [0, 0])
         for owner_tp in pl.range(TP_SIZE):
             if owner_tp != tp_rank:
-                pld.system.wait(
+                pld.system.defer_wait(
                     signal=hidden_done,
                     offsets=[owner_tp, 0],
                     expected=pl.cast(done_epoch * MAX_LOGIT_ROWS, pl.INT32),
@@ -194,7 +190,7 @@ def lm_head(
         FUSED_LM_HEAD_CORES,
         name_hint="lm_head_matmul_push",
         optimizations=[pl.cross_core_slot(slot_num=2)],
-    ) as _push_tid:
+    ):
         lm_core = pl.tile.get_block_idx()
         vocab_base = tp_rank * VOCAB_PER_TP
         for mm_ob in pl.range(lm_core, VOCAB_TILES, FUSED_LM_HEAD_CORES):
@@ -277,15 +273,10 @@ def lm_head(
                         op=pld.NotifyOp.AtomicAdd,
                     )
 
-    # Wait only (the notify rides inside the push). deps on the push scope so the
-    # wait runs alongside our own push; an unanchored wait dispatches immediately
-    # and spins holding a core group.
-    with pl.at(
-        level=pl.Level.CORE_GROUP, name_hint="lm_head_combine_wait", deps=[_push_tid]
-    ) as _cwait_tid:
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="lm_head_combine_wait") as _cwait_tid:
         for src_tp in pl.range(TP_SIZE):
             if src_tp != tp_rank:
-                pld.system.wait(
+                pld.system.defer_wait(
                     signal=logits_done,
                     offsets=[src_tp, 0],
                     expected=pl.cast(done_epoch * FUSED_LM_HEAD_CORES, pl.INT32),

--- a/models/deepseek_v4_flash_mtp/moe.py
+++ b/models/deepseek_v4_flash_mtp/moe.py
@@ -200,7 +200,7 @@ def dispatch(
     # loc_e on EVERY destination rank, so the blocking cross-rank puts fan out
     # across N_LOCAL cores. One slot counter per destination rank; token-major
     # order matches the meta pass's per-(dst, loc_e) cumulative count.
-    with pl.spmd(N_LOCAL, name_hint="dispatch_push", allow_early_resolve=True) as _push_tid:
+    with pl.spmd(N_LOCAL, name_hint="dispatch_push", allow_early_resolve=True):
         loc_e = pl.tile.get_block_idx()
         active_tokens = pl.cast(num_tokens, pl.INDEX)
         if active_tokens < 0:
@@ -257,21 +257,13 @@ def dispatch(
                     op=pld.NotifyOp.AtomicAdd,
                 )
 
-    # Wait only (the notify rides inside dispatch_push). The indices read is an
-    # anchor, not data: it deps this task on gate's route tasks, so the wait starts
-    # with dispatch_push instead of trailing dispatch_meta's spin. Anchor it to
-    # something -- an unanchored wait is dispatched immediately and spins holding a
-    # core group, so pipelined layers stack up spinners.
     with pl.at(
         level=pl.Level.CORE_GROUP,
         name_hint="dispatch_wait",
-        deps=[_push_tid],
-        allow_early_resolve=True,
     ) as _wait_tid:
-        _idx_anchor = pl.read(indices, [0, 0])
         for src in pl.range(N_RANKS):
             if src != my_rank:
-                pld.system.wait(
+                pld.system.defer_wait(
                     signal=data_arrived,
                     offsets=[src, 0],
                     expected=pl.cast(moe_epoch * N_LOCAL, pl.INT32),
@@ -306,9 +298,6 @@ def dispatch(
                 pl.write(recv_r_route_out, [e, out_col], pl.read(recv_route, [in_row, 0]))
             b = b + n
 
-    return _push_tid
-
-
 # === Combine =================================================================
 # Push recv_y rows back to their origin rank keyed by r_route, barrier, then a
 # dense reduce ffn_out[t] = sh[t] + Sigma_k routed_y_buf[t*TOPK+k].
@@ -324,7 +313,6 @@ def combine(
     num_tokens: pl.Scalar[pl.INT32],
     my_rank: pl.Scalar[pl.INT32],
     moe_epoch: pl.Scalar[pl.INT32],
-    dispatch_push_tid: pl.Scalar[pl.TASK_ID],
 ):
     recv_y_flat = pl.reshape(recv_y, [N_LOCAL * RECV_MAX, D])
     # One SPMD block per LOCAL EXPERT: block e pushes expert e's compact rows back to
@@ -332,9 +320,7 @@ def combine(
     # Rows are src-major, so the per-(e, src) base is a loop-carried prefix sum over
     # src inside the block (same shape as dispatch_gather). Each route maps to a
     # unique (dst, loc_e) and r_route, so the blocks' puts are write-disjoint.
-    # Keep the scatter TaskId so the arrival handshake cannot occupy AIV cores
-    # until every routed_y_buf put from this rank has completed.
-    with pl.spmd(N_LOCAL, name_hint="combine") as _combine_tid:
+    with pl.spmd(N_LOCAL, name_hint="combine"):
         e = pl.tile.get_block_idx()
         e_base_row = e * RECV_MAX
         b = pl.cast(0, pl.INDEX)
@@ -353,14 +339,7 @@ def combine(
                 )
             b = b + n
 
-    # Publish only after the complete scatter grid. Keeping this cross-rank wait
-    # out of the speculative early-dispatch chain prevents it and shared_routed
-    # from reserving the AIV cores needed by the scatter itself.
-    with pl.at(
-        level=pl.Level.CORE_GROUP,
-        name_hint="combine_wait",
-        deps=[_combine_tid, dispatch_push_tid],
-    ) as _cwait_tid:
+        # Each block publishes completion after its puts to every peer.
         for peer in pl.range(N_RANKS):
             if peer != my_rank:
                 pld.system.notify(
@@ -371,12 +350,13 @@ def combine(
                     op=pld.NotifyOp.AtomicAdd,
                 )
 
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="combine_wait") as _cwait_tid:
         for src in pl.range(N_RANKS):
             if src != my_rank:
-                pld.system.wait(
+                pld.system.defer_wait(
                     signal=combine_arrived,
                     offsets=[src, 0],
-                    expected=moe_epoch,
+                    expected=pl.cast(moe_epoch * N_LOCAL, pl.INT32),
                     cmp=pld.WaitCmp.Ge,
                 )
 
@@ -479,7 +459,7 @@ def moe(
     recv_r_route_out = pl.create_tensor([N_LOCAL, RECV_MAX], dtype=pl.INT32, manual_dep=True)
     recv_count_out = pl.create_tensor([N_LOCAL, 1], dtype=pl.INT32)
     recv_meta_local = pl.create_tensor([N_RANKS, N_LOCAL], dtype=pl.INT32, manual_dep=True)
-    dispatch_push_tid = dispatch(
+    dispatch(
         indices, x_norm_i8, x_norm_scale, weights,
         recv_x_out, recv_scale_out, recv_w_out, recv_r_route_out, recv_count_out, recv_meta_local,
         recv_meta, recv_x, recv_aux, recv_route, arrived, data_arrived,
@@ -500,7 +480,7 @@ def moe(
             recv_y, recv_r_route_out, sh,
             ffn_out, recv_meta_local,
             routed_y_buf, combine_arrived,
-            num_tokens, my_rank, moe_epoch, dispatch_push_tid,
+            num_tokens, my_rank, moe_epoch,
         )
 
         hc_post(ffn_out, x_hc, post_ffn, comb_ffn, x_next)


### PR DESCRIPTION
- Replace the isolated blocking waits for MoE payload dispatch, MoE
  combine, LM-head hidden dispatch, and LM-head logits combine with
  deferred completion.

- Keep each deferred wait in a dedicated top-level CORE_GROUP task. The
  task registers its remote counter conditions, releases the AIV core,
  and remains logically incomplete until every condition is satisfied.
  Existing downstream dependencies continue to use the waiter TaskId.

- Keep the MoE metadata wait blocking because the same task resumes
  after the wait to read the remote counts and build the local cumsum.
  This continuation is incompatible with deferred completion.

- Fold MoE combine completion publication into each of the N_LOCAL
  scatter blocks after its remote puts. Every block atomically publishes
  one completion to each peer, so the monotonic wait threshold becomes
  moe_epoch * N_LOCAL.

- Remove the push/combine TaskId returns, anchor reads, and explicit
  dependencies that were needed only to keep spinning waiters behind
  their matching producers.

- Preserve the existing point-to-point put, notify, and monotonic epoch
  protocol while removing the need to manually order locally independent
  send and wait tasks.