### PR TITLE
Perf: pipeline HCA AllToAll into O-A

### DIFF
--- a/models/deepseek_v4_flash_dspark/decode_csa.py
+++ b/models/deepseek_v4_flash_dspark/decode_csa.py
@@ -64,12 +64,13 @@ from decode_o_proj import (
     O_WINDOW_ROWS,
     decode_o_proj_tp1,
     decode_sharded_o_projection_reduce_scatter,
-    o_group_a2a,
+    o_group_a2a_finish,
 )
 from decode_sparse_attn_csa import (
     ROPE_CS_T_TILE,
     T_PAD,
     sparse_attn_csa,
+    sparse_attn_csa_a2a,
 )
 
 # Dynamic shape variables.
@@ -263,6 +264,7 @@ def decode_csa(
     qr_scale = pl.create_tensor([t_dim, 1], dtype=pl.FP32)
     position_ids_t1 = pl.reshape(position_ids, [t_dim, 1])
     attention_local_flat = pl.create_tensor([ATTENTION_WINDOW_ROWS, O_GROUP_IN], dtype=pl.BF16)
+    attn_out = pl.create_tensor([t_dim, D], dtype=pl.BF16)
     with pl.scope():
         late_dep = pl.system.task_dummy(deps=[rope_tid])
         qkv_proj_rope(
@@ -313,34 +315,43 @@ def decode_csa(
             [O_GROUPS * LOCAL_T_PAD, O_GROUP_IN],
             dtype=pl.BF16,
         )
-        attention_grouped, _heads_tid = sparse_attn_csa(
+        attention_signal, publish_tid = sparse_attn_csa_a2a(
             q, kv_cache, window_swa_indices,
             cmp_kv, cmp_block_table, idx_topk,
             position_ids_t1, attn_sink, freqs_cos, freqs_sin,
-            attention_grouped, cache_ready_dep,
-        )
-        attention_local_flat, attention_signal = o_group_a2a(
-            attention_grouped, attention_local_flat,
+            attention_grouped,
             attention_window, attention_signal,
             group_base, tp_rank, local_t,
+            cache_ready_dep,
+        )
+        attention_local_flat, attention_signal = o_group_a2a_finish(
+            attention_local_flat,
+            attention_window, attention_signal,
+            group_base, tp_rank, local_t,
+            publish_tid, 48,
         )
 
-    attention_local_groups = pl.reshape(attention_local_flat, [LOCAL_O_GROUPS, GROUP_T_PAD, O_GROUP_IN])
-    o_local = pl.create_tensor([LOCAL_T_PAD, D], dtype=pl.BF16)
-    o_local, o_signal = decode_sharded_o_projection_reduce_scatter(
-        attention_local_groups,
-        wo_a, wo_b, wo_b_scale,
-        local_t, o_local,
-        o_window, o_signal,
-        group_base, tp_rank,
-    )
-    attn_out = pl.create_tensor([t_dim, D], dtype=pl.BF16)
-    for block in pl.spmd(t_dim // CSA_WB_TOKEN_TILE, name_hint="csa_o_local_bridge"):
-        token_start = block * CSA_WB_TOKEN_TILE
-        attn_out[token_start : token_start + CSA_WB_TOKEN_TILE, 0:D] = o_local[
-            token_start : token_start + CSA_WB_TOKEN_TILE, 0:D
-        ]
-    hc_post(attn_out, x_hc, post_t, comb_t, x_out)
+        attention_local_groups = pl.reshape(
+            attention_local_flat,
+            [LOCAL_O_GROUPS, GROUP_T_PAD, O_GROUP_IN],
+        )
+        o_local = pl.create_tensor([LOCAL_T_PAD, D], dtype=pl.BF16)
+        o_local, o_signal = decode_sharded_o_projection_reduce_scatter(
+            attention_local_groups,
+            wo_a, wo_b, wo_b_scale,
+            local_t, o_local,
+            o_window, o_signal,
+            group_base, tp_rank,
+        )
+
+        for block in pl.spmd(t_dim // CSA_WB_TOKEN_TILE, name_hint="csa_o_local_bridge"):
+            token_start = block * CSA_WB_TOKEN_TILE
+            attn_out[token_start : token_start + CSA_WB_TOKEN_TILE, 0:D] = o_local[
+                token_start : token_start + CSA_WB_TOKEN_TILE, 0:D
+            ]
+
+    with pl.scope():
+        hc_post(attn_out, x_hc, post_t, comb_t, x_out)
     return x_out
 
 
@@ -1730,6 +1741,8 @@ if __name__ == "__main__":
         help="absolute decode start position; a scalar sets batch=1, "
              "and a comma-separated list sets batch to its length",
     )
+    parser.add_argument("--golden-data", type=str, default=None)
+    parser.add_argument("--save-data", action="store_true", default=False)
     parser.add_argument("--enable-chip-swimlane", type=int, choices=(0, 1, 2, 3, 4), default=0)
     parser.add_argument("--compile-only", action="store_true", default=False)
     parser.add_argument("--dump-passes", action="store_true", default=False)
@@ -1775,6 +1788,8 @@ if __name__ == "__main__":
             fn=decode_csa_tp1_test,
             specs=build_tensor_specs(start_pos=start_pos, batch=batch),
             golden_fn=golden_decode_csa_tp1,
+            golden_data=args.golden_data,
+            save_data=args.save_data,
             compile_only=args.compile_only,
             compile_cfg=dict(dump_passes=args.dump_passes),
             runtime_cfg=dict(
@@ -1804,6 +1819,8 @@ if __name__ == "__main__":
         fn=l3_decode_csa,
         specs=build_distributed_tensor_specs(local_t, start_pos=start_pos),
         golden_fn=golden_decode_csa,
+        golden_data=args.golden_data,
+        save_data=args.save_data,
         compile_only=args.compile_only,
         compile_cfg=compile_cfg,
         runtime_cfg=dict(

--- a/models/deepseek_v4_flash_dspark/decode_hca.py
+++ b/models/deepseek_v4_flash_dspark/decode_hca.py
@@ -67,13 +67,14 @@ from decode_o_proj import (
     O_WINDOW_ROWS,
     decode_sharded_o_projection_reduce_scatter,
     decode_o_proj_tp1,
-    o_group_a2a,
+    o_group_a2a_finish,
 )
 from decode_sparse_attn_hca import (
     HCA_MAX_COMPRESSED_ROWS,
     T_PAD,
     VALID_TOKEN_TILE,
     sparse_attn_hca,
+    sparse_attn_hca_a2a,
 )
 
 # Dynamic shape variables.
@@ -231,44 +232,48 @@ def decode_hca(
     cache_ready_dep = pl.system.task_dummy(deps=[ori_cache_write_tid, cmp_cache_write_tid])
 
     attention_local_flat = pl.create_tensor([ATTENTION_WINDOW_ROWS, O_GROUP_IN], dtype=pl.BF16)
+    attn_out = pl.create_tensor([t_dim, D], dtype=pl.BF16)
     with pl.scope():
         attention_grouped = pl.create_tensor(
             [O_GROUPS * LOCAL_T_PAD, O_GROUP_IN],
             dtype=pl.BF16,
         )
-        attention_grouped, _heads_tid = sparse_attn_hca(
+        attention_signal, publish_tid = sparse_attn_hca_a2a(
             q, kv_cache, window_swa_indices,
             cmp_kv, cmp_block_table,
             position_ids, kv_seq_lens,
             attn_sink, freqs_cos, freqs_sin,
-            attention_grouped, cache_ready_dep,
-        )
-        attention_local_flat, attention_signal = o_group_a2a(
-            attention_grouped, attention_local_flat,
+            attention_grouped,
             attention_window, attention_signal,
             group_base, tp_rank, local_t,
+            cache_ready_dep,
+        )
+        attention_local_flat, attention_signal = o_group_a2a_finish(
+            attention_local_flat,
+            attention_window, attention_signal,
+            group_base, tp_rank, local_t,
+            publish_tid, 48,
         )
 
-    attention_local_groups = pl.reshape(
-        attention_local_flat,
-        [LOCAL_O_GROUPS, GROUP_T_PAD, O_GROUP_IN],
-    )
-    o_local = pl.create_tensor([LOCAL_T_PAD, D], dtype=pl.BF16)
-    o_local, o_signal = decode_sharded_o_projection_reduce_scatter(
-        attention_local_groups,
-        wo_a, wo_b, wo_b_scale,
-        local_t, o_local,
-        o_window, o_signal,
-        group_base, tp_rank,
-    )
+        attention_local_groups = pl.reshape(
+            attention_local_flat,
+            [LOCAL_O_GROUPS, GROUP_T_PAD, O_GROUP_IN],
+        )
+        o_local = pl.create_tensor([LOCAL_T_PAD, D], dtype=pl.BF16)
+        o_local, o_signal = decode_sharded_o_projection_reduce_scatter(
+            attention_local_groups,
+            wo_a, wo_b, wo_b_scale,
+            local_t, o_local,
+            o_window, o_signal,
+            group_base, tp_rank,
+        )
 
-    attn_out = pl.create_tensor([t_dim, D], dtype=pl.BF16)
-    for bridge_block in pl.spmd(t_dim // HCA_WB_TOKEN_TILE, name_hint="hca_output_bridge"):
-        bridge_t0 = bridge_block * HCA_WB_TOKEN_TILE
-        attn_out[bridge_t0 : bridge_t0 + HCA_WB_TOKEN_TILE, 0:D] = o_local[
-            bridge_t0 : bridge_t0 + HCA_WB_TOKEN_TILE,
-            0:D,
-        ]
+        for bridge_block in pl.spmd(t_dim // HCA_WB_TOKEN_TILE, name_hint="hca_output_bridge"):
+            bridge_t0 = bridge_block * HCA_WB_TOKEN_TILE
+            attn_out[bridge_t0 : bridge_t0 + HCA_WB_TOKEN_TILE, 0:D] = o_local[
+                bridge_t0 : bridge_t0 + HCA_WB_TOKEN_TILE,
+                0:D,
+            ]
 
     with pl.scope():
         hc_post(attn_out, x_hc, post_t, comb_t, x_out)
@@ -1256,6 +1261,8 @@ if __name__ == "__main__":
         help="absolute decode start position; a scalar sets batch=1, "
              "and a comma-separated list sets batch to its length",
     )
+    parser.add_argument("--golden-data", type=str, default=None)
+    parser.add_argument("--save-data", action="store_true", default=False)
     parser.add_argument("--enable-chip-swimlane", type=int, choices=(0, 1, 2, 4), default=0)
     parser.add_argument("--compile-only", action="store_true", default=False)
     parser.add_argument("--dump-passes", action="store_true", default=False)
@@ -1284,6 +1291,8 @@ if __name__ == "__main__":
         parser.error(f"--device IDs must be distinct, got {device_ids}")
     if len(device_ids) != TP_SIZE:
         parser.error(f"--tp {TP_SIZE} needs exactly {TP_SIZE} device(s), got {device_ids}")
+    if args.golden_data is not None and args.start_pos is None and TP_SIZE != 1:
+        parser.error("distributed --golden-data requires --start-pos to select one replay shape")
 
     if args.start_pos is not None:
         batch = len(args.start_pos) if isinstance(args.start_pos, list) else 1
@@ -1300,6 +1309,8 @@ if __name__ == "__main__":
                 fn=decode_hca_tp1_test,
                 specs=build_tensor_specs(start_pos=args.start_pos, batch=local_t // S),
                 golden_fn=golden_decode_hca_tp1,
+                golden_data=args.golden_data,
+                save_data=args.save_data,
                 compile_only=args.compile_only,
                 compile_cfg=dict(dump_passes=args.dump_passes),
                 runtime_cfg=dict(
@@ -1337,6 +1348,8 @@ if __name__ == "__main__":
                 fn=l3_decode_hca,
                 specs=build_distributed_tensor_specs(local_t, start_pos=args.start_pos),
                 golden_fn=golden_decode_hca,
+                golden_data=args.golden_data,
+                save_data=args.save_data,
                 compile_only=args.compile_only,
                 compile_cfg=dict(
                     dump_passes=args.dump_passes,

--- a/models/deepseek_v4_flash_dspark/decode_hca.py
+++ b/models/deepseek_v4_flash_dspark/decode_hca.py
@@ -58,19 +58,21 @@ from rmsnorm import rms_norm
 from rope_interleave import rope_interleave
 from decode_compressor_ratio128 import compressor_ratio128
 from decode_o_proj import (
+    ATTENTION_READY_ROWS,
     ATTENTION_WINDOW_ROWS,
-    GROUP_T_PAD,
     LOCAL_O_GROUPS,
     LOCAL_O_WIDTH,
     LOCAL_T,
     LOCAL_T_PAD,
+    O_A_T_TILE,
     O_WINDOW_ROWS,
-    decode_sharded_o_projection_reduce_scatter,
     decode_o_proj_tp1,
-    o_group_a2a_finish,
+    decode_streaming_o_projection_reduce_scatter,
 )
 from decode_sparse_attn_hca import (
+    HCA_A2A_READY_COUNT,
     HCA_MAX_COMPRESSED_ROWS,
+    HCA_O_A_T_TILE,
     T_PAD,
     VALID_TOKEN_TILE,
     sparse_attn_hca,
@@ -134,6 +136,8 @@ if T != LOCAL_T:
     raise ValueError(f"HCA token capacity {T} must equal TP local token capacity {LOCAL_T}")
 if T_PAD != LOCAL_T_PAD:
     raise ValueError(f"HCA token capacity {T_PAD} must equal TP local token capacity {LOCAL_T_PAD}")
+if HCA_O_A_T_TILE != O_A_T_TILE:
+    raise ValueError(f"HCA ready tile {HCA_O_A_T_TILE} must equal O-A token tile {O_A_T_TILE}")
 
 
 @pl.jit.inline(auto_scope=False)
@@ -176,6 +180,7 @@ def decode_hca(
     x_out: pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32],
     attention_window: pld.DistributedTensor[[ATTENTION_WINDOW_ROWS, O_GROUP_IN], pl.BF16],
     attention_signal: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
+    attention_ready: pld.DistributedTensor[[ATTENTION_READY_ROWS, 1], pl.INT32],
     o_window: pld.DistributedTensor[[O_WINDOW_ROWS, D], pl.FP32],
     o_signal: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
     group_base: pl.Scalar[pl.INT32],
@@ -231,41 +236,41 @@ def decode_hca(
     )
     cache_ready_dep = pl.system.task_dummy(deps=[ori_cache_write_tid, cmp_cache_write_tid])
 
-    attention_local_flat = pl.create_tensor([ATTENTION_WINDOW_ROWS, O_GROUP_IN], dtype=pl.BF16)
     attn_out = pl.create_tensor([t_dim, D], dtype=pl.BF16)
     with pl.scope():
         attention_grouped = pl.create_tensor(
             [O_GROUPS * LOCAL_T_PAD, O_GROUP_IN],
             dtype=pl.BF16,
         )
-        attention_signal, publish_tid = sparse_attn_hca_a2a(
+        (
+            attention_signal,
+            attention_ready,
+            ready_registration_tid,
+            publish_tid,
+        ) = sparse_attn_hca_a2a(
             q, kv_cache, window_swa_indices,
             cmp_kv, cmp_block_table,
             position_ids, kv_seq_lens,
             attn_sink, freqs_cos, freqs_sin,
             attention_grouped,
-            attention_window, attention_signal,
+            attention_window, attention_signal, attention_ready,
             group_base, tp_rank, local_t,
             cache_ready_dep,
         )
-        attention_local_flat, attention_signal = o_group_a2a_finish(
-            attention_local_flat,
-            attention_window, attention_signal,
-            group_base, tp_rank, local_t,
-            publish_tid, 48,
-        )
-
-        attention_local_groups = pl.reshape(
-            attention_local_flat,
-            [LOCAL_O_GROUPS, GROUP_T_PAD, O_GROUP_IN],
-        )
         o_local = pl.create_tensor([LOCAL_T_PAD, D], dtype=pl.BF16)
-        o_local, o_signal = decode_sharded_o_projection_reduce_scatter(
-            attention_local_groups,
+        (
+            o_local,
+            attention_signal,
+            attention_ready,
+            o_signal,
+        ) = decode_streaming_o_projection_reduce_scatter(
+            attention_window, attention_signal, attention_ready,
             wo_a, wo_b, wo_b_scale,
             local_t, o_local,
             o_window, o_signal,
             group_base, tp_rank,
+            ready_registration_tid, publish_tid,
+            48, HCA_A2A_READY_COUNT,
         )
 
         for bridge_block in pl.spmd(t_dim // HCA_WB_TOKEN_TILE, name_hint="hca_output_bridge"):
@@ -320,6 +325,7 @@ def decode_hca_test(
     x_out: pl.Out[pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32]],
     attention_window: pld.DistributedTensor[[ATTENTION_WINDOW_ROWS, O_GROUP_IN], pl.BF16],
     attention_signal: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
+    attention_ready: pld.DistributedTensor[[ATTENTION_READY_ROWS, 1], pl.INT32],
     o_window: pld.DistributedTensor[[O_WINDOW_ROWS, D], pl.FP32],
     o_signal: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
     group_base: pl.Scalar[pl.INT32],
@@ -359,7 +365,7 @@ def decode_hca_test(
         attn_sink,
         wo_a, wo_b, wo_b_scale,
         x_out,
-        attention_window, attention_signal, o_window, o_signal,
+        attention_window, attention_signal, attention_ready, o_window, o_signal,
         group_base, tp_rank, local_t,
     )
 
@@ -422,12 +428,14 @@ def l3_decode_hca(
 
     attention_window_buf = pld.alloc_window_buffer([ATTENTION_WINDOW_ROWS, O_GROUP_IN], dtype=pl.BF16)
     attention_signal_buf = pld.alloc_window_buffer([TP_SIZE, 1], dtype=pl.INT32)
+    attention_ready_buf = pld.alloc_window_buffer([ATTENTION_READY_ROWS, 1], dtype=pl.INT32)
     o_window_buf = pld.alloc_window_buffer([O_WINDOW_ROWS, D], dtype=pl.FP32)
     o_signal_buf = pld.alloc_window_buffer([TP_SIZE, 1], dtype=pl.INT32)
 
     for rank in pl.range(pld.world_size()):
         attention_window = pld.window(attention_window_buf, [ATTENTION_WINDOW_ROWS, O_GROUP_IN], dtype=pl.BF16)
         attention_signal = pld.window(attention_signal_buf, [TP_SIZE, 1], dtype=pl.INT32)
+        attention_ready = pld.window(attention_ready_buf, [ATTENTION_READY_ROWS, 1], dtype=pl.INT32)
         o_window = pld.window(o_window_buf, [O_WINDOW_ROWS, D], dtype=pl.FP32)
         o_signal = pld.window(o_signal_buf, [TP_SIZE, 1], dtype=pl.INT32)
         decode_hca_test(
@@ -446,7 +454,7 @@ def l3_decode_hca(
             attn_sink[rank],
             wo_a[rank], wo_b[rank], wo_b_scale[rank],
             x_out[rank],
-            attention_window, attention_signal, o_window, o_signal,
+            attention_window, attention_signal, attention_ready, o_window, o_signal,
             0, rank, local_t, device=rank,
         )
 

--- a/models/deepseek_v4_flash_dspark/decode_o_proj.py
+++ b/models/deepseek_v4_flash_dspark/decode_o_proj.py
@@ -367,6 +367,92 @@ def o_group_a2a(
     return local_groups_out, exchange_signal
 
 
+@pl.jit.inline
+def o_group_a2a_finish(
+    local_groups_out: pl.Tensor[[ATTENTION_WINDOW_ROWS, O_GROUP_IN], pl.BF16],
+    exchange_window: pld.DistributedTensor[[ATTENTION_WINDOW_ROWS, O_GROUP_IN], pl.BF16],
+    exchange_signal: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
+    group_base: pl.Scalar[pl.INT32],
+    tp_rank: pl.Scalar[pl.INT32],
+    local_t: pl.Scalar[pl.INT32],
+    publish_dep: pl.Scalar[pl.TASK_ID],
+    publish_count: pl.Scalar[pl.INT32],
+):
+    """Finish a non-overlapping producer-fused exchange and release its window."""
+    with pl.at(
+        level=pl.Level.CORE_GROUP,
+        name_hint="o_group_a2a_wait",
+        deps=[publish_dep],
+    ) as wait_tid:
+        expected = pl.cast(publish_count, pl.INT32)
+        for source_tp in pl.range(TP_SIZE):
+            if source_tp != tp_rank:
+                pld.system.wait(
+                    signal=exchange_signal,
+                    offsets=[source_tp, 0],
+                    expected=expected,
+                    cmp=pld.WaitCmp.Ge,
+                )
+
+    group_t = TP_SIZE * local_t
+    with pl.spmd(
+        48,
+        name_hint="o_group_a2a_gather",
+        deps=[wait_tid],
+    ) as gather_tid:
+        worker = pl.tile.get_block_idx()
+        for local_group in pl.range(LOCAL_O_GROUPS):
+            group_base_row = local_group * GROUP_T_PAD
+            for group_row in pl.range(worker, group_t, 48):
+                copy_row = group_base_row + group_row
+                local_groups_out[
+                    copy_row : copy_row + 1,
+                    0:O_GROUP_IN,
+                ] = exchange_window[
+                    copy_row : copy_row + 1,
+                    0:O_GROUP_IN,
+                ]
+
+    with pl.at(
+        level=pl.Level.CORE_GROUP,
+        name_hint="o_group_a2a_complete",
+        deps=[gather_tid],
+    ):
+        completion_anchor = pl.read(local_groups_out, [0, 0])
+        for peer_tp in pl.range(TP_SIZE):
+            if peer_tp != tp_rank:
+                pld.system.notify(
+                    target=exchange_signal,
+                    peer=group_base + peer_tp,
+                    offsets=[tp_rank, 0],
+                    value=1,
+                    op=pld.NotifyOp.AtomicAdd,
+                )
+
+        completion_expected = pl.cast(publish_count + 1, pl.INT32)
+        for source_tp in pl.range(TP_SIZE):
+            if source_tp != tp_rank:
+                pld.system.wait(
+                    signal=exchange_signal,
+                    offsets=[source_tp, 0],
+                    expected=completion_expected,
+                    cmp=pld.WaitCmp.Ge,
+                )
+
+        reset_value = pl.cast(-completion_expected, pl.INT32)
+        self_rank = group_base + tp_rank
+        for source_tp in pl.range(TP_SIZE):
+            if source_tp != tp_rank:
+                pld.system.notify(
+                    target=exchange_signal,
+                    peer=self_rank,
+                    offsets=[source_tp, 0],
+                    value=reset_value,
+                    op=pld.NotifyOp.AtomicAdd,
+                )
+        pl.write(local_groups_out, [0, 0], completion_anchor)
+    return local_groups_out, exchange_signal
+
 
 @pl.jit
 def decode_attention_collectives_fixture(

--- a/models/deepseek_v4_flash_dspark/decode_o_proj.py
+++ b/models/deepseek_v4_flash_dspark/decode_o_proj.py
@@ -91,6 +91,8 @@ PROJ_B_ACT_TASK_T_TILE = 32  # proj_b_act token block per task
 O_A_T_TILE = 16
 O_A_K_TILE = 256
 O_A_N_TILE = 128
+O_A_LAUNCH_T_TILE = LOCAL_T_PAD
+ATTENTION_READY_ROWS = GROUP_T_PAD // O_A_T_TILE
 QUANT_T_TILE = 8
 O_B_T_TILE = 128
 O_B_K_TILE = 256
@@ -125,6 +127,10 @@ if O_RS_PUBLISH_WORKERS % TP_SIZE != 0:
     raise ValueError(f"TP size {TP_SIZE} must divide O-B publish workers {O_RS_PUBLISH_WORKERS}")
 if GROUP_T_PAD % O_B_T_TILE != 0:
     raise ValueError(f"O-B token tile {O_B_T_TILE} must divide token capacity {GROUP_T_PAD}")
+if GROUP_T_PAD % O_A_T_TILE != 0:
+    raise ValueError(f"O-A token tile {O_A_T_TILE} must divide token capacity {GROUP_T_PAD}")
+if GROUP_T_PAD % O_A_LAUNCH_T_TILE != 0 or O_A_LAUNCH_T_TILE % O_A_T_TILE != 0:
+    raise ValueError("O-A launch tile must divide token capacity and contain complete O-A tiles")
 if T_PAD % PROJ_B_MM_T_TILE != 0:
     raise ValueError(
         f"proj_b_mm token tile {PROJ_B_MM_T_TILE} must divide token capacity {T_PAD}"
@@ -566,6 +572,324 @@ def golden_decode_attention_collectives_fixture(tensors):
     tensors["attention_local_groups"][:] = exchanged
 
 
+@pl.jit.incore
+def streaming_o_a_tile(
+    attention_window: pld.DistributedTensor[[ATTENTION_WINDOW_ROWS, O_GROUP_IN], pl.BF16],
+    wo_a_flat: pl.Tensor[[LOCAL_O_WIDTH, O_GROUP_IN], pl.BF16],
+    o_a_fp32: pl.Out[pl.Tensor[[GROUP_T_PAD, LOCAL_O_WIDTH], pl.FP32]],
+    ready_row_base: pl.Scalar[pl.INDEX],
+):
+    """Project one ready source-sized attention launch for all local O groups."""
+    proj_a_unit = pl.tile.get_block_idx()
+    row_in_launch = proj_a_unit // (LOCAL_O_GROUPS * (O_LORA // O_A_N_TILE))
+    group_unit = proj_a_unit - row_in_launch * LOCAL_O_GROUPS * (O_LORA // O_A_N_TILE)
+    local_group = group_unit // (O_LORA // O_A_N_TILE)
+    n_block = group_unit - local_group * (O_LORA // O_A_N_TILE)
+    row_block = ready_row_base + row_in_launch
+    t0 = row_block * O_A_T_TILE
+    n0 = n_block * O_A_N_TILE
+    src_row = local_group * GROUP_T_PAD + t0
+    weight_row = local_group * O_LORA + n0
+    o_a_x0 = pl.load(attention_window, [src_row, 0], [O_A_T_TILE, O_A_K_TILE], target_memory=pl.MemorySpace.Mat)
+    o_a_w0 = pl.load(wo_a_flat, [weight_row, 0], [O_A_N_TILE, O_A_K_TILE], target_memory=pl.MemorySpace.Mat)
+    o_a_w0_t = pl.tile.transpose_view(o_a_w0)
+    o_a_acc = pl.matmul(o_a_x0, o_a_w0_t, out_dtype=pl.FP32)
+    for k0 in pl.pipeline(O_A_K_TILE, O_GROUP_IN, O_A_K_TILE, stage=2):
+        o_a_xk = pl.load(attention_window, [src_row, k0], [O_A_T_TILE, O_A_K_TILE], target_memory=pl.MemorySpace.Mat)
+        o_a_wk = pl.load(wo_a_flat, [weight_row, k0], [O_A_N_TILE, O_A_K_TILE], target_memory=pl.MemorySpace.Mat)
+        o_a_wk_t = pl.tile.transpose_view(o_a_wk)
+        o_a_acc = pl.matmul_acc(o_a_acc, o_a_xk, o_a_wk_t)
+    pl.store(o_a_acc, [t0, weight_row], o_a_fp32)
+    return o_a_fp32
+
+
+@pl.jit.inline(auto_scope=False)
+def o_group_a2a_release(
+    exchange_signal: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
+    exchange_ready: pld.DistributedTensor[[ATTENTION_READY_ROWS, 1], pl.INT32],
+    group_base: pl.Scalar[pl.INT32],
+    tp_rank: pl.Scalar[pl.INT32],
+    local_t: pl.Scalar[pl.INT32],
+    publish_dep: pl.Scalar[pl.TASK_ID],
+    consume_dep: pl.Scalar[pl.TASK_ID],
+    publish_count: pl.Scalar[pl.INT32],
+    ready_count: pl.Scalar[pl.INT32],
+):
+    """Reset consumed tile credits and release the fused A2A window."""
+    with pl.at(
+        level=pl.Level.CORE_GROUP,
+        name_hint="o_group_a2a_release",
+        deps=[publish_dep, consume_dep],
+        no_dep_args=[exchange_ready],
+    ):
+        publish_expected = pl.cast(publish_count, pl.INT32)
+        for source_tp in pl.range(TP_SIZE):
+            if source_tp != tp_rank:
+                pld.system.wait(
+                    signal=exchange_signal,
+                    offsets=[source_tp, 0],
+                    expected=publish_expected,
+                    cmp=pld.WaitCmp.Ge,
+                )
+
+        ready_reset = pl.cast(-ready_count, pl.INT32)
+        self_rank = group_base + tp_rank
+        for ready_row in pl.range((TP_SIZE * local_t) // O_A_T_TILE):
+            pld.system.notify(
+                target=exchange_ready,
+                peer=self_rank,
+                offsets=[ready_row, 0],
+                value=ready_reset,
+                op=pld.NotifyOp.AtomicAdd,
+            )
+
+        for peer_tp in pl.range(TP_SIZE):
+            if peer_tp != tp_rank:
+                pld.system.notify(
+                    target=exchange_signal,
+                    peer=group_base + peer_tp,
+                    offsets=[tp_rank, 0],
+                    value=1,
+                    op=pld.NotifyOp.AtomicAdd,
+                )
+
+        completion_expected = pl.cast(publish_count + 1, pl.INT32)
+        for source_tp in pl.range(TP_SIZE):
+            if source_tp != tp_rank:
+                pld.system.wait(
+                    signal=exchange_signal,
+                    offsets=[source_tp, 0],
+                    expected=completion_expected,
+                    cmp=pld.WaitCmp.Ge,
+                )
+
+        signal_reset = pl.cast(-completion_expected, pl.INT32)
+        for source_tp in pl.range(TP_SIZE):
+            if source_tp != tp_rank:
+                pld.system.notify(
+                    target=exchange_signal,
+                    peer=self_rank,
+                    offsets=[source_tp, 0],
+                    value=signal_reset,
+                    op=pld.NotifyOp.AtomicAdd,
+                )
+    return exchange_signal, exchange_ready
+
+
+@pl.jit.inline(auto_scope=False)
+def _decode_sharded_o_projection_publish(
+    act_scale_dq: pl.Tensor[[LOCAL_O_GROUPS, GROUP_T_PAD], pl.FP32],
+    o_b_i32: pl.Tensor[[GROUP_T_PAD, LOCAL_O_GROUPS * D], pl.INT32],
+    proj_b_tids: pl.Array[LOCAL_O_GROUPS, pl.TASK_ID],
+    wo_b_scale: pl.Tensor[[D], pl.FP32],
+    local_t: pl.Scalar[pl.INT32],
+    local_out: pl.Tensor[[LOCAL_T_PAD, D], pl.BF16],
+    reduce_window: pld.DistributedTensor[[O_WINDOW_ROWS, D], pl.FP32],
+    reduce_signal: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
+    group_base: pl.Scalar[pl.INT32],
+    tp_rank: pl.Scalar[pl.INT32],
+):
+    """Publish completed O-B groups and reduce their TP-owned rows."""
+    owner_rows = (local_t + ACT_T_TILE - 1) // ACT_T_TILE
+    publish_stage = pl.create_tensor([O_RS_PUBLISH_WORKERS * ACT_T_TILE, ACT_N_TILE], dtype=pl.FP32)
+    with pl.spmd(
+        O_RS_PUBLISH_WORKERS,
+        name_hint="tp_o_b_dequant_publish",
+        deps=[proj_b_tids[group] for group in range(LOCAL_O_GROUPS)],
+        optimizations=[pl.cross_core_slot(slot_num=2)],
+    ) as publish_tid:
+        worker = pl.tile.get_block_idx()
+        for owner_rank in pl.range(TP_SIZE):
+            owner_base = owner_rank * local_t
+            for block in pl.range(worker, owner_rows * (D // ACT_N_TILE), O_RS_PUBLISH_WORKERS):
+                row_block = block // (D // ACT_N_TILE)
+                n_block = block - row_block * (D // ACT_N_TILE)
+                owner_row = row_block * ACT_T_TILE
+                t0 = owner_base + owner_row
+                n0 = n_block * ACT_N_TILE
+                out_rows = pl.min(ACT_T_TILE, local_t - owner_row)
+                dequant_acc = pl.full([ACT_T_TILE, ACT_N_TILE], dtype=pl.FP32, value=0.0)
+                for local_group in pl.pipeline(LOCAL_O_GROUPS, stage=2):
+                    part_col = local_group * D + n0
+                    group_i32 = pl.slice(
+                        o_b_i32, [ACT_T_TILE, ACT_N_TILE], [t0, part_col],
+                        valid_shape=[out_rows, ACT_N_TILE],
+                    )
+                    group_partial_fp32 = pl.cast(group_i32, target_type=pl.FP32, mode="none")
+                    scale_row = pl.slice(act_scale_dq, [1, ACT_T_TILE], [local_group, t0], valid_shape=[1, out_rows])
+                    scale_col = pl.reshape(scale_row, [ACT_T_TILE, 1])
+                    group_dequant = pl.row_expand_mul(group_partial_fp32, scale_col)
+                    dequant_acc = pl.add(dequant_acc, group_dequant)
+                weight_scale = pl.reshape(wo_b_scale[n0 : n0 + ACT_N_TILE], [1, ACT_N_TILE])
+                o_b_fp32 = pl.col_expand_mul(dequant_acc, weight_scale)
+                publish_value = pl.set_validshape(o_b_fp32, out_rows, ACT_N_TILE)
+                stage_row = worker * ACT_T_TILE
+                publish_stage[stage_row : stage_row + ACT_T_TILE, 0:ACT_N_TILE] = publish_value
+                target_row = tp_rank * LOCAL_T_PAD + owner_row
+                pld.tensor.put(
+                    dst=reduce_window,
+                    peer=group_base + owner_rank,
+                    src=publish_stage,
+                    dst_offsets=[target_row, n0],
+                    src_offsets=[stage_row, 0],
+                    shape=[out_rows, ACT_N_TILE],
+                    chunk_rows=ACT_T_TILE,
+                    chunk_cols=ACT_N_TILE,
+                )
+
+        for owner_rank in pl.range(TP_SIZE):
+            if owner_rank != tp_rank:
+                pld.system.notify(
+                    target=reduce_signal,
+                    peer=group_base + owner_rank,
+                    offsets=[tp_rank, 0],
+                    value=1,
+                    op=pld.NotifyOp.AtomicAdd,
+                )
+
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="tp_o_rs_wait", deps=[publish_tid]) as wait_tid:
+        expected = pl.cast(O_RS_PUBLISH_WORKERS, pl.INT32)
+        for source_tp in pl.range(TP_SIZE):
+            if source_tp != tp_rank:
+                pld.system.wait(
+                    signal=reduce_signal,
+                    offsets=[source_tp, 0],
+                    expected=expected,
+                    cmp=pld.WaitCmp.Ge,
+                )
+
+    with pl.spmd(O_RS_REDUCE_WORKERS, name_hint="tp_o_rs_reduce", deps=[wait_tid]) as reduce_tid:
+        worker = pl.tile.get_block_idx()
+        for block in pl.range(worker, local_t * (D // O_RS_D_TILE), O_RS_REDUCE_WORKERS):
+            local_row = block // (D // O_RS_D_TILE)
+            d_block = block - local_row * (D // O_RS_D_TILE)
+            d0 = d_block * O_RS_D_TILE
+            reduce_acc = pl.load(reduce_window, [local_row, d0], [1, O_RS_D_TILE])
+            for source_tp in pl.range(1, TP_SIZE):
+                source_row = source_tp * LOCAL_T_PAD + local_row
+                source_partial = pl.load(reduce_window, [source_row, d0], [1, O_RS_D_TILE])
+                reduce_acc = pl.add(reduce_acc, source_partial)
+            reduced = pl.cast(reduce_acc, target_type=pl.BF16, mode="rint")
+            pl.store(reduced, [local_row, d0], local_out)
+
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="tp_o_rs_complete", deps=[reduce_tid]):
+        completion_anchor = pl.read(local_out, [0, 0])
+        for peer_tp in pl.range(TP_SIZE):
+            if peer_tp != tp_rank:
+                pld.system.notify(
+                    target=reduce_signal,
+                    peer=group_base + peer_tp,
+                    offsets=[tp_rank, 0],
+                    value=1,
+                    op=pld.NotifyOp.AtomicAdd,
+                )
+
+        completion_expected = pl.cast(O_RS_PUBLISH_WORKERS + 1, pl.INT32)
+        for source_tp in pl.range(TP_SIZE):
+            if source_tp != tp_rank:
+                pld.system.wait(
+                    signal=reduce_signal,
+                    offsets=[source_tp, 0],
+                    expected=completion_expected,
+                    cmp=pld.WaitCmp.Ge,
+                )
+
+        reset_value = pl.cast(-(O_RS_PUBLISH_WORKERS + 1), pl.INT32)
+        self_rank = group_base + tp_rank
+        for source_tp in pl.range(TP_SIZE):
+            if source_tp != tp_rank:
+                pld.system.notify(
+                    target=reduce_signal,
+                    peer=self_rank,
+                    offsets=[source_tp, 0],
+                    value=reset_value,
+                    op=pld.NotifyOp.AtomicAdd,
+                )
+        pl.write(local_out, [0, 0], completion_anchor)
+    return local_out, reduce_signal
+
+
+@pl.jit.inline(auto_scope=False)
+def _decode_streaming_o_projection_tail(
+    o_a_fp32: pl.Tensor[[GROUP_T_PAD, LOCAL_O_WIDTH], pl.FP32],
+    proj_a_dep: pl.Scalar[pl.TASK_ID],
+    wo_b: pl.Tensor[[D, LOCAL_O_WIDTH], pl.INT8],
+    wo_b_scale: pl.Tensor[[D], pl.FP32],
+    local_t: pl.Scalar[pl.INT32],
+    local_out: pl.Tensor[[LOCAL_T_PAD, D], pl.BF16],
+    reduce_window: pld.DistributedTensor[[O_WINDOW_ROWS, D], pl.FP32],
+    reduce_signal: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
+    group_base: pl.Scalar[pl.INT32],
+    tp_rank: pl.Scalar[pl.INT32],
+):
+    """Quantize completed O-A groups and publish their O-B projections."""
+    group_t = TP_SIZE * local_t
+    o_b_rows = (group_t + O_B_T_TILE - 1) // O_B_T_TILE
+    o_b_group_t = o_b_rows * O_B_T_TILE
+
+    o_a_i8 = pl.create_tensor([GROUP_T_PAD, LOCAL_O_WIDTH], dtype=pl.INT8)
+    act_scale_dq = pl.create_tensor([LOCAL_O_GROUPS, GROUP_T_PAD], dtype=pl.FP32)
+    o_b_i32 = pl.create_tensor([GROUP_T_PAD, LOCAL_O_GROUPS * D], dtype=pl.INT32)
+    proj_b_tids = pl.array.create(LOCAL_O_GROUPS, pl.TASK_ID)
+
+    for local_group in pl.parallel(LOCAL_O_GROUPS):
+        o_a_col = local_group * O_LORA
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="tp_o_a_quant", deps=[proj_a_dep]) as quant_tid:
+            for qt in pl.pipeline(0, group_t, QUANT_T_TILE, stage=2):
+                quant_rows = pl.min(QUANT_T_TILE, group_t - qt)
+                o_a_tile = pl.slice(o_a_fp32, [QUANT_T_TILE, O_LORA], [qt, o_a_col], valid_shape=[quant_rows, O_LORA])
+                o_a_abs = pl.abs(o_a_tile)
+                row_amax = pl.reshape(pl.row_max(o_a_abs), [1, QUANT_T_TILE])
+                amax_floor = pl.full([1, QUANT_T_TILE], dtype=pl.FP32, value=INT8_AMAX_EPS)
+                row_amax = pl.maximum(amax_floor, row_amax)
+                scale_max = pl.full([1, QUANT_T_TILE], dtype=pl.FP32, value=INT8_SCALE_MAX)
+                scale_q_row = pl.div(scale_max, row_amax)
+                scale_dq_row = pl.recip(scale_q_row)
+                scale_dq_valid = pl.set_validshape(scale_dq_row, 1, quant_rows)
+                act_scale_dq[local_group : local_group + 1, qt : qt + QUANT_T_TILE] = scale_dq_valid
+                scale_q_col = pl.reshape(scale_q_row, [QUANT_T_TILE, 1])
+                o_a_scaled = pl.row_expand_mul(o_a_tile, scale_q_col)
+                o_a_i32 = pl.cast(o_a_scaled, target_type=pl.INT32, mode="rint")
+                o_a_fp16 = pl.cast(o_a_i32, target_type=pl.FP16, mode="round")
+                o_a_quant = pl.cast(o_a_fp16, target_type=pl.INT8, mode="trunc")
+                o_a_quant_valid = pl.set_validshape(o_a_quant, quant_rows, O_LORA)
+                o_a_i8[qt : qt + QUANT_T_TILE, o_a_col : o_a_col + O_LORA] = o_a_quant_valid
+            for qt in pl.range(group_t, o_b_group_t, QUANT_T_TILE):
+                pad_rows = pl.min(QUANT_T_TILE, o_b_group_t - qt)
+                o_a_padding_fp16 = pl.full([QUANT_T_TILE, O_LORA], dtype=pl.FP16, value=0.0)
+                o_a_padding = pl.cast(o_a_padding_fp16, target_type=pl.INT8, mode="trunc")
+                o_a_padding_valid = pl.set_validshape(o_a_padding, pad_rows, O_LORA)
+                o_a_i8[qt : qt + QUANT_T_TILE, o_a_col : o_a_col + O_LORA] = o_a_padding_valid
+
+        with pl.spmd(o_b_rows * (D // O_B_D_TILE), name_hint="tp_o_b", deps=[quant_tid]) as proj_b_tid:
+            proj_b_unit = pl.tile.get_block_idx()
+            row_block = proj_b_unit // (D // O_B_D_TILE)
+            d_block = proj_b_unit - row_block * (D // O_B_D_TILE)
+            t0 = row_block * O_B_T_TILE
+            d0 = d_block * O_B_D_TILE
+            for n0 in pl.range(d0, d0 + O_B_D_TILE, O_B_N_TILE):
+                o_b_x0 = o_a_i8[t0 : t0 + O_B_T_TILE, o_a_col : o_a_col + O_B_K_TILE]
+                o_b_w0 = wo_b[n0 : n0 + O_B_N_TILE, o_a_col : o_a_col + O_B_K_TILE]
+                o_b_acc = pl.matmul(o_b_x0, o_b_w0, b_trans=True, out_dtype=pl.INT32)
+                for k0 in pl.pipeline(O_B_K_TILE, O_LORA, O_B_K_TILE, stage=2):
+                    b_k0 = o_a_col + k0
+                    o_b_xk = o_a_i8[t0 : t0 + O_B_T_TILE, b_k0 : b_k0 + O_B_K_TILE]
+                    o_b_wk = wo_b[n0 : n0 + O_B_N_TILE, b_k0 : b_k0 + O_B_K_TILE]
+                    o_b_acc = pl.matmul_acc(o_b_acc, o_b_xk, o_b_wk, b_trans=True)
+                partial_col = local_group * D + n0
+                o_b_i32[t0 : t0 + O_B_T_TILE, partial_col : partial_col + O_B_N_TILE] = o_b_acc
+        proj_b_tids[local_group] = proj_b_tid
+
+    local_out, reduce_signal = _decode_sharded_o_projection_publish(
+        act_scale_dq, o_b_i32, proj_b_tids,
+        wo_b_scale,
+        local_t, local_out,
+        reduce_window, reduce_signal,
+        group_base, tp_rank,
+    )
+    return local_out, reduce_signal
+
+
 @pl.jit.inline
 def decode_sharded_o_projection_reduce_scatter(
     attention_local_groups: pl.Tensor[[LOCAL_O_GROUPS, GROUP_T_PAD, O_GROUP_IN], pl.BF16],
@@ -584,7 +908,6 @@ def decode_sharded_o_projection_reduce_scatter(
     o_a_rows = (group_t + O_A_T_TILE - 1) // O_A_T_TILE
     o_b_rows = (group_t + O_B_T_TILE - 1) // O_B_T_TILE
     o_b_group_t = o_b_rows * O_B_T_TILE
-    owner_rows = (local_t + ACT_T_TILE - 1) // ACT_T_TILE
 
     attn_2d = pl.reshape(attention_local_groups, [LOCAL_O_GROUPS * GROUP_T_PAD, O_GROUP_IN])
     wo_a_flat = pl.reshape(wo_a, [LOCAL_O_WIDTH, O_GROUP_IN])
@@ -680,135 +1003,98 @@ def decode_sharded_o_projection_reduce_scatter(
                 o_b_i32[t0 : t0 + O_B_T_TILE, partial_col : partial_col + O_B_N_TILE] = o_b_acc
         proj_b_tids[local_group] = proj_b_tid
 
-    publish_stage = pl.create_tensor(
-        [O_RS_PUBLISH_WORKERS * ACT_T_TILE, ACT_N_TILE],
-        dtype=pl.FP32,
+    local_out, reduce_signal = _decode_sharded_o_projection_publish(
+        act_scale_dq, o_b_i32, proj_b_tids,
+        wo_b_scale,
+        local_t, local_out,
+        reduce_window, reduce_signal,
+        group_base, tp_rank,
     )
-    with pl.spmd(
-        O_RS_PUBLISH_WORKERS,
-        name_hint="tp_o_b_dequant_publish",
-        deps=[proj_b_tids[group] for group in range(LOCAL_O_GROUPS)],
-        optimizations=[pl.cross_core_slot(slot_num=2)],
-    ) as publish_tid:
-        worker = pl.tile.get_block_idx()
-        for owner_rank in pl.range(TP_SIZE):
-            owner_base = owner_rank * local_t
-            for block in pl.range(worker, owner_rows * (D // ACT_N_TILE), O_RS_PUBLISH_WORKERS):
-                row_block = block // (D // ACT_N_TILE)
-                n_block = block - row_block * (D // ACT_N_TILE)
-                owner_row = row_block * ACT_T_TILE
-                t0 = owner_base + owner_row
-                n0 = n_block * ACT_N_TILE
-                out_rows = pl.min(ACT_T_TILE, local_t - owner_row)
-                dequant_acc = pl.full([ACT_T_TILE, ACT_N_TILE], dtype=pl.FP32, value=0.0)
-                for local_group in pl.pipeline(LOCAL_O_GROUPS, stage=2):
-                    part_col = local_group * D + n0
-                    group_i32 = pl.slice(
-                        o_b_i32,
-                        [ACT_T_TILE, ACT_N_TILE],
-                        [t0, part_col],
-                        valid_shape=[out_rows, ACT_N_TILE],
-                    )
-                    group_partial_fp32 = pl.cast(group_i32, target_type=pl.FP32, mode="none")
-                    scale_row = pl.slice(
-                        act_scale_dq,
-                        [1, ACT_T_TILE],
-                        [local_group, t0],
-                        valid_shape=[1, out_rows],
-                    )
-                    scale_col = pl.reshape(scale_row, [ACT_T_TILE, 1])
-                    group_dequant = pl.row_expand_mul(group_partial_fp32, scale_col)
-                    dequant_acc = pl.add(dequant_acc, group_dequant)
-                weight_scale = pl.reshape(wo_b_scale[n0 : n0 + ACT_N_TILE], [1, ACT_N_TILE])
-                o_b_fp32 = pl.col_expand_mul(dequant_acc, weight_scale)
-                publish_value = pl.set_validshape(o_b_fp32, out_rows, ACT_N_TILE)
-                stage_row = worker * ACT_T_TILE
-                publish_stage[
-                    stage_row : stage_row + ACT_T_TILE,
-                    0:ACT_N_TILE,
-                ] = publish_value
-                target_row = tp_rank * LOCAL_T_PAD + owner_row
-                pld.tensor.put(
-                    dst=reduce_window,
-                    peer=group_base + owner_rank,
-                    src=publish_stage,
-                    dst_offsets=[target_row, n0],
-                    src_offsets=[stage_row, 0],
-                    shape=[out_rows, ACT_N_TILE],
-                    chunk_rows=ACT_T_TILE,
-                    chunk_cols=ACT_N_TILE,
-                )
-
-        for owner_rank in pl.range(TP_SIZE):
-            if owner_rank != tp_rank:
-                pld.system.notify(
-                    target=reduce_signal,
-                    peer=group_base + owner_rank,
-                    offsets=[tp_rank, 0],
-                    value=1,
-                    op=pld.NotifyOp.AtomicAdd,
-                )
-
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="tp_o_rs_wait", deps=[publish_tid]) as wait_tid:
-        expected = pl.cast(O_RS_PUBLISH_WORKERS, pl.INT32)
-        for source_tp in pl.range(TP_SIZE):
-            if source_tp != tp_rank:
-                pld.system.wait(
-                    signal=reduce_signal,
-                    offsets=[source_tp, 0],
-                    expected=expected,
-                    cmp=pld.WaitCmp.Ge,
-                )
-
-    with pl.spmd(O_RS_REDUCE_WORKERS, name_hint="tp_o_rs_reduce", deps=[wait_tid]) as reduce_tid:
-        worker = pl.tile.get_block_idx()
-        for block in pl.range(worker, local_t * (D // O_RS_D_TILE), O_RS_REDUCE_WORKERS):
-            local_row = block // (D // O_RS_D_TILE)
-            d_block = block - local_row * (D // O_RS_D_TILE)
-            d0 = d_block * O_RS_D_TILE
-            reduce_acc = pl.load(reduce_window, [local_row, d0], [1, O_RS_D_TILE])
-            for source_tp in pl.range(1, TP_SIZE):
-                source_row = source_tp * LOCAL_T_PAD + local_row
-                source_partial = pl.load(reduce_window, [source_row, d0], [1, O_RS_D_TILE])
-                reduce_acc = pl.add(reduce_acc, source_partial)
-            reduced = pl.cast(reduce_acc, target_type=pl.BF16, mode="rint")
-            pl.store(reduced, [local_row, d0], local_out)
-
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="tp_o_rs_complete", deps=[reduce_tid]):
-        completion_anchor = pl.read(local_out, [0, 0])
-        for peer_tp in pl.range(TP_SIZE):
-            if peer_tp != tp_rank:
-                pld.system.notify(
-                    target=reduce_signal,
-                    peer=group_base + peer_tp,
-                    offsets=[tp_rank, 0],
-                    value=1,
-                    op=pld.NotifyOp.AtomicAdd,
-                )
-
-        completion_expected = pl.cast(O_RS_PUBLISH_WORKERS + 1, pl.INT32)
-        for source_tp in pl.range(TP_SIZE):
-            if source_tp != tp_rank:
-                pld.system.wait(
-                    signal=reduce_signal,
-                    offsets=[source_tp, 0],
-                    expected=completion_expected,
-                    cmp=pld.WaitCmp.Ge,
-                )
-
-        reset_value = pl.cast(-(O_RS_PUBLISH_WORKERS + 1), pl.INT32)
-        self_rank = group_base + tp_rank
-        for source_tp in pl.range(TP_SIZE):
-            if source_tp != tp_rank:
-                pld.system.notify(
-                    target=reduce_signal,
-                    peer=self_rank,
-                    offsets=[source_tp, 0],
-                    value=reset_value,
-                    op=pld.NotifyOp.AtomicAdd,
-                )
-        pl.write(local_out, [0, 0], completion_anchor)
     return local_out, reduce_signal
+
+
+@pl.jit.inline(auto_scope=False)
+def decode_streaming_o_projection_reduce_scatter(
+    attention_window: pld.DistributedTensor[[ATTENTION_WINDOW_ROWS, O_GROUP_IN], pl.BF16],
+    attention_signal: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
+    attention_ready: pld.DistributedTensor[[ATTENTION_READY_ROWS, 1], pl.INT32],
+    wo_a: pl.Tensor[[LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
+    wo_b: pl.Tensor[[D, LOCAL_O_WIDTH], pl.INT8],
+    wo_b_scale: pl.Tensor[[D], pl.FP32],
+    local_t: pl.Scalar[pl.INT32],
+    local_out: pl.Tensor[[LOCAL_T_PAD, D], pl.BF16],
+    reduce_window: pld.DistributedTensor[[O_WINDOW_ROWS, D], pl.FP32],
+    reduce_signal: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
+    group_base: pl.Scalar[pl.INT32],
+    tp_rank: pl.Scalar[pl.INT32],
+    ready_registration_dep: pl.Scalar[pl.TASK_ID],
+    publish_dep: pl.Scalar[pl.TASK_ID],
+    publish_count: pl.Scalar[pl.INT32],
+    ready_count: pl.Scalar[pl.INT32],
+):
+    """Start each source-sized O-A launch once its HCA A2A tiles are ready."""
+    group_t = TP_SIZE * local_t
+    wo_a_flat = pl.reshape(wo_a, [LOCAL_O_WIDTH, O_GROUP_IN])
+    o_a_fp32 = pl.create_tensor([GROUP_T_PAD, LOCAL_O_WIDTH], dtype=pl.FP32)
+    proj_a_launch_tids = pl.array.create(GROUP_T_PAD // O_A_LAUNCH_T_TILE, pl.TASK_ID)
+    for ready_launch in pl.unroll(GROUP_T_PAD // O_A_LAUNCH_T_TILE):
+        proj_a_launch_tids[ready_launch] = pl.system.task_invalid()
+
+    if False:
+        o_a_fp32 = streaming_o_a_tile(attention_window, wo_a_flat, o_a_fp32, 0)
+
+    ready_rows_per_launch = O_A_LAUNCH_T_TILE // O_A_T_TILE
+    ready_launches = (group_t + O_A_LAUNCH_T_TILE - 1) // O_A_LAUNCH_T_TILE
+    next_source = (tp_rank + 1) % TP_SIZE
+    ready_launch_offset = next_source * ready_launches // TP_SIZE
+    for launch_step in pl.range(ready_launches):
+        ready_launch = (launch_step + ready_launch_offset) % ready_launches
+        ready_row_base = ready_launch * ready_rows_per_launch
+        ready_rows = pl.min(ready_rows_per_launch, group_t // O_A_T_TILE - ready_row_base)
+        with pl.at(
+            level=pl.Level.CORE_GROUP,
+            name_hint="tp_o_a_tile_wait",
+            deps=[ready_registration_dep],
+            no_dep_args=[attention_ready],
+        ) as ready_tid:
+            for ready_row_offset in pl.unroll(O_A_LAUNCH_T_TILE // O_A_T_TILE):
+                ready_row = ready_row_base + ready_row_offset
+                if ready_row < group_t // O_A_T_TILE:
+                    pld.system.defer_wait(
+                        signal=attention_ready,
+                        offsets=[ready_row, 0],
+                        expected=pl.cast(ready_count, pl.INT32),
+                        cmp=pld.WaitCmp.Ge,
+                    )
+
+        o_a_fp32, proj_a_launch_tid = pl.spmd_submit(
+            self.streaming_o_a_tile,  # noqa: F821 - materialized as a @pl.program method by @pl.jit
+            pl.no_dep(attention_window), wo_a_flat,
+            pl.no_dep(o_a_fp32),
+            ready_row_base,
+            core_num=ready_rows * LOCAL_O_GROUPS * (O_LORA // O_A_N_TILE),
+            deps=[ready_tid],
+        )
+        proj_a_launch_tids[ready_launch] = proj_a_launch_tid
+
+    o_a_done_tid = pl.system.task_dummy(
+        deps=[proj_a_launch_tids[ready_launch] for ready_launch in range(GROUP_T_PAD // O_A_LAUNCH_T_TILE)],
+    )
+
+    attention_signal, attention_ready = o_group_a2a_release(
+        attention_signal, attention_ready,
+        group_base, tp_rank, local_t,
+        publish_dep, o_a_done_tid,
+        publish_count, ready_count,
+    )
+    local_out, reduce_signal = _decode_streaming_o_projection_tail(
+        o_a_fp32, o_a_done_tid,
+        wo_b, wo_b_scale,
+        local_t, local_out,
+        reduce_window, reduce_signal,
+        group_base, tp_rank,
+    )
+    return local_out, attention_signal, attention_ready, reduce_signal
 
 
 def golden_decode_o_proj_tp1(o_packed_heads, wo_a, wo_b, wo_b_scale, tokens):

--- a/models/deepseek_v4_flash_dspark/decode_sparse_attn_csa.py
+++ b/models/deepseek_v4_flash_dspark/decode_sparse_attn_csa.py
@@ -14,6 +14,7 @@ masking folded in. The SWA and HCA variants live in sibling modules.
 
 
 import pypto.language as pl
+import pypto.language.distributed as pld
 
 from config import (
     FLASH as M,
@@ -67,6 +68,11 @@ ATTN_K_TILE = 128
 NUM_QK_CORES = 24        # qk_pv dispatch lanes = a2a3 AIC count; re-sweep for other AIC counts
 T_PAD = ((T + 16 - 1) // 16) * 16  # T padded up to the 16-row cube M floor
 ROPE_CS_T_TILE = 8    # rope cos/sin row block; T is a multiple of 8 by the batch contract
+CSA_A2A_T_TILE = 8
+LOCAL_O_GROUPS = O_GROUPS // TP
+GROUP_T_PAD = TP * T_PAD
+ATTENTION_WINDOW_ROWS = LOCAL_O_GROUPS * GROUP_T_PAD
+PACK_GROUPS = H_TILE // HEADS_PER_GROUP
 TOPK = WIN + CMP_TOPK
 # Floor to 2: a single sparse-K block miscompiles in pypto (S-stride cross-token
 # output mixup); a 2-block build with an all-invalid 2nd block is bit-exact.
@@ -83,11 +89,20 @@ SWA_RUNS = (SWA_TILE_WIN_ROWS + 2 * (BLOCK_SIZE - 1)) // BLOCK_SIZE
 # Token tile for the slot / bias vector work; the whole-T form would put
 # [T, IDX_TOPK] FP32 tiles well past the Vec limit.
 BIAS_T_TILE = min(T, 8)
-assert T % BIAS_T_TILE == 0
+if T % BIAS_T_TILE != 0:
+    raise ValueError("CSA token capacity must contain complete bias tiles")
+if O_GROUPS % TP != 0:
+    raise ValueError(f"output groups {O_GROUPS} must be divisible by TP size {TP}")
+if H_TILE % HEADS_PER_GROUP != 0:
+    raise ValueError(f"CSA head tile {H_TILE} must contain complete output groups")
+if LOCAL_O_GROUPS % PACK_GROUPS != 0:
+    raise ValueError(f"local output groups {LOCAL_O_GROUPS} must contain complete CSA pack tiles")
+if T % CSA_A2A_T_TILE != 0:
+    raise ValueError(f"CSA token capacity {T} must be divisible by A2A tile {CSA_A2A_T_TILE}")
 
 
-@pl.jit.inline
-def sparse_attn_csa(
+@pl.jit.inline(auto_scope=False)
+def _sparse_attn_csa_state(
     q: pl.Tensor[[T_DYN, H, HEAD_DIM], pl.BF16],
     ori_kv: pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     window_swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
@@ -95,23 +110,16 @@ def sparse_attn_csa(
     cmp_block_table: pl.Tensor[[B_DYN, CMP_MAX_BLOCKS], pl.INT32],
     idx_topk: pl.Tensor[[T_DYN, IDX_TOPK], pl.INT32],
     position_ids: pl.Tensor[[T_DYN, 1], pl.INT32],
-    attn_sink: pl.Tensor[[H], pl.FP32],
     freqs_cos: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
     freqs_sin: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
-    o_packed_heads: pl.Tensor[[O_GROUPS * T_PAD, O_GROUP_IN], pl.BF16],
     cache_ready_dep: pl.Scalar[pl.TASK_ID],
-) -> tuple[pl.Tensor, pl.Scalar[pl.TASK_ID]]:
-    """Write CSA heads as ``[group, T_PAD, O_GROUP_IN]`` slabs.
-
-    Only the first runtime ``t_dim`` rows in each group are valid. The
-    returned task ID covers every write to the packed output tensor.
-    """
+):
+    """Compute CSA sparse-block states and inverse-RoPE metadata."""
     # Compressed index contract: -1 invalid, [0, ...) compressed KV slots.
     ori_block_num = pl.tensor.dim(ori_kv, 0)
     t_dim = pl.tensor.dim(q, 0)
     t_heads = t_dim * H
     t_blk = t_dim * (H // H_TILE) * SPARSE_BLOCKS * H_TILE
-    t_hblocks = t_dim * (H // H_TILE)
     qk_items = t_dim * SPARSE_BLOCKS
     rope_cs_blocks = t_dim // ROPE_CS_T_TILE
     ori_kv_flat = pl.reshape(ori_kv, [ori_block_num * BLOCK_SIZE, HEAD_DIM])
@@ -198,7 +206,7 @@ def sparse_attn_csa(
     sparse_blk_li = pl.create_tensor([t_blk, 1], dtype=pl.FP32)
     sparse_blk_oi = pl.create_tensor([t_blk, HEAD_DIM], dtype=pl.FP32)
 
-    with pl.spmd(NUM_QK_CORES, name_hint="qk_pv", deps=[qk_plan_tid, cache_ready_dep], allow_early_resolve=True) as _qk_tid:
+    with pl.spmd(NUM_QK_CORES, name_hint="qk_pv", deps=[qk_plan_tid, cache_ready_dep], allow_early_resolve=True) as qk_tid:
         qk_core = pl.tile.get_block_idx()
         # Items for this lane: qk_core, qk_core + NUM_QK_CORES, ...  The per-lane
         # count is derived from the lane index (no stored per-core count); a lane
@@ -316,7 +324,7 @@ def sparse_attn_csa(
     # j^1 lane-swap index for merge_norm's rotation gather. Shaped [H_TILE, ROPE_DIM]
     # because gather's index must match its source rows.
     rope_swap_idx = pl.create_tensor([H_TILE, ROPE_DIM], dtype=pl.INT32)
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="rope_cs", allow_early_resolve=True):
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="rope_cs", allow_early_resolve=True) as rope_tid:
         sw_ones = pl.full([H_TILE, ROPE_DIM], dtype=pl.FP32, value=1.0)
         sw_idx_f = pl.cast(pl.arange(0, [1, ROPE_DIM], dtype=pl.INT32), target_type=pl.FP32)
         sw_col = pl.col_expand_mul(sw_ones, sw_idx_f)
@@ -342,10 +350,66 @@ def sparse_attn_csa(
             cs_sin_il = pl.gather(cs_sin, dim=-1, index=cs_dup_idx)
             rope_sin_signed[cs_t0 : cs_t0 + ROPE_CS_T_TILE, 0:ROPE_DIM] = pl.mul(cs_sin_il, cs_sign)
 
-    # Online-softmax merge across sparse-K tiles, sink-norm, then fused inverse RoPE,
-    # one spmd block per (token, head-tile). The rotated rope segment is packed
-    # straight into the group-major output.
-    with pl.spmd(t_hblocks, name_hint="merge_norm") as merge_tid:
+    return (
+        sparse_blk_mi,
+        sparse_blk_li,
+        sparse_blk_oi,
+        rope_cos_il,
+        rope_sin_signed,
+        rope_swap_idx,
+        qk_tid,
+        rope_tid,
+    )
+
+
+@pl.jit.inline
+def sparse_attn_csa(
+    q: pl.Tensor[[T_DYN, H, HEAD_DIM], pl.BF16],
+    ori_kv: pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    window_swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
+    cmp_kv: pl.Tensor[[CMP_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    cmp_block_table: pl.Tensor[[B_DYN, CMP_MAX_BLOCKS], pl.INT32],
+    idx_topk: pl.Tensor[[T_DYN, IDX_TOPK], pl.INT32],
+    position_ids: pl.Tensor[[T_DYN, 1], pl.INT32],
+    attn_sink: pl.Tensor[[H], pl.FP32],
+    freqs_cos: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
+    o_packed_heads: pl.Tensor[[O_GROUPS * T_PAD, O_GROUP_IN], pl.BF16],
+    cache_ready_dep: pl.Scalar[pl.TASK_ID],
+) -> tuple[pl.Tensor, pl.Scalar[pl.TASK_ID]]:
+    """Write CSA heads as ``[group, T_PAD, O_GROUP_IN]`` slabs.
+
+    Only the first runtime ``t_dim`` rows in each group are valid. The
+    returned task ID covers every write to the packed output tensor.
+    """
+    (
+        sparse_blk_mi,
+        sparse_blk_li,
+        sparse_blk_oi,
+        rope_cos_il,
+        rope_sin_signed,
+        rope_swap_idx,
+        qk_tid,
+        rope_tid,
+    ) = _sparse_attn_csa_state(
+        q,
+        ori_kv,
+        window_swa_indices,
+        cmp_kv,
+        cmp_block_table,
+        idx_topk,
+        position_ids,
+        freqs_cos,
+        freqs_sin,
+        cache_ready_dep,
+    )
+    t_dim = pl.tensor.dim(q, 0)
+
+    with pl.spmd(
+        t_dim * (H // H_TILE),
+        name_hint="merge_norm",
+        deps=[qk_tid, rope_tid],
+    ) as merge_tid:
         m_idx = pl.tile.get_block_idx()
         m_t = m_idx // (H // H_TILE)
         m_h_idx = m_idx - m_t * (H // H_TILE)
@@ -394,6 +458,150 @@ def sparse_attn_csa(
             o_packed_heads[n_pack_row : n_pack_row + 1, n_col : n_col + HEAD_DIM] = n_full_bf16[n_hi : n_hi + 1, :]
 
     return o_packed_heads, merge_tid
+
+
+@pl.jit.inline(auto_scope=False)
+def sparse_attn_csa_a2a(
+    q: pl.Tensor[[T_DYN, H, HEAD_DIM], pl.BF16],
+    ori_kv: pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    window_swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
+    cmp_kv: pl.Tensor[[CMP_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    cmp_block_table: pl.Tensor[[B_DYN, CMP_MAX_BLOCKS], pl.INT32],
+    idx_topk: pl.Tensor[[T_DYN, IDX_TOPK], pl.INT32],
+    position_ids: pl.Tensor[[T_DYN, 1], pl.INT32],
+    attn_sink: pl.Tensor[[H], pl.FP32],
+    freqs_cos: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
+    attention_grouped: pl.Tensor[[O_GROUPS * T_PAD, O_GROUP_IN], pl.BF16],
+    exchange_window: pld.DistributedTensor[[ATTENTION_WINDOW_ROWS, O_GROUP_IN], pl.BF16],
+    exchange_signal: pld.DistributedTensor[[TP, 1], pl.INT32],
+    group_base: pl.Scalar[pl.INT32],
+    tp_rank: pl.Scalar[pl.INT32],
+    local_t: pl.Scalar[pl.INT32],
+    cache_ready_dep: pl.Scalar[pl.TASK_ID],
+):
+    """Merge CSA heads and publish each completed token tile to its TP owner."""
+    (
+        sparse_blk_mi,
+        sparse_blk_li,
+        sparse_blk_oi,
+        rope_cos_il,
+        rope_sin_signed,
+        rope_swap_idx,
+        qk_tid,
+        rope_tid,
+    ) = _sparse_attn_csa_state(
+        q,
+        ori_kv,
+        window_swa_indices,
+        cmp_kv,
+        cmp_block_table,
+        idx_topk,
+        position_ids,
+        freqs_cos,
+        freqs_sin,
+        cache_ready_dep,
+    )
+    t_dim = pl.tensor.dim(q, 0)
+    pack_work_count = (t_dim // CSA_A2A_T_TILE) * (H // H_TILE)
+
+    with pl.spmd(
+        48,
+        name_hint="csa_merge_pack_publish",
+        deps=[qk_tid, rope_tid],
+    ) as publish_tid:
+        worker = pl.tile.get_block_idx()
+        for pack_work in pl.range(worker, pack_work_count, 48):
+            token_block = pack_work // (H // H_TILE)
+            m_h_idx = pack_work - token_block * (H // H_TILE)
+            m_t0 = token_block * CSA_A2A_T_TILE
+            m_h0 = m_h_idx * H_TILE
+            global_group0 = m_h0 // HEADS_PER_GROUP
+            destination_rank = global_group0 // LOCAL_O_GROUPS
+            local_group0 = global_group0 - destination_rank * LOCAL_O_GROUPS
+
+            for m_dt in pl.range(CSA_A2A_T_TILE):
+                m_t = m_t0 + m_dt
+                m_idx = m_t * (H // H_TILE) + m_h_idx
+                m_blk_base = m_idx * SPARSE_BLOCKS * H_TILE
+                m_mi = sparse_blk_mi[m_blk_base : m_blk_base + H_TILE, 0 : 1]
+                m_li = sparse_blk_li[m_blk_base : m_blk_base + H_TILE, 0 : 1]
+                m_oi = sparse_blk_oi[m_blk_base : m_blk_base + H_TILE, 0 : HEAD_DIM]
+
+                for m_sb in pl.pipeline(1, SPARSE_BLOCKS, stage=2):
+                    m_row = m_blk_base + m_sb * H_TILE
+                    m_cur_mi = sparse_blk_mi[m_row : m_row + H_TILE, 0 : 1]
+                    m_cur_li = sparse_blk_li[m_row : m_row + H_TILE, 0 : 1]
+                    m_cur_oi = sparse_blk_oi[m_row : m_row + H_TILE, 0 : HEAD_DIM]
+                    m_mi_new = pl.maximum(m_mi, m_cur_mi)
+                    m_alpha = pl.exp(pl.sub(m_mi, m_mi_new))
+                    m_beta = pl.exp(pl.sub(m_cur_mi, m_mi_new))
+                    m_li = pl.add(pl.mul(m_alpha, m_li), pl.mul(m_beta, m_cur_li))
+                    m_oi = pl.add(
+                        pl.row_expand_mul(m_oi, m_alpha),
+                        pl.row_expand_mul(m_cur_oi, m_beta),
+                    )
+                    m_mi = m_mi_new
+
+                n_sink_bias = pl.reshape(attn_sink[m_h0 : m_h0 + H_TILE], [H_TILE, 1])
+                n_sink_tile = pl.add(pl.sub(m_mi, m_mi), n_sink_bias)
+                n_denom = pl.add(m_li, pl.exp(pl.sub(n_sink_tile, m_mi)))
+                n_full = pl.row_expand_div(m_oi, n_denom)[0:H_TILE, 0:HEAD_DIM]
+                n_bf16 = pl.cast(n_full, target_type=pl.BF16, mode="rint")
+
+                m_rope = n_full[0:H_TILE, NOPE_DIM:HEAD_DIM]
+                m_cos_il = rope_cos_il[m_t : m_t + 1, 0:ROPE_DIM]
+                m_sin_signed = rope_sin_signed[m_t : m_t + 1, 0:ROPE_DIM]
+                m_swapped = pl.gather(
+                    m_rope,
+                    dim=-1,
+                    index=rope_swap_idx[0:H_TILE, 0:ROPE_DIM],
+                )
+                m_rot = pl.add(
+                    pl.col_expand_mul(m_rope, m_cos_il),
+                    pl.col_expand_mul(m_swapped, m_sin_signed),
+                )
+                n_rope_bf16 = pl.cast(m_rot, target_type=pl.BF16, mode="rint")
+                n_full_bf16 = pl.concat(n_bf16[:, 0:NOPE_DIM], n_rope_bf16)
+
+                for n_hi in pl.unroll(H_TILE):
+                    n_head = m_h0 + n_hi
+                    source_row = (n_head // HEADS_PER_GROUP) * T_PAD + m_t
+                    source_col = (n_head % HEADS_PER_GROUP) * HEAD_DIM
+                    attention_grouped[
+                        source_row : source_row + 1,
+                        source_col : source_col + HEAD_DIM,
+                    ] = n_full_bf16[n_hi : n_hi + 1, 0:HEAD_DIM]
+
+            for group_slot in pl.unroll(PACK_GROUPS):
+                source_row = (global_group0 + group_slot) * T_PAD + m_t0
+                target_row = (
+                    (local_group0 + group_slot) * GROUP_T_PAD
+                    + tp_rank * local_t
+                    + m_t0
+                )
+                pld.tensor.put(
+                    dst=exchange_window,
+                    peer=group_base + destination_rank,
+                    src=attention_grouped,
+                    dst_offsets=[target_row, 0],
+                    src_offsets=[source_row, 0],
+                    shape=[CSA_A2A_T_TILE, O_GROUP_IN],
+                    chunk_rows=CSA_A2A_T_TILE,
+                    chunk_cols=O_GROUP_IN,
+                )
+
+        for destination_rank in pl.range(TP):
+            if destination_rank != tp_rank:
+                pld.system.notify(
+                    target=exchange_signal,
+                    peer=group_base + destination_rank,
+                    offsets=[tp_rank, 0],
+                    value=1,
+                    op=pld.NotifyOp.AtomicAdd,
+                )
+
+    return exchange_signal, publish_tid
 
 
 @pl.jit

--- a/models/deepseek_v4_flash_dspark/decode_sparse_attn_hca.py
+++ b/models/deepseek_v4_flash_dspark/decode_sparse_attn_hca.py
@@ -10,6 +10,7 @@
 
 
 import pypto.language as pl
+import pypto.language.distributed as pld
 
 from config import (
     FLASH as M,
@@ -68,23 +69,43 @@ ATTN_K_TILE = 128
 ATTN_D_TILE = 256
 H_TILE = 16
 QK_M_TILE = 32
+HCA_A2A_T_TILE = 8
 CMP_PAGES_PER_WORK = ATTN_K_TILE // BLOCK_SIZE
 ROPE_TILE = 16
 ROPE_INTERLEAVE_TILE = 2 * ROPE_TILE
 ROPE_CS_T_TILE = 8
 T_PAD = ((T + 16 - 1) // 16) * 16
+LOCAL_O_GROUPS = O_GROUPS // TP
+GROUP_T_PAD = TP * T_PAD
+ATTENTION_WINDOW_ROWS = LOCAL_O_GROUPS * GROUP_T_PAD
+PACK_GROUPS = H_TILE // HEADS_PER_GROUP
 
-assert WIN == ATTN_K_TILE, "HCA raw window must form one baseline-sized attention tile"
-assert HCA_MAX_COMPRESSED_ROWS <= HCA_COMPRESSED_POOL_ROWS
-assert ATTN_K_TILE % BLOCK_SIZE == 0, "HCA work must contain complete cache pages"
-assert H % QK_M_TILE == 0 and QK_M_TILE % H_TILE == 0
-assert BLOCK_SIZE % GATHER_RUN_TILE == 0, "a contiguous gather run must stay inside one cache block"
-assert HEAD_DIM == 2 * ATTN_D_TILE, "HCA stream matmuls split the head width into exactly two bounded tiles"
-assert S % ROPE_CS_T_TILE == 0, "each request must contain complete inverse-RoPE token tiles"
+if WIN != ATTN_K_TILE:
+    raise ValueError("HCA raw window must form one baseline-sized attention tile")
+if HCA_MAX_COMPRESSED_ROWS > HCA_COMPRESSED_POOL_ROWS:
+    raise ValueError("HCA compressed rows exceed the configured pool")
+if ATTN_K_TILE % BLOCK_SIZE != 0:
+    raise ValueError("HCA work must contain complete cache pages")
+if H % QK_M_TILE != 0 or QK_M_TILE % H_TILE != 0:
+    raise ValueError("HCA head tiles must divide the attention head count")
+if BLOCK_SIZE % GATHER_RUN_TILE != 0:
+    raise ValueError("a contiguous gather run must stay inside one cache block")
+if HEAD_DIM != 2 * ATTN_D_TILE:
+    raise ValueError("HCA stream matmuls require two bounded head-width tiles")
+if S % ROPE_CS_T_TILE != 0:
+    raise ValueError("each request must contain complete inverse-RoPE token tiles")
+if O_GROUPS % TP != 0:
+    raise ValueError(f"output groups {O_GROUPS} must be divisible by TP size {TP}")
+if H_TILE % HEADS_PER_GROUP != 0:
+    raise ValueError(f"HCA head tile {H_TILE} must contain complete output groups")
+if LOCAL_O_GROUPS % PACK_GROUPS != 0:
+    raise ValueError(f"local output groups {LOCAL_O_GROUPS} must contain complete HCA pack tiles")
+if T % HCA_A2A_T_TILE != 0:
+    raise ValueError(f"HCA token capacity {T} must be divisible by A2A tile {HCA_A2A_T_TILE}")
 
 
 @pl.jit.inline(auto_scope=False)
-def sparse_attn_hca(
+def _sparse_attn_hca_stream(
     q: pl.Tensor[[T_DYN, H, HEAD_DIM], pl.BF16],
     ori_kv: pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     window_swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
@@ -95,10 +116,9 @@ def sparse_attn_hca(
     attn_sink: pl.Tensor[[H], pl.FP32],
     freqs_cos: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
     freqs_sin: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
-    o_packed_heads: pl.Tensor[[O_GROUPS * T_PAD, O_GROUP_IN], pl.BF16],
     cache_ready_dep: pl.Scalar[pl.TASK_ID],
-) -> tuple[pl.Tensor, pl.Scalar[pl.TASK_ID]]:
-    """Write HCA heads as grouped ``[T_PAD, O_GROUP_IN]`` slabs."""
+):
+    """Compute normalized HCA stream heads and inverse-RoPE metadata."""
     t_dim = pl.tensor.dim(q, 0)
     rope_cs_blocks = t_dim // ROPE_CS_T_TILE
     ori_block_num = pl.tensor.dim(ori_kv, 0)
@@ -744,10 +764,61 @@ def sparse_attn_hca(
         stream_output = pl.row_expand_div(stream_o, stream_denom)
         pl.store(stream_output, [stream_state_row, 0], stream_heads)
 
+    return (
+        stream_heads,
+        rope_cos_il,
+        rope_sin_signed,
+        rope_swap_idx,
+        stream_heads_tid,
+        rope_swap_tids[0],
+        rope_cs_tids[0],
+    )
+
+
+@pl.jit.inline(auto_scope=False)
+def sparse_attn_hca(
+    q: pl.Tensor[[T_DYN, H, HEAD_DIM], pl.BF16],
+    ori_kv: pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    window_swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
+    cmp_kv: pl.Tensor[[CMP_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    cmp_block_table: pl.Tensor[[B_DYN, CMP_TABLE_BLOCKS_DYN], pl.INT32],
+    position_ids: pl.Tensor[[T_DYN], pl.INT32],
+    kv_seq_lens: pl.Tensor[[B_DYN], pl.INT32],
+    attn_sink: pl.Tensor[[H], pl.FP32],
+    freqs_cos: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
+    o_packed_heads: pl.Tensor[[O_GROUPS * T_PAD, O_GROUP_IN], pl.BF16],
+    cache_ready_dep: pl.Scalar[pl.TASK_ID],
+) -> tuple[pl.Tensor, pl.Scalar[pl.TASK_ID]]:
+    """Write HCA heads as grouped ``[T_PAD, O_GROUP_IN]`` slabs."""
+    (
+        stream_heads,
+        rope_cos_il,
+        rope_sin_signed,
+        rope_swap_idx,
+        stream_heads_tid,
+        rope_swap_tid,
+        rope_cs_tid,
+    ) = _sparse_attn_hca_stream(
+        q,
+        ori_kv,
+        window_swa_indices,
+        cmp_kv,
+        cmp_block_table,
+        position_ids,
+        kv_seq_lens,
+        attn_sink,
+        freqs_cos,
+        freqs_sin,
+        cache_ready_dep,
+    )
+    t_dim = pl.tensor.dim(q, 0)
+    stream_block_count = t_dim * (H // H_TILE)
+
     with pl.spmd(
         stream_block_count,
         name_hint="hca_stream_pack",
-        deps=[stream_heads_tid, rope_swap_tids[0], rope_cs_tids[0]],
+        deps=[stream_heads_tid, rope_swap_tid, rope_cs_tid],
     ) as heads_tid:
         stream_idx = pl.tile.get_block_idx()
         stream_t = stream_idx // (H // H_TILE)
@@ -780,6 +851,131 @@ def sparse_attn_hca(
             ] = n_full_bf16[n_hi : n_hi + 1, 0:HEAD_DIM]
 
     return o_packed_heads, heads_tid
+
+
+@pl.jit.inline(auto_scope=False)
+def sparse_attn_hca_a2a(
+    q: pl.Tensor[[T_DYN, H, HEAD_DIM], pl.BF16],
+    ori_kv: pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    window_swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
+    cmp_kv: pl.Tensor[[CMP_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    cmp_block_table: pl.Tensor[[B_DYN, CMP_TABLE_BLOCKS_DYN], pl.INT32],
+    position_ids: pl.Tensor[[T_DYN], pl.INT32],
+    kv_seq_lens: pl.Tensor[[B_DYN], pl.INT32],
+    attn_sink: pl.Tensor[[H], pl.FP32],
+    freqs_cos: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
+    attention_grouped: pl.Tensor[[O_GROUPS * T_PAD, O_GROUP_IN], pl.BF16],
+    exchange_window: pld.DistributedTensor[[ATTENTION_WINDOW_ROWS, O_GROUP_IN], pl.BF16],
+    exchange_signal: pld.DistributedTensor[[TP, 1], pl.INT32],
+    group_base: pl.Scalar[pl.INT32],
+    tp_rank: pl.Scalar[pl.INT32],
+    local_t: pl.Scalar[pl.INT32],
+    cache_ready_dep: pl.Scalar[pl.TASK_ID],
+):
+    """Pack HCA heads and publish each completed token tile to its TP owner."""
+    (
+        stream_heads,
+        rope_cos_il,
+        rope_sin_signed,
+        rope_swap_idx,
+        stream_heads_tid,
+        rope_swap_tid,
+        rope_cs_tid,
+    ) = _sparse_attn_hca_stream(
+        q,
+        ori_kv,
+        window_swa_indices,
+        cmp_kv,
+        cmp_block_table,
+        position_ids,
+        kv_seq_lens,
+        attn_sink,
+        freqs_cos,
+        freqs_sin,
+        cache_ready_dep,
+    )
+    t_dim = pl.tensor.dim(q, 0)
+    pack_work_count = (t_dim // HCA_A2A_T_TILE) * (H // H_TILE)
+
+    with pl.spmd(
+        48,
+        name_hint="hca_stream_pack_publish",
+        deps=[stream_heads_tid, rope_swap_tid, rope_cs_tid],
+    ) as publish_tid:
+        worker = pl.tile.get_block_idx()
+        for pack_work in pl.range(worker, pack_work_count, 48):
+            token_block = pack_work // (H // H_TILE)
+            stream_h_tile = pack_work - token_block * (H // H_TILE)
+            stream_t0 = token_block * HCA_A2A_T_TILE
+            stream_h0 = stream_h_tile * H_TILE
+            global_group0 = stream_h0 // HEADS_PER_GROUP
+            destination_rank = global_group0 // LOCAL_O_GROUPS
+            local_group0 = global_group0 - destination_rank * LOCAL_O_GROUPS
+
+            for stream_dt in pl.unroll(HCA_A2A_T_TILE):
+                stream_t = stream_t0 + stream_dt
+                stream_state_row = stream_t * H + stream_h0
+                stream_output = stream_heads[
+                    stream_state_row : stream_state_row + H_TILE, 0:HEAD_DIM
+                ]
+                stream_bf16 = pl.cast(stream_output, target_type=pl.BF16, mode="rint")
+                stream_rope = stream_output[0:H_TILE, NOPE_DIM:HEAD_DIM]
+                stream_cos_il = rope_cos_il[stream_t : stream_t + 1, 0:ROPE_DIM]
+                stream_sin_signed = rope_sin_signed[stream_t : stream_t + 1, 0:ROPE_DIM]
+                stream_swap_zero = pl.full([H_TILE, ROPE_DIM], dtype=pl.INT32, value=0)
+                stream_swap_idx = pl.col_expand_add(
+                    stream_swap_zero,
+                    rope_swap_idx[0:1, 0:ROPE_DIM],
+                )
+                stream_swapped = pl.gather(stream_rope, dim=-1, index=stream_swap_idx)
+                stream_rot = pl.add(
+                    pl.col_expand_mul(stream_rope, stream_cos_il),
+                    pl.col_expand_mul(stream_swapped, stream_sin_signed),
+                )
+                n_rope_bf16 = pl.cast(stream_rot, target_type=pl.BF16, mode="rint")
+                n_full_bf16 = pl.concat(
+                    stream_bf16[0:H_TILE, 0:NOPE_DIM],
+                    n_rope_bf16,
+                )
+                for n_hi in pl.unroll(H_TILE):
+                    n_head = stream_h0 + n_hi
+                    source_row = (n_head // HEADS_PER_GROUP) * T_PAD + stream_t
+                    source_col = (n_head % HEADS_PER_GROUP) * HEAD_DIM
+                    attention_grouped[
+                        source_row : source_row + 1,
+                        source_col : source_col + HEAD_DIM,
+                    ] = n_full_bf16[n_hi : n_hi + 1, 0:HEAD_DIM]
+
+            for group_slot in pl.unroll(PACK_GROUPS):
+                source_row = (global_group0 + group_slot) * T_PAD + stream_t0
+                target_row = (
+                    (local_group0 + group_slot) * GROUP_T_PAD
+                    + tp_rank * local_t
+                    + stream_t0
+                )
+                pld.tensor.put(
+                    dst=exchange_window,
+                    peer=group_base + destination_rank,
+                    src=attention_grouped,
+                    dst_offsets=[target_row, 0],
+                    src_offsets=[source_row, 0],
+                    shape=[HCA_A2A_T_TILE, O_GROUP_IN],
+                    chunk_rows=HCA_A2A_T_TILE,
+                    chunk_cols=O_GROUP_IN,
+                )
+
+        for destination_rank in pl.range(TP):
+            if destination_rank != tp_rank:
+                pld.system.notify(
+                    target=exchange_signal,
+                    peer=group_base + destination_rank,
+                    offsets=[tp_rank, 0],
+                    value=1,
+                    op=pld.NotifyOp.AtomicAdd,
+                )
+
+    return exchange_signal, publish_tid
 
 
 @pl.jit

--- a/models/deepseek_v4_flash_dspark/decode_sparse_attn_hca.py
+++ b/models/deepseek_v4_flash_dspark/decode_sparse_attn_hca.py
@@ -70,6 +70,7 @@ ATTN_D_TILE = 256
 H_TILE = 16
 QK_M_TILE = 32
 HCA_A2A_T_TILE = 8
+HCA_O_A_T_TILE = 16
 CMP_PAGES_PER_WORK = ATTN_K_TILE // BLOCK_SIZE
 ROPE_TILE = 16
 ROPE_INTERLEAVE_TILE = 2 * ROPE_TILE
@@ -78,7 +79,9 @@ T_PAD = ((T + 16 - 1) // 16) * 16
 LOCAL_O_GROUPS = O_GROUPS // TP
 GROUP_T_PAD = TP * T_PAD
 ATTENTION_WINDOW_ROWS = LOCAL_O_GROUPS * GROUP_T_PAD
+ATTENTION_READY_ROWS = GROUP_T_PAD // HCA_O_A_T_TILE
 PACK_GROUPS = H_TILE // HEADS_PER_GROUP
+HCA_A2A_READY_COUNT = (HCA_O_A_T_TILE // HCA_A2A_T_TILE) * (LOCAL_O_GROUPS // PACK_GROUPS)
 
 if WIN != ATTN_K_TILE:
     raise ValueError("HCA raw window must form one baseline-sized attention tile")
@@ -102,6 +105,8 @@ if LOCAL_O_GROUPS % PACK_GROUPS != 0:
     raise ValueError(f"local output groups {LOCAL_O_GROUPS} must contain complete HCA pack tiles")
 if T % HCA_A2A_T_TILE != 0:
     raise ValueError(f"HCA token capacity {T} must be divisible by A2A tile {HCA_A2A_T_TILE}")
+if HCA_O_A_T_TILE % HCA_A2A_T_TILE != 0:
+    raise ValueError(f"O-A token tile {HCA_O_A_T_TILE} must contain complete HCA A2A tiles")
 
 
 @pl.jit.inline(auto_scope=False)
@@ -868,6 +873,7 @@ def sparse_attn_hca_a2a(
     attention_grouped: pl.Tensor[[O_GROUPS * T_PAD, O_GROUP_IN], pl.BF16],
     exchange_window: pld.DistributedTensor[[ATTENTION_WINDOW_ROWS, O_GROUP_IN], pl.BF16],
     exchange_signal: pld.DistributedTensor[[TP, 1], pl.INT32],
+    exchange_ready: pld.DistributedTensor[[ATTENTION_READY_ROWS, 1], pl.INT32],
     group_base: pl.Scalar[pl.INT32],
     tp_rank: pl.Scalar[pl.INT32],
     local_t: pl.Scalar[pl.INT32],
@@ -965,6 +971,15 @@ def sparse_attn_hca_a2a(
                     chunk_cols=O_GROUP_IN,
                 )
 
+            ready_row = (tp_rank * local_t + stream_t0) // HCA_O_A_T_TILE
+            pld.system.notify(
+                target=exchange_ready,
+                peer=group_base + destination_rank,
+                offsets=[ready_row, 0],
+                value=1,
+                op=pld.NotifyOp.AtomicAdd,
+            )
+
         for destination_rank in pl.range(TP):
             if destination_rank != tp_rank:
                 pld.system.notify(
@@ -975,7 +990,7 @@ def sparse_attn_hca_a2a(
                     op=pld.NotifyOp.AtomicAdd,
                 )
 
-    return exchange_signal, publish_tid
+    return exchange_signal, exchange_ready, stream_heads_tid, publish_tid
 
 
 @pl.jit

--- a/models/deepseek_v4_flash_dspark/decode_sparse_attn_swa.py
+++ b/models/deepseek_v4_flash_dspark/decode_sparse_attn_swa.py
@@ -14,6 +14,7 @@ variants live in sibling modules.
 
 
 import pypto.language as pl
+import pypto.language.distributed as pld
 
 from config import (
     FLASH as M,
@@ -64,6 +65,7 @@ GATHER_RUN = 16          # window sub-tile probed for physical contiguity -> one
 H_TILE = 32
 QK_M_TILE = 32           # qk_pv M rows per QK/PV matmul; upper bound on H_TILE
 ATTN_K_TILE = 128
+SWA_A2A_T_TILE = 8
 ROPE_TILE = 16
 ROPE_INTERLEAVE_TILE = 2 * ROPE_TILE
 T_PAD = ((T + 16 - 1) // 16) * 16  # T padded up to the 16-row cube M floor
@@ -72,27 +74,33 @@ BIAS_T_TILE = 8     # swa_valid_bias row block, same contract
 TOPK = WIN               # SWA sparse-K width: sliding window only
 SPARSE_BLOCKS = 1        # the SWA window fits one attention K tile
 PADDED_TOPK = SPARSE_BLOCKS * ATTN_K_TILE
+LOCAL_O_GROUPS = O_GROUPS // TP
+GROUP_T_PAD = TP * T_PAD
+ATTENTION_WINDOW_ROWS = LOCAL_O_GROUPS * GROUP_T_PAD
+PACK_GROUPS = H_TILE // HEADS_PER_GROUP
 
-assert BLOCK_SIZE % GATHER_RUN == 0, "a contiguous run must not straddle two paged blocks by construction"
-assert WIN == ATTN_K_TILE, f"SWA decode expects WIN ({WIN}) == ATTN_K_TILE ({ATTN_K_TILE})"
+if BLOCK_SIZE % GATHER_RUN != 0:
+    raise ValueError("a contiguous run must not straddle two paged blocks")
+if WIN != ATTN_K_TILE:
+    raise ValueError(f"SWA decode expects WIN ({WIN}) == ATTN_K_TILE ({ATTN_K_TILE})")
+if O_GROUPS % TP != 0:
+    raise ValueError(f"output groups {O_GROUPS} must be divisible by TP size {TP}")
+if H_TILE % HEADS_PER_GROUP != 0:
+    raise ValueError(f"SWA head tile {H_TILE} must contain complete output groups")
+if T % SWA_A2A_T_TILE != 0:
+    raise ValueError(f"SWA token capacity {T} must be divisible by A2A tile {SWA_A2A_T_TILE}")
 
 
-@pl.jit.inline
-def sparse_attn_swa(
+@pl.jit.inline(auto_scope=False)
+def _sparse_attn_swa_prepare(
     q: pl.Tensor[[T_DYN, H, HEAD_DIM], pl.BF16],
     ori_kv: pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
     sparse_bias: pl.Tensor[[T_DYN, PADDED_TOPK], pl.FP32],
-    attn_sink: pl.Tensor[[H], pl.FP32],
     freqs_cos: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
     freqs_sin: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
-    o_packed_heads: pl.Tensor[[O_GROUPS * T_PAD * HEADS_PER_GROUP, HEAD_DIM], pl.BF16],
-) -> tuple[pl.Tensor, pl.Scalar[pl.TASK_ID]]:
-    """Write SWA heads as ``[group, T_PAD, head-in-group, dim]`` slabs.
-
-    Only the first runtime ``t_dim`` rows in each group are valid. The
-    returned task ID covers every write to the packed output tensor.
-    """
+):
+    """Prepare SWA attention partials and inverse-RoPE metadata."""
     t_dim = pl.tensor.dim(q, 0)
     t_heads = t_dim * H
     t_win = t_dim * WIN
@@ -250,11 +258,52 @@ def sparse_attn_swa(
                 rope_cos_il[cs_t0 : cs_t0 + ROPE_CS_T_TILE, cp_c0 : cp_c0 + ROPE_INTERLEAVE_TILE] = cs_cos_dup
                 rope_sin_signed[cs_t0 : cs_t0 + ROPE_CS_T_TILE, cp_c0 : cp_c0 + ROPE_INTERLEAVE_TILE] = cs_sin_signed
 
-    # Flatten the one-block SWA merge over token/head tiles into a single
-    # grid. Each block writes H_TILE // HEADS_PER_GROUP output-projection groups
-    # using the same contiguous per-group stores.
-    with pl.spmd(MERGE_TASKS, name_hint="merge_norm", deps=[qk_tid, rope_tid],
-                 allow_early_resolve=True) as merge_tid:
+    return (
+        sparse_blk_mi,
+        sparse_blk_li,
+        sparse_blk_oi,
+        rope_cos_il,
+        rope_sin_signed,
+        rope_swap_idx,
+        qk_tid,
+        rope_tid,
+    )
+
+
+@pl.jit.inline(auto_scope=False)
+def sparse_attn_swa(
+    q: pl.Tensor[[T_DYN, H, HEAD_DIM], pl.BF16],
+    ori_kv: pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
+    sparse_bias: pl.Tensor[[T_DYN, PADDED_TOPK], pl.FP32],
+    attn_sink: pl.Tensor[[H], pl.FP32],
+    freqs_cos: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
+    o_packed_heads: pl.Tensor[[O_GROUPS * T_PAD * HEADS_PER_GROUP, HEAD_DIM], pl.BF16],
+) -> tuple[pl.Tensor, pl.Scalar[pl.TASK_ID]]:
+    """Write SWA heads as ``[group, T_PAD, head-in-group, dim]`` slabs."""
+    (
+        sparse_blk_mi,
+        sparse_blk_li,
+        sparse_blk_oi,
+        rope_cos_il,
+        rope_sin_signed,
+        rope_swap_idx,
+        qk_tid,
+        rope_tid,
+    ) = _sparse_attn_swa_prepare(
+        q, ori_kv, swa_indices, sparse_bias,
+        freqs_cos, freqs_sin,
+    )
+    t_dim = pl.tensor.dim(q, 0)
+    t_hblocks = t_dim * (H // H_TILE)
+
+    with pl.spmd(
+        MERGE_TASKS,
+        name_hint="merge_norm",
+        deps=[qk_tid, rope_tid],
+        allow_early_resolve=True,
+    ) as merge_tid:
         m_task = pl.tile.get_block_idx()
         for m_idx in pl.range(m_task, t_hblocks, MERGE_TASKS):
             m_t = m_idx // (H // H_TILE)
@@ -295,6 +344,129 @@ def sparse_attn_swa(
                 ]
 
     return o_packed_heads, merge_tid
+
+
+@pl.jit.inline(auto_scope=False)
+def sparse_attn_swa_a2a(
+    q: pl.Tensor[[T_DYN, H, HEAD_DIM], pl.BF16],
+    ori_kv: pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
+    swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
+    sparse_bias: pl.Tensor[[T_DYN, PADDED_TOPK], pl.FP32],
+    attn_sink: pl.Tensor[[H], pl.FP32],
+    freqs_cos: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
+    attention_grouped: pl.Tensor[[O_GROUPS * T_PAD, O_GROUP_IN], pl.BF16],
+    exchange_window: pld.DistributedTensor[[ATTENTION_WINDOW_ROWS, O_GROUP_IN], pl.BF16],
+    exchange_signal: pld.DistributedTensor[[TP, 1], pl.INT32],
+    group_base: pl.Scalar[pl.INT32],
+    tp_rank: pl.Scalar[pl.INT32],
+    local_t: pl.Scalar[pl.INT32],
+):
+    """Merge SWA heads and publish completed token slabs to their TP owners."""
+    (
+        sparse_blk_mi,
+        sparse_blk_li,
+        sparse_blk_oi,
+        rope_cos_il,
+        rope_sin_signed,
+        rope_swap_idx,
+        qk_tid,
+        rope_tid,
+    ) = _sparse_attn_swa_prepare(
+        q, ori_kv, swa_indices, sparse_bias,
+        freqs_cos, freqs_sin,
+    )
+    t_dim = pl.tensor.dim(q, 0)
+    pack_work_count = (t_dim // SWA_A2A_T_TILE) * (H // H_TILE)
+    o_packed_heads = pl.reshape(
+        attention_grouped,
+        [O_GROUPS * T_PAD * HEADS_PER_GROUP, HEAD_DIM],
+    )
+
+    with pl.spmd(
+        48,
+        name_hint="swa_merge_pack_publish",
+        deps=[qk_tid, rope_tid],
+    ) as publish_tid:
+        worker = pl.tile.get_block_idx()
+        for pack_work in pl.range(worker, pack_work_count, 48):
+            token_block = pack_work // (H // H_TILE)
+            head_tile = pack_work - token_block * (H // H_TILE)
+            token_start = token_block * SWA_A2A_T_TILE
+            head_start = head_tile * H_TILE
+            global_group_start = head_start // HEADS_PER_GROUP
+
+            for token_delta in pl.range(SWA_A2A_T_TILE):
+                token = token_start + token_delta
+                block_base = token * H + head_start
+                block_m = sparse_blk_mi[block_base : block_base + H_TILE, 0:1]
+                block_l = sparse_blk_li[block_base : block_base + H_TILE, 0:1]
+                block_o = sparse_blk_oi[block_base : block_base + H_TILE, 0:HEAD_DIM]
+
+                sink = pl.reshape(attn_sink[head_start : head_start + H_TILE], [H_TILE, 1])
+                sink_delta = pl.sub(sink, block_m)
+                sink_exp = pl.exp(sink_delta)
+                denom = pl.add(block_l, sink_exp)
+                normalized = pl.row_expand_div(block_o, denom)
+                full = normalized[0:H_TILE, 0:HEAD_DIM]
+                full_bf16 = pl.cast(full, target_type=pl.BF16, mode="rint")
+
+                rope = full[:, NOPE_DIM:HEAD_DIM]
+                swapped = pl.gather(rope, dim=-1, index=rope_swap_idx[:, :])
+                cos_il = rope_cos_il[token : token + 1, 0:ROPE_DIM]
+                sin_signed = rope_sin_signed[token : token + 1, 0:ROPE_DIM]
+                rope_cos = pl.col_expand_mul(rope, cos_il)
+                swap_sin = pl.col_expand_mul(swapped, sin_signed)
+                rotated = pl.add(rope_cos, swap_sin)
+                rope_bf16 = pl.cast(rotated, target_type=pl.BF16, mode="rint")
+
+                for group_slot in pl.unroll(PACK_GROUPS):
+                    source_head = group_slot * HEADS_PER_GROUP
+                    pack_row = (global_group_start + group_slot) * T_PAD + token
+                    destination_head = pack_row * HEADS_PER_GROUP
+                    o_packed_heads[
+                        destination_head : destination_head + HEADS_PER_GROUP,
+                        0:NOPE_DIM,
+                    ] = full_bf16[
+                        source_head : source_head + HEADS_PER_GROUP,
+                        0:NOPE_DIM,
+                    ]
+                    o_packed_heads[
+                        destination_head : destination_head + HEADS_PER_GROUP,
+                        NOPE_DIM:HEAD_DIM,
+                    ] = rope_bf16[
+                        source_head : source_head + HEADS_PER_GROUP,
+                        0:ROPE_DIM,
+                    ]
+
+            for group_slot in pl.unroll(PACK_GROUPS):
+                global_group = global_group_start + group_slot
+                destination_rank = global_group // LOCAL_O_GROUPS
+                local_group = global_group - destination_rank * LOCAL_O_GROUPS
+                source_row = global_group * T_PAD + token_start
+                target_row = local_group * GROUP_T_PAD + tp_rank * local_t + token_start
+                pld.tensor.put(
+                    dst=exchange_window,
+                    peer=group_base + destination_rank,
+                    src=attention_grouped,
+                    dst_offsets=[target_row, 0],
+                    src_offsets=[source_row, 0],
+                    shape=[SWA_A2A_T_TILE, O_GROUP_IN],
+                    chunk_rows=SWA_A2A_T_TILE,
+                    chunk_cols=O_GROUP_IN,
+                )
+
+        for peer_tp in pl.range(TP):
+            if peer_tp != tp_rank:
+                pld.system.notify(
+                    target=exchange_signal,
+                    peer=group_base + peer_tp,
+                    offsets=[tp_rank, 0],
+                    value=1,
+                    op=pld.NotifyOp.AtomicAdd,
+                )
+
+    return exchange_signal, publish_tid
 
 
 @pl.jit

--- a/models/deepseek_v4_flash_dspark/decode_swa.py
+++ b/models/deepseek_v4_flash_dspark/decode_swa.py
@@ -63,9 +63,15 @@ from decode_o_proj import (
     O_WINDOW_ROWS,
     decode_sharded_o_projection_reduce_scatter,
     decode_o_proj_tp1,
-    o_group_a2a,
+    o_group_a2a_finish,
 )
-from decode_sparse_attn_swa import ATTN_K_TILE, PADDED_TOPK, T_PAD, sparse_attn_swa
+from decode_sparse_attn_swa import (
+    ATTN_K_TILE,
+    PADDED_TOPK,
+    T_PAD,
+    sparse_attn_swa,
+    sparse_attn_swa_a2a,
+)
 
 # Dynamic shape variables.
 T_DYN = pl.dynamic("T_DYN")  # T = B * S
@@ -117,7 +123,7 @@ if T_PAD != LOCAL_T_PAD:
     raise ValueError(f"SWA padded token capacity {T_PAD} must equal TP capacity {LOCAL_T_PAD}")
 
 
-@pl.jit.inline
+@pl.jit.inline(auto_scope=False)
 def decode_swa(
     x_hc: pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32],
     # hc_pre weights
@@ -202,37 +208,44 @@ def decode_swa(
             invalid = pl.sub(valid, 1.0)
             sparse_bias[token_start : token_start + BIAS_T_TILE, 0 : ATTN_K_TILE] = pl.mul(invalid, -NEG_INF)
 
-    o_packed_heads = pl.create_tensor([O_GROUPS * T_PAD * HEADS_PER_GROUP, HEAD_DIM], dtype=pl.BF16)
-    sparse_attn_swa(
-        q, kv_cache, swa_indices, sparse_bias,
-        attn_sink, freqs_cos, freqs_sin,
-        o_packed_heads,
-    )
-
-    attention_grouped = pl.reshape(o_packed_heads, [O_GROUPS * LOCAL_T_PAD, O_GROUP_IN])
     attention_local_flat = pl.create_tensor([ATTENTION_WINDOW_ROWS, O_GROUP_IN], dtype=pl.BF16)
-    attention_local_flat, attention_signal = o_group_a2a(
-        attention_grouped, attention_local_flat,
-        attention_window, attention_signal,
-        group_base, tp_rank, local_t,
-    )
-
-    attention_local_groups = pl.reshape(attention_local_flat, [LOCAL_O_GROUPS, GROUP_T_PAD, O_GROUP_IN])
-    o_local = pl.create_tensor([LOCAL_T_PAD, D], dtype=pl.BF16)
-    o_local, o_signal = decode_sharded_o_projection_reduce_scatter(
-        attention_local_groups,
-        wo_a, wo_b, wo_b_scale,
-        local_t, o_local,
-        o_window, o_signal,
-        group_base, tp_rank,
-    )
-
     attn_out = pl.create_tensor([t_dim, D], dtype=pl.BF16)
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="swa_o_local"):
-        for token_start in pl.range(0, t_dim, BIAS_T_TILE):
-            o_local_rows = o_local[token_start : token_start + BIAS_T_TILE, 0 : D]
-            attn_out[token_start : token_start + BIAS_T_TILE, 0 : D] = o_local_rows
-    hc_post(attn_out, x_hc, post_t, comb_t, x_out)
+    with pl.scope():
+        attention_grouped = pl.create_tensor([O_GROUPS * LOCAL_T_PAD, O_GROUP_IN], dtype=pl.BF16)
+        attention_signal, publish_tid = sparse_attn_swa_a2a(
+            q, kv_cache, swa_indices, sparse_bias,
+            attn_sink, freqs_cos, freqs_sin,
+            attention_grouped,
+            attention_window, attention_signal,
+            group_base, tp_rank, local_t,
+        )
+        attention_local_flat, attention_signal = o_group_a2a_finish(
+            attention_local_flat,
+            attention_window, attention_signal,
+            group_base, tp_rank, local_t,
+            publish_tid, 48,
+        )
+
+        attention_local_groups = pl.reshape(
+            attention_local_flat,
+            [LOCAL_O_GROUPS, GROUP_T_PAD, O_GROUP_IN],
+        )
+        o_local = pl.create_tensor([LOCAL_T_PAD, D], dtype=pl.BF16)
+        o_local, o_signal = decode_sharded_o_projection_reduce_scatter(
+            attention_local_groups,
+            wo_a, wo_b, wo_b_scale,
+            local_t, o_local,
+            o_window, o_signal,
+            group_base, tp_rank,
+        )
+
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="swa_o_local"):
+            for token_start in pl.range(0, t_dim, BIAS_T_TILE):
+                o_local_rows = o_local[token_start : token_start + BIAS_T_TILE, 0 : D]
+                attn_out[token_start : token_start + BIAS_T_TILE, 0 : D] = o_local_rows
+
+    with pl.scope():
+        hc_post(attn_out, x_hc, post_t, comb_t, x_out)
     return x_out
 
 


### PR DESCRIPTION
- Publish HCA output from packing workers and fold CSA/SWA merge,
  normalization, inverse RoPE, and packing into distributed publishers
- Gather CSA/SWA output with reusable notification handshakes before the
  sharded O projection
- Publish HCA O-A tile readiness and start source-sized O-A launches
  directly from distributed attention windows
- Release HCA A2A credits only after publisher and O-A consumers complete
- Preserve CSA/SWA O-projection ordering while sharing the sharded O-B
  publish and ReduceScatter tail
- Add frozen-golden CLI forwarding for repeatable HCA and CSA timing

TP2 HCA decode median 6434.6 -> 5910.6 us (A2A3 devices 13,15,
frozen golden, 100 rounds, 5 warmup, median of four run medians).
The fused publisher path measured TP4 HCA 3879.8 -> 3012.5 us
(20 rounds, 5 warmup; devices 3,5,7,9), CSA 3295.6 -> 2642.7 us,
and SWA 2308.5 -> 1180.7 us (100 rounds, 5 warmup;
devices 1,9,11,13).