### PR TITLE
Fix: drop create_tensor init_value and mark cmp_kv InOut

### DIFF
--- a/models/deepseek_v4_flash_mtp/expert_shared.py
+++ b/models/deepseek_v4_flash_mtp/expert_shared.py
@@ -113,12 +113,16 @@ def expert_shared(
         # blocks for the decode shape). Activation, row-amax, scale, and requant
         # stay in one task so this stage can start alongside dispatch_push.
         h_tile_fp32 = pl.create_tensor([SH_M_TILE, MOE_INTER], dtype=pl.FP32)
-        h_tile_i8 = pl.create_tensor(
-            [SH_M_TILE, MOE_INTER], dtype=pl.INT8, init_value=0
-        )
+        h_tile_i8 = pl.create_tensor([SH_M_TILE, MOE_INTER], dtype=pl.INT8)
         h_tile_scale_dq = pl.create_tensor(
             [SH_M_TILE, SH_ROW_PAD], dtype=pl.FP32, manual_dep=True
         )
+        with pl.at(level=pl.Level.CORE_GROUP, name_hint="sh_h_tile_i8_init"):
+            h_tile_i8[:, :] = pl.cast(
+                pl.full([SH_M_TILE, MOE_INTER], dtype=pl.FP16, value=0.0),
+                target_type=pl.INT8,
+                mode="trunc",
+            )
         for row_block in pl.spmd(
             SH_VALID_M // SH_ROWS_PER_BLOCK,
             name_hint="sh_gate_up_act_q",

--- a/models/deepseek_v4_flash_mtp/prefill_compressor_ratio128.py
+++ b/models/deepseek_v4_flash_mtp/prefill_compressor_ratio128.py
@@ -90,9 +90,7 @@ def prefill_compressor_ratio128(
         [state_block_num * HCA_STATE_BLOCK_SIZE, COMPRESS_STATE_DIM],
     )
     cmp_kv_flat = pl.reshape(cmp_kv, [cmp_block_num * CMP_STORAGE_BLOCK_SIZE, HEAD_DIM])
-    pooled_kv_pad = pl.create_tensor(
-        [HCA_C128_RMS_PAD_ROWS, HEAD_DIM], dtype=pl.FP32, init_value=0
-    )
+    pooled_kv_pad = pl.create_tensor([HCA_C128_RMS_PAD_ROWS, HEAD_DIM], dtype=pl.FP32)
     normed_kv_pad = pl.create_tensor([HCA_C128_RMS_PAD_ROWS, HEAD_DIM], dtype=pl.FP32)
 
     for proj_idx in pl.spmd(OUT_DIM // OUT_TILE, name_hint="prefill_hca_c128_kv_score_proj"):
@@ -195,10 +193,9 @@ def prefill_compressor_ratio128(
             pooled_chunk_t = pl.row_sum(pl.mul(pool_kv_t, score_prob))
             pooled_kv_pad[write_i : write_i + 1, h0 : h0 + HEAD_TILE] = pl.reshape(pooled_chunk_t, [1, HEAD_TILE])
         else:
-            pooled_kv_pad[write_i : write_i + 1, h0 : h0 + HEAD_TILE] = pooled_kv_pad[
-                write_i : write_i + 1,
-                h0 : h0 + HEAD_TILE,
-            ]
+            pooled_kv_pad[write_i : write_i + 1, h0 : h0 + HEAD_TILE] = pl.full(
+                [1, HEAD_TILE], dtype=pl.FP32, value=0.0
+            )
 
     norm_w_2d = pl.reshape(norm_w, [1, HEAD_DIM])
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_hca_c128_rmsnorm_rope"):

--- a/models/deepseek_v4_flash_mtp/prefill_csa.py
+++ b/models/deepseek_v4_flash_mtp/prefill_csa.py
@@ -160,7 +160,7 @@ def prefill_attention_csa(
     kv_cache: pl.InOut[pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
     ori_block_table: pl.Tensor[[SPARSE_ORI_MAX_BLOCKS], pl.INT32],
     ori_slot_mapping: pl.Tensor[[T], pl.INT64],
-    cmp_kv: pl.Out[pl.Tensor[[CMP_BLOCK_NUM_DYN, CMP_STORAGE_BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
+    cmp_kv: pl.InOut[pl.Tensor[[CMP_BLOCK_NUM_DYN, CMP_STORAGE_BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
     cmp_block_table: pl.Tensor[[SPARSE_CMP_MAX_BLOCKS], pl.INT32],
     idx_kv_cache: pl.Out[pl.Tensor[[IDX_BLOCK_NUM_DYN, CMP_STORAGE_BLOCK_SIZE, 1, IDX_HEAD_DIM], pl.INT8]],
     idx_kv_scale: pl.Out[pl.Tensor[[IDX_BLOCK_NUM_DYN, CMP_STORAGE_BLOCK_SIZE, 1, 1], pl.FP32]],
@@ -368,7 +368,7 @@ def prefill_attention_csa_test(
     kv_cache: pl.InOut[pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
     ori_block_table: pl.Tensor[[SPARSE_ORI_MAX_BLOCKS], pl.INT32],
     ori_slot_mapping: pl.Tensor[[T], pl.INT64],
-    cmp_kv: pl.Out[pl.Tensor[[CMP_BLOCK_NUM_DYN, CMP_STORAGE_BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
+    cmp_kv: pl.InOut[pl.Tensor[[CMP_BLOCK_NUM_DYN, CMP_STORAGE_BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
     cmp_block_table: pl.Tensor[[SPARSE_CMP_MAX_BLOCKS], pl.INT32],
     idx_kv_cache: pl.InOut[pl.Tensor[[IDX_BLOCK_NUM_DYN, CMP_STORAGE_BLOCK_SIZE, 1, IDX_HEAD_DIM], pl.INT8]],
     idx_kv_scale: pl.InOut[pl.Tensor[[IDX_BLOCK_NUM_DYN, CMP_STORAGE_BLOCK_SIZE, 1, 1], pl.FP32]],
@@ -911,6 +911,7 @@ def build_tensor_specs(
             [CSA_CMP_BLOCK_NUM, CMP_STORAGE_BLOCK_SIZE, 1, HEAD_DIM],
             torch.bfloat16,
             init_value=init_cmp_kv,
+            is_output=True,
         ),
         TensorSpec("cmp_block_table", [SPARSE_CMP_MAX_BLOCKS], torch.int32, init_value=init_cmp_block_table),
         TensorSpec(
@@ -918,12 +919,14 @@ def build_tensor_specs(
             [PREFILL_IDX_BLOCK_NUM, CMP_STORAGE_BLOCK_SIZE, 1, IDX_HEAD_DIM],
             torch.int8,
             init_value=init_idx_kv_cache,
+            is_output=True,
         ),
         TensorSpec(
             "idx_kv_scale",
             [PREFILL_IDX_BLOCK_NUM, CMP_STORAGE_BLOCK_SIZE, 1, 1],
             torch.float32,
             init_value=init_idx_kv_scale,
+            is_output=True,
         ),
         TensorSpec("idx_block_table", [IDX_CACHE_MAX_BLOCKS], torch.int32, init_value=init_idx_block_table),
         TensorSpec("position_ids", [T], torch.int32, init_value=init_position_ids),
@@ -998,6 +1001,7 @@ if __name__ == "__main__":
             "x_out": ratio_reldiff(diff_thd=x_out_diff_thd, pct_thd=0.005, max_diff_hd=x_out_max_diff,
                                    valid_rows=compare_tokens, zero_tail=True),
             "kv_cache": ratio_allclose(atol=1e-4, rtol=1.0 / 128),
+            "idx_kv_cache": ratio_allclose(atol=1, rtol=0.0, max_error_ratio=0.0),
         },
     )
     if not result.passed:

--- a/models/deepseek_v4_flash_mtp/prefill_hca.py
+++ b/models/deepseek_v4_flash_mtp/prefill_hca.py
@@ -123,7 +123,7 @@ def prefill_attention_hca(
     kv_cache: pl.InOut[pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
     ori_slot_mapping: pl.Tensor[[T], pl.INT64],
     ori_block_table: pl.Tensor[[SPARSE_ORI_MAX_BLOCKS], pl.INT32],
-    cmp_kv: pl.Out[pl.Tensor[[CMP_BLOCK_NUM_DYN, CMP_STORAGE_BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
+    cmp_kv: pl.InOut[pl.Tensor[[CMP_BLOCK_NUM_DYN, CMP_STORAGE_BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
     cmp_block_table: pl.Tensor[[SPARSE_CMP_MAX_BLOCKS], pl.INT32],
     position_ids: pl.Tensor[[T], pl.INT32],
     cmp_slot_mapping: pl.Tensor[[T], pl.INT64],
@@ -277,7 +277,7 @@ def prefill_attention_hca_test(
     kv_cache: pl.InOut[pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
     ori_slot_mapping: pl.Tensor[[T], pl.INT64],
     ori_block_table: pl.Tensor[[SPARSE_ORI_MAX_BLOCKS], pl.INT32],
-    cmp_kv: pl.Out[pl.Tensor[[CMP_BLOCK_NUM_DYN, CMP_STORAGE_BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
+    cmp_kv: pl.InOut[pl.Tensor[[CMP_BLOCK_NUM_DYN, CMP_STORAGE_BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
     cmp_block_table: pl.Tensor[[SPARSE_CMP_MAX_BLOCKS], pl.INT32],
     position_ids: pl.Tensor[[T], pl.INT32],
     cmp_slot_mapping: pl.Tensor[[T], pl.INT64],
@@ -645,8 +645,8 @@ def build_tensor_specs(
         TensorSpec("cmp_wgate", [MAIN_OUT_DIM, D], torch.bfloat16, init_value=init_cmp_wgate),
         TensorSpec("cmp_ape", [COMPRESS_RATIO, MAIN_OUT_DIM], torch.float32, init_value=init_cmp_ape),
         TensorSpec("cmp_norm_w", [HEAD_DIM], torch.bfloat16, init_value=init_cmp_norm_w),
-        # Compressor caches are written in-place but not validated here (decode
-        # parity); the dedicated prefill_compressor_ratio128 test covers them.
+        # Compressor recurrent state is written in-place but not validated here
+        # (decode parity); cmp_kv is validated with the child precision contract.
         TensorSpec(
             "compress_state",
             [HCA_STATE_BLOCK_NUM, HCA_STATE_BLOCK_SIZE, MAIN_COMPRESS_STATE_DIM],
@@ -668,6 +668,7 @@ def build_tensor_specs(
             [HCA_CMP_BLOCK_NUM, CMP_STORAGE_BLOCK_SIZE, 1, HEAD_DIM],
             torch.bfloat16,
             init_value=init_cmp_kv,
+            is_output=True,
         ),
         TensorSpec("cmp_block_table", [SPARSE_CMP_MAX_BLOCKS], torch.int32, init_value=init_cmp_block_table),
         TensorSpec("position_ids", [T], torch.int32, init_value=init_position_ids),
@@ -722,6 +723,7 @@ if __name__ == "__main__":
             "x_out": ratio_reldiff(diff_thd=5e-3, pct_thd=0.005, max_diff_hd=1,
                                    valid_rows=compare_tokens, zero_tail=True),
             "kv_cache": ratio_allclose(atol=1e-4, rtol=1.0 / 128),
+            "cmp_kv": ratio_allclose(atol=1e-4, rtol=1.0 / 128, max_error_ratio=0.005),
         },
     )
     if not result.passed:

--- a/models/deepseek_v4_flash_mtp/prefill_swa.py
+++ b/models/deepseek_v4_flash_mtp/prefill_swa.py
@@ -180,11 +180,20 @@ def prefill_attention_swa(
                 valid_block_mask, mask_row, [idx_t, 0]
             )
 
-    cmp_block_table_dummy = pl.create_tensor(
-        [SPARSE_CMP_MAX_BLOCKS], dtype=pl.INT32, init_value=0
-    )
+    cmp_block_table_dummy = pl.create_tensor([SPARSE_CMP_MAX_BLOCKS], dtype=pl.INT32)
     cmp_kv_dummy = pl.create_tensor([CMP_BLOCK_NUM, BLOCK_SIZE, 1, HEAD_DIM], dtype=pl.BF16)
-    cmp_indices_dummy = pl.create_tensor([T, IDX_TOPK], dtype=pl.INT32, init_value=-1)
+    cmp_indices_dummy = pl.create_tensor([T, IDX_TOPK], dtype=pl.INT32)
+    cmp_block_table_dummy_2d = pl.reshape(
+        cmp_block_table_dummy, [1, SPARSE_CMP_MAX_BLOCKS]
+    )
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="prefill_swa_cmp_dummy_init"):
+        cmp_block_table_dummy_2d[:, :] = pl.full(
+            [1, SPARSE_CMP_MAX_BLOCKS], dtype=pl.INT32, value=0
+        )
+    for dummy_t in pl.spmd(T, name_hint="prefill_swa_cmp_indices_dummy_init"):
+        cmp_indices_dummy[dummy_t : dummy_t + 1, :] = pl.full(
+            [1, IDX_TOPK], dtype=pl.INT32, value=-1
+        )
     attn_out = pl.create_tensor([T, D], dtype=pl.BF16)
     sparse_attn(
         q, kv_cache, swa_indices,


### PR DESCRIPTION
- Declare `cmp_kv` as `pl.InOut` instead of `pl.Out` in the prefill CSA
  and HCA kernels and their `_test` wrappers, matching the runtime ABI
  for a cache the kernel reads back in place.
- Mark `cmp_kv`, `idx_kv_cache`, and `idx_kv_scale` as `is_output`
  TensorSpecs, and add their comparators to the standalone CSA and HCA
  tests: `idx_kv_cache` exact (atol=1, ratio 0) and `cmp_kv` at the
  kv_cache tolerance with a 0.5% error ratio.
- Replace `pl.create_tensor(..., init_value=...)` with device-side
  `pl.full` initialization in three places: the `h_tile_i8` scratch in
  `expert_shared`, the `pooled_kv_pad` zero-fill branch in
  `prefill_compressor_ratio128`, and the `cmp_block_table` / `cmp_indices`
  dummies in `prefill_swa`.
- Retarget the HCA compressor-cache comment at `compress_state`, which
  stays unvalidated for decode parity.

simpler removed `TensorCreateInfo::set_initial_value`, so host-side
initial values no longer reach the device; the official migration is a
device-side fill ordered by task dependencies. This supersedes the
temporary integration patch carried in hw-native-sys/pypto#2523, which
can be dropped from PyPTO CI once this lands.