### PR TITLE
Perf: retune dspark SWA decode task partitioning

### DIFF
--- a/models/deepseek_v4_flash_dspark/decode_o_proj.py
+++ b/models/deepseek_v4_flash_dspark/decode_o_proj.py
@@ -73,16 +73,16 @@ O_WINDOW_ROWS = TP_SIZE * LOCAL_T_PAD
 # local output projection tiling
 A_K_TILE = 256
 PROJ_A_MM_N_TILE = 128
-PROJ_A_ROW_TILE = 16
+PROJ_A_ROW_TILE = 128  # proj_a token block; one block covers T_PAD, 8 tasks/group
 B_K_TILE = 256
 # Keep the INT32 proj-b accumulator within the A2/A3 tile buffer.
 PROJ_B_MM_T_TILE = 128
 PROJ_B_MM_N_TILE = 256
 PROJ_B_ACT_N_TILE = 512
 QUANT_TOKEN_TILE = 8
-PROJ_B_D_TILE = 512
+PROJ_B_D_TILE = 512  # proj_b_mm D chunk per task; coarser starves the 24 AIC cores
 PROJ_B_ACT_T_TILE = 8
-PROJ_B_ACT_TASK_T_TILE = 8
+PROJ_B_ACT_TASK_T_TILE = 32  # proj_b_act token block per task
 
 # TP-sharded output projection tiling
 O_A_T_TILE = 16

--- a/models/deepseek_v4_flash_dspark/decode_sparse_attn_swa.py
+++ b/models/deepseek_v4_flash_dspark/decode_sparse_attn_swa.py
@@ -54,11 +54,15 @@ ORI_MAX_BLOCKS = KV_ORI_MAX_BLOCKS
 ORI_BLOCK_NUM = KV_ORI_BLOCK_NUM
 
 # tiling
-GATHER_SPLITS = 4
-GATHER_ROWS_PER_TASK = WIN // GATHER_SPLITS
+AIC_CORES = 24
+AIV_CORES = 48
+GATHER_TASKS = 32                     # leaves 16 AIV for the concurrent qproj_dequant grid
+GATHER_T = max(1, T // GATHER_TASKS)  # tokens per gather task
+QK_TASKS = AIC_CORES                  # 1 AIC + 2 AIV records each -> 24 AIC + 48 AIV
+MERGE_TASKS = AIV_CORES               # pure AIV, one full wave
 GATHER_RUN = 16          # window sub-tile probed for physical contiguity -> one bulk DMA
-H_TILE = 16
-QK_M_TILE = 32           # qk_pv M rows per QK/PV matmul; QK_M_TILE/H_TILE-way KV L1->L0 reuse
+H_TILE = 32
+QK_M_TILE = 32           # qk_pv M rows per QK/PV matmul; upper bound on H_TILE
 ATTN_K_TILE = 128
 ROPE_TILE = 16
 ROPE_INTERLEAVE_TILE = 2 * ROPE_TILE
@@ -94,7 +98,7 @@ def sparse_attn_swa(
     t_win = t_dim * WIN
     t_blk = t_dim * (H // H_TILE) * SPARSE_BLOCKS * H_TILE
     t_hblocks = t_dim * (H // H_TILE)
-    t_gather = t_dim * GATHER_SPLITS
+    t_gather = t_dim // GATHER_T
     rope_cs_blocks = t_dim // ROPE_CS_T_TILE
     ori_block_num = pl.tensor.dim(ori_kv, 0)
     ori_kv_flat = pl.reshape(ori_kv, [ori_block_num * BLOCK_SIZE, HEAD_DIM])
@@ -105,36 +109,36 @@ def sparse_attn_swa(
     swa_kv_flat = pl.create_tensor([t_win, HEAD_DIM], dtype=pl.BF16)
     gather_tids = pl.array.create(1, pl.TASK_ID)
     with pl.spmd(t_gather, name_hint="swa_gather_kv") as gather_tid:
-        g_task = pl.tile.get_block_idx()
-        g_t = g_task // GATHER_SPLITS
-        g_split = g_task - g_t * GATHER_SPLITS
-        g_r0 = g_split * GATHER_ROWS_PER_TASK
-        g_base = g_t * WIN
-        # Probe each sub-tile's first/last slot: endpoints GATHER_RUN-1 apart mean
-        # the whole run sits in one paged block and moves as one bulk copy.
-        for g_sub in pl.range(GATHER_ROWS_PER_TASK // GATHER_RUN):
-            g_sr0 = g_r0 + g_sub * GATHER_RUN
-            g_sdst = g_base + g_sr0
-            g_first = pl.read(swa_indices, [g_t, g_sr0])
-            g_last = pl.read(swa_indices, [g_t, g_sr0 + GATHER_RUN - 1])
-            # A -1 slot anywhere in the run pins g_run_ok below the match value,
-            # so an invalid or block-straddling run takes the per-row path.
-            g_run_ok = (g_last - g_first) + pl.min(g_first, 0) * GATHER_RUN
-            if g_run_ok == GATHER_RUN - 1:
-                g_run_src = pl.cast(g_first, pl.INDEX)
-                swa_kv_flat[g_sdst : g_sdst + GATHER_RUN, 0 : HEAD_DIM] = ori_kv_flat[
-                    g_run_src : g_run_src + GATHER_RUN, 0 : HEAD_DIM
-                ]
-            else:
-                for g_dr in pl.range(GATHER_RUN):
-                    g_dst = g_sdst + g_dr
-                    g_slot_i32 = pl.read(swa_indices, [g_t, g_sr0 + g_dr])
-                    if g_slot_i32 >= 0:
-                        g_slot = pl.cast(g_slot_i32, pl.INDEX)
-                        swa_kv_flat[g_dst : g_dst + 1, 0 : HEAD_DIM] = ori_kv_flat[g_slot : g_slot + 1, 0 : HEAD_DIM]
-                    else:
-                        swa_kv_flat[g_dst : g_dst + 1, 0 : HEAD_DIM] = pl.full(
-                            [1, HEAD_DIM], dtype=pl.BF16, value=0.0)
+        g_grp = pl.tile.get_block_idx()
+        for g_tok in pl.unroll(GATHER_T):
+            g_t = g_grp * GATHER_T + g_tok
+            g_base = g_t * WIN
+            # Probe each sub-tile's first/last slot: endpoints GATHER_RUN-1 apart mean
+            # the whole run sits in one paged block and moves as one bulk copy.
+            for g_sub in pl.range(WIN // GATHER_RUN):
+                g_sr0 = g_sub * GATHER_RUN
+                g_sdst = g_base + g_sr0
+                g_first = pl.read(swa_indices, [g_t, g_sr0])
+                g_last = pl.read(swa_indices, [g_t, g_sr0 + GATHER_RUN - 1])
+                # A -1 slot anywhere in the run pins g_run_ok below the match value,
+                # so an invalid or block-straddling run takes the per-row path.
+                g_run_ok = (g_last - g_first) + pl.min(g_first, 0) * GATHER_RUN
+                if g_run_ok == GATHER_RUN - 1:
+                    g_run_src = pl.cast(g_first, pl.INDEX)
+                    swa_kv_flat[g_sdst : g_sdst + GATHER_RUN, 0 : HEAD_DIM] = ori_kv_flat[
+                        g_run_src : g_run_src + GATHER_RUN, 0 : HEAD_DIM
+                    ]
+                else:
+                    for g_dr in pl.range(GATHER_RUN):
+                        g_dst = g_sdst + g_dr
+                        g_slot_i32 = pl.read(swa_indices, [g_t, g_sr0 + g_dr])
+                        if g_slot_i32 >= 0:
+                            g_slot = pl.cast(g_slot_i32, pl.INDEX)
+                            swa_kv_flat[g_dst : g_dst + 1, 0 : HEAD_DIM] = ori_kv_flat[g_slot : g_slot + 1, 0 : HEAD_DIM]
+                        else:
+                            swa_kv_flat[g_dst : g_dst + 1, 0 : HEAD_DIM] = pl.full(
+                                [1, HEAD_DIM], dtype=pl.BF16, value=0.0)
+
     gather_tids[0] = gather_tid
 
     # qk_pv writes per-tile (mi, li, oi) to GM; merge_norm reads them back. Not
@@ -145,39 +149,40 @@ def sparse_attn_swa(
     sparse_blk_li = pl.create_tensor([t_blk, 1], dtype=pl.FP32)
     sparse_blk_oi = pl.create_tensor([t_blk, HEAD_DIM], dtype=pl.FP32)
 
-    with pl.spmd(t_dim, name_hint="qk_pv", deps=[gather_tids[0]], allow_early_resolve=True) as qk_tid:
-        qk_t = pl.tile.get_block_idx()
-        qk_token_base = qk_t * (H // H_TILE) * SPARSE_BLOCKS * H_TILE
-        for qk_sb in pl.unroll(SPARSE_BLOCKS):
-            qk_s0 = qk_sb * ATTN_K_TILE
-            qk_bias_row = sparse_bias[qk_t : qk_t + 1, qk_s0 : qk_s0 + ATTN_K_TILE]
-            qk_base = qk_t * WIN + qk_s0
-            qk_kv = swa_kv_flat[qk_base : qk_base + ATTN_K_TILE, 0 : HEAD_DIM]
+    with pl.spmd(QK_TASKS, name_hint="qk_pv", deps=[gather_tids[0]], allow_early_resolve=True) as qk_tid:
+        qk_task = pl.tile.get_block_idx()
+        for qk_t in pl.range(qk_task, t_dim, QK_TASKS):
+            qk_token_base = qk_t * (H // H_TILE) * SPARSE_BLOCKS * H_TILE
+            for qk_sb in pl.unroll(SPARSE_BLOCKS):
+                qk_s0 = qk_sb * ATTN_K_TILE
+                qk_bias_row = sparse_bias[qk_t : qk_t + 1, qk_s0 : qk_s0 + ATTN_K_TILE]
+                qk_base = qk_t * WIN + qk_s0
+                qk_kv = swa_kv_flat[qk_base : qk_base + ATTN_K_TILE, 0 : HEAD_DIM]
 
-            # Keep both 32-head batches in one token task so they reuse the KV
-            # tile already resident in L1 instead of loading it once per block.
-            for qk_hb in pl.pipeline(H // QK_M_TILE, stage=2):
-                qk_h0 = qk_hb * QK_M_TILE
-                qk_head_row = qk_t * H + qk_h0
-                qk_q_tile = q_flat[qk_head_row : qk_head_row + QK_M_TILE, 0 : HEAD_DIM]
-                qk_raw = pl.matmul(qk_q_tile, qk_kv, b_trans=True, out_dtype=pl.FP32)
-                qk_scaled = pl.mul(qk_raw, SOFTMAX_SCALE)
-                qk_scores = pl.col_expand_add(qk_scaled, qk_bias_row)
-                qk_mi = pl.row_max(qk_scores)
-                # Invalid lanes (NEG_INF bias, zero kv rows) exp to ~0; all-invalid
-                # blocks die in the merge alpha/beta -- no mask multiply needed.
-                qk_exp = pl.exp(pl.row_expand_sub(qk_scores, qk_mi))
-                qk_li = pl.row_sum(qk_exp)
-                qk_exp_bf16 = pl.cast(qk_exp, target_type=pl.BF16, mode="rint")
-                qk_oi = pl.matmul(qk_exp_bf16, qk_kv, out_dtype=pl.FP32)
-                for qk_sub in pl.unroll(QK_M_TILE // H_TILE):
-                    qk_h_idx = qk_hb * (QK_M_TILE // H_TILE) + qk_sub
-                    qk_r0 = qk_sub * H_TILE
-                    qk_blk_base = qk_token_base + qk_h_idx * SPARSE_BLOCKS * H_TILE
-                    qk_row = qk_blk_base + qk_sb * H_TILE
-                    sparse_blk_mi[qk_row : qk_row + H_TILE, 0 : 1] = qk_mi[qk_r0 : qk_r0 + H_TILE, 0 : 1]
-                    sparse_blk_li[qk_row : qk_row + H_TILE, 0 : 1] = qk_li[qk_r0 : qk_r0 + H_TILE, 0 : 1]
-                    sparse_blk_oi[qk_row : qk_row + H_TILE, 0 : HEAD_DIM] = qk_oi[qk_r0 : qk_r0 + H_TILE, 0 : HEAD_DIM]
+                # Keep both 32-head batches in one token task so they reuse the KV
+                # tile already resident in L1 instead of loading it once per block.
+                for qk_hb in pl.pipeline(H // QK_M_TILE, stage=2):
+                    qk_h0 = qk_hb * QK_M_TILE
+                    qk_head_row = qk_t * H + qk_h0
+                    qk_q_tile = q_flat[qk_head_row : qk_head_row + QK_M_TILE, 0 : HEAD_DIM]
+                    qk_raw = pl.matmul(qk_q_tile, qk_kv, b_trans=True, out_dtype=pl.FP32)
+                    qk_scaled = pl.mul(qk_raw, SOFTMAX_SCALE)
+                    qk_scores = pl.col_expand_add(qk_scaled, qk_bias_row)
+                    qk_mi = pl.row_max(qk_scores)
+                    # Invalid lanes (NEG_INF bias, zero kv rows) exp to ~0; all-invalid
+                    # blocks die in the merge alpha/beta -- no mask multiply needed.
+                    qk_exp = pl.exp(pl.row_expand_sub(qk_scores, qk_mi))
+                    qk_li = pl.row_sum(qk_exp)
+                    qk_exp_bf16 = pl.cast(qk_exp, target_type=pl.BF16, mode="rint")
+                    qk_oi = pl.matmul(qk_exp_bf16, qk_kv, out_dtype=pl.FP32)
+                    for qk_sub in pl.unroll(QK_M_TILE // H_TILE):
+                        qk_h_idx = qk_hb * (QK_M_TILE // H_TILE) + qk_sub
+                        qk_r0 = qk_sub * H_TILE
+                        qk_blk_base = qk_token_base + qk_h_idx * SPARSE_BLOCKS * H_TILE
+                        qk_row = qk_blk_base + qk_sb * H_TILE
+                        sparse_blk_mi[qk_row : qk_row + H_TILE, 0 : 1] = qk_mi[qk_r0 : qk_r0 + H_TILE, 0 : 1]
+                        sparse_blk_li[qk_row : qk_row + H_TILE, 0 : 1] = qk_li[qk_r0 : qk_r0 + H_TILE, 0 : 1]
+                        sparse_blk_oi[qk_row : qk_row + H_TILE, 0 : HEAD_DIM] = qk_oi[qk_r0 : qk_r0 + H_TILE, 0 : HEAD_DIM]
 
     # Materialize the head-invariant interleaved cos and signed-sin rows once.
     # This runs alongside qk_pv and keeps the exact indexed RoPE arithmetic used
@@ -225,48 +230,48 @@ def sparse_attn_swa(
                 rope_sin_signed[cs_t0 : cs_t0 + ROPE_CS_T_TILE, cp_c0 : cp_c0 + ROPE_INTERLEAVE_TILE] = cs_sin_signed
 
     # Flatten the one-block SWA merge over token/head tiles into a single
-    # 32-block grid, which fits in one AIV wave and avoids eight group-grid
-    # submissions. Each block writes two output-projection groups using the
-    # same contiguous per-group stores.
-    with pl.spmd(t_hblocks, name_hint="merge_norm", deps=[qk_tid, rope_tid],
+    # grid. Each block writes H_TILE // HEADS_PER_GROUP output-projection groups
+    # using the same contiguous per-group stores.
+    with pl.spmd(MERGE_TASKS, name_hint="merge_norm", deps=[qk_tid, rope_tid],
                  allow_early_resolve=True) as merge_tid:
-        m_idx = pl.tile.get_block_idx()
-        m_t = m_idx // (H // H_TILE)
-        m_h_idx = m_idx - m_t * (H // H_TILE)
-        m_h0 = m_h_idx * H_TILE
-        m_blk_base = m_t * H + m_h0
-        m_mi = sparse_blk_mi[m_blk_base : m_blk_base + H_TILE, 0:1]
-        m_li = sparse_blk_li[m_blk_base : m_blk_base + H_TILE, 0:1]
-        m_oi = sparse_blk_oi[m_blk_base : m_blk_base + H_TILE, 0:HEAD_DIM]
+        m_task = pl.tile.get_block_idx()
+        for m_idx in pl.range(m_task, t_hblocks, MERGE_TASKS):
+            m_t = m_idx // (H // H_TILE)
+            m_h_idx = m_idx - m_t * (H // H_TILE)
+            m_h0 = m_h_idx * H_TILE
+            m_blk_base = m_t * H + m_h0
+            m_mi = sparse_blk_mi[m_blk_base : m_blk_base + H_TILE, 0:1]
+            m_li = sparse_blk_li[m_blk_base : m_blk_base + H_TILE, 0:1]
+            m_oi = sparse_blk_oi[m_blk_base : m_blk_base + H_TILE, 0:HEAD_DIM]
 
-        n_sink = pl.reshape(attn_sink[m_h0 : m_h0 + H_TILE], [H_TILE, 1])
-        n_sink_delta = pl.sub(n_sink, m_mi)
-        n_sink_exp = pl.exp(n_sink_delta)
-        n_denom = pl.add(m_li, n_sink_exp)
-        n_normalized = pl.row_expand_div(m_oi, n_denom)
-        n_full = n_normalized[0:H_TILE, 0:HEAD_DIM]
-        n_bf16 = pl.cast(n_full, target_type=pl.BF16, mode="rint")
+            n_sink = pl.reshape(attn_sink[m_h0 : m_h0 + H_TILE], [H_TILE, 1])
+            n_sink_delta = pl.sub(n_sink, m_mi)
+            n_sink_exp = pl.exp(n_sink_delta)
+            n_denom = pl.add(m_li, n_sink_exp)
+            n_normalized = pl.row_expand_div(m_oi, n_denom)
+            n_full = n_normalized[0:H_TILE, 0:HEAD_DIM]
+            n_bf16 = pl.cast(n_full, target_type=pl.BF16, mode="rint")
 
-        m_rope = n_full[:, NOPE_DIM:HEAD_DIM]
-        m_swapped = pl.gather(m_rope, dim=-1, index=rope_swap_idx[:, :])
-        m_cos_il = rope_cos_il[m_t : m_t + 1, 0:ROPE_DIM]
-        m_sin_signed = rope_sin_signed[m_t : m_t + 1, 0:ROPE_DIM]
-        m_rope_cos = pl.col_expand_mul(m_rope, m_cos_il)
-        m_swap_sin = pl.col_expand_mul(m_swapped, m_sin_signed)
-        m_rot = pl.add(m_rope_cos, m_swap_sin)
-        n_rope_bf16 = pl.cast(m_rot, target_type=pl.BF16, mode="rint")
+            m_rope = n_full[:, NOPE_DIM:HEAD_DIM]
+            m_swapped = pl.gather(m_rope, dim=-1, index=rope_swap_idx[:, :])
+            m_cos_il = rope_cos_il[m_t : m_t + 1, 0:ROPE_DIM]
+            m_sin_signed = rope_sin_signed[m_t : m_t + 1, 0:ROPE_DIM]
+            m_rope_cos = pl.col_expand_mul(m_rope, m_cos_il)
+            m_swap_sin = pl.col_expand_mul(m_swapped, m_sin_signed)
+            m_rot = pl.add(m_rope_cos, m_swap_sin)
+            n_rope_bf16 = pl.cast(m_rot, target_type=pl.BF16, mode="rint")
 
-        m_g0 = m_h0 // HEADS_PER_GROUP
-        for m_sg in pl.unroll(H_TILE // HEADS_PER_GROUP):
-            m_src_h0 = m_sg * HEADS_PER_GROUP
-            n_pack_row = (m_g0 + m_sg) * T_PAD + m_t
-            n_dst_head = n_pack_row * HEADS_PER_GROUP
-            o_packed_heads[n_dst_head : n_dst_head + HEADS_PER_GROUP, 0:NOPE_DIM] = n_bf16[
-                m_src_h0 : m_src_h0 + HEADS_PER_GROUP, 0:NOPE_DIM
-            ]
-            o_packed_heads[n_dst_head : n_dst_head + HEADS_PER_GROUP, NOPE_DIM:HEAD_DIM] = n_rope_bf16[
-                m_src_h0 : m_src_h0 + HEADS_PER_GROUP, 0:ROPE_DIM
-            ]
+            m_g0 = m_h0 // HEADS_PER_GROUP
+            for m_sg in pl.unroll(H_TILE // HEADS_PER_GROUP):
+                m_src_h0 = m_sg * HEADS_PER_GROUP
+                n_pack_row = (m_g0 + m_sg) * T_PAD + m_t
+                n_dst_head = n_pack_row * HEADS_PER_GROUP
+                o_packed_heads[n_dst_head : n_dst_head + HEADS_PER_GROUP, 0:NOPE_DIM] = n_bf16[
+                    m_src_h0 : m_src_h0 + HEADS_PER_GROUP, 0:NOPE_DIM
+                ]
+                o_packed_heads[n_dst_head : n_dst_head + HEADS_PER_GROUP, NOPE_DIM:HEAD_DIM] = n_rope_bf16[
+                    m_src_h0 : m_src_h0 + HEADS_PER_GROUP, 0:ROPE_DIM
+                ]
 
     return o_packed_heads, merge_tid
 

--- a/models/deepseek_v4_flash_dspark/decode_swa.py
+++ b/models/deepseek_v4_flash_dspark/decode_swa.py
@@ -912,6 +912,8 @@ if __name__ == "__main__":
         help="absolute decode start position; a scalar sets batch=1, "
              "and a comma-separated list sets batch to its length",
     )
+    parser.add_argument("--golden-data", type=str, default=None)
+    parser.add_argument("--save-data", action="store_true", default=False)
     parser.add_argument("--enable-chip-swimlane", type=int, choices=(0, 1, 2, 4), default=0)
     parser.add_argument("--compile-only", action="store_true", default=False)
     parser.add_argument("--dump-passes", action="store_true", default=False)
@@ -955,6 +957,8 @@ if __name__ == "__main__":
                 fn=decode_swa_tp1_test,
                 specs=build_tensor_specs(start_pos=args.start_pos, batch=local_t // S),
                 golden_fn=golden_decode_swa_tp1,
+                golden_data=args.golden_data,
+                save_data=args.save_data,
                 compile_only=args.compile_only,
                 compile_cfg=dict(dump_passes=args.dump_passes),
                 runtime_cfg=dict(
@@ -982,6 +986,8 @@ if __name__ == "__main__":
                 fn=l3_decode_swa,
                 specs=build_distributed_tensor_specs(local_t, start_pos=args.start_pos),
                 golden_fn=golden_decode_swa,
+                golden_data=args.golden_data,
+                save_data=args.save_data,
                 compile_only=args.compile_only,
                 compile_cfg=dict(
                     dump_passes=args.dump_passes,

--- a/models/deepseek_v4_flash_dspark/hc_post.py
+++ b/models/deepseek_v4_flash_dspark/hc_post.py
@@ -48,24 +48,24 @@ def hc_post(
     y_flat = pl.reshape(y, [t_dim, HC_DIM])
 
     token_tiles = (t_dim + T_TILE - 1) // T_TILE
-    for block in pl.spmd(token_tiles * HC_MULT, name_hint="hc_post"):
-        token_block = block // HC_MULT
-        out_h = block % HC_MULT
+    for token_block in pl.spmd(token_tiles, name_hint="hc_post"):
         t0 = token_block * T_TILE
         for t in pl.pipeline(t0, t0 + T_TILE, stage=2):
             if t < t_dim:
-                post_w = pl.read(post, [t, out_h])
+                # One cast per token: all HC_MULT outputs share the x row.
                 x_row = pl.cast(x[t : t + 1, 0:D], target_type=pl.FP32)
-                y_row = pl.mul(x_row, post_w)
-                for in_h in pl.pipeline(HC_MULT, stage=4):
-                    comb_w = pl.read(comb, [t, in_h * HC_MULT + out_h])
-                    res_d = in_h * D
-                    # residual is already FP32 (hc stream is FP32 end-to-end): no cast, read straight.
-                    res_row = residual_flat[t : t + 1, res_d : res_d + D]
-                    weighted = pl.mul(res_row, comb_w)
-                    y_row = pl.add(y_row, weighted)
-                # y is FP32 (feeds the next layer's hc_pre directly): no BF16 output cast.
-                y_flat[t : t + 1, out_h * D : out_h * D + D] = y_row
+                for out_h in pl.unroll(HC_MULT):
+                    post_w = pl.read(post, [t, out_h])
+                    y_row = pl.mul(x_row, post_w)
+                    for in_h in pl.pipeline(HC_MULT, stage=4):
+                        comb_w = pl.read(comb, [t, in_h * HC_MULT + out_h])
+                        res_d = in_h * D
+                        # residual is already FP32 (hc stream is FP32 end-to-end): no cast, read straight.
+                        res_row = residual_flat[t : t + 1, res_d : res_d + D]
+                        weighted = pl.mul(res_row, comb_w)
+                        y_row = pl.add(y_row, weighted)
+                    # y is FP32 (feeds the next layer's hc_pre directly): no BF16 output cast.
+                    y_flat[t : t + 1, out_h * D : out_h * D + D] = y_row
     return y
 
 

--- a/models/deepseek_v4_flash_dspark/hc_pre.py
+++ b/models/deepseek_v4_flash_dspark/hc_pre.py
@@ -48,13 +48,13 @@ HC_PAD = 8  # hc (4) padded for 32B-aligned vector ops
 
 
 # tiling (unchanged)
-T_TILE = 8  # vector row-tile (RMS / cast / split / mix_x)
+T_TILE = 8  # vector row-tile (RMS / cast / split / mix_x); other values miscompare
 LINEAR_T_TILE = 16  # cube matmul rows must be a 16-row boxed tile
 COMB_T_TILE = 8  # sinkhorn row-tile
 RMS_K_CHUNK = 512  # cast / rms K-fragment
 LINEAR_K_CHUNK = 256  # cube K-fragment per matmul_acc (32x256x4 FP32 weight fits L0B)
 D_CHUNK = 256  # mix_x inner D-fragment (BF16 load = 1KB, 512B-aligned)
-D_SPMD = 1024  # mix_x D per spmd block: decode fans 4096 reduce over D/D_SPMD cores
+D_SPMD = 4096  # mix_x D per spmd block: one task per token-tile covers all of D
 CAST_K_SPMD = 2048  # cast K per spmd block: decode fans the BF16->FP32 cast over HC_DIM/CAST_K_SPMD cores
 # Split the K=HC_DIM reduction into LINEAR_OK disjoint partials.
 LINEAR_OK = 4
@@ -68,7 +68,7 @@ RMS_CHUNKS_PER_SPLIT = RMS_K_PER_SPLIT // RMS_K_CHUNK
 
 # per-phase fan-out factors (compile-time constants; the token-tile factor is dynamic in T)
 CAST_KS = HC_DIM // CAST_K_SPMD  # cast tasks per token-tile (8)
-MIXX_DS = D // D_SPMD  # mix_x tasks per token-tile (4)
+MIXX_DS = D // D_SPMD  # mix_x tasks per token-tile
 
 assert HC_MULT == 4, (
     f"hc_pre is specialized to HC_MULT == 4, got {HC_MULT}; "

--- a/models/deepseek_v4_flash_dspark/hc_pre.py
+++ b/models/deepseek_v4_flash_dspark/hc_pre.py
@@ -6,8 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-# ci: no-dep-gen  # CI marker: full-occupancy pl.system.syncall -> dep_gen (DFX) trips 507018 (pypto#1931)
-"""DeepSeek-V4 hc_pre -- hyper-connection pre-mix, fused into ONE syncall-barriered task.
+"""DeepSeek-V4 hc_pre -- hyper-connection pre-mix, unified over decode and prefill.
 
 x[T, hc, D] holds hc streams of the hidden state (x_flat = x.reshape(T, hc*D)). With the
 projection hc_fn[mix_hc, hc*D], the per-group scales hc_scale[3] and biases hc_base[mix_hc]:
@@ -19,57 +18,14 @@ projection hc_fn[mix_hc, hc*D], the per-group scales hc_scale[3] and biases hc_b
     comb[T, hc, hc] = sinkhorn(softmax(reshape(mixes[:, 2hc:] * s2 + base, hc, hc)))
     x_mixed[T, D]   = sum_h pre[:, h] * x[:, h, :]
 
-TWO IMPLEMENTATIONS, selected by the ``HC_PRE_IMPL`` module flag (env ``DSV4_HC_PRE_IMPL``
-or ``--impl``); both are UNIFIED over decode + prefill and compute the identical math above:
-  * ``_hc_pre_syncall`` (default) -- the #684 fusion documented below: ONE full-occupancy
-    ``pl.spmd(24)`` with 2 hard ``pl.system.syncall`` barriers, run with dep_gen OFF.
-  * ``_hc_pre_separate`` -- the pre-#684 structure: each work-type is its OWN ``pl.spmd``
-    task (cast / rms / seed / linear / split_pre_post / write_post / comb_sinkhorn / mix_x),
-    ordered by the runtime task graph (dep_gen ON), tile sizes aligned to the syncall path.
-The rest of this docstring describes the default ``_hc_pre_syncall`` fusion.
-
-FUSION (unified decode + prefill): the whole op is ONE ``pl.spmd(NUM_CORES=24)`` launch --
-24 persistent blocks == 24 AIC + 48 AIV == every 910B core (the full-occupancy contract a
-hard ``pl.system.syncall(core_type="mix")`` requires). The body is 3 phases separated by 2
-barriers; each barrier publishes the prior phase's cross-core HBM writes:
-
-    Phase A  linear (split-K matmul -> mixes_partials, AIC)  +  rms (split-K SoS
-             -> sq_partials, AIV)
-    ── syncall ──  (every LINEAR_OK / RMS_OK partial visible)
-    Phase B  reduce the partials in ascending K order -> mixes_raw + sq_sum_acc   AIV
-    ── syncall ──  (mixes_raw + sq_sum_acc visible)
-    Phase D  per task: rsqrt(sq_sum) + scale/sigmoid GATE, then                    AIV
-             comb_sinkhorn (-> comb) | mix_x (-> x_mixed) | write_post (-> post)
-
-The old Phase C (a separate rsqrt+scale+sigmoid gate pass, published by a 3rd barrier) is
-FOLDED into Phase D: since the C->D handoff was cross-core (different grid-stride striping),
-it needed a barrier -- but each D task can just recompute the ONE gate it consumes from the
-published mixes_raw + sq_sum_acc on its OWN core (rsqrt+sigmoid is nearly free on
-this latency-bound kernel). That deletes a whole hard FFTS barrier (-8% decode / -11% prefill
-on the device chip swimlane, latency-bound so barrier removal > byte removal). comb_logits /
-post_pad_store survive only as SAME-CORE scratch (assemble then load-back, no barrier) because
-their downstream pl.load->pl.store needs an HC_PAD-wide 32B-aligned tile; the pre gate is
-consumed in tensor-world so it needs no buffer.
-
-Scheduling within a phase: each independent task-type is its OWN unconditional grid-stride
-loop (cube work strides over ``core`` 0..23, vector work over the global AIV-lane id
-``core*2 + aiv_id`` 0..47). Grid-stride IS the static round-robin schedule -- a pool larger
-than the core count wraps into further waves; a smaller one leaves extra cores running a
-0-trip loop that falls straight through to the next type (so a lane with no sinkhorn work
-starts mix_x immediately, overlapping the sinkhorn on a busy lane). LOOP ORDER is the
-scheduling policy: Phase D runs comb_sinkhorn FIRST -- its 20-iteration serial recurrence is
-a latency floor no core count shortens, so starting it first overlaps it with the
-throughput-bound mix_x on the other lanes.
-
-Split-K linear atomic-adds LINEAR_OK FP32 partials into mixes_raw; Barrier 1's zero-seed +
-Barrier 2's publish replace the old seed->RMW WAW edge. assemble(atomic=Add) is device-only
-and the hard barrier is not modeled by the a2a3sim / a5sim simulators, so those two sim CI
-checks are skipped for hc_pre -- validate on real device. mix_hc(24) pads to a 32-wide cube
+Each work-type is its own pl.spmd task (cast / rms / seed / linear / split_pre_post /
+write_post / comb_sinkhorn / mix_x); the runtime task graph orders them by GM read/write
+dependencies, so this kernel needs dep_gen ON. Split-K linear atomic-adds FP32 partials
+into mixes_raw over a zero seed. assemble(atomic=Add) is device-only, so the a2a3sim /
+a5sim CI checks skip hc_pre -- validate on real device. mix_hc(24) pads to a 32-wide cube
 N (MIX_PAD) and hc(4) to an 8-wide vector row (HC_PAD).
 """
 
-
-import os
 
 import pypto.language as pl
 
@@ -77,17 +33,6 @@ from config import FLASH as M, DECODE_BATCH, DECODE_SEQ, TP, PREFILL_BATCH, PREF
 
 
 T_DYN = pl.dynamic("T_DYN")  # T = B * S
-
-# Implementation selector (both versions are UNIFIED -- one code path for decode AND
-# prefill; no separate decode/prefill dispatch):
-#   "syncall"  (default) -- the #684 fused kernel: ONE full-occupancy pl.spmd(24) with
-#               2 hard pl.system.syncall barriers; runs with dep_gen OFF (pypto#1931).
-#   "separate" -- the pre-#684 multi-scope structure: each work-type is its own pl.spmd
-#               task, ordered by the runtime task graph (dep_gen ON), applied to ALL T.
-# Switch via env DSV4_HC_PRE_IMPL={syncall,separate} or by reassigning this module global
-# before the kernel is traced (the __main__ below wires it to --impl).
-HC_PRE_IMPL = os.environ.get("DSV4_HC_PRE_IMPL", "separate").lower()
-
 
 D = M.hidden_size
 HC_MULT = M.hc_mult
@@ -101,11 +46,6 @@ NORM_EPS = M.rms_norm_eps
 MIX_PAD = 32  # mix_hc (24) padded to a 32-wide cube N / vector row
 HC_PAD = 8  # hc (4) padded for 32B-aligned vector ops
 
-# Full-occupancy launch: NUM_CORES persistent blocks == physical AIC count (910B = 24), so a
-# hard mix-syncall reaches every AIC + AIV. Must equal the physical count exactly -- pypto does
-# NOT cap the launch, and >24 makes the runtime multi-round the blocks so some physical core is
-# in a later round when the barrier fires -> AICore timeout 507018.
-NUM_CORES = 24
 
 # tiling (unchanged)
 T_TILE = 8  # vector row-tile (RMS / cast / split / mix_x)
@@ -145,7 +85,7 @@ assert D % D_SPMD == 0 and D_SPMD % D_CHUNK == 0
 
 
 @pl.jit.inline
-def _hc_pre_syncall(
+def hc_pre(
     x: pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32],
     hc_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
     hc_scale: pl.Tensor[[3], pl.FP32],
@@ -154,377 +94,11 @@ def _hc_pre_syncall(
     post: pl.Tensor[[T_DYN, HC_MULT], pl.FP32],
     comb: pl.Tensor[[T_DYN, HC_MULT * HC_MULT], pl.FP32],
 ):
-    t_dim = pl.tensor.dim(x, 0)
-    token_tiles = (t_dim + T_TILE - 1) // T_TILE
-    t_linear = ((t_dim + LINEAR_T_TILE - 1) // LINEAR_T_TILE) * LINEAR_T_TILE  # pad t_dim up to whole 16-row cube tiles
-    x_flat = pl.reshape(x, [t_dim, HC_DIM])
-    scale0 = pl.read(hc_scale, [0])
-    scale1 = pl.read(hc_scale, [1])
-    scale2 = pl.read(hc_scale, [2])
-    hc_reshaped = pl.reshape(hc_base, [1, MIX_HC])
+    """Multi-scope hc_pre: one pl.spmd task per work-type, ordered by the task graph.
 
-    # Cross-barrier intermediates: allocated ONCE in GM/HBM, live across the phases.
-    # x arrives as FP32 (hc residual stream is FP32 end-to-end), so there is no x_fp32
-    # staging buffer: linear / rms read x_flat directly.
-    mixes_raw = pl.create_tensor([t_linear, MIX_PAD], dtype=pl.FP32)
-    linear_partial_rows = LINEAR_OK * t_linear
-    mixes_partials = pl.create_tensor([linear_partial_rows, MIX_PAD], dtype=pl.FP32)
-    # post_pad_store is SAME-CORE scratch: write_post writes its token-tile's post gate then
-    # reads it back on the SAME core (no barrier). It is kept (not deleted) because its
-    # downstream pl.load->pl.store needs an HC_PAD-wide (32B-aligned) tile -- a narrow
-    # [T_TILE, HC_MULT] FP32 tile is 16B rows and pto.alloc_tile rejects it. pre (mix_x) and
-    # comb (loaded straight from mixes_raw) are consumed in-tile, so they need no scratch.
-    post_pad_store = pl.create_tensor([t_linear, HC_PAD], dtype=pl.FP32)  # HC_PAD-wide same-core scratch; write_post narrows to post
-    # Only the final partial token tile uses these fixed-size staging buffers.
-    x_mixed_tail_store = pl.create_tensor([T_TILE, D], dtype=pl.BF16)
-    comb_tail_store = pl.create_tensor([COMB_T_TILE, HC_PAD * HC_MULT], dtype=pl.FP32)
-    # inv_rms same-core scratch for the comb gate: the per-token inv is a [T_TILE,1] COLUMN,
-    # which the comb groups (Tiles) need as a Tile too. pto rejects a transposed [T_TILE,1]
-    # tile (row-major, 4B row < 32B) and forbids Tile x Tensor ops, so the tensor-world inv
-    # is spilled to this [t_linear,1] buffer and loaded back as a [T_TILE,1] Tile (8 floats,
-    # vs the 128-float [.,16] comb_logits round-trip this replaces).
-    inv_gm = pl.create_tensor([t_linear, 1], dtype=pl.FP32)
-    sq_sum_acc = pl.create_tensor([1, t_linear], dtype=pl.FP32)  # RMS split-K sum-of-squares (row layout: [1,T_TILE] tiles stay 32B-aligned)
-    sq_partials = pl.create_tensor([RMS_OK, t_linear], dtype=pl.FP32)
-
-    # Per-phase grid-stride bounds (dynamic in t_dim; grid-stride round-robins any T over cores).
-    tt_n = token_tiles                 # token-tiles (pre / post / comb / rsqrt / sinkhorn / write_post base)
-    lin_n = (t_linear // LINEAR_T_TILE) * LINEAR_OK  # linear fans over row-block x OK K-slice
-    rms_n = tt_n * RMS_OK             # rms fans over token-tile x K-slice (split-K sum-of-squares)
-    linear_reduce_n = t_linear // LINEAR_T_TILE  # linear partials reduced per row-block
-    reduce_n = linear_reduce_n + tt_n  # flattened reduce pool: linear row-blocks | rms token-tiles
-    mixx_n = tt_n * MIXX_DS           # mix_x fans over token-tile x D-slice
-    pool_d = 2 * tt_n + mixx_n        # phase-D flattened pool: sinkhorn(tt_n)|mix_x(mixx_n)|write_post(tt_n)
-
-    with pl.spmd(NUM_CORES, name_hint="hc_pre_fused", sync_start=True, allow_early_resolve=True) as _hc_tid:  # inline form requires the TaskId capture
-        core = pl.tile.get_block_idx()  # 0 .. NUM_CORES-1
-
-        # Cube linear partials and vector RMS partials run concurrently.
-        for task in pl.range(core, lin_n, NUM_CORES):
-            t0 = (task // LINEAR_OK) * LINEAR_T_TILE
-            linear_split = task % LINEAR_OK
-            k_base = linear_split * LINEAR_K_PER_SPLIT
-            t_rows = pl.min(LINEAR_T_TILE, t_dim - t0)  # last row-block spills past t_dim; valid_shape zero-fills the tail
-            acc = pl.create_tensor([LINEAR_T_TILE, MIX_PAD], dtype=pl.FP32)
-            for kb in pl.pipeline(0, LINEAR_CHUNKS_PER_SPLIT, stage=2):
-                k0 = k_base + kb * LINEAR_K_CHUNK
-                x_linear_chunk = pl.slice(x_flat, [LINEAR_T_TILE, LINEAR_K_CHUNK], [t0, k0], valid_shape=[t_rows, LINEAR_K_CHUNK])
-                w_chunk = pl.slice(hc_fn, [MIX_PAD, LINEAR_K_CHUNK], [0, k0], valid_shape=[MIX_HC, LINEAR_K_CHUNK])
-                if kb == 0:
-                    acc = pl.matmul(x_linear_chunk, w_chunk, b_trans=True, out_dtype=pl.FP32)
-                else:
-                    acc = pl.matmul_acc(acc, x_linear_chunk, w_chunk, b_trans=True)
-            mixes_partials = pl.assemble(
-                mixes_partials,
-                acc,
-                [linear_split * t_linear + t0, 0],
-            )
-        for aiv_id in pl.split_aiv(2, mode=pl.SplitMode.NONE):
-            lane = core * 2 + aiv_id
-            for task in pl.range(lane, rms_n, NUM_CORES * 2):
-                t0 = (task // RMS_OK) * T_TILE
-                rms_split = task % RMS_OK
-                k_base = rms_split * RMS_K_PER_SPLIT
-                valid_rows = pl.min(T_TILE, t_dim - t0)
-                sq_part = pl.full([1, T_TILE], dtype=pl.FP32, value=0.0)
-                for kb in pl.pipeline(RMS_CHUNKS_PER_SPLIT, stage=4):
-                    k0 = k_base + kb * RMS_K_CHUNK
-                    x_chunk = pl.slice(
-                        x_flat,
-                        [T_TILE, RMS_K_CHUNK],
-                        [t0, k0],
-                        valid_shape=[valid_rows, RMS_K_CHUNK],
-                    )
-                    sq_part = pl.add(sq_part, pl.reshape(pl.row_sum(pl.mul(x_chunk, x_chunk)), [1, T_TILE]))
-                sq_partials = pl.assemble(sq_partials, sq_part, [rms_split, t0])
-        pl.system.syncall(core_type="mix")
-
-        # Split-K partials are reduced in ascending K order.
-        for aiv_id in pl.split_aiv(2, mode=pl.SplitMode.NONE):
-            lane = core * 2 + aiv_id
-            for reduce_task in pl.range(lane, reduce_n, NUM_CORES * 2):
-                if reduce_task < linear_reduce_n:
-                    linear_t0 = reduce_task * LINEAR_T_TILE
-                    mixes_total = mixes_partials[
-                        linear_t0 : linear_t0 + LINEAR_T_TILE,
-                        0:MIX_PAD,
-                    ]
-                    for linear_split in pl.range(1, LINEAR_OK):
-                        partial_t0 = linear_split * t_linear + linear_t0
-                        mixes_total = pl.add(
-                            mixes_total,
-                            mixes_partials[
-                                partial_t0 : partial_t0 + LINEAR_T_TILE,
-                                0:MIX_PAD,
-                            ],
-                        )
-                    mixes_raw = pl.assemble(mixes_raw, mixes_total, [linear_t0, 0])
-                else:
-                    rms_t0 = (reduce_task - linear_reduce_n) * T_TILE
-                    sq_total = sq_partials[0:1, rms_t0 : rms_t0 + T_TILE]
-                    for rms_split in pl.range(1, RMS_OK):
-                        sq_total = pl.add(
-                            sq_total,
-                            sq_partials[rms_split : rms_split + 1, rms_t0 : rms_t0 + T_TILE],
-                        )
-                    sq_sum_acc = pl.assemble(sq_sum_acc, sq_total, [0, rms_t0])
-        pl.system.syncall(core_type="mix")
-
-        # ===================== PHASE C+D FUSED: gate + sinkhorn/mix_x/write_post (AIV) =====
-        # Phase C (rsqrt + scale + sigmoid gates) is FOLDED into each Phase-D task: every
-        # task recomputes the gate it needs from the published mixes_raw + sq_sum_acc
-        # on its OWN core, just before using it. Recompute is nearly free here (latency-bound
-        # kernel), and it deletes an entire cross-core barrier plus the pre/post/comb gate
-        # round-trips -- the C->D handoff was the reason the old Barrier 3 existed. comb_logits
-        # stays only as SAME-CORE scratch (assemble then load back, no barrier).
-        #
-        # The three kinds share ONE flattened work pool so they run on DISJOINT cores in
-        # parallel -- otherwise per-type loops all start at the same lane base, stacking
-        # sinkhorn (a 20-iter serial-recurrence latency floor) + that lane's mix_x/write_post
-        # onto lane 0 while the other lanes idle. sinkhorn is placed first in the pool so its
-        # long chain starts immediately alongside the mix_x lanes. No trailing barrier
-        # (kernel end publishes the outputs).
-        for aiv_id in pl.split_aiv(2, mode=pl.SplitMode.NONE):
-            lane = core * 2 + aiv_id
-            # ONE flattened pool [sinkhorn(tt_n) | mix_x(mixx_n) | write_post(tt_n)] so grid-
-            # stride lands the three kinds on DISJOINT lanes -- sinkhorn, all mix_x D-slices,
-            # and write_post run on different cores concurrently (not serialized per lane).
-            for gw in pl.range(lane, pool_d, NUM_CORES * 2):
-                if gw < tt_n:
-                    t0 = gw * COMB_T_TILE
-                    valid_rows = pl.min(COMB_T_TILE, t_dim - t0)
-                    # Fold Phase C's comb gate here AND skip the comb_logits GM round-trip:
-                    # load the 4 comb groups DIRECTLY from mixes_raw (pad-capable loads at cols
-                    # 8/12/16/20 within the 32-wide MIX_PAD row), then apply inv_rms * scale2 +
-                    # group bias PER GROUP in-tile. The previous version assembled a [.,16]
-                    # comb_logits tile to GM and loaded the 4 misaligned 4-wide groups back
-                    # (pto cannot slice a 16B sub-tile in-register); loading straight from the
-                    # matmul output drops that store+load, matching the prefill path.
-                    # inv_rms for the comb gate must be a TILE (the comb groups below are
-                    # Tiles). Compute it in tensor-world, spill to inv_gm, and load it back as a
-                    # [T_TILE,1] Tile (a transposed [T_TILE,1] tile is rejected -- 4B row).
-                    ssq_row = sq_sum_acc[0:1, t0:t0 + COMB_T_TILE]  # [1,T_TILE] tensor
-                    inv_col_tensor = pl.reshape(pl.rsqrt(pl.add(pl.mul(ssq_row, HC_DIM_INV), NORM_EPS), high_precision=True), [COMB_T_TILE, 1])
-                    inv_gm = pl.assemble(inv_gm, inv_col_tensor, [t0, 0])
-                    inv_col_t = pl.load(
-                        inv_gm,
-                        [t0, 0],
-                        [COMB_T_TILE, 1],
-                        valid_shape=[valid_rows, 1],
-                        target_memory=pl.MemorySpace.Vec,
-                    )
-                    comb_off = HC_MULT * 2
-                    mix_g0 = pl.load(mixes_raw, [t0, comb_off + 0 * HC_MULT], [COMB_T_TILE, HC_PAD], valid_shape=[valid_rows, HC_MULT], target_memory=pl.MemorySpace.Vec)
-                    mix_g1 = pl.load(mixes_raw, [t0, comb_off + 1 * HC_MULT], [COMB_T_TILE, HC_PAD], valid_shape=[valid_rows, HC_MULT], target_memory=pl.MemorySpace.Vec)
-                    mix_g2 = pl.load(mixes_raw, [t0, comb_off + 2 * HC_MULT], [COMB_T_TILE, HC_PAD], valid_shape=[valid_rows, HC_MULT], target_memory=pl.MemorySpace.Vec)
-                    mix_g3 = pl.load(mixes_raw, [t0, comb_off + 3 * HC_MULT], [COMB_T_TILE, HC_PAD], valid_shape=[valid_rows, HC_MULT], target_memory=pl.MemorySpace.Vec)
-                    cb0 = pl.load(hc_reshaped, [0, comb_off + 0 * HC_MULT], [1, HC_PAD], valid_shape=[1, HC_MULT], target_memory=pl.MemorySpace.Vec)
-                    cb1 = pl.load(hc_reshaped, [0, comb_off + 1 * HC_MULT], [1, HC_PAD], valid_shape=[1, HC_MULT], target_memory=pl.MemorySpace.Vec)
-                    cb2 = pl.load(hc_reshaped, [0, comb_off + 2 * HC_MULT], [1, HC_PAD], valid_shape=[1, HC_MULT], target_memory=pl.MemorySpace.Vec)
-                    cb3 = pl.load(hc_reshaped, [0, comb_off + 3 * HC_MULT], [1, HC_PAD], valid_shape=[1, HC_MULT], target_memory=pl.MemorySpace.Vec)
-                    row0 = pl.add(pl.mul(pl.row_expand_mul(mix_g0, inv_col_t), scale2), pl.col_expand(mix_g0, cb0))
-                    row1 = pl.add(pl.mul(pl.row_expand_mul(mix_g1, inv_col_t), scale2), pl.col_expand(mix_g1, cb1))
-                    row2 = pl.add(pl.mul(pl.row_expand_mul(mix_g2, inv_col_t), scale2), pl.col_expand(mix_g2, cb2))
-                    row3 = pl.add(pl.mul(pl.row_expand_mul(mix_g3, inv_col_t), scale2), pl.col_expand(mix_g3, cb3))
-                    row0_p = pl.fillpad(row0, pad_value=pl.PadValue.min)
-                    row1_p = pl.fillpad(row1, pad_value=pl.PadValue.min)
-                    row2_p = pl.fillpad(row2, pad_value=pl.PadValue.min)
-                    row3_p = pl.fillpad(row3, pad_value=pl.PadValue.min)
-
-                    row_max_tmp = pl.create_tile([COMB_T_TILE, HC_PAD], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec)
-                    row_sum_tmp = pl.create_tile([COMB_T_TILE, HC_PAD], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec)
-                    row0_max = pl.row_max(row0_p, row_max_tmp)
-                    row1_max = pl.row_max(row1_p, row_max_tmp)
-                    row2_max = pl.row_max(row2_p, row_max_tmp)
-                    row3_max = pl.row_max(row3_p, row_max_tmp)
-                    row0_exp = pl.exp(pl.row_expand_sub(row0_p, row0_max))
-                    row1_exp = pl.exp(pl.row_expand_sub(row1_p, row1_max))
-                    row2_exp = pl.exp(pl.row_expand_sub(row2_p, row2_max))
-                    row3_exp = pl.exp(pl.row_expand_sub(row3_p, row3_max))
-                    row0_sum = pl.row_sum(row0_exp, row_sum_tmp)
-                    row1_sum = pl.row_sum(row1_exp, row_sum_tmp)
-                    row2_sum = pl.row_sum(row2_exp, row_sum_tmp)
-                    row3_sum = pl.row_sum(row3_exp, row_sum_tmp)
-                    row0_soft = pl.add(pl.row_expand_div(row0_exp, row0_sum), HC_EPS)
-                    row1_soft = pl.add(pl.row_expand_div(row1_exp, row1_sum), HC_EPS)
-                    row2_soft = pl.add(pl.row_expand_div(row2_exp, row2_sum), HC_EPS)
-                    row3_soft = pl.add(pl.row_expand_div(row3_exp, row3_sum), HC_EPS)
-
-                    row0_valid = pl.set_validshape(row0_soft, COMB_T_TILE, HC_MULT)
-                    row1_valid = pl.set_validshape(row1_soft, COMB_T_TILE, HC_MULT)
-                    row2_valid = pl.set_validshape(row2_soft, COMB_T_TILE, HC_MULT)
-                    row3_valid = pl.set_validshape(row3_soft, COMB_T_TILE, HC_MULT)
-                    row0_eff = pl.fillpad(row0_valid, pad_value=pl.PadValue.zero)
-                    row1_eff = pl.fillpad(row1_valid, pad_value=pl.PadValue.zero)
-                    row2_eff = pl.fillpad(row2_valid, pad_value=pl.PadValue.zero)
-                    row3_eff = pl.fillpad(row3_valid, pad_value=pl.PadValue.zero)
-
-                    row_sum_tmp_iter = pl.create_tile([COMB_T_TILE, HC_PAD], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec)
-                    col_sum = pl.add(pl.add(row0_eff, row1_eff), pl.add(row2_eff, row3_eff))
-                    col_sum = pl.add(col_sum, HC_EPS)
-                    row0_cur = pl.div(row0_eff, col_sum)
-                    row1_cur = pl.div(row1_eff, col_sum)
-                    row2_cur = pl.div(row2_eff, col_sum)
-                    row3_cur = pl.div(row3_eff, col_sum)
-
-                    for _sk_it in pl.pipeline(HC_SINKHORN_ITER - 1, stage=2):
-                        row0_rowsum = pl.add(pl.row_sum(row0_cur, row_sum_tmp_iter), HC_EPS)
-                        row1_rowsum = pl.add(pl.row_sum(row1_cur, row_sum_tmp_iter), HC_EPS)
-                        row2_rowsum = pl.add(pl.row_sum(row2_cur, row_sum_tmp_iter), HC_EPS)
-                        row3_rowsum = pl.add(pl.row_sum(row3_cur, row_sum_tmp_iter), HC_EPS)
-                        row0_norm = pl.row_expand_div(row0_cur, row0_rowsum)
-                        row1_norm = pl.row_expand_div(row1_cur, row1_rowsum)
-                        row2_norm = pl.row_expand_div(row2_cur, row2_rowsum)
-                        row3_norm = pl.row_expand_div(row3_cur, row3_rowsum)
-                        col_sum = pl.add(pl.add(row0_norm, row1_norm), pl.add(row2_norm, row3_norm))
-                        col_sum = pl.add(col_sum, HC_EPS)
-                        row0_cur = pl.div(row0_norm, col_sum)
-                        row1_cur = pl.div(row1_norm, col_sum)
-                        row2_cur = pl.div(row2_norm, col_sum)
-                        row3_cur = pl.div(row3_norm, col_sum)
-
-                    if valid_rows == COMB_T_TILE:
-                        row0_out = pl.set_validshape(row0_cur, COMB_T_TILE, HC_MULT)
-                        row1_out = pl.set_validshape(row1_cur, COMB_T_TILE, HC_MULT)
-                        row2_out = pl.set_validshape(row2_cur, COMB_T_TILE, HC_MULT)
-                        row3_out = pl.set_validshape(row3_cur, COMB_T_TILE, HC_MULT)
-                        pl.store(row0_out, [t0, 0 * HC_MULT], comb)
-                        pl.store(row1_out, [t0, 1 * HC_MULT], comb)
-                        pl.store(row2_out, [t0, 2 * HC_MULT], comb)
-                        pl.store(row3_out, [t0, 3 * HC_MULT], comb)
-                    else:
-                        pl.store(row0_cur, [0, 0 * HC_PAD], comb_tail_store)
-                        pl.store(row1_cur, [0, 1 * HC_PAD], comb_tail_store)
-                        pl.store(row2_cur, [0, 2 * HC_PAD], comb_tail_store)
-                        pl.store(row3_cur, [0, 3 * HC_PAD], comb_tail_store)
-                        row0_tail = pl.load(
-                            comb_tail_store,
-                            [0, 0 * HC_PAD],
-                            [COMB_T_TILE, HC_PAD],
-                            valid_shape=[valid_rows, HC_MULT],
-                            target_memory=pl.MemorySpace.Vec,
-                        )
-                        row1_tail = pl.load(
-                            comb_tail_store,
-                            [0, 1 * HC_PAD],
-                            [COMB_T_TILE, HC_PAD],
-                            valid_shape=[valid_rows, HC_MULT],
-                            target_memory=pl.MemorySpace.Vec,
-                        )
-                        row2_tail = pl.load(
-                            comb_tail_store,
-                            [0, 2 * HC_PAD],
-                            [COMB_T_TILE, HC_PAD],
-                            valid_shape=[valid_rows, HC_MULT],
-                            target_memory=pl.MemorySpace.Vec,
-                        )
-                        row3_tail = pl.load(
-                            comb_tail_store,
-                            [0, 3 * HC_PAD],
-                            [COMB_T_TILE, HC_PAD],
-                            valid_shape=[valid_rows, HC_MULT],
-                            target_memory=pl.MemorySpace.Vec,
-                        )
-                        pl.store(row0_tail, [t0, 0 * HC_MULT], comb)
-                        pl.store(row1_tail, [t0, 1 * HC_MULT], comb)
-                        pl.store(row2_tail, [t0, 2 * HC_MULT], comb)
-                        pl.store(row3_tail, [t0, 3 * HC_MULT], comb)
-
-                elif gw < tt_n + mixx_n:
-                    blk = gw - tt_n
-                    t0 = (blk // MIXX_DS) * T_TILE
-                    d_base = (blk % MIXX_DS) * D_SPMD
-                    valid_rows = pl.min(T_TILE, t_dim - t0)
-                    # Fold Phase C's pre gate: pre = sigmoid(mix[:, :hc] * inv * scale0 + base) + eps.
-                    # Recomputed here from mixes_raw (every D-slice of a token-tile redoes this
-                    # tiny [T_TILE, HC_PAD] sigmoid -- free, and it drops the pre_val HBM buffer).
-                    ssq_row = sq_sum_acc[0:1, t0:t0 + T_TILE]  # [1,T_TILE] row keeps the rsqrt tile 32B-aligned
-                    inv_col = pl.reshape(pl.rsqrt(pl.add(pl.mul(ssq_row, HC_DIM_INV), NORM_EPS), high_precision=True), [T_TILE, 1])
-                    pre_base = hc_reshaped[0:1, 0:HC_PAD]
-                    pre_scaled = pl.mul(pl.row_expand_mul(mixes_raw[t0:t0 + T_TILE, 0:HC_PAD], inv_col), scale0)
-                    pre_logits = pl.add(pre_scaled, pl.col_expand(pre_scaled, pre_base))
-                    pre_val = pl.add(pl.recip(pl.add(pl.exp(pl.neg(pre_logits)), 1.0)), HC_EPS)
-                    # pin the valid shape: the inline gate carries valid=?x? from the dynamic-
-                    # offset mixes_raw slice, but the transpose below wants a static 8x8 tile.
-                    pre_val = pl.set_validshape(pre_val, T_TILE, HC_PAD)
-                    pre_tile_t = pl.transpose(pre_val, axis1=0, axis2=1)
-                    pre0 = pl.reshape(pre_tile_t[0:1, 0:T_TILE], [T_TILE, 1])
-                    pre1 = pl.reshape(pre_tile_t[1:2, 0:T_TILE], [T_TILE, 1])
-                    pre2 = pl.reshape(pre_tile_t[2:3, 0:T_TILE], [T_TILE, 1])
-                    pre3 = pl.reshape(pre_tile_t[3:4, 0:T_TILE], [T_TILE, 1])
-                    for db in pl.pipeline(D_SPMD // D_CHUNK, stage=2):
-                        d0 = d_base + db * D_CHUNK
-                        x0 = pl.slice(x_flat, [T_TILE, D_CHUNK], [t0, 0 * D + d0], valid_shape=[valid_rows, D_CHUNK])
-                        x1 = pl.slice(x_flat, [T_TILE, D_CHUNK], [t0, 1 * D + d0], valid_shape=[valid_rows, D_CHUNK])
-                        x2 = pl.slice(x_flat, [T_TILE, D_CHUNK], [t0, 2 * D + d0], valid_shape=[valid_rows, D_CHUNK])
-                        x3 = pl.slice(x_flat, [T_TILE, D_CHUNK], [t0, 3 * D + d0], valid_shape=[valid_rows, D_CHUNK])
-                        y0 = pl.row_expand_mul(x0, pre0)
-                        y1 = pl.row_expand_mul(x1, pre1)
-                        y2 = pl.row_expand_mul(x2, pre2)
-                        y3 = pl.row_expand_mul(x3, pre3)
-                        y_tile = pl.add(pl.add(y0, y1), pl.add(y2, y3))
-                        y_bf16 = pl.cast(y_tile, target_type=pl.BF16, mode="rint")
-                        if valid_rows == T_TILE:
-                            x_mixed = pl.assemble(x_mixed, y_bf16, [t0, d0])
-                        else:
-                            x_mixed_tail_store = pl.assemble(x_mixed_tail_store, y_bf16, [0, d0])
-                            y_out = pl.load(
-                                x_mixed_tail_store,
-                                [0, d0],
-                                [T_TILE, D_CHUNK],
-                                valid_shape=[valid_rows, D_CHUNK],
-                                target_memory=pl.MemorySpace.Vec,
-                            )
-                            pl.store(y_out, [t0, d0], x_mixed)
-
-                else:
-                    ob = gw - tt_n - mixx_n
-                    t0 = ob * COMB_T_TILE
-                    valid_rows = pl.min(COMB_T_TILE, t_dim - t0)
-                    # Fold Phase C's post gate: post = 2 * sigmoid(mix[:, hc:2hc] * inv * scale1 + base).
-                    # The gate is tensor-world (mixes_raw slice -> sigmoid), and pl.store needs a Vec
-                    # TILE -- so post_pad is stashed HC_PAD-wide in same-core scratch and loaded back as
-                    # an aligned [COMB_T_TILE, HC_PAD] tile (a direct [.,HC_MULT] store would need a
-                    # 16B-row FP32 tile, which pto.alloc_tile rejects). pl.store then narrows valid
-                    # [COMB_T_TILE, HC_MULT] into the 4-wide post output.
-                    ssq_row = sq_sum_acc[0:1, t0:t0 + COMB_T_TILE]  # [1,COMB_T_TILE] row keeps the rsqrt tile 32B-aligned
-                    inv_col = pl.reshape(pl.rsqrt(pl.add(pl.mul(ssq_row, HC_DIM_INV), NORM_EPS), high_precision=True), [COMB_T_TILE, 1])
-                    post_base = hc_reshaped[0:1, HC_MULT:HC_MULT + HC_PAD]
-                    post_scaled = pl.mul(pl.row_expand_mul(mixes_raw[t0:t0 + COMB_T_TILE, HC_MULT:HC_MULT + HC_PAD], inv_col), scale1)
-                    post_logits = pl.add(post_scaled, pl.col_expand(post_scaled, post_base))
-                    post_pad = pl.mul(pl.recip(pl.add(pl.exp(pl.neg(post_logits)), 1.0)), 2.0)
-                    post_pad_store = pl.assemble(post_pad_store, post_pad, [t0, 0])
-                    if valid_rows == COMB_T_TILE:
-                        post_full = pl.load(post_pad_store, [t0, 0], [COMB_T_TILE, HC_PAD],
-                                            valid_shape=[COMB_T_TILE, HC_MULT], target_memory=pl.MemorySpace.Vec)
-                        pl.store(post_full, [t0, 0], post)
-                    else:
-                        post_tail = pl.load(post_pad_store, [t0, 0], [COMB_T_TILE, HC_PAD],
-                                            valid_shape=[valid_rows, HC_MULT], target_memory=pl.MemorySpace.Vec)
-                        pl.store(post_tail, [t0, 0], post)
-    return x_mixed
-
-
-@pl.jit.inline
-def _hc_pre_separate(
-    x: pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32],
-    hc_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
-    hc_scale: pl.Tensor[[3], pl.FP32],
-    hc_base: pl.Tensor[[MIX_HC], pl.FP32],
-    x_mixed: pl.Tensor[[T_DYN, D], pl.BF16],
-    post: pl.Tensor[[T_DYN, HC_MULT], pl.FP32],
-    comb: pl.Tensor[[T_DYN, HC_MULT * HC_MULT], pl.FP32],
-):
-    """Multi-scope (separate-task) hc_pre -- the pre-#684 structure, applied to ALL T.
-
-    Identical math to _hc_pre_syncall, but each work-type is its OWN pl.spmd task instead
-    of one full-occupancy pl.spmd + hard pl.system.syncall barriers. The runtime task
-    graph orders the scopes by their GM read/write dependencies (seed -> linear atomic-add
-    -> split_pre_post -> write_post / comb_sinkhorn / mix_x), so this path needs dep_gen ON
-    (the __main__ harness sets enable_dep_gen accordingly). Tile sizes are aligned to the
-    tuned syncall version (D_CHUNK / D_SPMD / LINEAR_* / t_linear round-up); cross-barrier
-    buffers are sized to the dynamic t_linear (the 8->16 padded row count), not a static
-    T_MAX. Kept as a switchable alternative to the fused kernel (perf is not the goal here).
+    Scope order comes from GM read/write dependencies (seed -> linear atomic-add ->
+    split_pre_post -> write_post / comb_sinkhorn / mix_x), so this kernel needs dep_gen ON.
+    Cross-scope buffers are sized to the dynamic t_linear (the 8->16 padded row count).
     """
     t_dim = pl.tensor.dim(x, 0)
     token_tiles = (t_dim + T_TILE - 1) // T_TILE
@@ -816,50 +390,6 @@ def _hc_pre_separate(
     return x_mixed
 
 
-def _bind_hc_pre():
-    """Define and return the public `hc_pre` inline kernel for the selected HC_PRE_IMPL.
-
-    pypto constrains how the choice can be expressed:
-      * a kernel-body branch on the module-global string (``if HC_PRE_IMPL == ...``) fails
-        -- pypto's frontend treats it as device control flow and cannot resolve the name;
-      * an alias (``hc_pre = _hc_pre_syncall``) fails at the call site -- pypto matches the
-        call-site NAME against the callee's registered ``__name__`` ("hc_pre" != the impl).
-    So `hc_pre` must BE a decorated inline named ``hc_pre`` that calls the chosen impl by
-    its literal name; the selection is a plain-Python ``if`` at import (never seen by a
-    kernel). Re-invoke to rebind after changing HC_PRE_IMPL (the __main__ --impl path).
-    """
-    if HC_PRE_IMPL == "separate":
-        @pl.jit.inline
-        def hc_pre(
-            x: pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32],
-            hc_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
-            hc_scale: pl.Tensor[[3], pl.FP32],
-            hc_base: pl.Tensor[[MIX_HC], pl.FP32],
-            x_mixed: pl.Tensor[[T_DYN, D], pl.BF16],
-            post: pl.Tensor[[T_DYN, HC_MULT], pl.FP32],
-            comb: pl.Tensor[[T_DYN, HC_MULT * HC_MULT], pl.FP32],
-        ):
-            _hc_pre_separate(x, hc_fn, hc_scale, hc_base, x_mixed, post, comb)
-            return x_mixed
-    else:
-        @pl.jit.inline
-        def hc_pre(
-            x: pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32],
-            hc_fn: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32],
-            hc_scale: pl.Tensor[[3], pl.FP32],
-            hc_base: pl.Tensor[[MIX_HC], pl.FP32],
-            x_mixed: pl.Tensor[[T_DYN, D], pl.BF16],
-            post: pl.Tensor[[T_DYN, HC_MULT], pl.FP32],
-            comb: pl.Tensor[[T_DYN, HC_MULT * HC_MULT], pl.FP32],
-        ):
-            _hc_pre_syncall(x, hc_fn, hc_scale, hc_base, x_mixed, post, comb)
-            return x_mixed
-    return hc_pre
-
-
-# Public entry point. Callers do `from hc_pre import hc_pre`; env DSV4_HC_PRE_IMPL (or the
-# __main__ --impl flag, which rebinds) picks the implementation at import time.
-hc_pre = _bind_hc_pre()
 
 
 @pl.jit
@@ -1012,35 +542,9 @@ if __name__ == "__main__":
     parser.add_argument("--compile-only", action="store_true", default=False)
     parser.add_argument("--dump-passes", action="store_true", default=False)
     parser.add_argument("--no-dep-gen", action="store_true", default=False,
-                        help="deprecated no-op: dep_gen is auto-selected per --impl (OFF for "
-                             "'syncall' per pypto#1931, ON for 'separate'); kept for CLI / CI back-compat.")
-    parser.add_argument("--impl", choices=["syncall", "separate"], default=HC_PRE_IMPL,
-                        help="hc_pre implementation: 'syncall' (fused single task, #684) or "
-                             "'separate' (multi-scope task graph, pre-#684). Both are unified "
-                             "over decode+prefill. Default from env DSV4_HC_PRE_IMPL.")
+                        help="deprecated no-op: this kernel always needs dep_gen ON to order its "
+                             "task graph; kept for CLI / CI back-compat.")
     args = parser.parse_args()
-
-    # Select the implementation for this run: set the flag, then rebind the module-global
-    # `hc_pre` to the chosen inline kernel BEFORE run_jit traces hc_pre_test (which resolves
-    # `hc_pre` from the module namespace at trace time).
-    HC_PRE_IMPL = args.impl
-    hc_pre = _bind_hc_pre()
-    print(f"hc_pre implementation: {HC_PRE_IMPL}")
-
-    # hc_pre "syncall" is specialized to Ascend 910B: it sets NUM_CORES=24 == the physical
-    # AIC count and its hard full-occupancy mix-syncall hangs (AICore timeout 507018) unless
-    # the launch fills every physical core; A5 (Ascend950) has a different AIC count (36), so
-    # the syncall impl is rejected on A5. The "separate" impl has no such barrier -- it uses
-    # data-derived pl.spmd(work_count) + CORE_GROUP + atomic-add (the same structural pattern
-    # as hc_head/hc_post, which already pass on A5), so it is core-count-agnostic and runs on
-    # A5. Its tile sizes are 910B-tuned (perf, not correctness); a5 perf may be suboptimal
-    # until re-swept, but precision is unaffected.
-    if args.platform in ("a5", "a5sim") and HC_PRE_IMPL == "syncall":
-        raise SystemExit(
-            f"hc_pre 'syncall' impl is specialized to Ascend 910B (NUM_CORES={NUM_CORES} == physical "
-            f"AIC count); its full-occupancy mix-syncall would hang (AICore timeout 507018) on "
-            f"{args.platform!r}. Re-run with --impl separate on {args.platform!r}, or -p a2a3."
-        )
 
     modes_to_run = list(MODES.keys()) if args.mode == "all" else [args.mode]
 
@@ -1058,12 +562,8 @@ if __name__ == "__main__":
                 platform=args.platform,
                 device_id=args.device,
                 enable_chip_swimlane=args.enable_chip_swimlane,
-                # dep_gen: the "syncall" version's full-occupancy pl.system.syncall is
-                # incompatible with dep_gen -- the DFX instrumentation perturbs core
-                # occupancy and trips AICore timeout 507018 (pypto#1931) -- so it runs with
-                # dep_gen OFF. The "separate" version has no hard syncall and RELIES on
-                # dep_gen to order its multi-scope task graph, so it runs with dep_gen ON.
-                enable_dep_gen=(HC_PRE_IMPL == "separate"),
+                # The multi-scope task graph is ordered by dep_gen, not by explicit deps.
+                enable_dep_gen=True,
             ),
             rtol=1e-3,
             atol=1e-3,

--- a/models/deepseek_v4_flash_dspark/hc_pre.py
+++ b/models/deepseek_v4_flash_dspark/hc_pre.py
@@ -6,25 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-"""DeepSeek-V4 hc_pre -- hyper-connection pre-mix, unified over decode and prefill.
-
-x[T, hc, D] holds hc streams of the hidden state (x_flat = x.reshape(T, hc*D)). With the
-projection hc_fn[mix_hc, hc*D], the per-group scales hc_scale[3] and biases hc_base[mix_hc]:
-
-    inv_rms[T, 1]   = rsqrt(mean_k(x_flat^2) + eps)
-    mixes[T, mix_hc]= inv_rms * (x_flat @ hc_fn^T)              # 1/rms deferred past the matmul
-    pre [T, hc]     = sigmoid(mixes[:, :hc]   * s0 + base) + eps
-    post[T, hc]     = 2 * sigmoid(mixes[:, hc:2hc] * s1 + base)
-    comb[T, hc, hc] = sinkhorn(softmax(reshape(mixes[:, 2hc:] * s2 + base, hc, hc)))
-    x_mixed[T, D]   = sum_h pre[:, h] * x[:, h, :]
-
-Each work-type is its own pl.spmd task (cast / rms / seed / linear / split_pre_post /
-write_post / comb_sinkhorn / mix_x); the runtime task graph orders them by GM read/write
-dependencies, so this kernel needs dep_gen ON. Split-K linear atomic-adds FP32 partials
-into mixes_raw over a zero seed. assemble(atomic=Add) is device-only, so the a2a3sim /
-a5sim CI checks skip hc_pre -- validate on real device. mix_hc(24) pads to a 32-wide cube
-N (MIX_PAD) and hc(4) to an 8-wide vector row (HC_PAD).
-"""
+"""DeepSeek-V4 hc_pre -- hyper-connection pre-mix, unified over decode and prefill."""
 
 
 import pypto.language as pl
@@ -32,8 +14,10 @@ import pypto.language as pl
 from config import FLASH as M, DECODE_BATCH, DECODE_SEQ, TP, PREFILL_BATCH, PREFILL_SEQ
 
 
+# Dynamic shape variables.
 T_DYN = pl.dynamic("T_DYN")  # T = B * S
 
+# model config
 D = M.hidden_size
 HC_MULT = M.hc_mult
 MIX_HC = M.mix_hc
@@ -43,45 +27,21 @@ HC_SINKHORN_ITER = M.hc_sinkhorn_iters
 HC_EPS = M.hc_eps
 NORM_EPS = M.rms_norm_eps
 
+# tiling
 MIX_PAD = 32  # mix_hc (24) padded to a 32-wide cube N / vector row
 HC_PAD = 8  # hc (4) padded for 32B-aligned vector ops
-
-
-# tiling (unchanged)
-T_TILE = 8  # vector row-tile (RMS / cast / split / mix_x); other values miscompare
+T_TILE = 8  # other values miscompare
 LINEAR_T_TILE = 16  # cube matmul rows must be a 16-row boxed tile
-COMB_T_TILE = 8  # sinkhorn row-tile
-RMS_K_CHUNK = 512  # cast / rms K-fragment
-LINEAR_K_CHUNK = 256  # cube K-fragment per matmul_acc (32x256x4 FP32 weight fits L0B)
-D_CHUNK = 256  # mix_x inner D-fragment (BF16 load = 1KB, 512B-aligned)
-D_SPMD = 4096  # mix_x D per spmd block: one task per token-tile covers all of D
-CAST_K_SPMD = 2048  # cast K per spmd block: decode fans the BF16->FP32 cast over HC_DIM/CAST_K_SPMD cores
-# Split the K=HC_DIM reduction into LINEAR_OK disjoint partials.
+COMB_T_TILE = 8
+RMS_K_TILE = 512
+LINEAR_K_TILE = 256
+D_TILE = 256
+D_SPMD = 4096
 LINEAR_OK = 4
 LINEAR_K_PER_SPLIT = HC_DIM // LINEAR_OK
-LINEAR_CHUNKS_PER_SPLIT = LINEAR_K_PER_SPLIT // LINEAR_K_CHUNK
 
-# Split the RMS sum-of-squares K reduction into RMS_OK disjoint partials.
-RMS_OK = 16
-RMS_K_PER_SPLIT = HC_DIM // RMS_OK
-RMS_CHUNKS_PER_SPLIT = RMS_K_PER_SPLIT // RMS_K_CHUNK
-
-# per-phase fan-out factors (compile-time constants; the token-tile factor is dynamic in T)
-CAST_KS = HC_DIM // CAST_K_SPMD  # cast tasks per token-tile (8)
-MIXX_DS = D // D_SPMD  # mix_x tasks per token-tile
-
-assert HC_MULT == 4, (
-    f"hc_pre is specialized to HC_MULT == 4, got {HC_MULT}; "
-    "regenerate the pre0..pre3 / row0..row3 unrolling before using it."
-)
-assert (DECODE_BATCH // TP * DECODE_SEQ) % T_TILE == 0
-assert (PREFILL_BATCH * PREFILL_SEQ) % T_TILE == 0
-assert (PREFILL_BATCH * PREFILL_SEQ) % LINEAR_T_TILE == 0
-assert (DECODE_BATCH // TP * DECODE_SEQ) % LINEAR_T_TILE == 0 or DECODE_BATCH // TP * DECODE_SEQ <= LINEAR_T_TILE
-assert HC_DIM % LINEAR_K_CHUNK == 0
-assert HC_DIM % CAST_K_SPMD == 0 and CAST_K_SPMD % RMS_K_CHUNK == 0
-assert HC_DIM % RMS_OK == 0 and RMS_K_PER_SPLIT % RMS_K_CHUNK == 0
-assert D % D_SPMD == 0 and D_SPMD % D_CHUNK == 0
+# pre0..pre3 / row0..row3 are hand-unrolled over the hc lanes.
+assert HC_MULT == 4, f"hc_pre is specialized to HC_MULT == 4, got {HC_MULT}"
 
 
 @pl.jit.inline
@@ -94,11 +54,10 @@ def hc_pre(
     post: pl.Tensor[[T_DYN, HC_MULT], pl.FP32],
     comb: pl.Tensor[[T_DYN, HC_MULT * HC_MULT], pl.FP32],
 ):
-    """Multi-scope hc_pre: one pl.spmd task per work-type, ordered by the task graph.
+    """One pl.spmd task per work-type, ordered by their GM read/write dependencies.
 
-    Scope order comes from GM read/write dependencies (seed -> linear atomic-add ->
-    split_pre_post -> write_post / comb_sinkhorn / mix_x), so this kernel needs dep_gen ON.
-    Cross-scope buffers are sized to the dynamic t_linear (the 8->16 padded row count).
+    rms -> linear -> linear_reduce -> split_pre_post / comb_sinkhorn / mix_x. Cross-scope
+    buffers are sized to t_linear, the token count padded up to whole 16-row cube tiles.
     """
     t_dim = pl.tensor.dim(x, 0)
     token_tiles = (t_dim + T_TILE - 1) // T_TILE
@@ -110,73 +69,58 @@ def hc_pre(
     hc_base_2d = pl.reshape(hc_base, [1, MIX_HC])  # for per-group comb base loads in comb_sinkhorn
 
     inv_rms = pl.create_tensor([t_linear, 1], dtype=pl.FP32)
-    # x arrives as FP32 from the prior hc_post (the hc residual stream is FP32 end-to-end),
-    # so the old BF16->FP32 cast scope + x_fp32 staging buffer are gone: linear / rms read
-    # x_flat directly. The 8->16 pad rows of the cube tile are never materialized -- the
-    # linear matmul masks them with valid_shape (zero-fill past t_dim), and rms only reads
-    # the t_dim real rows.
-    mixes_raw = pl.create_tensor([t_linear, MIX_PAD], dtype=pl.FP32)
-    linear_partial_rows = LINEAR_OK * t_linear
-    mixes_partials = pl.create_tensor([linear_partial_rows, MIX_PAD], dtype=pl.FP32)
 
-    # rms: full-K sum-of-squares per token-tile -> inv_rms (one scope, no split-K).
+    # rms: full-K sum-of-squares per token-tile -> inv_rms.
     for t in pl.spmd(token_tiles, name_hint="hc_pre_rms", allow_early_resolve=True):
         t0 = t * T_TILE
         valid_rows = pl.min(T_TILE, t_dim - t0)
         sq_sum = pl.full([1, T_TILE], dtype=pl.FP32, value=0.0)
-        for kb in pl.pipeline(HC_DIM // RMS_K_CHUNK, stage=4):
-            k0 = kb * RMS_K_CHUNK
+        for kb in pl.pipeline(HC_DIM // RMS_K_TILE, stage=4):
+            k0 = kb * RMS_K_TILE
             if valid_rows == T_TILE:
-                x_chunk_full = x_flat[t0:t0 + T_TILE, k0:k0 + RMS_K_CHUNK]
-                sq_sum = pl.add(
-                    sq_sum,
-                    pl.reshape(pl.row_sum(pl.mul(x_chunk_full, x_chunk_full)), [1, T_TILE]),
-                )
+                x_chunk_full = x_flat[t0:t0 + T_TILE, k0:k0 + RMS_K_TILE]
+                x_sq_full = pl.mul(x_chunk_full, x_chunk_full)
+                x_sq_row_full = pl.reshape(pl.row_sum(x_sq_full), [1, T_TILE])
+                sq_sum = pl.add(sq_sum, x_sq_row_full)
             else:
-                x_chunk_tail = pl.slice(
-                    x_flat,
-                    [T_TILE, RMS_K_CHUNK],
-                    [t0, k0],
-                    valid_shape=[valid_rows, RMS_K_CHUNK],
-                )
-                sq_sum = pl.add(
-                    sq_sum,
-                    pl.reshape(pl.row_sum(pl.mul(x_chunk_tail, x_chunk_tail)), [1, T_TILE]),
-                )
-        inv = pl.reshape(pl.rsqrt(pl.add(pl.mul(sq_sum, HC_DIM_INV), NORM_EPS), high_precision=True), [T_TILE, 1])
-        inv_rms = pl.assemble(inv_rms, inv, [t0, 0])
+                x_chunk_tail = pl.slice(x_flat, [T_TILE, RMS_K_TILE], [t0, k0], valid_shape=[valid_rows, RMS_K_TILE])
+                x_sq_tail = pl.mul(x_chunk_tail, x_chunk_tail)
+                x_sq_row_tail = pl.reshape(pl.row_sum(x_sq_tail), [1, T_TILE])
+                sq_sum = pl.add(sq_sum, x_sq_row_tail)
+        sq_mean = pl.add(pl.mul(sq_sum, HC_DIM_INV), NORM_EPS)
+        inv = pl.reshape(pl.rsqrt(sq_mean, high_precision=True), [T_TILE, 1])
+        inv_rms[t0:t0 + T_TILE, 0:1] = inv
 
-    # Linear split-K partials are reduced in ascending K order.
+    # linear: split-K matmul -> per-split partials. The t_dim..t_linear pad rows are
+    # zero-filled by valid_shape, never materialized.
+    mixes_partials = pl.create_tensor([LINEAR_OK * t_linear, MIX_PAD], dtype=pl.FP32)
     for task in pl.spmd((t_linear // LINEAR_T_TILE) * LINEAR_OK, name_hint="hc_pre_linear", allow_early_resolve=True):
         t0 = (task // LINEAR_OK) * LINEAR_T_TILE
         linear_split = task % LINEAR_OK
         k_base = linear_split * LINEAR_K_PER_SPLIT
         t_rows = pl.min(LINEAR_T_TILE, t_dim - t0)  # last row-block spills past t_dim; valid_shape zero-fills the tail
         acc = pl.create_tensor([LINEAR_T_TILE, MIX_PAD], dtype=pl.FP32)
-        for kb in pl.pipeline(0, LINEAR_CHUNKS_PER_SPLIT, stage=2):
-            k0 = k_base + kb * LINEAR_K_CHUNK
-            x_linear_chunk = pl.slice(x_flat, [LINEAR_T_TILE, LINEAR_K_CHUNK], [t0, k0], valid_shape=[t_rows, LINEAR_K_CHUNK])
-            w_chunk = pl.slice(hc_fn, [MIX_PAD, LINEAR_K_CHUNK], [0, k0], valid_shape=[MIX_HC, LINEAR_K_CHUNK])
+        for kb in pl.pipeline(0, LINEAR_K_PER_SPLIT // LINEAR_K_TILE, stage=2):
+            k0 = k_base + kb * LINEAR_K_TILE
+            x_linear_chunk = pl.slice(x_flat, [LINEAR_T_TILE, LINEAR_K_TILE], [t0, k0], valid_shape=[t_rows, LINEAR_K_TILE])
+            w_chunk = pl.slice(hc_fn, [MIX_PAD, LINEAR_K_TILE], [0, k0], valid_shape=[MIX_HC, LINEAR_K_TILE])
             if kb == 0:
                 acc = pl.matmul(x_linear_chunk, w_chunk, b_trans=True, out_dtype=pl.FP32)
             else:
                 acc = pl.matmul_acc(acc, x_linear_chunk, w_chunk, b_trans=True)
-        mixes_partials = pl.assemble(mixes_partials, acc, [linear_split * t_linear + t0, 0])
+        partial_row0 = linear_split * t_linear + t0
+        mixes_partials[partial_row0 : partial_row0 + LINEAR_T_TILE, 0:MIX_PAD] = acc
 
-    for linear_block in pl.spmd(
-        t_linear // LINEAR_T_TILE,
-        name_hint="hc_pre_linear_reduce",
-        allow_early_resolve=True,
-    ):
+    # Partials are reduced in ascending K order.
+    mixes_raw = pl.create_tensor([t_linear, MIX_PAD], dtype=pl.FP32)
+    for linear_block in pl.spmd(t_linear // LINEAR_T_TILE, name_hint="hc_pre_linear_reduce", allow_early_resolve=True):
         linear_t0 = linear_block * LINEAR_T_TILE
         mixes_total = mixes_partials[linear_t0 : linear_t0 + LINEAR_T_TILE, 0:MIX_PAD]
         for linear_split in pl.range(1, LINEAR_OK):
             partial_t0 = linear_split * t_linear + linear_t0
-            mixes_total = pl.add(
-                mixes_total,
-                mixes_partials[partial_t0 : partial_t0 + LINEAR_T_TILE, 0:MIX_PAD],
-            )
-        mixes_raw = pl.assemble(mixes_raw, mixes_total, [linear_t0, 0])
+            partial_tile = mixes_partials[partial_t0 : partial_t0 + LINEAR_T_TILE, 0:MIX_PAD]
+            mixes_total = pl.add(mixes_total, partial_tile)
+        mixes_raw[linear_t0 : linear_t0 + LINEAR_T_TILE, 0:MIX_PAD] = mixes_total
 
     # split_pre_post: inv_rms-scaled pre gate -> pre_val_store (for mix_x), post gate -> post.
     # Both compute at HC_PAD width; post narrows to HC_MULT via a valid-shape slice (an 8-wide
@@ -185,8 +129,6 @@ def hc_pre(
     pre_val_store = pl.create_tensor([t_linear, HC_PAD], dtype=pl.FP32)
     # Only the final partial token tile uses these fixed-size staging buffers.
     post_tail_store = pl.create_tensor([T_TILE, HC_PAD], dtype=pl.FP32)
-    x_mixed_tail_store = pl.create_tensor([T_TILE, D], dtype=pl.BF16)
-    comb_tail_store = pl.create_tensor([COMB_T_TILE, HC_PAD * HC_MULT], dtype=pl.FP32)
     for ob in pl.spmd(token_tiles, name_hint="split_pre_post", allow_early_resolve=True):
         t0 = ob * T_TILE
         valid_rows = pl.min(T_TILE, t_dim - t0)
@@ -197,7 +139,7 @@ def hc_pre(
         pre_logits = pl.add(pre_scaled, pl.col_expand(pre_scaled, pre_base))
         pre_sig = pl.recip(pl.add(pl.exp(pl.neg(pre_logits)), 1.0))
         pre_val = pl.add(pre_sig, HC_EPS)
-        pre_val_store = pl.assemble(pre_val_store, pre_val, [t0, 0])
+        pre_val_store[t0:t0 + T_TILE, 0:HC_PAD] = pre_val
 
         post_base = pl.reshape(hc_base[HC_MULT:HC_MULT + HC_PAD], [1, HC_PAD])
         post_scaled = pl.mul(pl.row_expand_mul(mixes_raw[t0:t0 + T_TILE, HC_MULT:HC_MULT + HC_PAD], inv_col), scale1)
@@ -205,37 +147,19 @@ def hc_pre(
         post_sig = pl.recip(pl.add(pl.exp(pl.neg(post_logits)), 1.0))
         post_pad = pl.mul(post_sig, 2.0)
         if valid_rows == T_TILE:
-            post[t0:t0 + T_TILE, 0:HC_MULT] = pl.slice(
-                post_pad,
-                [T_TILE, HC_PAD],
-                [0, 0],
-                valid_shape=[T_TILE, HC_MULT],
-            )
+            post[t0:t0 + T_TILE, 0:HC_MULT] = pl.slice(post_pad, [T_TILE, HC_PAD], [0, 0], valid_shape=[T_TILE, HC_MULT])
         else:
-            post_tail_store = pl.assemble(post_tail_store, post_pad, [0, 0])
-            post_tile = pl.load(
-                post_tail_store,
-                [0, 0],
-                [T_TILE, HC_PAD],
-                valid_shape=[valid_rows, HC_MULT],
-                target_memory=pl.MemorySpace.Vec,
-            )
+            post_tail_store[0:T_TILE, 0:HC_PAD] = post_pad
+            post_tile = pl.load(post_tail_store, [0, 0], [T_TILE, HC_PAD], valid_shape=[valid_rows, HC_MULT], target_memory=pl.MemorySpace.Vec)
             pl.store(post_tile, [t0, 0], post)
 
-    # comb_sinkhorn: comb gate (direct from mixes_raw, no comb_logits round-trip) + softmax +
-    # 20-iter Sinkhorn (column-first) -> comb. inv_rms is already a [t_linear,1] column buffer,
-    # so the [T_TILE,1] inv tile loads directly (no transpose / no spill); the 4 comb groups
-    # load pad-capable from mixes_raw at cols 8/12/16/20, then inv_rms * scale2 + group bias.
+    # comb_sinkhorn: comb gate from mixes_raw cols 8/12/16/20, softmax, then a
+    # column-first 20-iteration Sinkhorn -> comb.
+    comb_tail_store = pl.create_tensor([COMB_T_TILE, HC_PAD * HC_MULT], dtype=pl.FP32)
     for ob in pl.spmd(token_tiles, name_hint="comb_sinkhorn", allow_early_resolve=True):
         t0 = ob * COMB_T_TILE
         valid_rows = pl.min(COMB_T_TILE, t_dim - t0)
-        inv_col_t = pl.load(
-            inv_rms,
-            [t0, 0],
-            [COMB_T_TILE, 1],
-            valid_shape=[valid_rows, 1],
-            target_memory=pl.MemorySpace.Vec,
-        )
+        inv_col_t = pl.load(inv_rms, [t0, 0], [COMB_T_TILE, 1], valid_shape=[valid_rows, 1], target_memory=pl.MemorySpace.Vec)
         comb_off = HC_MULT * 2
         mix_g0 = pl.load(mixes_raw, [t0, comb_off + 0 * HC_MULT], [COMB_T_TILE, HC_PAD], valid_shape=[valid_rows, HC_MULT], target_memory=pl.MemorySpace.Vec)
         mix_g1 = pl.load(mixes_raw, [t0, comb_off + 1 * HC_MULT], [COMB_T_TILE, HC_PAD], valid_shape=[valid_rows, HC_MULT], target_memory=pl.MemorySpace.Vec)
@@ -320,40 +244,17 @@ def hc_pre(
             pl.store(row1_cur, [0, 1 * HC_PAD], comb_tail_store)
             pl.store(row2_cur, [0, 2 * HC_PAD], comb_tail_store)
             pl.store(row3_cur, [0, 3 * HC_PAD], comb_tail_store)
-            row0_tail = pl.load(
-                comb_tail_store,
-                [0, 0 * HC_PAD],
-                [COMB_T_TILE, HC_PAD],
-                valid_shape=[valid_rows, HC_MULT],
-                target_memory=pl.MemorySpace.Vec,
-            )
-            row1_tail = pl.load(
-                comb_tail_store,
-                [0, 1 * HC_PAD],
-                [COMB_T_TILE, HC_PAD],
-                valid_shape=[valid_rows, HC_MULT],
-                target_memory=pl.MemorySpace.Vec,
-            )
-            row2_tail = pl.load(
-                comb_tail_store,
-                [0, 2 * HC_PAD],
-                [COMB_T_TILE, HC_PAD],
-                valid_shape=[valid_rows, HC_MULT],
-                target_memory=pl.MemorySpace.Vec,
-            )
-            row3_tail = pl.load(
-                comb_tail_store,
-                [0, 3 * HC_PAD],
-                [COMB_T_TILE, HC_PAD],
-                valid_shape=[valid_rows, HC_MULT],
-                target_memory=pl.MemorySpace.Vec,
-            )
+            row0_tail = pl.load(comb_tail_store, [0, 0 * HC_PAD], [COMB_T_TILE, HC_PAD], valid_shape=[valid_rows, HC_MULT], target_memory=pl.MemorySpace.Vec)
+            row1_tail = pl.load(comb_tail_store, [0, 1 * HC_PAD], [COMB_T_TILE, HC_PAD], valid_shape=[valid_rows, HC_MULT], target_memory=pl.MemorySpace.Vec)
+            row2_tail = pl.load(comb_tail_store, [0, 2 * HC_PAD], [COMB_T_TILE, HC_PAD], valid_shape=[valid_rows, HC_MULT], target_memory=pl.MemorySpace.Vec)
+            row3_tail = pl.load(comb_tail_store, [0, 3 * HC_PAD], [COMB_T_TILE, HC_PAD], valid_shape=[valid_rows, HC_MULT], target_memory=pl.MemorySpace.Vec)
             pl.store(row0_tail, [t0, 0 * HC_MULT], comb)
             pl.store(row1_tail, [t0, 1 * HC_MULT], comb)
             pl.store(row2_tail, [t0, 2 * HC_MULT], comb)
             pl.store(row3_tail, [t0, 3 * HC_MULT], comb)
 
-    # mix_x: x_mixed = sum_h pre[:,h]*x[:,h,:], fanned over D (D/D_SPMD tasks per tile).
+    # mix_x: x_mixed = sum_h pre[:,h]*x[:,h,:], fanned over D/D_SPMD blocks per token tile.
+    x_mixed_tail_store = pl.create_tensor([T_TILE, D], dtype=pl.BF16)
     for blk in pl.spmd(token_tiles * (D // D_SPMD), name_hint="mix_x", allow_early_resolve=True):
         t0 = (blk // (D // D_SPMD)) * T_TILE
         d_base = (blk % (D // D_SPMD)) * D_SPMD
@@ -363,12 +264,12 @@ def hc_pre(
         pre1 = pl.reshape(pre_tile_t[1:2, 0:T_TILE], [T_TILE, 1])
         pre2 = pl.reshape(pre_tile_t[2:3, 0:T_TILE], [T_TILE, 1])
         pre3 = pl.reshape(pre_tile_t[3:4, 0:T_TILE], [T_TILE, 1])
-        for db in pl.pipeline(D_SPMD // D_CHUNK, stage=2):
-            d0 = d_base + db * D_CHUNK
-            x0 = pl.slice(x_flat, [T_TILE, D_CHUNK], [t0, 0 * D + d0], valid_shape=[valid_rows, D_CHUNK])
-            x1 = pl.slice(x_flat, [T_TILE, D_CHUNK], [t0, 1 * D + d0], valid_shape=[valid_rows, D_CHUNK])
-            x2 = pl.slice(x_flat, [T_TILE, D_CHUNK], [t0, 2 * D + d0], valid_shape=[valid_rows, D_CHUNK])
-            x3 = pl.slice(x_flat, [T_TILE, D_CHUNK], [t0, 3 * D + d0], valid_shape=[valid_rows, D_CHUNK])
+        for db in pl.pipeline(D_SPMD // D_TILE, stage=2):
+            d0 = d_base + db * D_TILE
+            x0 = pl.slice(x_flat, [T_TILE, D_TILE], [t0, 0 * D + d0], valid_shape=[valid_rows, D_TILE])
+            x1 = pl.slice(x_flat, [T_TILE, D_TILE], [t0, 1 * D + d0], valid_shape=[valid_rows, D_TILE])
+            x2 = pl.slice(x_flat, [T_TILE, D_TILE], [t0, 2 * D + d0], valid_shape=[valid_rows, D_TILE])
+            x3 = pl.slice(x_flat, [T_TILE, D_TILE], [t0, 3 * D + d0], valid_shape=[valid_rows, D_TILE])
             y0 = pl.row_expand_mul(x0, pre0)
             y1 = pl.row_expand_mul(x1, pre1)
             y2 = pl.row_expand_mul(x2, pre2)
@@ -376,16 +277,10 @@ def hc_pre(
             y_tile = pl.add(pl.add(y0, y1), pl.add(y2, y3))
             y_bf16 = pl.cast(y_tile, target_type=pl.BF16, mode="rint")
             if valid_rows == T_TILE:
-                x_mixed = pl.assemble(x_mixed, y_bf16, [t0, d0])
+                x_mixed[t0:t0 + T_TILE, d0:d0 + D_TILE] = y_bf16
             else:
-                x_mixed_tail_store = pl.assemble(x_mixed_tail_store, y_bf16, [0, d0])
-                y_out = pl.load(
-                    x_mixed_tail_store,
-                    [0, d0],
-                    [T_TILE, D_CHUNK],
-                    valid_shape=[valid_rows, D_CHUNK],
-                    target_memory=pl.MemorySpace.Vec,
-                )
+                x_mixed_tail_store[0:T_TILE, d0:d0 + D_TILE] = y_bf16
+                y_out = pl.load(x_mixed_tail_store, [0, d0], [T_TILE, D_TILE], valid_shape=[valid_rows, D_TILE], target_memory=pl.MemorySpace.Vec)
                 pl.store(y_out, [t0, d0], x_mixed)
     return x_mixed
 
@@ -425,10 +320,9 @@ def _golden_a2a3_cube_linear(x_flat_2d, hc_fn):
     w_groups = hc_fn.reshape(1, MIX_HC, LINEAR_OK, groups_per_split, cube_acc_k)
     split_mixes = torch.zeros(t_dim, MIX_HC, LINEAR_OK, dtype=torch.float32)
     for group0 in range(0, groups_per_split, group_block):
-        group_dots = (
-            x_groups[..., group0:group0 + group_block, :].double()
-            * w_groups[..., group0:group0 + group_block, :].double()
-        ).sum(dim=-1)
+        x_block = x_groups[..., group0:group0 + group_block, :].double()
+        w_block = w_groups[..., group0:group0 + group_block, :].double()
+        group_dots = (x_block * w_block).sum(dim=-1)
         for group in range(group_dots.shape[-1]):
             split_mixes = (split_mixes.double() + group_dots[..., group]).float()
 
@@ -452,8 +346,8 @@ def golden_hc_pre(tensors):
     x_flat_2d = x.reshape(t_dim, HC_DIM)
 
     sq_sum = torch.zeros(t_dim, 1, dtype=torch.float32)
-    for k0 in range(0, HC_DIM, RMS_K_CHUNK):
-        x_chunk = x_flat_2d[:, k0:k0 + RMS_K_CHUNK]
+    for k0 in range(0, HC_DIM, RMS_K_TILE):
+        x_chunk = x_flat_2d[:, k0:k0 + RMS_K_TILE]
         sq_sum += (x_chunk * x_chunk).sum(dim=1, keepdim=True)
     rsqrt = torch.rsqrt(sq_sum * HC_DIM_INV + NORM_EPS)
 
@@ -531,19 +425,14 @@ if __name__ == "__main__":
     }
 
     parser = argparse.ArgumentParser()
-    parser.add_argument("-p", "--platform", type=str, default="a2a3",
-                        choices=["a2a3", "a2a3sim", "a5", "a5sim"])
+    parser.add_argument("-p", "--platform", type=str, default="a2a3", choices=["a2a3", "a2a3sim", "a5", "a5sim"])
     parser.add_argument("-d", "--device", type=int, default=0)
-    parser.add_argument("--mode", choices=["decode", "prefill", "all"], default="all",
-                        help="Use decode or prefill batch sizes, or 'all' to test both.")
+    parser.add_argument("--mode", choices=["decode", "prefill", "all"], default="all", help="decode / prefill batch sizes, or both.")
     parser.add_argument("--enable-chip-swimlane", action="store_true", default=False)
     parser.add_argument("--runtime-dir", type=str, default=None)
     parser.add_argument("--golden-data", type=str, default=None)
     parser.add_argument("--compile-only", action="store_true", default=False)
     parser.add_argument("--dump-passes", action="store_true", default=False)
-    parser.add_argument("--no-dep-gen", action="store_true", default=False,
-                        help="deprecated no-op: this kernel always needs dep_gen ON to order its "
-                             "task graph; kept for CLI / CI back-compat.")
     args = parser.parse_args()
 
     modes_to_run = list(MODES.keys()) if args.mode == "all" else [args.mode]
@@ -562,8 +451,6 @@ if __name__ == "__main__":
                 platform=args.platform,
                 device_id=args.device,
                 enable_chip_swimlane=args.enable_chip_swimlane,
-                # The multi-scope task graph is ordered by dep_gen, not by explicit deps.
-                enable_dep_gen=True,
             ),
             rtol=1e-3,
             atol=1e-3,

--- a/models/deepseek_v4_flash_dspark/qkv_proj_rope.py
+++ b/models/deepseek_v4_flash_dspark/qkv_proj_rope.py
@@ -61,8 +61,8 @@ QR_SPLIT_K_TILE = D // QR_OK  # qr_proj K per split (=2048)
 KV_M_TILE = MATMUL_T_TILE  # kv_proj token (M) tile; decode pads from 8 real rows to 16
 KV_N_TILE = 128  # kv_proj HEAD_DIM (N) per matmul
 KV_K_TILE = 256  # kv_proj D (K) reduction tile   | divides KV_SPLIT_K_TILE
-KV_OK = 4  # kv_proj split-K factor         | D//KV_OK cores share each N-group
-KV_SPLIT_K_TILE = D // KV_OK  # kv_proj K per split (=1024)
+KV_OK = 2  # kv_proj split-K factor         | D//KV_OK cores share each N-group
+KV_SPLIT_K_TILE = D // KV_OK  # kv_proj K per split (=2048)
 QPROJ_M_TILE = 64  # dense qproj token tile; fills the 128 KiB L0C accumulator
 QPROJ_TAIL_M_TILE = MATMUL_T_TILE  # partial-M path validated by decode/small physical T
 KV_RMS_T_TILE = 8  # kv rms-norm + rope fused token (T) tile
@@ -371,7 +371,7 @@ def _q_proj_rope_tile(
     # 64-row block is lowered through the established 16-row cube shape.
     for qproj_n_idx in pl.spmd(
         (H * HEAD_DIM) // QPROJ_MM_N_TILE,
-        name_hint="qproj_matmul_full",
+        name_hint="qproj_matmul",
     ):
         w_col0 = qproj_n_idx * QPROJ_MM_N_TILE
         for t0 in pl.range(0, qproj_full_rows, QPROJ_M_TILE):
@@ -388,11 +388,7 @@ def _q_proj_rope_tile(
                     col_acc = pl.matmul_acc(col_acc, qr_i8_chunk, wq_chunk)
             q_proj_i32[t0 : t0 + QPROJ_M_TILE, w_col0 : w_col0 + QPROJ_MM_N_TILE] = col_acc
 
-    for qproj_tail_n_idx in pl.spmd(
-        (H * HEAD_DIM) // QPROJ_MM_N_TILE,
-        name_hint="qproj_matmul_tail",
-    ):
-        tail_w_col0 = qproj_tail_n_idx * QPROJ_MM_N_TILE
+        tail_w_col0 = w_col0
         for tail_t0 in pl.range(qproj_full_rows, qproj_t_matmul, QPROJ_TAIL_M_TILE):
             qproj_tail_rows = pl.min(QPROJ_TAIL_M_TILE, tile_rows - tail_t0)
             tail_acc = pl.create_tensor([QPROJ_TAIL_M_TILE, QPROJ_MM_N_TILE], dtype=pl.INT32)


### PR DESCRIPTION
The attention and output-projection grids were fanned out well past the
point where per-task dispatch stops paying for itself -- swa_gather_kv,
merge_norm and proj_a_mm each launched 512 tasks for one decode step.
Grids are now sized against the 24 AIC / 48 AIV core counts, and the
memory-bound stages are deliberately coarser than one task per core.

- swa_gather_kv: 32 tasks of GATHER_T tokens, leaving 16 AIV for the
  concurrent qproj_dequant grid; drops the degenerate GATHER_SPLITS knob
- qk_pv: fixed 24-task grid -- its 1 AIC + 2 AIV records per task fill
  24 AIC and 48 AIV in a single wave
- merge_norm: fixed 48-task grid, H_TILE 16 -> 32 (bounded by QK_M_TILE)
- hc_post: grid is token_tiles with out_h folded into the task, so the x
  row is cast once per token instead of once per output
- proj_a_mm: PROJ_A_ROW_TILE 16 -> 128, one block covering T_PAD
- proj_b_act: PROJ_B_ACT_TASK_T_TILE 8 -> 32
- kv_proj_matmul: KV_OK 4 -> 2, halving the split-K partials per output
- qproj_matmul_tail folded into qproj_matmul: both used the same spmd
  grid over output columns and wrote disjoint row ranges, so the second
  grid only ever cost a dispatch
- hc_pre mix_x: one task per token tile covering all of D
- decode_swa takes --save-data / --golden-data to replay a frozen golden

hc_pre also loses its second implementation: only the multi-scope path
was used, so the fused syncall variant, the binder working around
pypto's call-site name matching, the HC_PRE_IMPL / DSV4_HC_PRE_IMPL /
--impl selector, and the enable_dep_gen wiring are gone. Its docstrings
described a split-K atomic-add and a sim-CI skip that follows from it,
but no atomic-add exists here and the file carries no ci: no-sim marker.
Tile constants are renamed to match hc_head.py, pl.assemble stores
become subscript stores, and constants left unreferenced by the removed
cast scope and the single-scope rms are deleted.

decode_swa tp1, B=16 S=8, a2a3 device 0, 100 rounds / 5 warmup:
981.7 -> 566.2 us.