### PR TITLE
Fix: align two CP fixture specs with the compiled parameter ABI

### DIFF
--- a/models/deepseek_v4_flash_dspark/prefill_kv_allgather.py
+++ b/models/deepseek_v4_flash_dspark/prefill_kv_allgather.py
@@ -188,7 +188,8 @@ def build_tensor_specs(local_t=FIXTURE_LOCAL_T):
 
     return [
         TensorSpec("hidden_local", [TP_SIZE, local_t, D], torch.bfloat16, init_value=init_hidden_local),
-        TensorSpec("group_out", [TP_SIZE, group_t, D], torch.bfloat16, is_output=True),
+        # init_value keeps the spec on the InOut branch the kernel declares.
+        TensorSpec("group_out", [TP_SIZE, group_t, D], torch.bfloat16, init_value=0.0, is_output=True),
     ]
 
 

--- a/models/deepseek_v4_flash_mtp/prefill_cp_swa.py
+++ b/models/deepseek_v4_flash_mtp/prefill_cp_swa.py
@@ -816,9 +816,13 @@ def build_tensor_specs(cp_size: int = CP_SIZE):
     ):
         value = meta[name]
         specs.append(TensorSpec(name, list(value.shape), value.dtype, init_value=value))
-    for name in ("reverse_index", "final_win_seg_src", "final_win_row_src", "final_slot_mapping"):
-        specs.append(TensorSpec(name, list(meta[name].shape), meta[name].dtype, init_value=meta[name]))
+    # Spec order must match the kernel signature: run_jit binds its dummy compile
+    # args positionally, so owner_rank_table sits between reverse_index and the
+    # final_win_* triple exactly as prefill_cp_swa_test declares them.
+    specs.append(TensorSpec("reverse_index", list(meta["reverse_index"].shape), meta["reverse_index"].dtype, init_value=meta["reverse_index"]))
     specs.append(TensorSpec("owner_rank_table", list(owner_rank.shape), owner_rank.dtype, init_value=owner_rank))
+    for name in ("final_win_seg_src", "final_win_row_src", "final_slot_mapping"):
+        specs.append(TensorSpec(name, list(meta[name].shape), meta[name].dtype, init_value=meta[name]))
     specs.append(TensorSpec("x_out", list(x.shape), torch.float32, is_output=True))
     return specs, ctx
 


### PR DESCRIPTION
- prefill_cp_swa: order the specs as prefill_cp_swa_test declares them.
  run_jit compiles with dummy args built positionally from the spec list,
  so owner_rank_table sitting after final_slot_mapping bound its [4] shape
  to final_slot_mapping and the [128] shape of final_win_seg_src to
  owner_rank_table: the artifact named the parameters from the signature
  and sized them from the spec order. L3 dispatch reorders the real
  tensors by name, so the swap only ever showed as two wrong compiled
  shapes.
- prefill_kv_allgather: give the group_out spec an init_value so it
  derives InOut, matching the pl.InOut the kernel declares.

Both entries pass on a2a3 (2 cards each): prefill_cp_swa validates
kv_cache and x_out, prefill_kv_allgather validates group_out.
