### PR TITLE
Fix: select TaskTensor after Simpler split the 128-byte descriptor

### DIFF
--- a/models/qwen3_14b/kernels/paged_attention_cce/kernel/runtime_tensor_compat.hpp
+++ b/models/qwen3_14b/kernels/paged_attention_cce/kernel/runtime_tensor_compat.hpp
@@ -10,14 +10,43 @@
 
 #include "tensor.h"
 
-// Simpler's address-free Buffer ABI added task_interface/buffer.h and renamed
-// the device-side Tensor descriptor to ChipTensor.  Keep this external kernel
-// source compilable with both the preceding PyPTO runtime and the new ABI so
-// the pypto-lib compatibility change can land before PyPTO updates its pin.
-#if __has_include("task_interface/buffer.h")
+// The 128-byte descriptor a kernel reads out of the task payload has been
+// spelled three different ways across three Simpler ABIs.  Keep this external
+// kernel source compilable with all of them, newest first, so a pypto-lib
+// change can land before PyPTO updates its runtime pin.
+//
+//   TaskTensor  -- simpler#1974 split the fused type: `ChipTensor` kept the
+//                  name but became the 72-byte *argument* as it arrives at the
+//                  boundary, while the 128-byte descriptor became each
+//                  runtime's own type (`simpler::tmr::Tensor` /
+//                  `simpler::hbg::Tensor`), aliased `TaskTensor` by the
+//                  per-runtime `tensor.h` shim this file already includes.
+//   ChipTensor  -- simpler#1681 renamed the descriptor for the address-free
+//                  Buffer ABI, which also added task_interface/buffer.h.
+//   Tensor      -- the original spelling.
+//
+// The first probe is the header the #1974 shim itself pulls in to define
+// `TaskTensor`, so it is true exactly when that alias exists.  It is a version
+// probe, not a runtime selector: both split headers live under src/common and
+// arrive together, whichever runtime is being built for.
+//
+// Getting this wrong is silent.  Naming `ChipTensor` against a post-#1974
+// runtime still compiles -- the kernel just reads `owner_task_id`'s bytes as
+// `start_offset` and garbage as `shapes`/`strides`, which surfaces on device
+// as an fftsplus aivector error rather than as a diagnostic.  The static_assert
+// below is what turns that back into a compile-time failure.
+#if __has_include("tensormap_and_ringbuffer/tensor.h")
+using PyPTORuntimeTensor = TaskTensor;
+#elif __has_include("task_interface/buffer.h")
 using PyPTORuntimeTensor = ChipTensor;
 #else
 using PyPTORuntimeTensor = Tensor;
 #endif
+
+static_assert(
+    sizeof(PyPTORuntimeTensor) == 128,
+    "PyPTORuntimeTensor must be the 128-byte payload descriptor; a 72-byte "
+    "match means this picked up the post-#1974 boundary ChipTensor"
+);
 
 #endif  // PYPTO_QWEN_RUNTIME_TENSOR_COMPAT_HPP


### PR DESCRIPTION
- Add a newest-first arm to the qwen3_14b paged_attention_cce runtime
  tensor probe: select TaskTensor when tensormap_and_ringbuffer/tensor.h
  is present, leaving the task_interface/buffer.h ChipTensor arm and the
  bare Tensor arm intact so all three Simpler ABIs still compile
- Guard the selection with static_assert(sizeof(PyPTORuntimeTensor) ==
  128), turning a future descriptor split back into a compile error
  instead of a device fault

Simpler #1974 split the fused tensor type: ChipTensor kept the name but
became the 72-byte argument as it arrives at the boundary, while the
128-byte descriptor a kernel reads out of the task payload became each
runtime's own type (simpler::tmr::Tensor / simpler::hbg::Tensor),
aliased TaskTensor by the per-runtime tensor.h shim. Naming ChipTensor
against a post-split runtime still compiles, so the kernel silently read
owner_task_id's bytes as start_offset and garbage as shapes/strides,
surfacing on device as an fftsplus aivector error with
sched_error_code=100 at completed=15/285. The fix is needed by PyPTO's
runtime bump to 799640e6 (hw-native-sys/pypto#2530); the three-arm probe
keeps this source compilable against the current pin, so it can land
first.
