### PR TITLE
CI: give the e2e retry room and full first-attempt error extraction

### DIFF
--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -502,9 +502,11 @@ jobs:
     runs-on: [self-hosted, linux, arm64, npu-a5]
     # Compile (~5 min) + resident weight upload (~8 min for 335 GB of INT8 shards)
     # + 33 forward passes fit in ~15 min once the cards are lent; the ceiling
-    # must still exceed task-submit's own worst case (--timeout 5400 queue wait +
-    # --max-time 2400 run), or the job dies before task-submit can report.
-    timeout-minutes: 150
+    # must still cover setup plus task-submit's worst case per attempt
+    # (--timeout 5400 queue wait + --max-time 2400 run = 130 min) times the two
+    # attempts the loop step may make, or the job is cancelled before
+    # task-submit can report and e2e.json / the artifact are lost.
+    timeout-minutes: 290
     defaults:
       run:
         working-directory: checkout
@@ -735,18 +737,28 @@ jobs:
           ids = last(r"^\[SESSION\] generated ids: (\[.*\])$")
           eos = last(r"^\[SESSION\] eos at decode step (\d+)$")
           passed = bool(last(r"^\[SESSION\] PASS: EP8 .* token loop completed$")) and rc == 0
-          error = last(r"^(?:RuntimeError|ValueError|TimeoutError|OSError|AssertionError)[^\n]*$") \
-              or last(r"^\S*\[ERROR\][^\n]*$") or last(r"^.*(?:507\d{3}|SCHEDULER_TIMEOUT|non-finite|NaN)[^\n]*$")
-          if error is None and rc != 0:
-              # No recognisable traceback or device error: the program printed a
-              # plain one-line complaint (a missing package, a bad argument) and
-              # exited. Take the last non-boilerplate line before task-submit's
-              # own verdict so the summary shows the cause instead of "exit code 1".
-              tail = [l for l in log.splitlines()
-                      if l.strip() and not l.startswith(("[npu-lock]", "===", "[SESSION]", "提示", "任务", "等待"))
-                      and "[STRACE]" not in l and "[TIMING]" not in l]
-              if tail:
-                  error = tail[-1].strip()[:300]
+          def extract_error(text, tail_fallback):
+              # Same ladder for both attempts: exception line, then runtime
+              # [ERROR] line, then a device error code, and finally (for a
+              # nonzero exit with none of those) the last non-boilerplate line
+              # before task-submit's own verdict — a plain one-line complaint
+              # (a missing package, a bad argument) rather than "exit code 1".
+              for pattern in (
+                  r"^(?:RuntimeError|ValueError|TimeoutError|OSError|AssertionError)[^\n]*$",
+                  r"^\S*\[ERROR\][^\n]*$",
+                  r"^.*(?:507\d{3}|SCHEDULER_TIMEOUT|non-finite|NaN)[^\n]*$",
+              ):
+                  hits = re.findall(pattern, text, re.M)
+                  if hits:
+                      return hits[-1]
+              if tail_fallback:
+                  tail = [l for l in text.splitlines()
+                          if l.strip() and not l.startswith(("[npu-lock]", "===", "[SESSION]", "提示", "任务", "等待"))
+                          and "[STRACE]" not in l and "[TIMING]" not in l]
+                  if tail:
+                      return tail[-1].strip()[:300]
+              return None
+          error = extract_error(log, rc != 0)
           n_ids = len(ast.literal_eval(ids)) if ids else None
           # When a first attempt failed and was retried, surface its error line
           # next to the (final) verdict so a flaky night reads as exactly what
@@ -757,10 +769,7 @@ jobs:
                   log1 = open("e2e-attempt1.log", errors="replace").read()
               except FileNotFoundError:
                   log1 = ""
-              hits = re.findall(
-                  r"^(?:RuntimeError|ValueError|TimeoutError|OSError|AssertionError)[^\n]*$",
-                  log1, re.M)
-              first_attempt_error = hits[-1] if hits else "see e2e-attempt1.log"
+              first_attempt_error = extract_error(log1, True) or "see e2e-attempt1.log"
           json.dump({
               "status": "pass" if passed else "fail",
               "exit_code": rc,

--- a/.github/workflows/daily_ci.yml
+++ b/.github/workflows/daily_ci.yml
@@ -502,11 +502,13 @@ jobs:
     runs-on: [self-hosted, linux, arm64, npu-a5]
     # Compile (~5 min) + resident weight upload (~8 min for 335 GB of INT8 shards)
     # + 33 forward passes fit in ~15 min once the cards are lent; the ceiling
-    # must still cover setup plus task-submit's worst case per attempt
-    # (--timeout 5400 queue wait + --max-time 2400 run = 130 min) times the two
-    # attempts the loop step may make, or the job is cancelled before
-    # task-submit can report and e2e.json / the artifact are lost.
-    timeout-minutes: 290
+    # must still cover job setup (~25 min on a cold ccache) plus task-submit's
+    # worst case per attempt (--timeout 5400 queue wait + --max-time 2400 run
+    # = 130 min) times the two attempts the loop step may make, with margin
+    # left for cleanup and the artifact upload (25 + 2 x 130 + 35 = 320) — or
+    # the job is cancelled before task-submit can report and e2e.json / the
+    # artifact are lost.
+    timeout-minutes: 320
     defaults:
       run:
         working-directory: checkout


### PR DESCRIPTION
Two follow-ups from #1044's CodeRabbit review:

- **Job timeout vs two attempts** (Major): `timeout-minutes: 150` only covered one task-submit worst case (`--timeout 5400` queue wait + `--max-time 2400` run = 130 min) plus setup. If attempt 1 burns the worst case, the retry starts with minutes left and the job gets cancelled before `e2e.json` is written or the artifact uploads — exactly the go-dark the retry exists to avoid. Raised to 290 (setup + 2 × 130 min), comment updated with the math.
- **First-attempt error extraction** (Minor): `first_attempt_error` only matched exception class names, so a first attempt that died on a runtime `[ERROR]` line or a device error code (507xxx / SCHEDULER_TIMEOUT / non-finite) reported just `see e2e-attempt1.log`. The final-log error ladder (exception line → `[ERROR]` line → device code → non-boilerplate tail) is now a helper applied to both logs, preserving the existing final-log semantics (tail fallback only on nonzero exit).

The third review comment (retry only the known divergence) is answered on the thread: the retry deliberately stays unconditional-but-once — failure classification from logs is brittle (the divergence surfaces as a generic AssertionError, and a transient platform 507xxx is exactly as worth one retry), the job is a report-only monitor, and `attempts`/`first_attempt_error` keep every retried night fully visible. Revisit if the artifact record shows wasted retries.