### PR TITLE
Refactor: fold DeepSeek-V4 Flash MTP split-K peels into matmul_acc init_cond

### DIFF
--- a/docs/pypto-coding/pypto-coding-style.md
+++ b/docs/pypto-coding/pypto-coding-style.md
@@ -337,7 +337,7 @@ first K step is not peeled:
 
 ```python
 with pl.at(level=pl.Level.CORE_GROUP, name_hint="kproj"):
-    acc = pl.create_tensor([M, N], dtype=pl.FP32)
+    acc = pl.create_tensor([M, N], dtype=pl.FP32)   # inside the region: a tile, not GM (§4)
     for kb in pl.pipeline(0, K // K_STEP, stage=2):
         k0 = kb * K_STEP
         tile_a = pl.slice(a, [M, K_STEP], [m0, k0])
@@ -388,13 +388,25 @@ MTE primitives manipulate tensor views and stage data without explicit
 load/store. The compiler decides where the actual TLOAD/TSTORE land based
 on where each `pl.slice` / `pl.assemble` sits relative to `pl.at`.
 
-### `pl.create_tensor(shape, dtype=...)` — orchestration only
+### `pl.create_tensor(shape, dtype=...)` — where it goes decides what it is
 
-`create_tensor` lives **outside** `pl.at`. Use it when multiple `pl.at`
-regions cooperate to fill one intermediate tensor — the tensor is allocated
-once in orchestration, then each region writes its piece via `assemble`. If
-the result of a single `pl.at` flows directly to its caller without further
-assembly, no `create_tensor` is needed.
+Placement is not a style choice: a `create_tensor` **outside** `pl.at`
+allocates a GM tensor, one **inside** yields a tile (§5).
+
+Put it outside when several `pl.at` regions cooperate to fill one
+intermediate tensor — allocated once in orchestration, then each region
+writes its piece via `assemble`. If the result of a single `pl.at` flows
+straight to its caller without further assembly, no `create_tensor` is
+needed at all.
+
+Put it inside for a region-local accumulator — the tile an `init_cond`
+K-loop carries (§3). That one **must** be allocated in the region; hoisting
+it to orchestration makes it a GM tensor and ptoas rejects the accumulator
+load:
+
+```text
+error: 'pto.tload' op expects A2/A3 tload dst to use loc=vec or loc=mat
+```
 
 ```python
 # Multi-stage assembly: q_proj is built by per-tile assembles

--- a/docs/pypto-coding/pypto-coding-style.md
+++ b/docs/pypto-coding/pypto-coding-style.md
@@ -327,23 +327,38 @@ out = pl.matmul(tile_a, tile_b)
 out = pl.matmul(tile_a, tile_b, out_dtype=pl.FP32, b_trans=True)
 ```
 
-### `pl.matmul_acc(acc, lhs, rhs, *, a_trans=False, b_trans=False)`
+### `pl.matmul_acc(acc, lhs, rhs, *, a_trans=False, b_trans=False, init_cond=None)`
 
 Fused multiply-accumulate: `acc += lhs @ rhs`. Use this inside a K-loop to
-keep the partial sum on chip. The first iteration uses `pl.matmul`,
-subsequent iterations use `pl.matmul_acc` — the accumulator is the value
-`pl.matmul` returned, so nothing is allocated for it:
+keep the partial sum on chip. `init_cond` overwrites `acc` with `lhs @ rhs`
+on the steps where the predicate holds instead of accumulating into it, so
+one call covers the whole K-loop — the accumulator is never zeroed and the
+first K step is not peeled:
 
 ```python
 with pl.at(level=pl.Level.CORE_GROUP, name_hint="kproj"):
+    acc = pl.create_tensor([M, N], dtype=pl.FP32)
     for kb in pl.pipeline(0, K // K_STEP, stage=2):
         k0 = kb * K_STEP
         tile_a = pl.slice(a, [M, K_STEP], [m0, k0])
         tile_b = pl.slice(b, [K_STEP, N], [k0, n0])
-        if kb == 0:
-            acc = pl.matmul(tile_a, tile_b)
-        else:
-            acc = pl.matmul_acc(acc, tile_a, tile_b)
+        acc = pl.matmul_acc(acc, tile_a, tile_b, init_cond=(kb == 0))
+```
+
+`init_cond` is 2D-only. An operand of rank greater than 2 — a grouped GEMM
+that keeps its group axis, say — is rejected, and the K-loop peels its first
+step instead: `pl.matmul` on `kb == 0`, `pl.matmul_acc` after.
+
+```python
+acc = pl.create_tensor([1, M, N], dtype=pl.INT32)
+for kb in pl.pipeline(0, K // K_STEP, stage=2):
+    k0 = kb * K_STEP
+    tile_a = pl.slice(a, [M, K_STEP], [m0, k0])
+    tile_b = w[g : g + 1, n0 : n0 + N, k0 : k0 + K_STEP]
+    if kb == 0:
+        acc = pl.matmul(tile_a, tile_b, b_trans=True, out_dtype=pl.INT32)
+    else:
+        acc = pl.matmul_acc(acc, tile_a, tile_b, b_trans=True)
 ```
 
 ### `pl.matmul_bias(lhs, rhs, bias)`
@@ -641,14 +656,12 @@ projection with cast/residual epilogue:
 q_proj = pl.create_tensor([BATCH, Q_HIDDEN], dtype=pl.BF16)
 for q0 in pl.parallel(0, Q_HIDDEN, Q_OUT_STEP):
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="q_proj"):
+        q_acc = pl.create_tensor([BATCH, Q_OUT_STEP], dtype=pl.FP32)
         for kb in pl.pipeline(0, HIDDEN // K_STEP, stage=2):
             k0 = kb * K_STEP
             tile_a = pl.slice(normed, [BATCH, K_STEP], [0, k0])    # vec src
             tile_b = pl.slice(wq, [K_STEP, Q_OUT_STEP], [k0, q0])  # cube right
-            if kb == 0:
-                q_acc = pl.matmul(tile_a, tile_b)              # cube
-            else:
-                q_acc = pl.matmul_acc(q_acc, tile_a, tile_b)   # cube
+            q_acc = pl.matmul_acc(q_acc, tile_a, tile_b, init_cond=(kb == 0))  # cube
         q_bf16 = pl.cast(q_acc, target_type=pl.BF16)           # vector
         q_proj = pl.assemble(q_proj, q_bf16, [0, q0])          # mte
 ```

--- a/docs/pypto-coding/pypto-coding-style.md
+++ b/docs/pypto-coding/pypto-coding-style.md
@@ -345,9 +345,9 @@ with pl.at(level=pl.Level.CORE_GROUP, name_hint="kproj"):
         acc = pl.matmul_acc(acc, tile_a, tile_b, init_cond=(kb == 0))
 ```
 
-`init_cond` is 2D-only. An operand of rank greater than 2 — a grouped GEMM
-that keeps its group axis, say — is rejected, and the K-loop peels its first
-step instead: `pl.matmul` on `kb == 0`, `pl.matmul_acc` after.
+The predicate covers every operand shape `matmul_acc` accumulates, grouped
+GEMMs included — a rank-3 weight slice that keeps its group axis takes
+`init_cond` the same way:
 
 ```python
 acc = pl.create_tensor([1, M, N], dtype=pl.INT32)
@@ -355,10 +355,7 @@ for kb in pl.pipeline(0, K // K_STEP, stage=2):
     k0 = kb * K_STEP
     tile_a = pl.slice(a, [M, K_STEP], [m0, k0])
     tile_b = w[g : g + 1, n0 : n0 + N, k0 : k0 + K_STEP]
-    if kb == 0:
-        acc = pl.matmul(tile_a, tile_b, b_trans=True, out_dtype=pl.INT32)
-    else:
-        acc = pl.matmul_acc(acc, tile_a, tile_b, b_trans=True)
+    acc = pl.matmul_acc(acc, tile_a, tile_b, b_trans=True, init_cond=(kb == 0))
 ```
 
 ### `pl.matmul_bias(lhs, rhs, bias)`

--- a/models/deepseek_v4_flash_mtp/decode_compressor_ratio128.py
+++ b/models/deepseek_v4_flash_mtp/decode_compressor_ratio128.py
@@ -136,12 +136,8 @@ def compressor_ratio128(
             # bursts). Cuts the transaction-bound MTE2 cost. Matches ratio4/CSA layout.
             wkv_tile = wkv[o0 : o0 + OUT_TILE, k0 : k0 + K_TILE]
             wgate_tile = wgate[o0 : o0 + OUT_TILE, k0 : k0 + K_TILE]
-            if k0 == 0:
-                kv_acc = pl.matmul(x_tile, wkv_tile, out_dtype=pl.FP32, b_trans=True)
-                score_acc = pl.matmul(x_tile, wgate_tile, out_dtype=pl.FP32, b_trans=True)
-            else:
-                kv_acc = pl.matmul_acc(kv_acc, x_tile, wkv_tile, b_trans=True)
-                score_acc = pl.matmul_acc(score_acc, x_tile, wgate_tile, b_trans=True)
+            kv_acc = pl.matmul_acc(kv_acc, x_tile, wkv_tile, b_trans=True, init_cond=(k0 == 0))
+            score_acc = pl.matmul_acc(score_acc, x_tile, wgate_tile, b_trans=True, init_cond=(k0 == 0))
 
         kv_proj_pad[global_row0 : global_row0 + MM_B_TILE, o0 : o0 + OUT_TILE] = kv_acc
         score_proj_pad[global_row0 : global_row0 + MM_B_TILE, o0 : o0 + OUT_TILE] = score_acc

--- a/models/deepseek_v4_flash_mtp/decode_compressor_ratio4.py
+++ b/models/deepseek_v4_flash_mtp/decode_compressor_ratio4.py
@@ -120,12 +120,8 @@ def compressor_ratio4(
             # bursts). Cuts the transaction-bound MTE2 cost ~14% busy / ~7% compressor wall.
             wkv_tile = wkv[o0 : o0 + OUT_TILE, k0 : k0 + K_TILE]
             wgate_tile = wgate[o0 : o0 + OUT_TILE, k0 : k0 + K_TILE]
-            if k0 == 0:
-                kv_acc = pl.matmul(x_tile, wkv_tile, out_dtype=pl.FP32, b_trans=True)
-                score_acc = pl.matmul(x_tile, wgate_tile, out_dtype=pl.FP32, b_trans=True)
-            else:
-                kv_acc = pl.matmul_acc(kv_acc, x_tile, wkv_tile, b_trans=True)
-                score_acc = pl.matmul_acc(score_acc, x_tile, wgate_tile, b_trans=True)
+            kv_acc = pl.matmul_acc(kv_acc, x_tile, wkv_tile, b_trans=True, init_cond=(k0 == 0))
+            score_acc = pl.matmul_acc(score_acc, x_tile, wgate_tile, b_trans=True, init_cond=(k0 == 0))
 
         cmp4_kv_proj_pad[global_row0 : global_row0 + MM_B_TILE, o0 : o0 + OUT_TILE] = kv_acc
         cmp4_score_proj_pad[global_row0 : global_row0 + MM_B_TILE, o0 : o0 + OUT_TILE] = score_acc

--- a/models/deepseek_v4_flash_mtp/decode_indexer.py
+++ b/models/deepseek_v4_flash_mtp/decode_indexer.py
@@ -149,10 +149,7 @@ def indexer(
                 q0 = kb * Q_TILE
                 qr_tile = pl.slice(qr, [T_PAD, Q_TILE], [0, q0], valid_shape=[T, Q_TILE])
                 wq_tile = wq_b[q0 : q0 + Q_TILE, o_base + ns : o_base + ns + MM_N_TILE]
-                if q0 == 0:
-                    qr_acc = pl.matmul(qr_tile, wq_tile, out_dtype=pl.INT32)
-                else:
-                    qr_acc = pl.matmul_acc(qr_acc, qr_tile, wq_tile)
+                qr_acc = pl.matmul_acc(qr_acc, qr_tile, wq_tile, init_cond=(q0 == 0))
             qr_acc_pad[0:T_PAD, o_base + ns : o_base + ns + MM_N_TILE] = qr_acc
     qr_proj = pl.create_tensor([T, IDX_N_HEADS * IDX_HEAD_DIM], dtype=pl.FP32)
     for ot in pl.spmd(IDX_N_HEADS * IDX_HEAD_DIM // Q_OUT_TILE, name_hint="idx_qr_proj_dequant", allow_early_resolve=True):
@@ -245,10 +242,7 @@ def indexer(
             d0 = k_base + db * D_TILE
             x_tile = pl.slice(x_flat, [MM_ROW_TILE, D_TILE], [0, d0], valid_shape=[pl.min(MM_ROW_TILE, T), D_TILE])
             weights_proj_tile = weights_proj[d0 : d0 + D_TILE, :]
-            if db == 0:
-                weights_acc = pl.matmul(x_tile, weights_proj_tile, out_dtype=pl.FP32)
-            else:
-                weights_acc = pl.matmul_acc(weights_acc, x_tile, weights_proj_tile)
+            weights_acc = pl.matmul_acc(weights_acc, x_tile, weights_proj_tile, init_cond=(db == 0))
         weights_partial[kb * MM_ROW_TILE : kb * MM_ROW_TILE + MM_ROW_TILE, :] = weights_acc
 
     with pl.at(level=pl.Level.CORE_GROUP, name_hint="weights_proj_reduce", allow_early_resolve=True):

--- a/models/deepseek_v4_flash_mtp/decode_indexer_compressor.py
+++ b/models/deepseek_v4_flash_mtp/decode_indexer_compressor.py
@@ -123,12 +123,8 @@ def indexer_compressor(
             # ND2NZ form here was ~2x slower on this matmul (43us -> ~20us per task).
             wkv_tile = wkv[o0 : o0 + PROJ_OUT_TILE, k0 : k0 + K_TILE]
             wgate_tile = wgate[o0 : o0 + PROJ_OUT_TILE, k0 : k0 + K_TILE]
-            if k0 == 0:
-                kv_acc = pl.matmul(x_tile, wkv_tile, out_dtype=pl.FP32, b_trans=True)
-                score_acc = pl.matmul(x_tile, wgate_tile, out_dtype=pl.FP32, b_trans=True)
-            else:
-                kv_acc = pl.matmul_acc(kv_acc, x_tile, wkv_tile, b_trans=True)
-                score_acc = pl.matmul_acc(score_acc, x_tile, wgate_tile, b_trans=True)
+            kv_acc = pl.matmul_acc(kv_acc, x_tile, wkv_tile, b_trans=True, init_cond=(k0 == 0))
+            score_acc = pl.matmul_acc(score_acc, x_tile, wgate_tile, b_trans=True, init_cond=(k0 == 0))
 
         kv_proj_pad[global_row0 : global_row0 + MM_B_TILE, o0 : o0 + PROJ_OUT_TILE] = kv_acc
         score_proj_pad[global_row0 : global_row0 + MM_B_TILE, o0 : o0 + PROJ_OUT_TILE] = score_acc

--- a/models/deepseek_v4_flash_mtp/decode_sparse_attn_csa.py
+++ b/models/deepseek_v4_flash_mtp/decode_sparse_attn_csa.py
@@ -450,14 +450,9 @@ def sparse_attn_csa(
                     acc_b = pl.create_tensor([MM_T_TILE, PROJ_B_MM_N_TILE], dtype=pl.INT32)
                     for kb in pl.pipeline(0, O_LORA // B_K_TILE, stage=2):
                         k0 = col_g + kb * B_K_TILE
-                        if kb == 0:
-                            b_act = o_r_i8_pad[:, col_g : col_g + B_K_TILE]
-                            b_weight = wo_b[n0 : n0 + PROJ_B_MM_N_TILE, col_g : col_g + B_K_TILE]
-                            acc_b = pl.matmul(b_act, b_weight, b_trans=True, out_dtype=pl.INT32)
-                        else:
-                            b_act = o_r_i8_pad[:, k0 : k0 + B_K_TILE]
-                            b_weight = wo_b[n0 : n0 + PROJ_B_MM_N_TILE, k0 : k0 + B_K_TILE]
-                            acc_b = pl.matmul_acc(acc_b, b_act, b_weight, b_trans=True)
+                        b_act = o_r_i8_pad[:, k0 : k0 + B_K_TILE]
+                        b_weight = wo_b[n0 : n0 + PROJ_B_MM_N_TILE, k0 : k0 + B_K_TILE]
+                        acc_b = pl.matmul_acc(acc_b, b_act, b_weight, b_trans=True, init_cond=(kb == 0))
                     partials[0:MM_T_TILE, g * D + n0 : g * D + n0 + PROJ_B_MM_N_TILE] = acc_b
             proj_b_tids[g] = pb_tid
 

--- a/models/deepseek_v4_flash_mtp/decode_sparse_attn_swa.py
+++ b/models/deepseek_v4_flash_mtp/decode_sparse_attn_swa.py
@@ -353,14 +353,9 @@ def sparse_attn_swa(
                     acc_b = pl.create_tensor([MM_T_TILE, PROJ_B_MM_N_TILE], dtype=pl.INT32)
                     for kb in pl.pipeline(0, O_LORA // B_K_TILE, stage=2):
                         k0 = col_g + kb * B_K_TILE
-                        if kb == 0:
-                            b_act = o_r_i8_pad[:, col_g : col_g + B_K_TILE]
-                            b_weight = wo_b[n0 : n0 + PROJ_B_MM_N_TILE, col_g : col_g + B_K_TILE]
-                            acc_b = pl.matmul(b_act, b_weight, b_trans=True, out_dtype=pl.INT32)
-                        else:
-                            b_act = o_r_i8_pad[:, k0 : k0 + B_K_TILE]
-                            b_weight = wo_b[n0 : n0 + PROJ_B_MM_N_TILE, k0 : k0 + B_K_TILE]
-                            acc_b = pl.matmul_acc(acc_b, b_act, b_weight, b_trans=True)
+                        b_act = o_r_i8_pad[:, k0 : k0 + B_K_TILE]
+                        b_weight = wo_b[n0 : n0 + PROJ_B_MM_N_TILE, k0 : k0 + B_K_TILE]
+                        acc_b = pl.matmul_acc(acc_b, b_act, b_weight, b_trans=True, init_cond=(kb == 0))
                     partials[0:MM_T_TILE, g * D + n0 : g * D + n0 + PROJ_B_MM_N_TILE] = acc_b
             proj_b_tids[g] = pb_tid
 

--- a/models/deepseek_v4_flash_mtp/expert_routed.py
+++ b/models/deepseek_v4_flash_mtp/expert_routed.py
@@ -106,10 +106,7 @@ def expert_routed(
                                     n0 : n0 + MM_INTER_TILE,
                                     k0 : k0 + K_TILE,
                                 ]
-                                if k0 == 0:
-                                    gate_acc = pl.matmul(x_k, w1_k, b_trans=True, out_dtype=pl.INT32)
-                                else:
-                                    gate_acc = pl.matmul_acc(gate_acc, x_k, w1_k, b_trans=True)
+                                gate_acc = pl.matmul_acc(gate_acc, x_k, w1_k, b_trans=True, init_cond=(k0 == 0))
                             gate_tile_i32[:, n0 : n0 + MM_INTER_TILE] = pl.reshape(
                                 gate_acc, [RECV_TILE, MM_INTER_TILE]
                             )
@@ -127,10 +124,7 @@ def expert_routed(
                                     u0 : u0 + MM_INTER_TILE,
                                     uk0 : uk0 + K_TILE,
                                 ]
-                                if uk0 == 0:
-                                    up_acc = pl.matmul(x_u, w3_k, b_trans=True, out_dtype=pl.INT32)
-                                else:
-                                    up_acc = pl.matmul_acc(up_acc, x_u, w3_k, b_trans=True)
+                                up_acc = pl.matmul_acc(up_acc, x_u, w3_k, b_trans=True, init_cond=(uk0 == 0))
                             up_tile_i32[:, u0 : u0 + MM_INTER_TILE] = pl.reshape(
                                 up_acc, [RECV_TILE, MM_INTER_TILE]
                             )
@@ -226,10 +220,7 @@ def expert_routed(
                             for k0 in pl.pipeline(0, MOE_INTER, INTER_K, stage=2):
                                 h_k = h_tile_i8[:, k0 : k0 + INTER_K]
                                 w2_k = routed_w2[local_e : local_e + 1, d0 : d0 + D_OUT_TILE, k0 : k0 + INTER_K]
-                                if k0 == 0:
-                                    y_acc = pl.matmul(h_k, w2_k, b_trans=True, out_dtype=pl.INT32)
-                                else:
-                                    y_acc = pl.matmul_acc(y_acc, h_k, w2_k, b_trans=True)
+                                y_acc = pl.matmul_acc(y_acc, h_k, w2_k, b_trans=True, init_cond=(k0 == 0))
                             y_i32[:, d0 : d0 + D_OUT_TILE] = pl.reshape(y_acc, [RECV_TILE, D_OUT_TILE])
 
                     recv_y_tile = pl.create_tensor([RECV_TILE, D], dtype=pl.BF16)

--- a/models/deepseek_v4_flash_mtp/expert_shared.py
+++ b/models/deepseek_v4_flash_mtp/expert_shared.py
@@ -86,10 +86,7 @@ def expert_shared(
             for k0 in pl.pipeline(0, D, K_TILE, stage=2):
                 xs_k = pl.slice(x_local_i8, [SH_M_TILE, K_TILE], [ts0, k0], valid_shape=[SH_VALID_M, K_TILE])
                 sw1_k = shared_w1[n0 : n0 + MM_INTER_TILE, k0 : k0 + K_TILE]
-                if k0 == 0:
-                    gate_acc = pl.matmul(xs_k, sw1_k, b_trans=True, out_dtype=pl.INT32)
-                else:
-                    gate_acc = pl.matmul_acc(gate_acc, xs_k, sw1_k, b_trans=True)
+                gate_acc = pl.matmul_acc(gate_acc, xs_k, sw1_k, b_trans=True, init_cond=(k0 == 0))
             gate_i32[:, n0 : n0 + MM_INTER_TILE] = gate_acc
 
         # up (w3) cube matmul -> INT32 GM accumulator.
@@ -103,10 +100,7 @@ def expert_shared(
             for k0 in pl.pipeline(0, D, K_TILE, stage=2):
                 xs_k = pl.slice(x_local_i8, [SH_M_TILE, K_TILE], [ts0, k0], valid_shape=[SH_VALID_M, K_TILE])
                 sw3_k = shared_w3[n0 : n0 + MM_INTER_TILE, k0 : k0 + K_TILE]
-                if k0 == 0:
-                    up_acc = pl.matmul(xs_k, sw3_k, b_trans=True, out_dtype=pl.INT32)
-                else:
-                    up_acc = pl.matmul_acc(up_acc, xs_k, sw3_k, b_trans=True)
+                up_acc = pl.matmul_acc(up_acc, xs_k, sw3_k, b_trans=True, init_cond=(k0 == 0))
             up_i32[:, n0 : n0 + MM_INTER_TILE] = up_acc
 
         # Each AIV block owns two rows across the full intermediate axis (four
@@ -241,10 +235,7 @@ def expert_shared(
                 sw2_k = shared_w2[
                     d0 : d0 + D_OUT_TILE, k0 : k0 + INTER_K
                 ]
-                if k0 == 0:
-                    y_acc = pl.matmul(hs_k, sw2_k, b_trans=True, out_dtype=pl.INT32)
-                else:
-                    y_acc = pl.matmul_acc(y_acc, hs_k, sw2_k, b_trans=True)
+                y_acc = pl.matmul_acc(y_acc, hs_k, sw2_k, b_trans=True, init_cond=(k0 == 0))
             y_i32[:, d0 : d0 + D_OUT_TILE] = y_acc
 
         # Dequant w2 output (per-row h scale x per-channel w2 scale) -> BF16.

--- a/models/deepseek_v4_flash_mtp/gate.py
+++ b/models/deepseek_v4_flash_mtp/gate.py
@@ -181,10 +181,7 @@ def gate(
             gd_kd = kb * GATE_D_TILE
             gd_x = xg_buf[t1 : t1 + GATE_M_TILE, gd_kd : gd_kd + GATE_D_TILE]
             gd_w = gate_w[n0 : n0 + GATE_N_TILE, gd_kd : gd_kd + GATE_D_TILE]
-            if gd_kd == 0:
-                gate_logits_tile = pl.matmul(gd_x, gd_w, out_dtype=pl.FP32, b_trans=True)
-            else:
-                gate_logits_tile = pl.matmul_acc(gate_logits_tile, gd_x, gd_w, b_trans=True)
+            gate_logits_tile = pl.matmul_acc(gate_logits_tile, gd_x, gd_w, b_trans=True, init_cond=(gd_kd == 0))
         # xg omitted inv_rms; logits = inv_rms * (xg @ gate_w.T). Per-token row-scale.
         gate_logits_tile = pl.row_expand_mul(gate_logits_tile, inv_rms_buf[t1 : t1 + GATE_M_TILE, 0:1])
         gp_relu = pl.maximum(gate_logits_tile, 0.0)

--- a/models/deepseek_v4_flash_mtp/hc_head.py
+++ b/models/deepseek_v4_flash_mtp/hc_head.py
@@ -88,10 +88,7 @@ def hc_head(
             k0 = k_base + kb * LINEAR_K_TILE
             x_lin = x_flat[t0 : t0 + LINEAR_T_TILE, k0 : k0 + LINEAR_K_TILE]
             w = pl.slice(hc_head_fn, [HC_PAD, LINEAR_K_TILE], [0, k0], valid_shape=[HC_MULT, LINEAR_K_TILE])
-            if kb == 0:
-                acc = pl.matmul(x_lin, w, b_trans=True, out_dtype=pl.FP32)
-            else:
-                acc = pl.matmul_acc(acc, x_lin, w, b_trans=True)
+            acc = pl.matmul_acc(acc, x_lin, w, b_trans=True, init_cond=(kb == 0))
         mixes_raw = pl.assemble(mixes_raw, acc, [t0, 0], atomic=pl.AtomicType.Add)
 
     # reduce: gate + hc mix, fanned over (token-tile x D-slice). The rsqrt/sigmoid gate is

--- a/models/deepseek_v4_flash_mtp/hc_pre.py
+++ b/models/deepseek_v4_flash_mtp/hc_pre.py
@@ -111,10 +111,7 @@ def hc_pre(
             k0 = k_base + kb * LINEAR_K_TILE
             x_linear_chunk = pl.slice(x_flat, [LINEAR_T_TILE, LINEAR_K_TILE], [t0, k0], valid_shape=[t_rows, LINEAR_K_TILE])
             w_chunk = pl.slice(hc_fn, [MIX_PAD, LINEAR_K_TILE], [0, k0], valid_shape=[MIX_HC, LINEAR_K_TILE])
-            if kb == 0:
-                acc = pl.matmul(x_linear_chunk, w_chunk, b_trans=True, out_dtype=pl.FP32)
-            else:
-                acc = pl.matmul_acc(acc, x_linear_chunk, w_chunk, b_trans=True)
+            acc = pl.matmul_acc(acc, x_linear_chunk, w_chunk, b_trans=True, init_cond=(kb == 0))
         partial_row0 = linear_split * t_linear + t0
         mixes_partials[partial_row0 : partial_row0 + LINEAR_T_TILE, 0:MIX_PAD] = acc
 

--- a/models/deepseek_v4_flash_mtp/prefill_compressor_ratio128.py
+++ b/models/deepseek_v4_flash_mtp/prefill_compressor_ratio128.py
@@ -104,12 +104,8 @@ def prefill_compressor_ratio128(
             # long bursts) instead of ND2NZ (strided short bursts). Matches ratio4/CSA/decode-HCA.
             wkv_tile = wkv[o0 : o0 + OUT_TILE, k0 : k0 + K_TILE]
             wgate_tile = wgate[o0 : o0 + OUT_TILE, k0 : k0 + K_TILE]
-            if k0 == 0:
-                kv_acc = pl.matmul(x_tile, wkv_tile, out_dtype=pl.FP32, b_trans=True)
-                score_acc = pl.matmul(x_tile, wgate_tile, out_dtype=pl.FP32, b_trans=True)
-            else:
-                kv_acc = pl.matmul_acc(kv_acc, x_tile, wkv_tile, b_trans=True)
-                score_acc = pl.matmul_acc(score_acc, x_tile, wgate_tile, b_trans=True)
+            kv_acc = pl.matmul_acc(kv_acc, x_tile, wkv_tile, b_trans=True, init_cond=(k0 == 0))
+            score_acc = pl.matmul_acc(score_acc, x_tile, wgate_tile, b_trans=True, init_cond=(k0 == 0))
         kv_proj_scratch[0:T, o0 : o0 + OUT_TILE] = kv_acc
         score_proj_scratch[0:T, o0 : o0 + OUT_TILE] = score_acc
 

--- a/models/deepseek_v4_flash_mtp/prefill_compressor_ratio4.py
+++ b/models/deepseek_v4_flash_mtp/prefill_compressor_ratio4.py
@@ -97,12 +97,8 @@ def compressor_ratio4(
             # long bursts) instead of ND2NZ (strided short bursts). Matches ratio4/CSA/HCA layout.
             wkv_tile = wkv[o0 : o0 + OUT_TILE, k0 : k0 + K_TILE]
             wgate_tile = wgate[o0 : o0 + OUT_TILE, k0 : k0 + K_TILE]
-            if k0 == 0:
-                kv_acc = pl.matmul(x_tile, wkv_tile, out_dtype=pl.FP32, b_trans=True)
-                score_acc = pl.matmul(x_tile, wgate_tile, out_dtype=pl.FP32, b_trans=True)
-            else:
-                kv_acc = pl.matmul_acc(kv_acc, x_tile, wkv_tile, b_trans=True)
-                score_acc = pl.matmul_acc(score_acc, x_tile, wgate_tile, b_trans=True)
+            kv_acc = pl.matmul_acc(kv_acc, x_tile, wkv_tile, b_trans=True, init_cond=(k0 == 0))
+            score_acc = pl.matmul_acc(score_acc, x_tile, wgate_tile, b_trans=True, init_cond=(k0 == 0))
         cmp4_kv_proj_scratch[0:T, o0 : o0 + OUT_TILE] = kv_acc
         cmp4_score_proj_scratch[0:T, o0 : o0 + OUT_TILE] = score_acc
 

--- a/models/deepseek_v4_flash_mtp/prefill_indexer.py
+++ b/models/deepseek_v4_flash_mtp/prefill_indexer.py
@@ -148,10 +148,7 @@ def prefill_indexer(
             q0 = kb * Q_TILE
             qr_tile = qr[:, q0 : q0 + Q_TILE]
             wq_tile = wq_b[q0 : q0 + Q_TILE, o0 : o0 + Q_OUT_TILE]
-            if q0 == 0:
-                qr_acc = pl.matmul(qr_tile, wq_tile, out_dtype=pl.INT32)
-            else:
-                qr_acc = pl.matmul_acc(qr_acc, qr_tile, wq_tile)
+            qr_acc = pl.matmul_acc(qr_acc, qr_tile, wq_tile, init_cond=(q0 == 0))
         wq_scale = pl.reshape(wq_b_scale[o0 : o0 + Q_OUT_TILE], [1, Q_OUT_TILE])
         for r0 in pl.range(0, T, QR_PROJ_ROW_TILE):
             acc_fp32 = pl.cast(qr_acc[r0 : r0 + QR_PROJ_ROW_TILE, :], target_type=pl.FP32, mode="none")
@@ -255,10 +252,7 @@ def prefill_indexer(
             d0 = db * D_TILE
             x_tile = x[wrow0 : wrow0 + WEIGHTS_ROW_TILE, d0 : d0 + D_TILE]
             wp_tile = weights_proj[d0 : d0 + D_TILE, :]
-            if d0 == 0:
-                weights_acc = pl.matmul(x_tile, wp_tile, out_dtype=pl.FP32)
-            else:
-                weights_acc = pl.matmul_acc(weights_acc, x_tile, wp_tile)
+            weights_acc = pl.matmul_acc(weights_acc, x_tile, wp_tile, init_cond=(d0 == 0))
         weights[wrow0 : wrow0 + WEIGHTS_ROW_TILE, :] = pl.mul(weights_acc, WEIGHTS_SCALE)
 
     # === inner compressor: build the paged compressed index KV cache ===
@@ -394,10 +388,7 @@ def _prefill_indexer_cp_score_topk(
             q0 = kb * Q_TILE
             qr_tile = qr[:, q0 : q0 + Q_TILE]
             wq_tile = wq_b[q0 : q0 + Q_TILE, o0 : o0 + Q_OUT_TILE]
-            if q0 == 0:
-                qr_acc = pl.matmul(qr_tile, wq_tile, out_dtype=pl.INT32)
-            else:
-                qr_acc = pl.matmul_acc(qr_acc, qr_tile, wq_tile)
+            qr_acc = pl.matmul_acc(qr_acc, qr_tile, wq_tile, init_cond=(q0 == 0))
         wq_scale = pl.reshape(wq_b_scale[o0 : o0 + Q_OUT_TILE], [1, Q_OUT_TILE])
         for r0 in pl.range(0, T, QR_PROJ_ROW_TILE):
             qr_acc_tile = qr_acc[r0 : r0 + QR_PROJ_ROW_TILE, :]
@@ -499,10 +490,7 @@ def _prefill_indexer_cp_score_topk(
             d0 = db * D_TILE
             x_tile = x[wrow0 : wrow0 + WEIGHTS_ROW_TILE, d0 : d0 + D_TILE]
             wp_tile = weights_proj[d0 : d0 + D_TILE, :]
-            if d0 == 0:
-                weights_acc = pl.matmul(x_tile, wp_tile, out_dtype=pl.FP32)
-            else:
-                weights_acc = pl.matmul_acc(weights_acc, x_tile, wp_tile)
+            weights_acc = pl.matmul_acc(weights_acc, x_tile, wp_tile, init_cond=(d0 == 0))
         weights[wrow0 : wrow0 + WEIGHTS_ROW_TILE, :] = pl.mul(weights_acc, WEIGHTS_SCALE)
 
     # Score paged INT8 cache rows.

--- a/models/deepseek_v4_flash_mtp/prefill_indexer_compressor.py
+++ b/models/deepseek_v4_flash_mtp/prefill_indexer_compressor.py
@@ -109,12 +109,8 @@ def _prefill_indexer_compressor_with_completion(
             # compressor (prefill_compressor_ratio4) and the decode indexer compressor.
             wkv_tile = wkv[o0 : o0 + OUT_TILE, k0 : k0 + K_TILE]
             wgate_tile = wgate[o0 : o0 + OUT_TILE, k0 : k0 + K_TILE]
-            if k0 == 0:
-                kv_acc = pl.matmul(x_tile, wkv_tile, out_dtype=pl.FP32, b_trans=True)
-                score_acc = pl.matmul(x_tile, wgate_tile, out_dtype=pl.FP32, b_trans=True)
-            else:
-                kv_acc = pl.matmul_acc(kv_acc, x_tile, wkv_tile, b_trans=True)
-                score_acc = pl.matmul_acc(score_acc, x_tile, wgate_tile, b_trans=True)
+            kv_acc = pl.matmul_acc(kv_acc, x_tile, wkv_tile, b_trans=True, init_cond=(k0 == 0))
+            score_acc = pl.matmul_acc(score_acc, x_tile, wgate_tile, b_trans=True, init_cond=(k0 == 0))
         kv_proj_scratch[0:T, o0 : o0 + OUT_TILE] = kv_acc
         score_proj_scratch[0:T, o0 : o0 + OUT_TILE] = score_acc
 

--- a/models/deepseek_v4_flash_mtp/qkv_proj_rope.py
+++ b/models/deepseek_v4_flash_mtp/qkv_proj_rope.py
@@ -178,10 +178,7 @@ def qkv_proj_rope(
                 qr_rows = pl.min(QR_M_TILE, t_dim - t0)
                 q_x_chunk_bf16 = pl.slice(x_view, [QR_M_TILE, QR_K_TILE], [t0, qr_d0], valid_shape=[qr_rows, QR_K_TILE])
                 w_chunk = wq_a[qr_d0 : qr_d0 + QR_K_TILE, q_a_col0 : q_a_col0 + QR_N_TILE]
-                if db == 0:
-                    q_acc = pl.matmul(q_x_chunk_bf16, w_chunk, out_dtype=pl.FP32)
-                else:
-                    q_acc = pl.matmul_acc(q_acc, q_x_chunk_bf16, w_chunk)
+                q_acc = pl.matmul_acc(q_acc, q_x_chunk_bf16, w_chunk, init_cond=(db == 0))
             qr_fp32 = pl.assemble(qr_fp32, q_acc, [t0, q_a_col0], atomic=pl.AtomicType.Add)
 
     # Two passes per block: pass 1 computes amax; pass 2 recomputes norm and quantizes.
@@ -235,10 +232,7 @@ def qkv_proj_rope(
                 qr_proj_col0 = qb * Q_PROJ_TILE
                 qr_i8_chunk = qr_i8_matmul[t0 : t0 + QPROJ_M_TILE, qr_proj_col0 : qr_proj_col0 + Q_PROJ_TILE]
                 wq_chunk = wq_b[qr_proj_col0 : qr_proj_col0 + Q_PROJ_TILE, w_col0 : w_col0 + QPROJ_MM_N_TILE]
-                if qr_proj_col0 == 0:
-                    col_acc = pl.matmul(qr_i8_chunk, wq_chunk, out_dtype=pl.INT32)
-                else:
-                    col_acc = pl.matmul_acc(col_acc, qr_i8_chunk, wq_chunk)
+                col_acc = pl.matmul_acc(col_acc, qr_i8_chunk, wq_chunk, init_cond=(qr_proj_col0 == 0))
             q_proj_i32[t0 : t0 + QPROJ_M_TILE, w_col0 : w_col0 + QPROJ_MM_N_TILE] = col_acc
 
     # Fuse qproj dequant, per-head RMSNorm, NOPE writeback, and interleaved RoPE.
@@ -320,10 +314,7 @@ def qkv_proj_rope(
                 kv_rows = pl.min(KV_M_TILE, t_dim - t0)
                 kv_x_chunk_bf16 = pl.slice(x_view, [KV_M_TILE, KV_K_TILE], [t0, d0], valid_shape=[kv_rows, KV_K_TILE])
                 wkv_chunk = wkv[d0 : d0 + KV_K_TILE, kv_col0 : kv_col0 + KV_N_TILE]
-                if db == 0:
-                    kv_acc = pl.matmul(kv_x_chunk_bf16, wkv_chunk, out_dtype=pl.FP32)
-                else:
-                    kv_acc = pl.matmul_acc(kv_acc, kv_x_chunk_bf16, wkv_chunk)
+                kv_acc = pl.matmul_acc(kv_acc, kv_x_chunk_bf16, wkv_chunk, init_cond=(db == 0))
             kv_fp32 = pl.assemble(kv_fp32, kv_acc, [t0, kv_col0], atomic=pl.AtomicType.Add)
 
     # Fused KV RMSNorm + interleaved (CANN A3) RoPE. One spmd task per [KV_RMS_T_TILE, HEAD_DIM]


### PR DESCRIPTION
## What

Every K loop in DeepSeek-V4 Flash MTP opened with the same shape — peel the
first step onto `pl.matmul` so the accumulator has a value, then
`pl.matmul_acc` for the rest:

```python
if k0 == 0:
    acc = pl.matmul(x_k, w_k, b_trans=True, out_dtype=pl.FP32)
else:
    acc = pl.matmul_acc(acc, x_k, w_k, b_trans=True)
```

`pl.matmul_acc` now takes an `init_cond` predicate that overwrites the
accumulator on the steps where it holds, which collapses that to one call:

```python
acc = pl.matmul_acc(acc, x_k, w_k, b_trans=True, init_cond=(k0 == 0))
```

26 peel sites (32 `matmul_acc` calls) across 16 kernels — every split-K peel
in the model — and the coding-style guide, which taught the peel as *the*
idiom.

## Why

The branch existed only to give the accumulator a first value. It cost a
compile-time-resolvable `if` in the hot K loop of every projection in the
model and made each site three lines longer than the operation it expresses.

## Notes for reviewers

- **No allocation changes.** Every accumulator was already declared by
  `pl.create_tensor` ahead of its loop, with a dtype matching the peeled
  `pl.matmul`'s `out_dtype`. The peeled call's `out_dtype` is dropped because
  `matmul_acc` takes the dtype from `acc`.
- **`decode_sparse_attn_csa` / `swa` needed a second look.** Those two branches
  also sliced their operands differently — `col_g` on the peeled step, `k0`
  after. Since `k0 = col_g + kb * B_K_TILE`, the two agree at `kb == 0`, so the
  general form subsumes both and the peeled `col_g` slices are gone.
- **`expert_routed`'s three grouped loops are now converted too.** Their
  accumulators are rank 3 (the weight slice `routed_w1[local_i : local_i + 1,
  ...]` keeps the expert axis), which `init_cond` originally rejected. pypto
  `73276e27` lifted that, so no peel is left anywhere in the model. Wall time
  on that case is below the noise floor: six alternating 100-round samples
  each span 497–540 µs predicated against 475–602 µs peeled, overlapping, so
  treat it as neutral rather than as any measured change.

## Validation

a2a3, device 3, run against the pre-change tree on the same toolchain.

All 15 converted kernels pass their golden, as do `decode_csa`, `decode_swa`,
`decode_hca`, `prefill_swa`, `lm_head`, `decode_layer`, `decode_fwd`,
`prefill_fwd`, `decode_mtp` and `prefill_mtp`.

Wall time (`effective_us` mean, 100 rounds / 5 warmup, headline convention):

| case | before | after | Δ |
|---|---|---|---|
| decode_compressor_ratio128 | 128.2 | 127.6 | −0.5% |
| decode_compressor_ratio4 | 47.0 | 47.2 | +0.4% |
| decode_indexer | 92.6 | 92.8 | +0.2% |
| decode_indexer_compressor | 40.5 | 40.7 | +0.5% |
| decode_sparse_attn_csa | 169.3 | 168.9 | −0.2% |
| decode_sparse_attn_swa | 139.4 | 139.3 | −0.1% |
| expert_shared | 62.3 | 62.2 | −0.2% |
| gate | 38.4 | 38.1 | −0.8% |
| hc_head | 24.3 | 24.5 | +0.8% |
| hc_pre | 32.1 | 31.9 | −0.6% |
| prefill_compressor_ratio128 | 125.3 | 125.1 | −0.2% |
| prefill_compressor_ratio4 | 91.7 | 92.7 | +1.1% |
| prefill_indexer | 251.1 | 250.5 | −0.2% |
| prefill_indexer_compressor | 118.8 | 118.2 | −0.5% |
| qkv_proj_rope | 80.9 | 80.6 | −0.4% |

Every delta is inside run-to-run noise. **This is a readability change, not a
speedup** — do not read the negative numbers as wins.

`prefill_csa`, `prefill_hca` and `prefill_layer` fail on this branch, but they
fail identically on a stashed baseline tree, so they are pre-existing and
untouched by this change: the first two on `compiled parameter ABI mismatch
(cmp_kv: direction spec=In artifact=Out)` — the kernel declares `cmp_kv:
pl.Out[...]` while its `TensorSpec` omits `is_output=True` — and the third in
the runtime on `release_domain ... mailbox has an unresolved timed-out control
command`.

### Toolchain requirement

This branch needs pypto **`73276e27`** ("let matmul_acc's `init_cond` accept
the operands it already accumulates") or later, for `expert_routed`'s rank-3
grouped operands. Two earlier floors are subsumed by it:

- `ec17de82` — without it `expert_shared` fails to compile with `Right buffer
  usage (131072 bytes) exceeds platform limit (65536 bytes)`, because its
  `[256, 512]` INT8 weight tile is 2× L0B and the predicated form is not
  auto-tiled.
- `73276e27` itself, for the grouped loops above.

Validated on pypto `4b01d98c`. `73276e27` is recent, so a CI runner holding a
stale pypto cache would fail on `expert_routed` rather than on anything in
this diff.

