### PR TITLE
Fix: drop allow_early_resolve from the DeepSeek-V4 decode and prefill paths

### DIFF
--- a/models/deepseek_v4_pro/decode_indexer_compressor.py
+++ b/models/deepseek_v4_pro/decode_indexer_compressor.py
@@ -209,7 +209,7 @@ def indexer_compressor(
 
     cmp_cos_il = pl.create_tensor([RMS_PAD_TILE, ROPE_HEAD_DIM], dtype=pl.FP32)
     cmp_sin_signed = pl.create_tensor([RMS_PAD_TILE, ROPE_HEAD_DIM], dtype=pl.FP32)
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="cmp_rope_tables", allow_early_resolve=True):
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="cmp_rope_tables"):
         cos_b = pl.full([RMS_PAD_TILE, ROPE_HEAD_DIM // 2], dtype=pl.FP32, value=0.0)
         sin_b = pl.full([RMS_PAD_TILE, ROPE_HEAD_DIM // 2], dtype=pl.FP32, value=0.0)
         cos_b[0:B, 0 : ROPE_HEAD_DIM // 2] = cos[0:B, 0 : ROPE_HEAD_DIM // 2]

--- a/models/deepseek_v4_pro/decode_sparse_attn.py
+++ b/models/deepseek_v4_pro/decode_sparse_attn.py
@@ -126,7 +126,7 @@ def sparse_attn(
     wo_a_2d = pl.reshape(wo_a, [O_GROUPS * O_LORA, O_GROUP_IN])
     # The unread sink materializes the shared-L2 wo_a cache-warm task.
     warm_sink = pl.create_tensor([WARM_BLOCK_TILE * MM_T_TILE, PROJ_A_MM_N_TILE], dtype=pl.FP32)
-    with pl.spmd(WARM_BLOCK_TILE, name_hint="wo_a_warm", allow_early_resolve=True):
+    with pl.spmd(WARM_BLOCK_TILE, name_hint="wo_a_warm"):
         w_blk = pl.tile.get_block_idx()
         w_r0 = w_blk * WARM_ROW_TILE
         w_a = q_flat[0:MM_T_TILE, 0:A_K_TILE]
@@ -145,7 +145,7 @@ def sparse_attn(
     qk_order = pl.create_tensor([T * SPARSE_BLOCKS], dtype=pl.INT32)
     qk_wcur = pl.create_tensor([1], dtype=pl.INT32)
 
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="csa_slots_build_valid_qk_plan", allow_early_resolve=True) as qk_plan_tid:
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="csa_slots_build_valid_qk_plan") as qk_plan_tid:
         c_raw = pl.cast(idx_topk[0:T, 0:IDX_TOPK], target_type=pl.FP32)
         c_pos = pl.cast(position_ids[0:T, 0:1], target_type=pl.FP32)
         c_pos_one = pl.add(c_pos, 1.0)
@@ -211,7 +211,7 @@ def sparse_attn(
     sparse_blk_li = pl.create_tensor([T * (H // H_TILE) * SPARSE_BLOCKS * H_TILE, 1], dtype=pl.FP32)
     sparse_blk_oi = pl.create_tensor([T * (H // H_TILE) * SPARSE_BLOCKS * H_TILE, HEAD_DIM], dtype=pl.FP32)
 
-    with pl.spmd(QK_CORE_TILE, name_hint="qk_pv", deps=[qk_plan_tid], allow_early_resolve=True) as _qk_tid:
+    with pl.spmd(QK_CORE_TILE, name_hint="qk_pv", deps=[qk_plan_tid]) as _qk_tid:
         qk_core = pl.tile.get_block_idx()
         qk_lane_iters = (T * SPARSE_BLOCKS - qk_core + QK_CORE_TILE - 1) // QK_CORE_TILE
         for qk_it in pl.range(qk_lane_iters):
@@ -286,7 +286,7 @@ def sparse_attn(
     # Inverse RoPE: out[j] = x[j] * cos[j] + x[j ^ 1] * sign[j] * sin[j].
     rope_cos_il = pl.create_tensor([T, ROPE_DIM], dtype=pl.FP32)
     rope_sin_signed = pl.create_tensor([T, ROPE_DIM], dtype=pl.FP32)
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="rope_cs", allow_early_resolve=True):
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="rope_cs"):
         cs_cos_f32 = pl.cast(freqs_cos[0:T, 0:HALF_ROPE], target_type=pl.FP32)
         cs_sin_f32 = pl.cast(freqs_sin[0:T, 0:HALF_ROPE], target_type=pl.FP32)
         cs_cos_il = pl.full([T, ROPE_DIM], dtype=pl.FP32, value=0.0)
@@ -377,7 +377,6 @@ def sparse_attn(
                 O_GROUP_TILE * (O_LORA // PROJ_A_MM_N_TILE // PA_NF_TILE),
                 name_hint="proj_a_mm",
                 deps=[merge_tids[group_bundle]],
-                allow_early_resolve=True,
             ) as pa_tid:
                 pa_idx = pl.tile.get_block_idx()
                 pa_local_group = pa_idx // (O_LORA // PROJ_A_MM_N_TILE // PA_NF_TILE)
@@ -401,7 +400,6 @@ def sparse_attn(
                 O_GROUP_TILE,
                 name_hint="quant",
                 deps=[pa_tid],
-                allow_early_resolve=True,
             ) as q_tid:
                 q_local_group = pl.tile.get_block_idx()
                 g = group_bundle * O_GROUP_TILE + q_local_group
@@ -428,7 +426,6 @@ def sparse_attn(
                 O_GROUP_TILE * (D // PROJ_B_D_TILE),
                 name_hint="proj_b_mm",
                 deps=[q_tid],
-                allow_early_resolve=True,
             ) as pb_tid:
                 pb_idx = pl.tile.get_block_idx()
                 pb_local_group = pb_idx // (D // PROJ_B_D_TILE)
@@ -457,7 +454,6 @@ def sparse_attn(
         (D // PROJ_B_ACT_N_TILE) * (T // PROJ_B_ACT_TASK_T_TILE),
         name_hint="proj_b_act",
         deps=[proj_b_tids[i] for i in range(O_GROUPS // O_GROUP_TILE)],
-        allow_early_resolve=True,
     ) as _act_tid:
         act_idx = pl.tile.get_block_idx()
         nreg = act_idx // (T // PROJ_B_ACT_TASK_T_TILE)

--- a/models/deepseek_v4_pro/decode_sparse_attn_hca.py
+++ b/models/deepseek_v4_pro/decode_sparse_attn_hca.py
@@ -112,7 +112,7 @@ def sparse_attn_hca(
 ):
     """Run sparse decode attention, inverse RoPE, and grouped output projection."""
     sparse_bias = pl.create_tensor([T, PADDED_TOPK], dtype=pl.FP32)
-    for v_blk in pl.spmd(T // VALID_TOKEN_TILE, name_hint="build_valid", allow_early_resolve=True):
+    for v_blk in pl.spmd(T // VALID_TOKEN_TILE, name_hint="build_valid"):
         v_t0 = v_blk * VALID_TOKEN_TILE
         v_win_f = pl.cast(window_swa_indices[v_t0 : v_t0 + VALID_TOKEN_TILE, 0 : WIN], target_type=pl.FP32)
         v_idx_f = pl.cast(cmp_sparse_indices[v_t0 : v_t0 + VALID_TOKEN_TILE, 0 : CMP_TOPK], target_type=pl.FP32)
@@ -184,7 +184,7 @@ def sparse_attn_hca(
     sparse_blk_li = pl.create_tensor([T * (H // H_TILE) * SPARSE_BLOCKS * H_TILE, 1], dtype=pl.FP32)
     sparse_blk_oi = pl.create_tensor([T * (H // H_TILE) * SPARSE_BLOCKS * H_TILE, HEAD_DIM], dtype=pl.FP32)
 
-    with pl.spmd(T * SPARSE_BLOCKS, name_hint="qk_pv", deps=[gather_tid], allow_early_resolve=True) as _qk_tid:
+    with pl.spmd(T * SPARSE_BLOCKS, name_hint="qk_pv", deps=[gather_tid]) as _qk_tid:
         qk_item = pl.tile.get_block_idx()
         qk_t = qk_item // SPARSE_BLOCKS
         qk_sb = qk_item - qk_t * SPARSE_BLOCKS
@@ -221,7 +221,7 @@ def sparse_attn_hca(
     # Inverse RoPE: out[j] = x[j] * cos[j] + x[j ^ 1] * sign[j] * sin[j].
     rope_cos_il = pl.create_tensor([T, ROPE_DIM], dtype=pl.FP32)
     rope_sin_signed = pl.create_tensor([T, ROPE_DIM], dtype=pl.FP32)
-    with pl.at(level=pl.Level.CORE_GROUP, name_hint="rope_cs", allow_early_resolve=True):
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="rope_cs"):
         cs_cos_f32 = pl.cast(freqs_cos[0:T, 0:HALF_ROPE], target_type=pl.FP32)
         cs_sin_f32 = pl.cast(freqs_sin[0:T, 0:HALF_ROPE], target_type=pl.FP32)
         cs_cos_il = pl.full([T, ROPE_DIM], dtype=pl.FP32, value=0.0)
@@ -312,7 +312,6 @@ def sparse_attn_hca(
                 O_GROUP_TILE * (O_LORA // PROJ_A_MM_N_TILE // PA_NF_TILE),
                 name_hint="proj_a_mm",
                 deps=[merge_tids[group_bundle]],
-                allow_early_resolve=True,
             ) as pa_tid:
                 pa_idx = pl.tile.get_block_idx()
                 pa_local_group = pa_idx // (O_LORA // PROJ_A_MM_N_TILE // PA_NF_TILE)
@@ -341,7 +340,6 @@ def sparse_attn_hca(
                 O_GROUP_TILE,
                 name_hint="quant",
                 deps=[pa_tid],
-                allow_early_resolve=True,
             ) as q_tid:
                 q_local_group = pl.tile.get_block_idx()
                 g = group_bundle * O_GROUP_TILE + q_local_group
@@ -373,7 +371,6 @@ def sparse_attn_hca(
                 O_GROUP_TILE * (D // PROJ_B_D_TILE),
                 name_hint="proj_b_mm",
                 deps=[q_tid],
-                allow_early_resolve=True,
             ) as pb_tid:
                 pb_idx = pl.tile.get_block_idx()
                 pb_local_group = pb_idx // (D // PROJ_B_D_TILE)
@@ -399,7 +396,6 @@ def sparse_attn_hca(
         (D // PROJ_B_ACT_N_TILE) * (T // PROJ_B_ACT_TASK_T_TILE),
         name_hint="proj_b_act",
         deps=[proj_b_tids[i] for i in range(O_GROUPS // O_GROUP_TILE)],
-        allow_early_resolve=True,
     ) as _act_tid:
         act_idx = pl.tile.get_block_idx()
         nreg = act_idx // (T // PROJ_B_ACT_TASK_T_TILE)

--- a/models/deepseek_v4_pro/decode_sparse_attn_swa.py
+++ b/models/deepseek_v4_pro/decode_sparse_attn_swa.py
@@ -125,7 +125,7 @@ def sparse_attn_swa(
     sparse_blk_li = pl.create_tensor([T * (H // H_TILE) * SPARSE_BLOCKS * H_TILE, 1], dtype=pl.FP32)
     sparse_blk_oi = pl.create_tensor([T * (H // H_TILE) * SPARSE_BLOCKS * H_TILE, HEAD_DIM], dtype=pl.FP32)
 
-    with pl.spmd(T, name_hint="qk_pv", deps=[gather_tids[0]], allow_early_resolve=True) as qk_tid:
+    with pl.spmd(T, name_hint="qk_pv", deps=[gather_tids[0]]) as qk_tid:
         qk_t = pl.tile.get_block_idx()
         qk_token_base = qk_t * (H // H_TILE) * SPARSE_BLOCKS * H_TILE
         for qk_sb in pl.unroll(SPARSE_BLOCKS):
@@ -178,7 +178,7 @@ def sparse_attn_swa(
     merge_tids = pl.array.create(O_GROUPS // O_GROUP_TILE, pl.TASK_ID)
 
     for merge_group in pl.parallel(O_GROUPS // O_GROUP_TILE):
-        with pl.spmd(T, name_hint="merge_norm", deps=[qk_tid, rope_tid], allow_early_resolve=True) as merge_tid:
+        with pl.spmd(T, name_hint="merge_norm", deps=[qk_tid, rope_tid]) as merge_tid:
             m_t = pl.tile.get_block_idx()
             m_h_idx = merge_group
             m_h0 = m_h_idx * H_TILE
@@ -231,7 +231,6 @@ def sparse_attn_swa(
                 O_GROUP_TILE * (O_LORA // PROJ_A_MM_N_TILE // PA_NF_TILE),
                 name_hint="proj_a_mm",
                 deps=[merge_tids[group_bundle]],
-                allow_early_resolve=True,
             ) as pa_tid:
                 pa_idx = pl.tile.get_block_idx()
                 pa_local_group = pa_idx // (O_LORA // PROJ_A_MM_N_TILE // PA_NF_TILE)
@@ -260,7 +259,6 @@ def sparse_attn_swa(
                 O_GROUP_TILE,
                 name_hint="quant",
                 deps=[pa_tid],
-                allow_early_resolve=True,
             ) as q_tid:
                 q_local_group = pl.tile.get_block_idx()
                 g = group_bundle * O_GROUP_TILE + q_local_group
@@ -292,7 +290,6 @@ def sparse_attn_swa(
                 O_GROUP_TILE * (D // PROJ_B_D_TILE),
                 name_hint="proj_b_mm",
                 deps=[q_tid],
-                allow_early_resolve=True,
             ) as pb_tid:
                 pb_idx = pl.tile.get_block_idx()
                 pb_local_group = pb_idx // (D // PROJ_B_D_TILE)
@@ -321,7 +318,6 @@ def sparse_attn_swa(
         (D // PROJ_B_ACT_N_TILE) * (T // PROJ_B_ACT_TASK_T_TILE),
         name_hint="proj_b_act",
         deps=[proj_b_tids[i] for i in range(O_GROUPS // O_GROUP_TILE)],
-        allow_early_resolve=True,
     ) as _act_tid:
         act_idx = pl.tile.get_block_idx()
         nreg = act_idx // (T // PROJ_B_ACT_TASK_T_TILE)

--- a/models/deepseek_v4_pro/expert_routed.py
+++ b/models/deepseek_v4_pro/expert_routed.py
@@ -223,7 +223,6 @@ def expert_routed(
                     with pl.spmd(
                         D // (W2_INNER * D_OUT_TILE),
                         name_hint="exp_w2_mm",
-                        allow_early_resolve=True,
                     ):
                         wb_idx = pl.tile.get_block_idx()
                         d_base = wb_idx * (W2_INNER * D_OUT_TILE)
@@ -243,7 +242,6 @@ def expert_routed(
                     with pl.spmd(
                         D // (W2_ACT_INNER * D_OUT_TILE_ACT),
                         name_hint="exp_w2_act",
-                        allow_early_resolve=True,
                     ):
                         db_idx = pl.tile.get_block_idx()
                         act_d_base = db_idx * (W2_ACT_INNER * D_OUT_TILE_ACT)

--- a/models/deepseek_v4_pro/expert_shared.py
+++ b/models/deepseek_v4_pro/expert_shared.py
@@ -53,7 +53,7 @@ def expert_shared(
 
         gate_i32 = pl.create_tensor([SH_M_TILE, MOE_INTER], dtype=pl.INT32)
 
-        for nb_idx in pl.spmd(MOE_INTER // MM_INTER_TILE, name_hint="sh_gate_mm", allow_early_resolve=True):
+        for nb_idx in pl.spmd(MOE_INTER // MM_INTER_TILE, name_hint="sh_gate_mm"):
             n0 = nb_idx * MM_INTER_TILE
             gate_acc = pl.create_tensor([SH_M_TILE, MM_INTER_TILE], dtype=pl.INT32)
             for k0 in pl.pipeline(0, D, K_TILE, stage=2):
@@ -67,7 +67,7 @@ def expert_shared(
 
         up_i32 = pl.create_tensor([SH_M_TILE, MOE_INTER], dtype=pl.INT32)
 
-        for nb_idx in pl.spmd(MOE_INTER // MM_INTER_TILE, name_hint="sh_up_mm", allow_early_resolve=True):
+        for nb_idx in pl.spmd(MOE_INTER // MM_INTER_TILE, name_hint="sh_up_mm"):
             n0 = nb_idx * MM_INTER_TILE
             up_acc = pl.create_tensor([SH_M_TILE, MM_INTER_TILE], dtype=pl.INT32)
             for k0 in pl.pipeline(0, D, K_TILE, stage=2):
@@ -82,7 +82,7 @@ def expert_shared(
         h_tile_fp32 = pl.create_tensor([SH_M_TILE, MOE_INTER], dtype=pl.FP32)
         h_tile_i8 = pl.create_tensor([SH_M_TILE, MOE_INTER], dtype=pl.INT8, init_value=0)
         h_tile_scale_dq = pl.create_tensor([SH_M_TILE, SH_ROW_PAD], dtype=pl.FP32, manual_dep=True)
-        for row_block in pl.spmd(SH_VALID_M // SH_ROW_TILE, name_hint="sh_gate_up_act_q", allow_early_resolve=True):
+        for row_block in pl.spmd(SH_VALID_M // SH_ROW_TILE, name_hint="sh_gate_up_act_q"):
             row0 = row_block * SH_ROW_TILE
             x_scale = pl.slice(x_local_scale_dq, [SH_ROW_PAD, 1], [ts0 + row0, 0], valid_shape=[SH_ROW_TILE, 1])
             row_amax = pl.full([1, SH_ROW_PAD], dtype=pl.FP32, value=INT8_AMAX_EPS)
@@ -146,7 +146,7 @@ def expert_shared(
                 h_i8 = pl.cast(h_fp16, target_type=pl.INT8, mode="trunc")
                 h_tile_i8[row0 : row0 + SH_ROW_TILE, k0 : k0 + QUANT_TILE] = h_i8[0:SH_ROW_TILE, :]
 
-        for db_idx in pl.spmd(D // D_OUT_TILE, name_hint="sh_w2_mm", allow_early_resolve=True):
+        for db_idx in pl.spmd(D // D_OUT_TILE, name_hint="sh_w2_mm"):
             d0 = db_idx * D_OUT_TILE
             y_acc = pl.create_tensor([SH_M_TILE, D_OUT_TILE], dtype=pl.INT32)
             for k0 in pl.pipeline(0, MOE_INTER, INTER_K_TILE, stage=2):

--- a/models/deepseek_v4_pro/gate.py
+++ b/models/deepseek_v4_pro/gate.py
@@ -108,7 +108,7 @@ def gate(
     xg_buf = pl.create_tensor([T_PAD, D], dtype=pl.FP32)
     inv_rms_buf = pl.create_tensor([T_PAD, 1], dtype=pl.FP32)
     xn_scale_buf = pl.create_tensor([T_PAD, 1], dtype=pl.FP32)
-    for tok in pl.spmd(active_gate_tokens, name_hint="ffn_norm", allow_early_resolve=True):
+    for tok in pl.spmd(active_gate_tokens, name_hint="ffn_norm"):
         rms_x_bf16 = pl.tile.load(x_mixed, [tok, 0], [1, D])
         rms_x = pl.cast(rms_x_bf16, pl.FP32)
         rms_w_bf16 = pl.tile.load(norm_w_2d, [0, 0], [1, D])
@@ -158,7 +158,7 @@ def gate(
         pl.tile.store(xg_sq, [tok, 0], xn_scale_buf, shapes=[1, 1])
 
     for t0 in pl.parallel(0, active_gate_tokens, T_TILE):
-        with pl.at(level=pl.Level.CORE_GROUP, name_hint="x_norm_quant", allow_early_resolve=True):
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="x_norm_quant"):
             xn_sq_col = xn_scale_buf[t0 : t0 + T_TILE, 0:1]
             for xq_b_k in pl.pipeline(0, D, QUANT_TILE, stage=2):
                 xn_q_chunk = xg_buf[t0 : t0 + T_TILE, xq_b_k : xq_b_k + QUANT_TILE]
@@ -184,7 +184,7 @@ def gate(
             biased_scores_buf[:, N_EXPERTS:SCORE_PAD] = biased_pad
 
     route_scores_buf = pl.create_tensor([T_PAD, SCORE_PAD], dtype=pl.FP32)
-    for gb_idx in pl.spmd(active_gate_tiles * (N_EXPERTS // GATE_N_TILE), name_hint="gate", allow_early_resolve=True):
+    for gb_idx in pl.spmd(active_gate_tiles * (N_EXPERTS // GATE_N_TILE), name_hint="gate"):
         tg = gb_idx // (N_EXPERTS // GATE_N_TILE)
         nb = gb_idx % (N_EXPERTS // GATE_N_TILE)
         t1 = tg * GATE_M_TILE
@@ -224,7 +224,7 @@ def gate(
 
     active_route_tiles = (active_tokens + GATE_T_TILE - 1) // GATE_T_TILE
     if layer_id < N_HASH_LAYERS:
-        for th_idx in pl.spmd(active_route_tiles, name_hint="route_hash", allow_early_resolve=True):
+        for th_idx in pl.spmd(active_route_tiles, name_hint="route_hash"):
             t1 = th_idx * GATE_T_TILE
             hs_idx_tile = pl.create_tensor([GATE_T_TILE, TOPK_PAD], dtype=pl.INT32)
             for hs_tt in pl.range(GATE_T_TILE):
@@ -256,7 +256,7 @@ def gate(
                         hs_out_weight = pl.read(hs_weights_pad, [hs_wt_tt, hs_wt_k])
                         pl.write(weights, [hs_out_t, hs_wt_k], hs_out_weight)
     else:
-        for ts_idx in pl.spmd(active_route_tiles, name_hint="route_sort", allow_early_resolve=True):
+        for ts_idx in pl.spmd(active_route_tiles, name_hint="route_sort"):
             t1 = ts_idx * GATE_T_TILE
             # ptoas pto.tmrgsort requires a single source row.
             topk_idx_tile = pl.create_tensor([GATE_T_TILE, TOPK_PAD], dtype=pl.INT32)

--- a/models/deepseek_v4_pro/hc_head.py
+++ b/models/deepseek_v4_pro/hc_head.py
@@ -56,7 +56,7 @@ def hc_head(
 
     for task in pl.spmd(
         (t_dim // T_TILE) * (HC_DIM // MIX_SPLIT_TILE),
-        name_hint="hc_head_mix", allow_early_resolve=True,
+        name_hint="hc_head_mix",
     ):
         tt = task // (HC_DIM // MIX_SPLIT_TILE)
         split = task - tt * (HC_DIM // MIX_SPLIT_TILE)
@@ -93,7 +93,7 @@ def hc_head(
         stats[stats_row : stats_row + 1, 0:STAT_COLS] = acc
 
     y_flat = pl.reshape(y, [t_dim, D])
-    for task in pl.spmd((t_dim // T_TILE) * (D // D_SPLIT_TILE), name_hint="hc_head_reduce", allow_early_resolve=True):
+    for task in pl.spmd((t_dim // T_TILE) * (D // D_SPLIT_TILE), name_hint="hc_head_reduce"):
         tt = task // (D // D_SPLIT_TILE)
         d_split = task - tt * (D // D_SPLIT_TILE)
         t0 = tt * T_TILE

--- a/models/deepseek_v4_pro/hc_pre.py
+++ b/models/deepseek_v4_pro/hc_pre.py
@@ -94,7 +94,7 @@ def _hc_pre_syncall(
     sq_sum_acc = pl.create_tensor([1, t_linear], dtype=pl.FP32)
     sq_partials = pl.create_tensor([HC_DIM // RMS_K_SPLIT_TILE, t_linear], dtype=pl.FP32)
     # Capture the TaskId required by the inline spmd form.
-    with pl.spmd(NUM_CORES, name_hint="hc_pre_fused", sync_start=True, allow_early_resolve=True) as _hc_tid:
+    with pl.spmd(NUM_CORES, name_hint="hc_pre_fused", sync_start=True) as _hc_tid:
         core = pl.tile.get_block_idx()
 
         for task in pl.range(core, lin_n, NUM_CORES):
@@ -385,7 +385,7 @@ def _hc_pre_separate(
 
     x_flat = pl.reshape(x, [t_dim, HC_DIM])
     inv_rms = pl.create_tensor([t_linear, 1], dtype=pl.FP32)
-    for t in pl.spmd(t_dim // T_TILE, name_hint="hc_pre_rms", allow_early_resolve=True):
+    for t in pl.spmd(t_dim // T_TILE, name_hint="hc_pre_rms"):
         t0 = t * T_TILE
         sq_sum = pl.full([1, T_TILE], dtype=pl.FP32, value=0.0)
         for k0 in pl.pipeline(0, HC_DIM, RMS_K_TILE, stage=4):
@@ -404,7 +404,7 @@ def _hc_pre_separate(
     mixes_partials = pl.create_tensor([linear_partial_rows, MIX_PAD], dtype=pl.FP32)
     for task in pl.spmd(
         (t_linear // LINEAR_T_TILE) * (HC_DIM // LINEAR_K_SPLIT_TILE),
-        name_hint="hc_pre_linear", allow_early_resolve=True,
+        name_hint="hc_pre_linear",
     ):
         t0 = (task // (HC_DIM // LINEAR_K_SPLIT_TILE)) * LINEAR_T_TILE
         linear_split = task % (HC_DIM // LINEAR_K_SPLIT_TILE)
@@ -426,7 +426,7 @@ def _hc_pre_separate(
         mixes_partials[partial_t0 : partial_t0 + LINEAR_T_TILE, 0:MIX_PAD] = acc
 
     pre_val_store = pl.create_tensor([t_linear, HC_PAD], dtype=pl.FP32)
-    for ob in pl.spmd(t_dim // T_TILE, name_hint="split_pre_post", allow_early_resolve=True):
+    for ob in pl.spmd(t_dim // T_TILE, name_hint="split_pre_post"):
         t0 = ob * T_TILE
         inv_col = inv_rms[t0:t0 + T_TILE, 0:1]
         pre_mixes = mixes_partials[t0:t0 + T_TILE, 0:HC_PAD]
@@ -462,7 +462,7 @@ def _hc_pre_separate(
         post[t0:t0 + T_TILE, 0:HC_MULT] = pl.slice(post_pad, [T_TILE, HC_PAD], [0, 0], valid_shape=[T_TILE, HC_MULT])
 
     hc_base_2d = pl.reshape(hc_base, [1, MIX_HC])
-    for ob in pl.spmd(t_dim // COMB_T_TILE, name_hint="comb_sinkhorn", allow_early_resolve=True):
+    for ob in pl.spmd(t_dim // COMB_T_TILE, name_hint="comb_sinkhorn"):
         t0 = ob * COMB_T_TILE
         inv_col_t = pl.load(inv_rms, [t0, 0], [COMB_T_TILE, 1], target_memory=pl.MemorySpace.Vec)
         comb_off = HC_MULT * 2
@@ -618,7 +618,7 @@ def _hc_pre_separate(
         pl.store(row2_out, [t0, 2 * HC_MULT], comb)
         pl.store(row3_out, [t0, 3 * HC_MULT], comb)
 
-    for blk in pl.spmd((t_dim // T_TILE) * (D // MIX_D_TILE), name_hint="mix_x", allow_early_resolve=True):
+    for blk in pl.spmd((t_dim // T_TILE) * (D // MIX_D_TILE), name_hint="mix_x"):
         t0 = (blk // (D // MIX_D_TILE)) * T_TILE
         d_base = (blk % (D // MIX_D_TILE)) * MIX_D_TILE
         pre_tile_t = pl.transpose(pre_val_store[t0:t0 + T_TILE, 0:HC_PAD], axis1=0, axis2=1)

--- a/models/deepseek_v4_pro/moe.py
+++ b/models/deepseek_v4_pro/moe.py
@@ -174,7 +174,6 @@ def dispatch(
         level=pl.Level.CORE_GROUP,
         name_hint="dispatch_meta",
         deps=[_reuse_tid],
-        allow_early_resolve=True,
     ) as _meta_tid:
         active_tokens = pl.cast(num_tokens, pl.INDEX)
         if active_tokens < 0:

--- a/models/deepseek_v4_pro/mtp_projection.py
+++ b/models/deepseek_v4_pro/mtp_projection.py
@@ -61,7 +61,7 @@ def mtp_projection(
     t_linear = ((t_dim + LINEAR_T_TILE - 1) // LINEAR_T_TILE) * LINEAR_T_TILE
     hidden_i8 = pl.create_tensor([t_linear, D], dtype=pl.INT8)
     hidden_scale_dq = pl.create_tensor([t_linear, 1], dtype=pl.FP32)
-    for hidden_block in pl.spmd(t_dim // T_TILE, name_hint="mtp_projection_hidden", allow_early_resolve=True):
+    for hidden_block in pl.spmd(t_dim // T_TILE, name_hint="mtp_projection_hidden"):
         t0 = hidden_block * T_TILE
         hidden_sq_sum = pl.full([1, T_TILE], dtype=pl.FP32, value=0.0)
         hidden_amax = pl.full([1, T_TILE], dtype=pl.FP32, value=INT8_AMAX_EPS)
@@ -107,7 +107,7 @@ def mtp_projection(
     prev_linear_rows = t_linear * HC_MULT
     prev_i8 = pl.create_tensor([prev_linear_rows, D], dtype=pl.INT8)
     prev_scale_dq = pl.create_tensor([HC_MULT, t_linear], dtype=pl.FP32)
-    for prev_block in pl.spmd((t_dim // T_TILE) * HC_MULT, name_hint="mtp_projection_prev", allow_early_resolve=True):
+    for prev_block in pl.spmd((t_dim // T_TILE) * HC_MULT, name_hint="mtp_projection_prev"):
         prev_t = prev_block // HC_MULT
         hc = prev_block - prev_t * HC_MULT
         t0 = prev_t * T_TILE

--- a/models/deepseek_v4_pro/rmsnorm.py
+++ b/models/deepseek_v4_pro/rmsnorm.py
@@ -34,7 +34,7 @@ def rms_norm(
     x_normed: pl.Tensor[[T_DYN, D], pl.BF16],
 ):
     t_dim = pl.tensor.dim(x, 0)
-    with pl.spmd((t_dim // T_TILE) * (D // APPLY_D_TILE), name_hint="rms_norm", allow_early_resolve=True) as rms_tid:
+    with pl.spmd((t_dim // T_TILE) * (D // APPLY_D_TILE), name_hint="rms_norm") as rms_tid:
         rms_blk = pl.tile.get_block_idx()
         tg_idx = rms_blk // (D // APPLY_D_TILE)
         rms_dsplit = rms_blk - tg_idx * (D // APPLY_D_TILE)


### PR DESCRIPTION
## Problem

Tonight's verification dispatch of the nightly `e2e-flash-a5` job (run 32859553422, on main with #1019) failed with a new signature:

```
AssertionError: decode[0]@6: ranks sampled different tokens: [603, 16, 16, 16, 16, 16, 16, 16]
```

All values finite; rank 0 (and, mildly, rank 6) numerically drifted from the other ranks (pre-hc max-abs delta ~16–22, logits delta ~2.6), flipping a near-tie argmax (603 at 24.444 vs 16 at 24.200). The same class — small finite cross-rank drift flipping a sampled token — has been seen at other decode steps on other toolchain stacks.

## Cause

On a5, `allow_early_resolve` is not a pure scheduling hint: during the acceleration batch it was shown (seeded fixtures, per-output sha256) that the same binary on the same input can produce different results with the hint set, and it surfaced then exactly as cross-rank divergence in the 8-card real-weight run. Each rank resolves independently, so the replicated streams can drift a few ULPs apart and the per-step all-ranks-agree assertion trips. #1014 kept the hint on 45 scopes across the DeepSeek-V4 model files, including the decode CSA/HCA/SWA attention, the MoE gate (`route_hash`/`route_sort`), and hc_pre.

## Fix

Remove every `allow_early_resolve=True` under `models/deepseek_v4_pro/` (45 sites, 12 files). In the earlier A/B this made the affected kernels bit-reproducible and was performance-neutral to slightly faster (fused decode CSA 566 → 554 µs).

## Validation

- Both programs compile clean on the nightly's pinned toolchain (pypto 7292b8da).
- Real-weight EP8/TP2 32-step token-loop runs on the pinned stack (CI invocation, fresh JIT compile each): **2/2 PASS** — `task_20260825_231325_200166218584` and `task_20260825_231326_200177832363`, both with every step greedy-matched and rank-identical and the full golden continuation `' Paris. It is located in the north-central part of the country, along the Seine River. Paris is known for its rich history, art, fashion, and culture'`.
