### PR TITLE
Add: integrate DeepSeek V4 D-Spark full decode forward

### DIFF
--- a/models/deepseek_v4_flash_dspark/decode_fwd.py
+++ b/models/deepseek_v4_flash_dspark/decode_fwd.py
@@ -7,6 +7,7 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
 # ci: devices=2  # CI: EP2/TP2 full decode forward
+# ci: no-sim    # CI marker: full multi-layer / multi-card forward — device-only, skip on *sim
 """DeepSeek-V4 D-Spark decode forward."""
 
 import sys

--- a/models/deepseek_v4_flash_dspark/decode_fwd.py
+++ b/models/deepseek_v4_flash_dspark/decode_fwd.py
@@ -34,12 +34,18 @@ def _parse_parallel_arg(name, default):
 # importing attention, MoE, or output-projection modules.
 TP_SIZE = _parse_parallel_arg("tp", _TP_DEFAULT)
 EP_SIZE = _parse_parallel_arg("ep", _EP_DEFAULT)
+FWD_WEIGHT_BANK_SIZE = _parse_parallel_arg("weight-bank-size", 1)
 if TP_SIZE not in _TP_CHOICES:
     raise ValueError(f"--tp must be one of {_TP_CHOICES} (got {TP_SIZE})")
 if EP_SIZE not in _EP_CHOICES:
     raise ValueError(f"--ep must be one of {_EP_CHOICES} (got {EP_SIZE})")
 if EP_SIZE % TP_SIZE != 0:
     raise ValueError(f"EP={EP_SIZE} must be divisible by TP={TP_SIZE}")
+if FWD_WEIGHT_BANK_SIZE not in (1, 43):
+    raise ValueError("--weight-bank-size must be 1 or 43")
+
+FWD_CSA_WEIGHT_BANK_SIZE = 21 if FWD_WEIGHT_BANK_SIZE == 43 else 1
+FWD_HCA_WEIGHT_BANK_SIZE = 20 if FWD_WEIGHT_BANK_SIZE == 43 else 1
 
 config.TP = TP_SIZE
 config.EP = EP_SIZE
@@ -136,6 +142,8 @@ MIXED_PREFIX_LAYER_COUNT = 4
 MIXED_PREFIX_CSA_LAYER_COUNT = 1
 MIXED_PREFIX_HCA_LAYER_COUNT = 1
 MIXED_PREFIX_TEST_VOCAB = 256
+FULL43_RUNTIME_WEIGHT_BANK = 1
+HC_FN_STORAGE_ROWS = 32
 
 
 def _validate_import_contract():
@@ -1806,6 +1814,1918 @@ def l3_decode_fwd(
     return x_out
 
 
+@pl.jit(auto_scope=False)
+def decode_fwd_full43(
+    hc_attn_fn: pl.Tensor[
+        [FWD_WEIGHT_BANK_SIZE * HC_FN_STORAGE_ROWS, HC_DIM], pl.FP32
+    ],
+    hc_attn_scale: pl.Tensor[[FWD_WEIGHT_BANK_SIZE * 3], pl.FP32],
+    hc_attn_base: pl.Tensor[[FWD_WEIGHT_BANK_SIZE * MIX_HC], pl.FP32],
+    attn_norm_w: pl.Tensor[[FWD_WEIGHT_BANK_SIZE * D], pl.BF16],
+    wq_a: pl.Tensor[[FWD_WEIGHT_BANK_SIZE * D, Q_LORA], pl.BF16],
+    wq_b: pl.Tensor[
+        [FWD_WEIGHT_BANK_SIZE * Q_LORA, H * HEAD_DIM], pl.INT8
+    ],
+    wq_b_scale: pl.Tensor[
+        [FWD_WEIGHT_BANK_SIZE * H * HEAD_DIM], pl.FP32
+    ],
+    wkv: pl.Tensor[[FWD_WEIGHT_BANK_SIZE * D, HEAD_DIM], pl.BF16],
+    gamma_cq: pl.Tensor[[FWD_WEIGHT_BANK_SIZE * Q_LORA], pl.BF16],
+    gamma_ckv: pl.Tensor[[FWD_WEIGHT_BANK_SIZE * HEAD_DIM], pl.BF16],
+    raw_kv_pool: pl.InOut[
+        pl.Tensor[
+            [FWD_PACKED_RAW_BLOCKS_DYN, BLOCK_SIZE, 1, HEAD_DIM],
+            pl.BF16,
+        ]
+    ],
+    freqs_cos: pl.Tensor[[T_DYN, ROPE_HEAD_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[T_DYN, ROPE_HEAD_DIM], pl.BF16],
+    swa_slot_mapping: pl.Tensor[[T_DYN], pl.INT64],
+    swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
+    swa_lens: pl.Tensor[[T_DYN], pl.INT32],
+    position_ids: pl.Tensor[[T_DYN], pl.INT32],
+    csa_cmp_freqs_cos: pl.Tensor[[T_DYN, ROPE_HEAD_DIM], pl.BF16],
+    csa_cmp_freqs_sin: pl.Tensor[[T_DYN, ROPE_HEAD_DIM], pl.BF16],
+    csa_cmp_wkv: pl.Tensor[
+        [FWD_CSA_WEIGHT_BANK_SIZE * CSA_MAIN_OUT_DIM, D], pl.BF16
+    ],
+    csa_cmp_wgate: pl.Tensor[
+        [FWD_CSA_WEIGHT_BANK_SIZE * CSA_MAIN_OUT_DIM, D], pl.BF16
+    ],
+    csa_cmp_ape: pl.Tensor[
+        [FWD_CSA_WEIGHT_BANK_SIZE * CSA_COMPRESS_RATIO, CSA_MAIN_OUT_DIM],
+        pl.FP32,
+    ],
+    csa_cmp_norm_w: pl.Tensor[
+        [FWD_CSA_WEIGHT_BANK_SIZE * HEAD_DIM], pl.BF16
+    ],
+    csa_compress_state: pl.InOut[
+        pl.Tensor[
+            [
+                FWD_CSA_MAIN_STATE_BLOCKS_DYN,
+                CSA_MAIN_STATE_BLOCK_SIZE,
+                CSA_MAIN_STATE_DIM,
+            ],
+            pl.FP32,
+        ]
+    ],
+    csa_compress_state_block_table: pl.Tensor[
+        [CSA_B_DYN, CSA_MAIN_STATE_MAX_BLOCKS], pl.INT32
+    ],
+    csa_idx_wq_b: pl.Tensor[
+        [
+            FWD_CSA_WEIGHT_BANK_SIZE * Q_LORA,
+            CSA_IDX_N_HEADS * CSA_IDX_HEAD_DIM,
+        ],
+        pl.INT8,
+    ],
+    csa_idx_wq_b_scale: pl.Tensor[
+        [FWD_CSA_WEIGHT_BANK_SIZE * CSA_IDX_N_HEADS * CSA_IDX_HEAD_DIM],
+        pl.FP32,
+    ],
+    csa_weights_proj: pl.Tensor[
+        [FWD_CSA_WEIGHT_BANK_SIZE * D, CSA_IDX_N_HEADS], pl.BF16
+    ],
+    csa_hadamard_idx: pl.Tensor[
+        [FWD_CSA_WEIGHT_BANK_SIZE * CSA_IDX_HEAD_DIM, CSA_IDX_HEAD_DIM],
+        pl.BF16,
+    ],
+    csa_inner_wkv: pl.Tensor[
+        [FWD_CSA_WEIGHT_BANK_SIZE * CSA_INNER_OUT_DIM, D], pl.BF16
+    ],
+    csa_inner_wgate: pl.Tensor[
+        [FWD_CSA_WEIGHT_BANK_SIZE * CSA_INNER_OUT_DIM, D], pl.BF16
+    ],
+    csa_inner_ape: pl.Tensor[
+        [FWD_CSA_WEIGHT_BANK_SIZE * CSA_COMPRESS_RATIO, CSA_INNER_OUT_DIM],
+        pl.FP32,
+    ],
+    csa_inner_norm_w: pl.Tensor[
+        [FWD_CSA_WEIGHT_BANK_SIZE * CSA_IDX_HEAD_DIM], pl.BF16
+    ],
+    csa_inner_compress_state: pl.InOut[
+        pl.Tensor[
+            [
+                FWD_CSA_INNER_STATE_BLOCKS_DYN,
+                CSA_INNER_STATE_BLOCK_SIZE,
+                CSA_INNER_STATE_DIM,
+            ],
+            pl.FP32,
+        ]
+    ],
+    csa_inner_compress_state_block_table: pl.Tensor[
+        [CSA_B_DYN, CSA_INNER_STATE_MAX_BLOCKS], pl.INT32
+    ],
+    csa_cmp_kv: pl.InOut[
+        pl.Tensor[
+            [FWD_CSA_CMP_BLOCKS_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16
+        ]
+    ],
+    csa_cmp_block_table: pl.Tensor[
+        [CSA_B_DYN, CSA_CMP_MAX_BLOCKS], pl.INT32
+    ],
+    csa_idx_kv_cache: pl.InOut[
+        pl.Tensor[
+            [FWD_CSA_IDX_BLOCKS_DYN, BLOCK_SIZE, 1, CSA_IDX_HEAD_DIM],
+            pl.INT8,
+        ]
+    ],
+    csa_idx_kv_scale: pl.InOut[
+        pl.Tensor[
+            [FWD_CSA_IDX_BLOCKS_DYN, BLOCK_SIZE, 1, 1], pl.FP32
+        ]
+    ],
+    csa_idx_block_table: pl.Tensor[
+        [CSA_B_DYN, CSA_IDX_MAX_BLOCKS], pl.INT32
+    ],
+    csa_ori_slot_mapping: pl.Tensor[[T_DYN], pl.INT64],
+    csa_window_swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
+    csa_window_swa_lens: pl.Tensor[[T_DYN], pl.INT32],
+    csa_cmp_slot_mapping: pl.Tensor[[T_DYN], pl.INT64],
+    csa_idx_slot_mapping: pl.Tensor[[T_DYN], pl.INT64],
+    csa_state_slot_mapping: pl.Tensor[[T_DYN], pl.INT64],
+    csa_inner_state_slot_mapping: pl.Tensor[[T_DYN], pl.INT64],
+    csa_kv_seq_lens: pl.Tensor[[CSA_B_DYN], pl.INT32],
+    hca_cmp_freqs_cos: pl.Tensor[[HCA_B, ROPE_HEAD_DIM // 2], pl.FP32],
+    hca_cmp_freqs_sin: pl.Tensor[[HCA_B, ROPE_HEAD_DIM // 2], pl.FP32],
+    hca_cmp_wkv: pl.Tensor[
+        [FWD_HCA_WEIGHT_BANK_SIZE * HCA_MAIN_OUT_DIM, D], pl.BF16
+    ],
+    hca_cmp_wgate: pl.Tensor[
+        [FWD_HCA_WEIGHT_BANK_SIZE * HCA_MAIN_OUT_DIM, D], pl.BF16
+    ],
+    hca_cmp_ape: pl.Tensor[
+        [FWD_HCA_WEIGHT_BANK_SIZE * HCA_COMPRESS_RATIO, HCA_MAIN_OUT_DIM],
+        pl.FP32,
+    ],
+    hca_cmp_norm_w: pl.Tensor[
+        [FWD_HCA_WEIGHT_BANK_SIZE * HEAD_DIM], pl.BF16
+    ],
+    hca_compress_state: pl.InOut[
+        pl.Tensor[
+            [
+                FWD_HCA_STATE_BLOCKS_DYN,
+                HCA_COMPRESS_STATE_BLOCK_SIZE,
+                HCA_COMPRESS_STATE_DIM,
+            ],
+            pl.FP32,
+        ]
+    ],
+    hca_compress_state_block_table: pl.Tensor[
+        [HCA_B_DYN, HCA_COMPRESS_STATE_MAX_BLOCKS], pl.INT32
+    ],
+    hca_cmp_kv: pl.InOut[
+        pl.Tensor[
+            [FWD_HCA_CMP_BLOCKS_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16
+        ]
+    ],
+    hca_cmp_block_table: pl.Tensor[
+        [HCA_B_DYN, HCA_CMP_TABLE_BLOCKS_DYN], pl.INT32
+    ],
+    hca_ori_slot_mapping: pl.Tensor[[T_DYN], pl.INT64],
+    hca_window_swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
+    hca_window_swa_lens: pl.Tensor[[T_DYN], pl.INT32],
+    hca_cmp_slot_mapping: pl.Tensor[[T_DYN], pl.INT64],
+    hca_state_slot_mapping: pl.Tensor[[T_DYN], pl.INT64],
+    hca_kv_seq_lens: pl.Tensor[[HCA_B_DYN], pl.INT32],
+    attn_sink: pl.Tensor[[FWD_WEIGHT_BANK_SIZE * H], pl.FP32],
+    wo_a: pl.Tensor[
+        [FWD_WEIGHT_BANK_SIZE * LOCAL_O_GROUPS, O_LORA, O_GROUP_IN],
+        pl.BF16,
+    ],
+    wo_b: pl.Tensor[
+        [FWD_WEIGHT_BANK_SIZE * D, LOCAL_O_WIDTH], pl.INT8
+    ],
+    wo_b_scale: pl.Tensor[[FWD_WEIGHT_BANK_SIZE * D], pl.FP32],
+    hc_ffn_fn: pl.Tensor[
+        [FWD_WEIGHT_BANK_SIZE * HC_FN_STORAGE_ROWS, HC_DIM], pl.FP32
+    ],
+    hc_ffn_scale: pl.Tensor[[FWD_WEIGHT_BANK_SIZE * 3], pl.FP32],
+    hc_ffn_base: pl.Tensor[[FWD_WEIGHT_BANK_SIZE * MIX_HC], pl.FP32],
+    norm_w: pl.Tensor[[FWD_WEIGHT_BANK_SIZE * D], pl.BF16],
+    gate_w: pl.Tensor[
+        [FWD_WEIGHT_BANK_SIZE * N_EXPERTS_GLOBAL, D], pl.FP32
+    ],
+    gate_bias: pl.Tensor[
+        [FWD_WEIGHT_BANK_SIZE * N_EXPERTS_GLOBAL], pl.FP32
+    ],
+    tid2eid: pl.Tensor[[FWD_WEIGHT_BANK_SIZE * VOCAB, TOPK], pl.INT32],
+    input_ids: pl.Tensor[[MOE_TOKENS], pl.INT64],
+    routed_w1: pl.Tensor[
+        [FWD_WEIGHT_BANK_SIZE * N_LOCAL, MOE_INTER, D], pl.INT8
+    ],
+    routed_w1_scale: pl.Tensor[
+        [FWD_WEIGHT_BANK_SIZE * N_LOCAL, MOE_INTER], pl.FP32
+    ],
+    routed_w3: pl.Tensor[
+        [FWD_WEIGHT_BANK_SIZE * N_LOCAL, MOE_INTER, D], pl.INT8
+    ],
+    routed_w3_scale: pl.Tensor[
+        [FWD_WEIGHT_BANK_SIZE * N_LOCAL, MOE_INTER], pl.FP32
+    ],
+    routed_w2: pl.Tensor[
+        [FWD_WEIGHT_BANK_SIZE * N_LOCAL, D, MOE_INTER], pl.INT8
+    ],
+    routed_w2_scale: pl.Tensor[
+        [FWD_WEIGHT_BANK_SIZE * N_LOCAL, D], pl.FP32
+    ],
+    shared_w1: pl.Tensor[
+        [FWD_WEIGHT_BANK_SIZE * MOE_INTER, D], pl.INT8
+    ],
+    shared_w1_scale: pl.Tensor[
+        [FWD_WEIGHT_BANK_SIZE * MOE_INTER], pl.FP32
+    ],
+    shared_w3: pl.Tensor[
+        [FWD_WEIGHT_BANK_SIZE * MOE_INTER, D], pl.INT8
+    ],
+    shared_w3_scale: pl.Tensor[
+        [FWD_WEIGHT_BANK_SIZE * MOE_INTER], pl.FP32
+    ],
+    shared_w2: pl.Tensor[
+        [FWD_WEIGHT_BANK_SIZE * D, MOE_INTER], pl.INT8
+    ],
+    shared_w2_scale: pl.Tensor[[FWD_WEIGHT_BANK_SIZE * D], pl.FP32],
+    x_ping: pl.InOut[pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32]],
+    x_pong: pl.InOut[pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32]],
+    x_attn_active: pl.InOut[
+        pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32]
+    ],
+    x_moe_next: pl.InOut[
+        pl.Tensor[[MOE_TOKENS, HC_MULT, D], pl.FP32]
+    ],
+    x_out: pl.Out[pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32]],
+    attention_window: pld.DistributedTensor[
+        [ATTENTION_WINDOW_ROWS, O_GROUP_IN], pl.BF16
+    ],
+    attention_signal: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
+    o_window: pld.DistributedTensor[[O_WINDOW_ROWS, D], pl.FP32],
+    o_signal: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
+    recv_meta: pld.DistributedTensor[[N_RANKS, N_LOCAL], pl.INT32],
+    recv_x: pld.DistributedTensor[[N_LOCAL * RECV_MAX, D], pl.INT8],
+    recv_aux: pld.DistributedTensor[
+        [N_LOCAL * RECV_MAX, AUX_PAD], pl.FP32
+    ],
+    recv_route: pld.DistributedTensor[
+        [N_LOCAL * RECV_MAX, IDX_PAD], pl.INT32
+    ],
+    arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
+    data_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
+    routed_y_buf: pld.DistributedTensor[[N_ROUTES, D], pl.BF16],
+    combine_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
+    group_base: pl.Scalar[pl.INT32],
+    tp_rank: pl.Scalar[pl.INT32],
+    my_rank: pl.Scalar[pl.INT32],
+):
+    """Run the fixed 2-SWA, 21-CSA, 20-HCA model in one rank child."""
+    x_ping.bind_dynamic(0, T_DYN)
+    raw_kv_pool.bind_dynamic(0, FWD_PACKED_RAW_BLOCKS_DYN)
+    freqs_cos.bind_dynamic(0, T_DYN)
+    freqs_sin.bind_dynamic(0, T_DYN)
+    swa_slot_mapping.bind_dynamic(0, T_DYN)
+    swa_indices.bind_dynamic(0, T_DYN)
+    swa_lens.bind_dynamic(0, T_DYN)
+    position_ids.bind_dynamic(0, T_DYN)
+    csa_cmp_freqs_cos.bind_dynamic(0, T_DYN)
+    csa_cmp_freqs_sin.bind_dynamic(0, T_DYN)
+    csa_compress_state.bind_dynamic(0, FWD_CSA_MAIN_STATE_BLOCKS_DYN)
+    csa_compress_state_block_table.bind_dynamic(0, CSA_B_DYN)
+    csa_inner_compress_state.bind_dynamic(
+        0, FWD_CSA_INNER_STATE_BLOCKS_DYN
+    )
+    csa_inner_compress_state_block_table.bind_dynamic(0, CSA_B_DYN)
+    csa_cmp_kv.bind_dynamic(0, FWD_CSA_CMP_BLOCKS_DYN)
+    csa_cmp_block_table.bind_dynamic(0, CSA_B_DYN)
+    csa_idx_kv_cache.bind_dynamic(0, FWD_CSA_IDX_BLOCKS_DYN)
+    csa_idx_kv_scale.bind_dynamic(0, FWD_CSA_IDX_BLOCKS_DYN)
+    csa_idx_block_table.bind_dynamic(0, CSA_B_DYN)
+    csa_ori_slot_mapping.bind_dynamic(0, T_DYN)
+    csa_window_swa_indices.bind_dynamic(0, T_DYN)
+    csa_window_swa_lens.bind_dynamic(0, T_DYN)
+    csa_cmp_slot_mapping.bind_dynamic(0, T_DYN)
+    csa_idx_slot_mapping.bind_dynamic(0, T_DYN)
+    csa_state_slot_mapping.bind_dynamic(0, T_DYN)
+    csa_inner_state_slot_mapping.bind_dynamic(0, T_DYN)
+    csa_kv_seq_lens.bind_dynamic(0, CSA_B_DYN)
+    hca_compress_state.bind_dynamic(0, FWD_HCA_STATE_BLOCKS_DYN)
+    hca_compress_state_block_table.bind_dynamic(0, HCA_B_DYN)
+    hca_cmp_kv.bind_dynamic(0, FWD_HCA_CMP_BLOCKS_DYN)
+    hca_cmp_block_table.bind_dynamic(0, HCA_B_DYN)
+    hca_cmp_block_table.bind_dynamic(1, HCA_CMP_TABLE_BLOCKS_DYN)
+    hca_ori_slot_mapping.bind_dynamic(0, T_DYN)
+    hca_window_swa_indices.bind_dynamic(0, T_DYN)
+    hca_window_swa_lens.bind_dynamic(0, T_DYN)
+    hca_cmp_slot_mapping.bind_dynamic(0, T_DYN)
+    hca_state_slot_mapping.bind_dynamic(0, T_DYN)
+    hca_kv_seq_lens.bind_dynamic(0, HCA_B_DYN)
+    x_pong.bind_dynamic(0, T_DYN)
+    x_attn_active.bind_dynamic(0, T_DYN)
+    x_out.bind_dynamic(0, T_DYN)
+
+    local_t = pl.cast(pl.tensor.dim(x_ping, 0), pl.INT32)
+    raw_blocks_per_layer = (
+        pl.tensor.dim(raw_kv_pool, 0) // MAIN_LAYER_COUNT
+    )
+    csa_state_blocks_per_layer = (
+        pl.tensor.dim(csa_compress_state, 0) // CSA_LAYER_COUNT
+    )
+    csa_cmp_blocks_per_layer = (
+        pl.tensor.dim(csa_cmp_kv, 0) // CSA_LAYER_COUNT
+    )
+    csa_inner_state_blocks_per_layer = (
+        pl.tensor.dim(csa_inner_compress_state, 0) // CSA_LAYER_COUNT
+    )
+    csa_idx_blocks_per_layer = (
+        pl.tensor.dim(csa_idx_kv_cache, 0) // CSA_LAYER_COUNT
+    )
+    hca_state_blocks_per_layer = (
+        pl.tensor.dim(hca_compress_state, 0) // HCA_LAYER_COUNT
+    )
+    hca_cmp_blocks_per_layer = (
+        pl.tensor.dim(hca_cmp_kv, 0) // HCA_LAYER_COUNT
+    )
+
+    with pl.scope():
+        weight_layer_swa0 = pl.const(0, pl.INT32)
+        hc_attn_fn_layer_swa0 = pl.slice(
+            hc_attn_fn, [MIX_HC, HC_DIM], [0, 0]
+        )
+        hc_ffn_fn_layer_swa0 = pl.slice(
+            hc_ffn_fn, [MIX_HC, HC_DIM], [0, 0]
+        )
+        wq_a_layer_swa0: pl.Tensor[[D, Q_LORA], pl.BF16] = pl.slice(
+            wq_a, [D, Q_LORA], [0, 0]
+        )
+        wq_b_layer_swa0: pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8] = pl.slice(
+            wq_b, [Q_LORA, H * HEAD_DIM], [0, 0]
+        )
+        wq_b_scale_layer_swa0: pl.Tensor[[H * HEAD_DIM], pl.FP32] = pl.slice(
+            wq_b_scale, [H * HEAD_DIM], [0]
+        )
+        wkv_layer_swa0: pl.Tensor[[D, HEAD_DIM], pl.BF16] = pl.slice(
+            wkv, [D, HEAD_DIM], [0, 0]
+        )
+        gamma_cq_layer_swa0: pl.Tensor[[Q_LORA], pl.BF16] = pl.slice(
+            gamma_cq, [Q_LORA], [0]
+        )
+        gamma_ckv_layer_swa0: pl.Tensor[[HEAD_DIM], pl.BF16] = pl.slice(
+            gamma_ckv, [HEAD_DIM], [0]
+        )
+        wo_a_layer_swa0: pl.Tensor[
+            [LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16
+        ] = pl.slice(
+            wo_a,
+            [LOCAL_O_GROUPS, O_LORA, O_GROUP_IN],
+            [weight_layer_swa0 * LOCAL_O_GROUPS, 0, 0],
+        )
+        routed_w1_layer_swa0: pl.Tensor[
+            [N_LOCAL, MOE_INTER, D], pl.INT8
+        ] = pl.slice(
+            routed_w1,
+            [N_LOCAL, MOE_INTER, D],
+            [weight_layer_swa0 * N_LOCAL, 0, 0],
+        )
+        hc_attn_scale_layer_swa0 = pl.slice(hc_attn_scale, [3], [0])
+        hc_attn_base_layer_swa0 = pl.slice(hc_attn_base, [MIX_HC], [0])
+        attn_norm_w_layer_swa0 = pl.slice(attn_norm_w, [D], [0])
+        attn_sink_layer_swa0 = pl.slice(attn_sink, [H], [0])
+        wo_b_layer_swa0 = pl.slice(wo_b, [D, LOCAL_O_WIDTH], [0, 0])
+        wo_b_scale_layer_swa0 = pl.slice(wo_b_scale, [D], [0])
+        hc_ffn_scale_layer_swa0 = pl.slice(hc_ffn_scale, [3], [0])
+        hc_ffn_base_layer_swa0 = pl.slice(hc_ffn_base, [MIX_HC], [0])
+        norm_w_layer_swa0 = pl.slice(norm_w, [D], [0])
+        gate_w_layer_swa0 = pl.slice(
+            gate_w, [N_EXPERTS_GLOBAL, D], [0, 0]
+        )
+        gate_bias_layer_swa0 = pl.slice(gate_bias, [N_EXPERTS_GLOBAL], [0])
+        tid2eid_layer_swa0 = pl.slice(tid2eid, [VOCAB, TOPK], [0, 0])
+        routed_w1_scale_layer_swa0 = pl.slice(
+            routed_w1_scale, [N_LOCAL, MOE_INTER], [0, 0]
+        )
+        routed_w3_scale_layer_swa0 = pl.slice(
+            routed_w3_scale, [N_LOCAL, MOE_INTER], [0, 0]
+        )
+        routed_w2_scale_layer_swa0 = pl.slice(
+            routed_w2_scale, [N_LOCAL, D], [0, 0]
+        )
+        shared_w1_layer_swa0 = pl.slice(shared_w1, [MOE_INTER, D], [0, 0])
+        shared_w1_scale_layer_swa0 = pl.slice(
+            shared_w1_scale, [MOE_INTER], [0]
+        )
+        shared_w3_layer_swa0 = pl.slice(shared_w3, [MOE_INTER, D], [0, 0])
+        shared_w3_scale_layer_swa0 = pl.slice(
+            shared_w3_scale, [MOE_INTER], [0]
+        )
+        shared_w2_layer_swa0 = pl.slice(shared_w2, [D, MOE_INTER], [0, 0])
+        shared_w2_scale_layer_swa0 = pl.slice(shared_w2_scale, [D], [0])
+        routed_w3_layer_swa0: pl.Tensor[
+            [N_LOCAL, MOE_INTER, D], pl.INT8
+        ] = pl.slice(
+            routed_w3,
+            [N_LOCAL, MOE_INTER, D],
+            [weight_layer_swa0 * N_LOCAL, 0, 0],
+        )
+        routed_w2_layer_swa0: pl.Tensor[
+            [N_LOCAL, D, MOE_INTER], pl.INT8
+        ] = pl.slice(
+            routed_w2,
+            [N_LOCAL, D, MOE_INTER],
+            [weight_layer_swa0 * N_LOCAL, 0, 0],
+        )
+        raw_kv_layer_swa0 = pl.slice(
+            raw_kv_pool,
+            [raw_blocks_per_layer, BLOCK_SIZE, 1, HEAD_DIM],
+            [0, 0, 0, 0],
+        )
+        decode_layer_swa(
+            x_ping,
+            hc_attn_fn_layer_swa0, hc_attn_scale_layer_swa0,
+            hc_attn_base_layer_swa0, attn_norm_w_layer_swa0,
+            wq_a_layer_swa0, wq_b_layer_swa0, wq_b_scale_layer_swa0, wkv_layer_swa0,
+            gamma_cq_layer_swa0, gamma_ckv_layer_swa0,
+            freqs_cos, freqs_sin, raw_kv_layer_swa0,
+            swa_slot_mapping, swa_indices, swa_lens, position_ids,
+            attn_sink_layer_swa0, wo_a_layer_swa0, wo_b_layer_swa0, wo_b_scale_layer_swa0,
+            hc_ffn_fn_layer_swa0, hc_ffn_scale_layer_swa0,
+            hc_ffn_base_layer_swa0, norm_w_layer_swa0,
+            gate_w_layer_swa0, gate_bias_layer_swa0, tid2eid_layer_swa0, input_ids,
+            routed_w1_layer_swa0, routed_w1_scale_layer_swa0,
+            routed_w3_layer_swa0, routed_w3_scale_layer_swa0,
+            routed_w2_layer_swa0, routed_w2_scale_layer_swa0,
+            shared_w1_layer_swa0, shared_w1_scale_layer_swa0,
+            shared_w3_layer_swa0, shared_w3_scale_layer_swa0,
+            shared_w2_layer_swa0, shared_w2_scale_layer_swa0,
+            x_attn_active, x_moe_next, x_pong,
+            attention_window, attention_signal, o_window, o_signal,
+            recv_meta, recv_x, recv_aux, recv_route,
+            arrived, data_arrived, routed_y_buf, combine_arrived,
+            pl.const(0, pl.INT32), group_base, tp_rank, local_t, my_rank,
+            pl.const(1, pl.INT32),
+        )
+
+    with pl.scope():
+        weight_layer_swa1 = pl.const(1, pl.INT32) % FWD_WEIGHT_BANK_SIZE
+        hc_attn_fn_layer_swa1 = pl.slice(
+            hc_attn_fn,
+            [MIX_HC, HC_DIM],
+            [weight_layer_swa1 * HC_FN_STORAGE_ROWS, 0],
+        )
+        hc_ffn_fn_layer_swa1 = pl.slice(
+            hc_ffn_fn,
+            [MIX_HC, HC_DIM],
+            [weight_layer_swa1 * HC_FN_STORAGE_ROWS, 0],
+        )
+        wq_a_layer_swa1: pl.Tensor[[D, Q_LORA], pl.BF16] = pl.slice(
+            wq_a, [D, Q_LORA], [weight_layer_swa1 * D, 0]
+        )
+        wq_b_layer_swa1: pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8] = pl.slice(
+            wq_b, [Q_LORA, H * HEAD_DIM], [weight_layer_swa1 * Q_LORA, 0]
+        )
+        wq_b_scale_layer_swa1: pl.Tensor[[H * HEAD_DIM], pl.FP32] = pl.slice(
+            wq_b_scale,
+            [H * HEAD_DIM],
+            [weight_layer_swa1 * H * HEAD_DIM],
+        )
+        wkv_layer_swa1: pl.Tensor[[D, HEAD_DIM], pl.BF16] = pl.slice(
+            wkv, [D, HEAD_DIM], [weight_layer_swa1 * D, 0]
+        )
+        gamma_cq_layer_swa1: pl.Tensor[[Q_LORA], pl.BF16] = pl.slice(
+            gamma_cq, [Q_LORA], [weight_layer_swa1 * Q_LORA]
+        )
+        gamma_ckv_layer_swa1: pl.Tensor[[HEAD_DIM], pl.BF16] = pl.slice(
+            gamma_ckv, [HEAD_DIM], [weight_layer_swa1 * HEAD_DIM]
+        )
+        wo_a_layer_swa1: pl.Tensor[
+            [LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16
+        ] = pl.slice(
+            wo_a,
+            [LOCAL_O_GROUPS, O_LORA, O_GROUP_IN],
+            [weight_layer_swa1 * LOCAL_O_GROUPS, 0, 0],
+        )
+        routed_w1_layer_swa1: pl.Tensor[
+            [N_LOCAL, MOE_INTER, D], pl.INT8
+        ] = pl.slice(
+            routed_w1,
+            [N_LOCAL, MOE_INTER, D],
+            [weight_layer_swa1 * N_LOCAL, 0, 0],
+        )
+        hc_attn_scale_layer_swa1 = pl.slice(
+            hc_attn_scale, [3], [weight_layer_swa1 * 3]
+        )
+        hc_attn_base_layer_swa1 = pl.slice(
+            hc_attn_base, [MIX_HC], [weight_layer_swa1 * MIX_HC]
+        )
+        attn_norm_w_layer_swa1 = pl.slice(
+            attn_norm_w, [D], [weight_layer_swa1 * D]
+        )
+        attn_sink_layer_swa1 = pl.slice(attn_sink, [H], [weight_layer_swa1 * H])
+        wo_b_layer_swa1 = pl.slice(
+            wo_b, [D, LOCAL_O_WIDTH], [weight_layer_swa1 * D, 0]
+        )
+        wo_b_scale_layer_swa1 = pl.slice(
+            wo_b_scale, [D], [weight_layer_swa1 * D]
+        )
+        hc_ffn_scale_layer_swa1 = pl.slice(
+            hc_ffn_scale, [3], [weight_layer_swa1 * 3]
+        )
+        hc_ffn_base_layer_swa1 = pl.slice(
+            hc_ffn_base, [MIX_HC], [weight_layer_swa1 * MIX_HC]
+        )
+        norm_w_layer_swa1 = pl.slice(norm_w, [D], [weight_layer_swa1 * D])
+        gate_w_layer_swa1 = pl.slice(
+            gate_w,
+            [N_EXPERTS_GLOBAL, D],
+            [weight_layer_swa1 * N_EXPERTS_GLOBAL, 0],
+        )
+        gate_bias_layer_swa1 = pl.slice(
+            gate_bias,
+            [N_EXPERTS_GLOBAL],
+            [weight_layer_swa1 * N_EXPERTS_GLOBAL],
+        )
+        tid2eid_layer_swa1 = pl.slice(
+            tid2eid, [VOCAB, TOPK], [weight_layer_swa1 * VOCAB, 0]
+        )
+        routed_w1_scale_layer_swa1 = pl.slice(
+            routed_w1_scale,
+            [N_LOCAL, MOE_INTER],
+            [weight_layer_swa1 * N_LOCAL, 0],
+        )
+        routed_w3_scale_layer_swa1 = pl.slice(
+            routed_w3_scale,
+            [N_LOCAL, MOE_INTER],
+            [weight_layer_swa1 * N_LOCAL, 0],
+        )
+        routed_w2_scale_layer_swa1 = pl.slice(
+            routed_w2_scale,
+            [N_LOCAL, D],
+            [weight_layer_swa1 * N_LOCAL, 0],
+        )
+        shared_w1_layer_swa1 = pl.slice(
+            shared_w1, [MOE_INTER, D], [weight_layer_swa1 * MOE_INTER, 0]
+        )
+        shared_w1_scale_layer_swa1 = pl.slice(
+            shared_w1_scale, [MOE_INTER], [weight_layer_swa1 * MOE_INTER]
+        )
+        shared_w3_layer_swa1 = pl.slice(
+            shared_w3, [MOE_INTER, D], [weight_layer_swa1 * MOE_INTER, 0]
+        )
+        shared_w3_scale_layer_swa1 = pl.slice(
+            shared_w3_scale, [MOE_INTER], [weight_layer_swa1 * MOE_INTER]
+        )
+        shared_w2_layer_swa1 = pl.slice(
+            shared_w2, [D, MOE_INTER], [weight_layer_swa1 * D, 0]
+        )
+        shared_w2_scale_layer_swa1 = pl.slice(
+            shared_w2_scale, [D], [weight_layer_swa1 * D]
+        )
+        routed_w3_layer_swa1: pl.Tensor[
+            [N_LOCAL, MOE_INTER, D], pl.INT8
+        ] = pl.slice(
+            routed_w3,
+            [N_LOCAL, MOE_INTER, D],
+            [weight_layer_swa1 * N_LOCAL, 0, 0],
+        )
+        routed_w2_layer_swa1: pl.Tensor[
+            [N_LOCAL, D, MOE_INTER], pl.INT8
+        ] = pl.slice(
+            routed_w2,
+            [N_LOCAL, D, MOE_INTER],
+            [weight_layer_swa1 * N_LOCAL, 0, 0],
+        )
+        raw_kv_layer_swa1 = pl.slice(
+            raw_kv_pool,
+            [raw_blocks_per_layer, BLOCK_SIZE, 1, HEAD_DIM],
+            [raw_blocks_per_layer, 0, 0, 0],
+        )
+        decode_layer_swa(
+            x_pong,
+            hc_attn_fn_layer_swa1, hc_attn_scale_layer_swa1,
+            hc_attn_base_layer_swa1, attn_norm_w_layer_swa1,
+            wq_a_layer_swa1, wq_b_layer_swa1, wq_b_scale_layer_swa1, wkv_layer_swa1,
+            gamma_cq_layer_swa1, gamma_ckv_layer_swa1,
+            freqs_cos, freqs_sin, raw_kv_layer_swa1,
+            swa_slot_mapping, swa_indices, swa_lens, position_ids,
+            attn_sink_layer_swa1, wo_a_layer_swa1, wo_b_layer_swa1, wo_b_scale_layer_swa1,
+            hc_ffn_fn_layer_swa1, hc_ffn_scale_layer_swa1,
+            hc_ffn_base_layer_swa1, norm_w_layer_swa1,
+            gate_w_layer_swa1, gate_bias_layer_swa1, tid2eid_layer_swa1, input_ids,
+            routed_w1_layer_swa1, routed_w1_scale_layer_swa1,
+            routed_w3_layer_swa1, routed_w3_scale_layer_swa1,
+            routed_w2_layer_swa1, routed_w2_scale_layer_swa1,
+            shared_w1_layer_swa1, shared_w1_scale_layer_swa1,
+            shared_w3_layer_swa1, shared_w3_scale_layer_swa1,
+            shared_w2_layer_swa1, shared_w2_scale_layer_swa1,
+            x_attn_active, x_moe_next, x_ping,
+            attention_window, attention_signal, o_window, o_signal,
+            recv_meta, recv_x, recv_aux, recv_route,
+            arrived, data_arrived, routed_y_buf, combine_arrived,
+            pl.const(1, pl.INT32), group_base, tp_rank, local_t, my_rank,
+            pl.const(2, pl.INT32),
+        )
+
+    for ordinal in pl.range(HCA_LAYER_COUNT):
+        csa_model_layer = pl.cast(ordinal * 2 + 2, pl.INT32)
+        hca_model_layer = pl.cast(ordinal * 2 + 3, pl.INT32)
+        csa_weight_layer = csa_model_layer % FWD_WEIGHT_BANK_SIZE
+        hca_weight_layer = hca_model_layer % FWD_WEIGHT_BANK_SIZE
+        csa_extra_layer = ordinal % FWD_CSA_WEIGHT_BANK_SIZE
+        hca_extra_layer = ordinal % FWD_HCA_WEIGHT_BANK_SIZE
+
+        with pl.scope():
+            hc_attn_fn_layer_csa = pl.slice(
+                hc_attn_fn,
+                [MIX_HC, HC_DIM],
+                [csa_weight_layer * HC_FN_STORAGE_ROWS, 0],
+            )
+            hc_ffn_fn_layer_csa = pl.slice(
+                hc_ffn_fn,
+                [MIX_HC, HC_DIM],
+                [csa_weight_layer * HC_FN_STORAGE_ROWS, 0],
+            )
+            wq_a_layer_csa: pl.Tensor[[D, Q_LORA], pl.BF16] = pl.slice(
+                wq_a, [D, Q_LORA], [csa_weight_layer * D, 0]
+            )
+            wq_b_layer_csa: pl.Tensor[
+                [Q_LORA, H * HEAD_DIM], pl.INT8
+            ] = pl.slice(
+                wq_b,
+                [Q_LORA, H * HEAD_DIM],
+                [csa_weight_layer * Q_LORA, 0],
+            )
+            wq_b_scale_layer_csa: pl.Tensor[
+                [H * HEAD_DIM], pl.FP32
+            ] = pl.slice(
+                wq_b_scale,
+                [H * HEAD_DIM],
+                [csa_weight_layer * H * HEAD_DIM],
+            )
+            wkv_layer_csa: pl.Tensor[[D, HEAD_DIM], pl.BF16] = pl.slice(
+                wkv, [D, HEAD_DIM], [csa_weight_layer * D, 0]
+            )
+            gamma_cq_layer_csa: pl.Tensor[[Q_LORA], pl.BF16] = pl.slice(
+                gamma_cq, [Q_LORA], [csa_weight_layer * Q_LORA]
+            )
+            gamma_ckv_layer_csa: pl.Tensor[[HEAD_DIM], pl.BF16] = pl.slice(
+                gamma_ckv, [HEAD_DIM], [csa_weight_layer * HEAD_DIM]
+            )
+            wo_a_layer_csa: pl.Tensor[
+                [LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16
+            ] = pl.slice(
+                wo_a,
+                [LOCAL_O_GROUPS, O_LORA, O_GROUP_IN],
+                [csa_weight_layer * LOCAL_O_GROUPS, 0, 0],
+            )
+            routed_w1_layer_csa: pl.Tensor[
+                [N_LOCAL, MOE_INTER, D], pl.INT8
+            ] = pl.slice(
+                routed_w1,
+                [N_LOCAL, MOE_INTER, D],
+                [csa_weight_layer * N_LOCAL, 0, 0],
+            )
+            routed_w3_layer_csa: pl.Tensor[
+                [N_LOCAL, MOE_INTER, D], pl.INT8
+            ] = pl.slice(
+                routed_w3,
+                [N_LOCAL, MOE_INTER, D],
+                [csa_weight_layer * N_LOCAL, 0, 0],
+            )
+            routed_w2_layer_csa: pl.Tensor[
+                [N_LOCAL, D, MOE_INTER], pl.INT8
+            ] = pl.slice(
+                routed_w2,
+                [N_LOCAL, D, MOE_INTER],
+                [csa_weight_layer * N_LOCAL, 0, 0],
+            )
+            raw_kv_layer_csa = pl.slice(
+                raw_kv_pool,
+                [raw_blocks_per_layer, BLOCK_SIZE, 1, HEAD_DIM],
+                [csa_model_layer * raw_blocks_per_layer, 0, 0, 0],
+            )
+            csa_state_layer_csa = pl.slice(
+                csa_compress_state,
+                [
+                    csa_state_blocks_per_layer,
+                    CSA_MAIN_STATE_BLOCK_SIZE,
+                    CSA_MAIN_STATE_DIM,
+                ],
+                [ordinal * csa_state_blocks_per_layer, 0, 0],
+            )
+            csa_cmp_kv_layer_csa = pl.slice(
+                csa_cmp_kv,
+                [csa_cmp_blocks_per_layer, BLOCK_SIZE, 1, HEAD_DIM],
+                [ordinal * csa_cmp_blocks_per_layer, 0, 0, 0],
+            )
+            csa_inner_state_layer_csa = pl.slice(
+                csa_inner_compress_state,
+                [
+                    csa_inner_state_blocks_per_layer,
+                    CSA_INNER_STATE_BLOCK_SIZE,
+                    CSA_INNER_STATE_DIM,
+                ],
+                [ordinal * csa_inner_state_blocks_per_layer, 0, 0],
+            )
+            csa_idx_cache_layer_csa = pl.slice(
+                csa_idx_kv_cache,
+                [
+                    csa_idx_blocks_per_layer,
+                    BLOCK_SIZE,
+                    1,
+                    CSA_IDX_HEAD_DIM,
+                ],
+                [ordinal * csa_idx_blocks_per_layer, 0, 0, 0],
+            )
+            csa_idx_scale_layer_csa = pl.slice(
+                csa_idx_kv_scale,
+                [csa_idx_blocks_per_layer, BLOCK_SIZE, 1, 1],
+                [ordinal * csa_idx_blocks_per_layer, 0, 0, 0],
+            )
+            hc_attn_scale_layer_csa = pl.slice(
+                hc_attn_scale, [3], [csa_weight_layer * 3]
+            )
+            hc_attn_base_layer_csa = pl.slice(
+                hc_attn_base, [MIX_HC], [csa_weight_layer * MIX_HC]
+            )
+            attn_norm_w_layer_csa = pl.slice(
+                attn_norm_w, [D], [csa_weight_layer * D]
+            )
+            csa_cmp_wkv_layer_csa = pl.slice(
+                csa_cmp_wkv,
+                [CSA_MAIN_OUT_DIM, D],
+                [csa_extra_layer * CSA_MAIN_OUT_DIM, 0],
+            )
+            csa_cmp_wgate_layer_csa = pl.slice(
+                csa_cmp_wgate,
+                [CSA_MAIN_OUT_DIM, D],
+                [csa_extra_layer * CSA_MAIN_OUT_DIM, 0],
+            )
+            csa_cmp_ape_layer_csa = pl.slice(
+                csa_cmp_ape,
+                [CSA_COMPRESS_RATIO, CSA_MAIN_OUT_DIM],
+                [csa_extra_layer * CSA_COMPRESS_RATIO, 0],
+            )
+            csa_cmp_norm_w_layer_csa = pl.slice(
+                csa_cmp_norm_w,
+                [HEAD_DIM],
+                [csa_extra_layer * HEAD_DIM],
+            )
+            csa_idx_wq_b_layer_csa = pl.slice(
+                csa_idx_wq_b,
+                [Q_LORA, CSA_IDX_N_HEADS * CSA_IDX_HEAD_DIM],
+                [csa_extra_layer * Q_LORA, 0],
+            )
+            csa_idx_wq_b_scale_layer_csa = pl.slice(
+                csa_idx_wq_b_scale,
+                [CSA_IDX_N_HEADS * CSA_IDX_HEAD_DIM],
+                [csa_extra_layer * CSA_IDX_N_HEADS * CSA_IDX_HEAD_DIM],
+            )
+            csa_weights_proj_layer_csa = pl.slice(
+                csa_weights_proj,
+                [D, CSA_IDX_N_HEADS],
+                [csa_extra_layer * D, 0],
+            )
+            csa_hadamard_idx_layer_csa = pl.slice(
+                csa_hadamard_idx,
+                [CSA_IDX_HEAD_DIM, CSA_IDX_HEAD_DIM],
+                [csa_extra_layer * CSA_IDX_HEAD_DIM, 0],
+            )
+            csa_inner_wkv_layer_csa = pl.slice(
+                csa_inner_wkv,
+                [CSA_INNER_OUT_DIM, D],
+                [csa_extra_layer * CSA_INNER_OUT_DIM, 0],
+            )
+            csa_inner_wgate_layer_csa = pl.slice(
+                csa_inner_wgate,
+                [CSA_INNER_OUT_DIM, D],
+                [csa_extra_layer * CSA_INNER_OUT_DIM, 0],
+            )
+            csa_inner_ape_layer_csa = pl.slice(
+                csa_inner_ape,
+                [CSA_COMPRESS_RATIO, CSA_INNER_OUT_DIM],
+                [csa_extra_layer * CSA_COMPRESS_RATIO, 0],
+            )
+            csa_inner_norm_w_layer_csa = pl.slice(
+                csa_inner_norm_w,
+                [CSA_IDX_HEAD_DIM],
+                [csa_extra_layer * CSA_IDX_HEAD_DIM],
+            )
+            attn_sink_layer_csa = pl.slice(
+                attn_sink, [H], [csa_weight_layer * H]
+            )
+            wo_b_layer_csa = pl.slice(
+                wo_b, [D, LOCAL_O_WIDTH], [csa_weight_layer * D, 0]
+            )
+            wo_b_scale_layer_csa = pl.slice(
+                wo_b_scale, [D], [csa_weight_layer * D]
+            )
+            hc_ffn_scale_layer_csa = pl.slice(
+                hc_ffn_scale, [3], [csa_weight_layer * 3]
+            )
+            hc_ffn_base_layer_csa = pl.slice(
+                hc_ffn_base, [MIX_HC], [csa_weight_layer * MIX_HC]
+            )
+            norm_w_layer_csa = pl.slice(norm_w, [D], [csa_weight_layer * D])
+            gate_w_layer_csa = pl.slice(
+                gate_w,
+                [N_EXPERTS_GLOBAL, D],
+                [csa_weight_layer * N_EXPERTS_GLOBAL, 0],
+            )
+            gate_bias_layer_csa = pl.slice(
+                gate_bias,
+                [N_EXPERTS_GLOBAL],
+                [csa_weight_layer * N_EXPERTS_GLOBAL],
+            )
+            tid2eid_layer_csa = pl.slice(
+                tid2eid, [VOCAB, TOPK], [csa_weight_layer * VOCAB, 0]
+            )
+            routed_w1_scale_layer_csa = pl.slice(
+                routed_w1_scale,
+                [N_LOCAL, MOE_INTER],
+                [csa_weight_layer * N_LOCAL, 0],
+            )
+            routed_w3_scale_layer_csa = pl.slice(
+                routed_w3_scale,
+                [N_LOCAL, MOE_INTER],
+                [csa_weight_layer * N_LOCAL, 0],
+            )
+            routed_w2_scale_layer_csa = pl.slice(
+                routed_w2_scale,
+                [N_LOCAL, D],
+                [csa_weight_layer * N_LOCAL, 0],
+            )
+            shared_w1_layer_csa = pl.slice(
+                shared_w1,
+                [MOE_INTER, D],
+                [csa_weight_layer * MOE_INTER, 0],
+            )
+            shared_w1_scale_layer_csa = pl.slice(
+                shared_w1_scale,
+                [MOE_INTER],
+                [csa_weight_layer * MOE_INTER],
+            )
+            shared_w3_layer_csa = pl.slice(
+                shared_w3,
+                [MOE_INTER, D],
+                [csa_weight_layer * MOE_INTER, 0],
+            )
+            shared_w3_scale_layer_csa = pl.slice(
+                shared_w3_scale,
+                [MOE_INTER],
+                [csa_weight_layer * MOE_INTER],
+            )
+            shared_w2_layer_csa = pl.slice(
+                shared_w2, [D, MOE_INTER], [csa_weight_layer * D, 0]
+            )
+            shared_w2_scale_layer_csa = pl.slice(
+                shared_w2_scale, [D], [csa_weight_layer * D]
+            )
+            decode_layer_csa(
+                x_ping,
+                hc_attn_fn_layer_csa, hc_attn_scale_layer_csa,
+                hc_attn_base_layer_csa, attn_norm_w_layer_csa,
+                wq_a_layer_csa, wq_b_layer_csa, wq_b_scale_layer_csa, wkv_layer_csa,
+                gamma_cq_layer_csa, gamma_ckv_layer_csa,
+                freqs_cos, freqs_sin,
+                csa_cmp_freqs_cos, csa_cmp_freqs_sin,
+                csa_cmp_wkv_layer_csa, csa_cmp_wgate_layer_csa,
+                csa_cmp_ape_layer_csa, csa_cmp_norm_w_layer_csa,
+                csa_state_layer_csa, csa_compress_state_block_table,
+                csa_idx_wq_b_layer_csa, csa_idx_wq_b_scale_layer_csa,
+                csa_weights_proj_layer_csa, csa_hadamard_idx_layer_csa,
+                csa_inner_wkv_layer_csa, csa_inner_wgate_layer_csa,
+                csa_inner_ape_layer_csa, csa_inner_norm_w_layer_csa,
+                csa_inner_state_layer_csa,
+                csa_inner_compress_state_block_table,
+                raw_kv_layer_csa, csa_cmp_kv_layer_csa, csa_cmp_block_table,
+                csa_idx_cache_layer_csa, csa_idx_scale_layer_csa,
+                csa_idx_block_table,
+                csa_ori_slot_mapping, csa_window_swa_indices,
+                csa_window_swa_lens, csa_cmp_slot_mapping,
+                csa_idx_slot_mapping, csa_state_slot_mapping,
+                csa_inner_state_slot_mapping, position_ids,
+                csa_kv_seq_lens, attn_sink_layer_csa,
+                wo_a_layer_csa, wo_b_layer_csa, wo_b_scale_layer_csa,
+                hc_ffn_fn_layer_csa, hc_ffn_scale_layer_csa,
+                hc_ffn_base_layer_csa, norm_w_layer_csa,
+                gate_w_layer_csa, gate_bias_layer_csa, tid2eid_layer_csa, input_ids,
+                routed_w1_layer_csa, routed_w1_scale_layer_csa,
+                routed_w3_layer_csa, routed_w3_scale_layer_csa,
+                routed_w2_layer_csa, routed_w2_scale_layer_csa,
+                shared_w1_layer_csa, shared_w1_scale_layer_csa,
+                shared_w3_layer_csa, shared_w3_scale_layer_csa,
+                shared_w2_layer_csa, shared_w2_scale_layer_csa,
+                x_attn_active, x_moe_next, x_pong,
+                attention_window, attention_signal, o_window, o_signal,
+                recv_meta, recv_x, recv_aux, recv_route,
+                arrived, data_arrived, routed_y_buf, combine_arrived,
+                csa_model_layer, group_base, tp_rank, local_t, my_rank,
+                csa_model_layer + 1,
+            )
+
+        with pl.scope():
+            hc_attn_fn_layer_hca = pl.slice(
+                hc_attn_fn,
+                [MIX_HC, HC_DIM],
+                [hca_weight_layer * HC_FN_STORAGE_ROWS, 0],
+            )
+            hc_ffn_fn_layer_hca = pl.slice(
+                hc_ffn_fn,
+                [MIX_HC, HC_DIM],
+                [hca_weight_layer * HC_FN_STORAGE_ROWS, 0],
+            )
+            wq_a_layer_hca: pl.Tensor[[D, Q_LORA], pl.BF16] = pl.slice(
+                wq_a, [D, Q_LORA], [hca_weight_layer * D, 0]
+            )
+            wq_b_layer_hca: pl.Tensor[
+                [Q_LORA, H * HEAD_DIM], pl.INT8
+            ] = pl.slice(
+                wq_b,
+                [Q_LORA, H * HEAD_DIM],
+                [hca_weight_layer * Q_LORA, 0],
+            )
+            wq_b_scale_layer_hca: pl.Tensor[
+                [H * HEAD_DIM], pl.FP32
+            ] = pl.slice(
+                wq_b_scale,
+                [H * HEAD_DIM],
+                [hca_weight_layer * H * HEAD_DIM],
+            )
+            wkv_layer_hca: pl.Tensor[[D, HEAD_DIM], pl.BF16] = pl.slice(
+                wkv, [D, HEAD_DIM], [hca_weight_layer * D, 0]
+            )
+            gamma_cq_layer_hca: pl.Tensor[[Q_LORA], pl.BF16] = pl.slice(
+                gamma_cq, [Q_LORA], [hca_weight_layer * Q_LORA]
+            )
+            gamma_ckv_layer_hca: pl.Tensor[[HEAD_DIM], pl.BF16] = pl.slice(
+                gamma_ckv, [HEAD_DIM], [hca_weight_layer * HEAD_DIM]
+            )
+            wo_a_layer_hca: pl.Tensor[
+                [LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16
+            ] = pl.slice(
+                wo_a,
+                [LOCAL_O_GROUPS, O_LORA, O_GROUP_IN],
+                [hca_weight_layer * LOCAL_O_GROUPS, 0, 0],
+            )
+            routed_w1_layer_hca: pl.Tensor[
+                [N_LOCAL, MOE_INTER, D], pl.INT8
+            ] = pl.slice(
+                routed_w1,
+                [N_LOCAL, MOE_INTER, D],
+                [hca_weight_layer * N_LOCAL, 0, 0],
+            )
+            routed_w3_layer_hca: pl.Tensor[
+                [N_LOCAL, MOE_INTER, D], pl.INT8
+            ] = pl.slice(
+                routed_w3,
+                [N_LOCAL, MOE_INTER, D],
+                [hca_weight_layer * N_LOCAL, 0, 0],
+            )
+            routed_w2_layer_hca: pl.Tensor[
+                [N_LOCAL, D, MOE_INTER], pl.INT8
+            ] = pl.slice(
+                routed_w2,
+                [N_LOCAL, D, MOE_INTER],
+                [hca_weight_layer * N_LOCAL, 0, 0],
+            )
+            raw_kv_layer_hca = pl.slice(
+                raw_kv_pool,
+                [raw_blocks_per_layer, BLOCK_SIZE, 1, HEAD_DIM],
+                [hca_model_layer * raw_blocks_per_layer, 0, 0, 0],
+            )
+            hca_state_layer_hca = pl.slice(
+                hca_compress_state,
+                [
+                    hca_state_blocks_per_layer,
+                    HCA_COMPRESS_STATE_BLOCK_SIZE,
+                    HCA_COMPRESS_STATE_DIM,
+                ],
+                [ordinal * hca_state_blocks_per_layer, 0, 0],
+            )
+            hca_cmp_kv_layer_hca = pl.slice(
+                hca_cmp_kv,
+                [hca_cmp_blocks_per_layer, BLOCK_SIZE, 1, HEAD_DIM],
+                [ordinal * hca_cmp_blocks_per_layer, 0, 0, 0],
+            )
+            hc_attn_scale_layer_hca = pl.slice(
+                hc_attn_scale, [3], [hca_weight_layer * 3]
+            )
+            hc_attn_base_layer_hca = pl.slice(
+                hc_attn_base, [MIX_HC], [hca_weight_layer * MIX_HC]
+            )
+            attn_norm_w_layer_hca = pl.slice(
+                attn_norm_w, [D], [hca_weight_layer * D]
+            )
+            hca_cmp_wkv_layer_hca = pl.slice(
+                hca_cmp_wkv,
+                [HCA_MAIN_OUT_DIM, D],
+                [hca_extra_layer * HCA_MAIN_OUT_DIM, 0],
+            )
+            hca_cmp_wgate_layer_hca = pl.slice(
+                hca_cmp_wgate,
+                [HCA_MAIN_OUT_DIM, D],
+                [hca_extra_layer * HCA_MAIN_OUT_DIM, 0],
+            )
+            hca_cmp_ape_layer_hca = pl.slice(
+                hca_cmp_ape,
+                [HCA_COMPRESS_RATIO, HCA_MAIN_OUT_DIM],
+                [hca_extra_layer * HCA_COMPRESS_RATIO, 0],
+            )
+            hca_cmp_norm_w_layer_hca = pl.slice(
+                hca_cmp_norm_w,
+                [HEAD_DIM],
+                [hca_extra_layer * HEAD_DIM],
+            )
+            attn_sink_layer_hca = pl.slice(
+                attn_sink, [H], [hca_weight_layer * H]
+            )
+            wo_b_layer_hca = pl.slice(
+                wo_b, [D, LOCAL_O_WIDTH], [hca_weight_layer * D, 0]
+            )
+            wo_b_scale_layer_hca = pl.slice(
+                wo_b_scale, [D], [hca_weight_layer * D]
+            )
+            hc_ffn_scale_layer_hca = pl.slice(
+                hc_ffn_scale, [3], [hca_weight_layer * 3]
+            )
+            hc_ffn_base_layer_hca = pl.slice(
+                hc_ffn_base, [MIX_HC], [hca_weight_layer * MIX_HC]
+            )
+            norm_w_layer_hca = pl.slice(norm_w, [D], [hca_weight_layer * D])
+            gate_w_layer_hca = pl.slice(
+                gate_w,
+                [N_EXPERTS_GLOBAL, D],
+                [hca_weight_layer * N_EXPERTS_GLOBAL, 0],
+            )
+            gate_bias_layer_hca = pl.slice(
+                gate_bias,
+                [N_EXPERTS_GLOBAL],
+                [hca_weight_layer * N_EXPERTS_GLOBAL],
+            )
+            tid2eid_layer_hca = pl.slice(
+                tid2eid, [VOCAB, TOPK], [hca_weight_layer * VOCAB, 0]
+            )
+            routed_w1_scale_layer_hca = pl.slice(
+                routed_w1_scale,
+                [N_LOCAL, MOE_INTER],
+                [hca_weight_layer * N_LOCAL, 0],
+            )
+            routed_w3_scale_layer_hca = pl.slice(
+                routed_w3_scale,
+                [N_LOCAL, MOE_INTER],
+                [hca_weight_layer * N_LOCAL, 0],
+            )
+            routed_w2_scale_layer_hca = pl.slice(
+                routed_w2_scale,
+                [N_LOCAL, D],
+                [hca_weight_layer * N_LOCAL, 0],
+            )
+            shared_w1_layer_hca = pl.slice(
+                shared_w1,
+                [MOE_INTER, D],
+                [hca_weight_layer * MOE_INTER, 0],
+            )
+            shared_w1_scale_layer_hca = pl.slice(
+                shared_w1_scale,
+                [MOE_INTER],
+                [hca_weight_layer * MOE_INTER],
+            )
+            shared_w3_layer_hca = pl.slice(
+                shared_w3,
+                [MOE_INTER, D],
+                [hca_weight_layer * MOE_INTER, 0],
+            )
+            shared_w3_scale_layer_hca = pl.slice(
+                shared_w3_scale,
+                [MOE_INTER],
+                [hca_weight_layer * MOE_INTER],
+            )
+            shared_w2_layer_hca = pl.slice(
+                shared_w2, [D, MOE_INTER], [hca_weight_layer * D, 0]
+            )
+            shared_w2_scale_layer_hca = pl.slice(
+                shared_w2_scale, [D], [hca_weight_layer * D]
+            )
+            decode_layer_hca(
+                x_pong,
+                hc_attn_fn_layer_hca, hc_attn_scale_layer_hca,
+                hc_attn_base_layer_hca, attn_norm_w_layer_hca,
+                wq_a_layer_hca, wq_b_layer_hca, wq_b_scale_layer_hca, wkv_layer_hca,
+                gamma_cq_layer_hca, gamma_ckv_layer_hca,
+                freqs_cos, freqs_sin,
+                hca_cmp_freqs_cos, hca_cmp_freqs_sin,
+                hca_cmp_wkv_layer_hca, hca_cmp_wgate_layer_hca,
+                hca_cmp_ape_layer_hca, hca_cmp_norm_w_layer_hca,
+                hca_state_layer_hca, hca_compress_state_block_table,
+                raw_kv_layer_hca, hca_cmp_kv_layer_hca, hca_cmp_block_table,
+                hca_ori_slot_mapping, hca_window_swa_indices,
+                hca_window_swa_lens, hca_cmp_slot_mapping,
+                hca_state_slot_mapping, position_ids, hca_kv_seq_lens,
+                attn_sink_layer_hca, wo_a_layer_hca, wo_b_layer_hca, wo_b_scale_layer_hca,
+                hc_ffn_fn_layer_hca, hc_ffn_scale_layer_hca,
+                hc_ffn_base_layer_hca, norm_w_layer_hca,
+                gate_w_layer_hca, gate_bias_layer_hca, tid2eid_layer_hca, input_ids,
+                routed_w1_layer_hca, routed_w1_scale_layer_hca,
+                routed_w3_layer_hca, routed_w3_scale_layer_hca,
+                routed_w2_layer_hca, routed_w2_scale_layer_hca,
+                shared_w1_layer_hca, shared_w1_scale_layer_hca,
+                shared_w3_layer_hca, shared_w3_scale_layer_hca,
+                shared_w2_layer_hca, shared_w2_scale_layer_hca,
+                x_attn_active, x_moe_next, x_ping,
+                attention_window, attention_signal, o_window, o_signal,
+                recv_meta, recv_x, recv_aux, recv_route,
+                arrived, data_arrived, routed_y_buf, combine_arrived,
+                hca_model_layer, group_base, tp_rank, local_t, my_rank,
+                hca_model_layer + 1,
+            )
+
+    with pl.scope():
+        csa_ordinal_last = pl.const(20, pl.INT32)
+        model_layer_last = pl.const(42, pl.INT32)
+        weight_layer_last = model_layer_last % FWD_WEIGHT_BANK_SIZE
+        extra_layer_last = csa_ordinal_last % FWD_CSA_WEIGHT_BANK_SIZE
+        hc_attn_fn_layer_last = pl.slice(
+            hc_attn_fn,
+            [MIX_HC, HC_DIM],
+            [weight_layer_last * HC_FN_STORAGE_ROWS, 0],
+        )
+        hc_ffn_fn_layer_last = pl.slice(
+            hc_ffn_fn,
+            [MIX_HC, HC_DIM],
+            [weight_layer_last * HC_FN_STORAGE_ROWS, 0],
+        )
+        wq_a_layer_last: pl.Tensor[[D, Q_LORA], pl.BF16] = pl.slice(
+            wq_a, [D, Q_LORA], [weight_layer_last * D, 0]
+        )
+        wq_b_layer_last: pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8] = pl.slice(
+            wq_b, [Q_LORA, H * HEAD_DIM], [weight_layer_last * Q_LORA, 0]
+        )
+        wq_b_scale_layer_last: pl.Tensor[[H * HEAD_DIM], pl.FP32] = pl.slice(
+            wq_b_scale,
+            [H * HEAD_DIM],
+            [weight_layer_last * H * HEAD_DIM],
+        )
+        wkv_layer_last: pl.Tensor[[D, HEAD_DIM], pl.BF16] = pl.slice(
+            wkv, [D, HEAD_DIM], [weight_layer_last * D, 0]
+        )
+        gamma_cq_layer_last: pl.Tensor[[Q_LORA], pl.BF16] = pl.slice(
+            gamma_cq, [Q_LORA], [weight_layer_last * Q_LORA]
+        )
+        gamma_ckv_layer_last: pl.Tensor[[HEAD_DIM], pl.BF16] = pl.slice(
+            gamma_ckv, [HEAD_DIM], [weight_layer_last * HEAD_DIM]
+        )
+        wo_a_layer_last: pl.Tensor[
+            [LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16
+        ] = pl.slice(
+            wo_a,
+            [LOCAL_O_GROUPS, O_LORA, O_GROUP_IN],
+            [weight_layer_last * LOCAL_O_GROUPS, 0, 0],
+        )
+        routed_w1_layer_last: pl.Tensor[
+            [N_LOCAL, MOE_INTER, D], pl.INT8
+        ] = pl.slice(
+            routed_w1,
+            [N_LOCAL, MOE_INTER, D],
+            [weight_layer_last * N_LOCAL, 0, 0],
+        )
+        routed_w3_layer_last: pl.Tensor[
+            [N_LOCAL, MOE_INTER, D], pl.INT8
+        ] = pl.slice(
+            routed_w3,
+            [N_LOCAL, MOE_INTER, D],
+            [weight_layer_last * N_LOCAL, 0, 0],
+        )
+        routed_w2_layer_last: pl.Tensor[
+            [N_LOCAL, D, MOE_INTER], pl.INT8
+        ] = pl.slice(
+            routed_w2,
+            [N_LOCAL, D, MOE_INTER],
+            [weight_layer_last * N_LOCAL, 0, 0],
+        )
+        raw_kv_layer_last = pl.slice(
+            raw_kv_pool,
+            [raw_blocks_per_layer, BLOCK_SIZE, 1, HEAD_DIM],
+            [model_layer_last * raw_blocks_per_layer, 0, 0, 0],
+        )
+        csa_state_layer_last = pl.slice(
+            csa_compress_state,
+            [
+                csa_state_blocks_per_layer,
+                CSA_MAIN_STATE_BLOCK_SIZE,
+                CSA_MAIN_STATE_DIM,
+            ],
+            [csa_ordinal_last * csa_state_blocks_per_layer, 0, 0],
+        )
+        csa_cmp_kv_layer_last = pl.slice(
+            csa_cmp_kv,
+            [csa_cmp_blocks_per_layer, BLOCK_SIZE, 1, HEAD_DIM],
+            [csa_ordinal_last * csa_cmp_blocks_per_layer, 0, 0, 0],
+        )
+        csa_inner_state_layer_last = pl.slice(
+            csa_inner_compress_state,
+            [
+                csa_inner_state_blocks_per_layer,
+                CSA_INNER_STATE_BLOCK_SIZE,
+                CSA_INNER_STATE_DIM,
+            ],
+            [csa_ordinal_last * csa_inner_state_blocks_per_layer, 0, 0],
+        )
+        csa_idx_cache_layer_last = pl.slice(
+            csa_idx_kv_cache,
+            [
+                csa_idx_blocks_per_layer,
+                BLOCK_SIZE,
+                1,
+                CSA_IDX_HEAD_DIM,
+            ],
+            [csa_ordinal_last * csa_idx_blocks_per_layer, 0, 0, 0],
+        )
+        csa_idx_scale_layer_last = pl.slice(
+            csa_idx_kv_scale,
+            [csa_idx_blocks_per_layer, BLOCK_SIZE, 1, 1],
+            [csa_ordinal_last * csa_idx_blocks_per_layer, 0, 0, 0],
+        )
+        hc_attn_scale_layer_last = pl.slice(
+            hc_attn_scale, [3], [weight_layer_last * 3]
+        )
+        hc_attn_base_layer_last = pl.slice(
+            hc_attn_base, [MIX_HC], [weight_layer_last * MIX_HC]
+        )
+        attn_norm_w_layer_last = pl.slice(
+            attn_norm_w, [D], [weight_layer_last * D]
+        )
+        csa_cmp_wkv_layer_last = pl.slice(
+            csa_cmp_wkv,
+            [CSA_MAIN_OUT_DIM, D],
+            [extra_layer_last * CSA_MAIN_OUT_DIM, 0],
+        )
+        csa_cmp_wgate_layer_last = pl.slice(
+            csa_cmp_wgate,
+            [CSA_MAIN_OUT_DIM, D],
+            [extra_layer_last * CSA_MAIN_OUT_DIM, 0],
+        )
+        csa_cmp_ape_layer_last = pl.slice(
+            csa_cmp_ape,
+            [CSA_COMPRESS_RATIO, CSA_MAIN_OUT_DIM],
+            [extra_layer_last * CSA_COMPRESS_RATIO, 0],
+        )
+        csa_cmp_norm_w_layer_last = pl.slice(
+            csa_cmp_norm_w, [HEAD_DIM], [extra_layer_last * HEAD_DIM]
+        )
+        csa_idx_wq_b_layer_last = pl.slice(
+            csa_idx_wq_b,
+            [Q_LORA, CSA_IDX_N_HEADS * CSA_IDX_HEAD_DIM],
+            [extra_layer_last * Q_LORA, 0],
+        )
+        csa_idx_wq_b_scale_layer_last = pl.slice(
+            csa_idx_wq_b_scale,
+            [CSA_IDX_N_HEADS * CSA_IDX_HEAD_DIM],
+            [extra_layer_last * CSA_IDX_N_HEADS * CSA_IDX_HEAD_DIM],
+        )
+        csa_weights_proj_layer_last = pl.slice(
+            csa_weights_proj,
+            [D, CSA_IDX_N_HEADS],
+            [extra_layer_last * D, 0],
+        )
+        csa_hadamard_idx_layer_last = pl.slice(
+            csa_hadamard_idx,
+            [CSA_IDX_HEAD_DIM, CSA_IDX_HEAD_DIM],
+            [extra_layer_last * CSA_IDX_HEAD_DIM, 0],
+        )
+        csa_inner_wkv_layer_last = pl.slice(
+            csa_inner_wkv,
+            [CSA_INNER_OUT_DIM, D],
+            [extra_layer_last * CSA_INNER_OUT_DIM, 0],
+        )
+        csa_inner_wgate_layer_last = pl.slice(
+            csa_inner_wgate,
+            [CSA_INNER_OUT_DIM, D],
+            [extra_layer_last * CSA_INNER_OUT_DIM, 0],
+        )
+        csa_inner_ape_layer_last = pl.slice(
+            csa_inner_ape,
+            [CSA_COMPRESS_RATIO, CSA_INNER_OUT_DIM],
+            [extra_layer_last * CSA_COMPRESS_RATIO, 0],
+        )
+        csa_inner_norm_w_layer_last = pl.slice(
+            csa_inner_norm_w,
+            [CSA_IDX_HEAD_DIM],
+            [extra_layer_last * CSA_IDX_HEAD_DIM],
+        )
+        attn_sink_layer_last = pl.slice(attn_sink, [H], [weight_layer_last * H])
+        wo_b_layer_last = pl.slice(
+            wo_b, [D, LOCAL_O_WIDTH], [weight_layer_last * D, 0]
+        )
+        wo_b_scale_layer_last = pl.slice(
+            wo_b_scale, [D], [weight_layer_last * D]
+        )
+        hc_ffn_scale_layer_last = pl.slice(
+            hc_ffn_scale, [3], [weight_layer_last * 3]
+        )
+        hc_ffn_base_layer_last = pl.slice(
+            hc_ffn_base, [MIX_HC], [weight_layer_last * MIX_HC]
+        )
+        norm_w_layer_last = pl.slice(norm_w, [D], [weight_layer_last * D])
+        gate_w_layer_last = pl.slice(
+            gate_w,
+            [N_EXPERTS_GLOBAL, D],
+            [weight_layer_last * N_EXPERTS_GLOBAL, 0],
+        )
+        gate_bias_layer_last = pl.slice(
+            gate_bias,
+            [N_EXPERTS_GLOBAL],
+            [weight_layer_last * N_EXPERTS_GLOBAL],
+        )
+        tid2eid_layer_last = pl.slice(
+            tid2eid, [VOCAB, TOPK], [weight_layer_last * VOCAB, 0]
+        )
+        routed_w1_scale_layer_last = pl.slice(
+            routed_w1_scale,
+            [N_LOCAL, MOE_INTER],
+            [weight_layer_last * N_LOCAL, 0],
+        )
+        routed_w3_scale_layer_last = pl.slice(
+            routed_w3_scale,
+            [N_LOCAL, MOE_INTER],
+            [weight_layer_last * N_LOCAL, 0],
+        )
+        routed_w2_scale_layer_last = pl.slice(
+            routed_w2_scale, [N_LOCAL, D], [weight_layer_last * N_LOCAL, 0]
+        )
+        shared_w1_layer_last = pl.slice(
+            shared_w1, [MOE_INTER, D], [weight_layer_last * MOE_INTER, 0]
+        )
+        shared_w1_scale_layer_last = pl.slice(
+            shared_w1_scale, [MOE_INTER], [weight_layer_last * MOE_INTER]
+        )
+        shared_w3_layer_last = pl.slice(
+            shared_w3, [MOE_INTER, D], [weight_layer_last * MOE_INTER, 0]
+        )
+        shared_w3_scale_layer_last = pl.slice(
+            shared_w3_scale, [MOE_INTER], [weight_layer_last * MOE_INTER]
+        )
+        shared_w2_layer_last = pl.slice(
+            shared_w2, [D, MOE_INTER], [weight_layer_last * D, 0]
+        )
+        shared_w2_scale_layer_last = pl.slice(
+            shared_w2_scale, [D], [weight_layer_last * D]
+        )
+        decode_layer_csa(
+            x_ping,
+            hc_attn_fn_layer_last, hc_attn_scale_layer_last,
+            hc_attn_base_layer_last, attn_norm_w_layer_last,
+            wq_a_layer_last, wq_b_layer_last, wq_b_scale_layer_last, wkv_layer_last,
+            gamma_cq_layer_last, gamma_ckv_layer_last,
+            freqs_cos, freqs_sin,
+            csa_cmp_freqs_cos, csa_cmp_freqs_sin,
+            csa_cmp_wkv_layer_last, csa_cmp_wgate_layer_last,
+            csa_cmp_ape_layer_last, csa_cmp_norm_w_layer_last,
+            csa_state_layer_last, csa_compress_state_block_table,
+            csa_idx_wq_b_layer_last, csa_idx_wq_b_scale_layer_last,
+            csa_weights_proj_layer_last, csa_hadamard_idx_layer_last,
+            csa_inner_wkv_layer_last, csa_inner_wgate_layer_last,
+            csa_inner_ape_layer_last, csa_inner_norm_w_layer_last,
+            csa_inner_state_layer_last,
+            csa_inner_compress_state_block_table,
+            raw_kv_layer_last, csa_cmp_kv_layer_last, csa_cmp_block_table,
+            csa_idx_cache_layer_last, csa_idx_scale_layer_last,
+            csa_idx_block_table,
+            csa_ori_slot_mapping, csa_window_swa_indices,
+            csa_window_swa_lens, csa_cmp_slot_mapping,
+            csa_idx_slot_mapping, csa_state_slot_mapping,
+            csa_inner_state_slot_mapping, position_ids,
+            csa_kv_seq_lens, attn_sink_layer_last,
+            wo_a_layer_last, wo_b_layer_last, wo_b_scale_layer_last,
+            hc_ffn_fn_layer_last, hc_ffn_scale_layer_last,
+            hc_ffn_base_layer_last, norm_w_layer_last,
+            gate_w_layer_last, gate_bias_layer_last, tid2eid_layer_last, input_ids,
+            routed_w1_layer_last, routed_w1_scale_layer_last,
+            routed_w3_layer_last, routed_w3_scale_layer_last,
+            routed_w2_layer_last, routed_w2_scale_layer_last,
+            shared_w1_layer_last, shared_w1_scale_layer_last,
+            shared_w3_layer_last, shared_w3_scale_layer_last,
+            shared_w2_layer_last, shared_w2_scale_layer_last,
+            x_attn_active, x_moe_next, x_out,
+            attention_window, attention_signal, o_window, o_signal,
+            recv_meta, recv_x, recv_aux, recv_route,
+            arrived, data_arrived, routed_y_buf, combine_arrived,
+            model_layer_last, group_base, tp_rank, local_t, my_rank,
+            pl.const(43, pl.INT32),
+        )
+        clear_moe_signals(
+            x_moe_next, arrived, data_arrived, combine_arrived
+        )
+    return x_out
+
+
+@pl.jit.host
+def l3_decode_fwd_full43(
+    hc_attn_fn: pl.Tensor[
+        [N_RANKS, FWD_WEIGHT_BANK_SIZE * HC_FN_STORAGE_ROWS, HC_DIM],
+        pl.FP32,
+    ],
+    hc_attn_scale: pl.Tensor[[N_RANKS, FWD_WEIGHT_BANK_SIZE * 3], pl.FP32],
+    hc_attn_base: pl.Tensor[
+        [N_RANKS, FWD_WEIGHT_BANK_SIZE * MIX_HC], pl.FP32
+    ],
+    attn_norm_w: pl.Tensor[[N_RANKS, FWD_WEIGHT_BANK_SIZE * D], pl.BF16],
+    wq_a: pl.Tensor[
+        [N_RANKS, FWD_WEIGHT_BANK_SIZE * D, Q_LORA], pl.BF16
+    ],
+    wq_b: pl.Tensor[
+        [N_RANKS, FWD_WEIGHT_BANK_SIZE * Q_LORA, H * HEAD_DIM], pl.INT8
+    ],
+    wq_b_scale: pl.Tensor[
+        [N_RANKS, FWD_WEIGHT_BANK_SIZE * H * HEAD_DIM], pl.FP32
+    ],
+    wkv: pl.Tensor[
+        [N_RANKS, FWD_WEIGHT_BANK_SIZE * D, HEAD_DIM], pl.BF16
+    ],
+    gamma_cq: pl.Tensor[
+        [N_RANKS, FWD_WEIGHT_BANK_SIZE * Q_LORA], pl.BF16
+    ],
+    gamma_ckv: pl.Tensor[
+        [N_RANKS, FWD_WEIGHT_BANK_SIZE * HEAD_DIM], pl.BF16
+    ],
+    raw_kv_pool: pl.InOut[
+        pl.Tensor[
+            [
+                N_RANKS,
+                FWD_PACKED_RAW_BLOCKS_DYN,
+                BLOCK_SIZE,
+                1,
+                HEAD_DIM,
+            ],
+            pl.BF16,
+        ]
+    ],
+    freqs_cos: pl.Tensor[[N_RANKS, T_DYN, ROPE_HEAD_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[N_RANKS, T_DYN, ROPE_HEAD_DIM], pl.BF16],
+    swa_slot_mapping: pl.Tensor[[N_RANKS, T_DYN], pl.INT64],
+    swa_indices: pl.Tensor[[N_RANKS, T_DYN, WIN], pl.INT32],
+    swa_lens: pl.Tensor[[N_RANKS, T_DYN], pl.INT32],
+    position_ids: pl.Tensor[[N_RANKS, T_DYN], pl.INT32],
+    csa_cmp_freqs_cos: pl.Tensor[
+        [N_RANKS, T_DYN, ROPE_HEAD_DIM], pl.BF16
+    ],
+    csa_cmp_freqs_sin: pl.Tensor[
+        [N_RANKS, T_DYN, ROPE_HEAD_DIM], pl.BF16
+    ],
+    csa_cmp_wkv: pl.Tensor[
+        [N_RANKS, FWD_CSA_WEIGHT_BANK_SIZE * CSA_MAIN_OUT_DIM, D], pl.BF16
+    ],
+    csa_cmp_wgate: pl.Tensor[
+        [N_RANKS, FWD_CSA_WEIGHT_BANK_SIZE * CSA_MAIN_OUT_DIM, D], pl.BF16
+    ],
+    csa_cmp_ape: pl.Tensor[
+        [
+            N_RANKS,
+            FWD_CSA_WEIGHT_BANK_SIZE * CSA_COMPRESS_RATIO,
+            CSA_MAIN_OUT_DIM,
+        ],
+        pl.FP32,
+    ],
+    csa_cmp_norm_w: pl.Tensor[
+        [N_RANKS, FWD_CSA_WEIGHT_BANK_SIZE * HEAD_DIM], pl.BF16
+    ],
+    csa_compress_state: pl.InOut[
+        pl.Tensor[
+            [
+                N_RANKS,
+                FWD_CSA_MAIN_STATE_BLOCKS_DYN,
+                CSA_MAIN_STATE_BLOCK_SIZE,
+                CSA_MAIN_STATE_DIM,
+            ],
+            pl.FP32,
+        ]
+    ],
+    csa_compress_state_block_table: pl.Tensor[
+        [N_RANKS, CSA_B_DYN, CSA_MAIN_STATE_MAX_BLOCKS], pl.INT32
+    ],
+    csa_idx_wq_b: pl.Tensor[
+        [
+            N_RANKS,
+            FWD_CSA_WEIGHT_BANK_SIZE * Q_LORA,
+            CSA_IDX_N_HEADS * CSA_IDX_HEAD_DIM,
+        ],
+        pl.INT8,
+    ],
+    csa_idx_wq_b_scale: pl.Tensor[
+        [
+            N_RANKS,
+            FWD_CSA_WEIGHT_BANK_SIZE * CSA_IDX_N_HEADS * CSA_IDX_HEAD_DIM,
+        ],
+        pl.FP32,
+    ],
+    csa_weights_proj: pl.Tensor[
+        [N_RANKS, FWD_CSA_WEIGHT_BANK_SIZE * D, CSA_IDX_N_HEADS], pl.BF16
+    ],
+    csa_hadamard_idx: pl.Tensor[
+        [
+            N_RANKS,
+            FWD_CSA_WEIGHT_BANK_SIZE * CSA_IDX_HEAD_DIM,
+            CSA_IDX_HEAD_DIM,
+        ],
+        pl.BF16,
+    ],
+    csa_inner_wkv: pl.Tensor[
+        [N_RANKS, FWD_CSA_WEIGHT_BANK_SIZE * CSA_INNER_OUT_DIM, D],
+        pl.BF16,
+    ],
+    csa_inner_wgate: pl.Tensor[
+        [N_RANKS, FWD_CSA_WEIGHT_BANK_SIZE * CSA_INNER_OUT_DIM, D],
+        pl.BF16,
+    ],
+    csa_inner_ape: pl.Tensor[
+        [
+            N_RANKS,
+            FWD_CSA_WEIGHT_BANK_SIZE * CSA_COMPRESS_RATIO,
+            CSA_INNER_OUT_DIM,
+        ],
+        pl.FP32,
+    ],
+    csa_inner_norm_w: pl.Tensor[
+        [N_RANKS, FWD_CSA_WEIGHT_BANK_SIZE * CSA_IDX_HEAD_DIM], pl.BF16
+    ],
+    csa_inner_compress_state: pl.InOut[
+        pl.Tensor[
+            [
+                N_RANKS,
+                FWD_CSA_INNER_STATE_BLOCKS_DYN,
+                CSA_INNER_STATE_BLOCK_SIZE,
+                CSA_INNER_STATE_DIM,
+            ],
+            pl.FP32,
+        ]
+    ],
+    csa_inner_compress_state_block_table: pl.Tensor[
+        [N_RANKS, CSA_B_DYN, CSA_INNER_STATE_MAX_BLOCKS], pl.INT32
+    ],
+    csa_cmp_kv: pl.InOut[
+        pl.Tensor[
+            [
+                N_RANKS,
+                FWD_CSA_CMP_BLOCKS_DYN,
+                BLOCK_SIZE,
+                1,
+                HEAD_DIM,
+            ],
+            pl.BF16,
+        ]
+    ],
+    csa_cmp_block_table: pl.Tensor[
+        [N_RANKS, CSA_B_DYN, CSA_CMP_MAX_BLOCKS], pl.INT32
+    ],
+    csa_idx_kv_cache: pl.InOut[
+        pl.Tensor[
+            [
+                N_RANKS,
+                FWD_CSA_IDX_BLOCKS_DYN,
+                BLOCK_SIZE,
+                1,
+                CSA_IDX_HEAD_DIM,
+            ],
+            pl.INT8,
+        ]
+    ],
+    csa_idx_kv_scale: pl.InOut[
+        pl.Tensor[
+            [N_RANKS, FWD_CSA_IDX_BLOCKS_DYN, BLOCK_SIZE, 1, 1],
+            pl.FP32,
+        ]
+    ],
+    csa_idx_block_table: pl.Tensor[
+        [N_RANKS, CSA_B_DYN, CSA_IDX_MAX_BLOCKS], pl.INT32
+    ],
+    csa_ori_slot_mapping: pl.Tensor[[N_RANKS, T_DYN], pl.INT64],
+    csa_window_swa_indices: pl.Tensor[
+        [N_RANKS, T_DYN, WIN], pl.INT32
+    ],
+    csa_window_swa_lens: pl.Tensor[[N_RANKS, T_DYN], pl.INT32],
+    csa_cmp_slot_mapping: pl.Tensor[[N_RANKS, T_DYN], pl.INT64],
+    csa_idx_slot_mapping: pl.Tensor[[N_RANKS, T_DYN], pl.INT64],
+    csa_state_slot_mapping: pl.Tensor[[N_RANKS, T_DYN], pl.INT64],
+    csa_inner_state_slot_mapping: pl.Tensor[
+        [N_RANKS, T_DYN], pl.INT64
+    ],
+    csa_kv_seq_lens: pl.Tensor[[N_RANKS, CSA_B_DYN], pl.INT32],
+    hca_cmp_freqs_cos: pl.Tensor[
+        [N_RANKS, HCA_B, ROPE_HEAD_DIM // 2], pl.FP32
+    ],
+    hca_cmp_freqs_sin: pl.Tensor[
+        [N_RANKS, HCA_B, ROPE_HEAD_DIM // 2], pl.FP32
+    ],
+    hca_cmp_wkv: pl.Tensor[
+        [N_RANKS, FWD_HCA_WEIGHT_BANK_SIZE * HCA_MAIN_OUT_DIM, D], pl.BF16
+    ],
+    hca_cmp_wgate: pl.Tensor[
+        [N_RANKS, FWD_HCA_WEIGHT_BANK_SIZE * HCA_MAIN_OUT_DIM, D], pl.BF16
+    ],
+    hca_cmp_ape: pl.Tensor[
+        [
+            N_RANKS,
+            FWD_HCA_WEIGHT_BANK_SIZE * HCA_COMPRESS_RATIO,
+            HCA_MAIN_OUT_DIM,
+        ],
+        pl.FP32,
+    ],
+    hca_cmp_norm_w: pl.Tensor[
+        [N_RANKS, FWD_HCA_WEIGHT_BANK_SIZE * HEAD_DIM], pl.BF16
+    ],
+    hca_compress_state: pl.InOut[
+        pl.Tensor[
+            [
+                N_RANKS,
+                FWD_HCA_STATE_BLOCKS_DYN,
+                HCA_COMPRESS_STATE_BLOCK_SIZE,
+                HCA_COMPRESS_STATE_DIM,
+            ],
+            pl.FP32,
+        ]
+    ],
+    hca_compress_state_block_table: pl.Tensor[
+        [N_RANKS, HCA_B_DYN, HCA_COMPRESS_STATE_MAX_BLOCKS], pl.INT32
+    ],
+    hca_cmp_kv: pl.InOut[
+        pl.Tensor[
+            [N_RANKS, FWD_HCA_CMP_BLOCKS_DYN, BLOCK_SIZE, 1, HEAD_DIM],
+            pl.BF16,
+        ]
+    ],
+    hca_cmp_block_table: pl.Tensor[
+        [N_RANKS, HCA_B_DYN, HCA_CMP_TABLE_BLOCKS_DYN], pl.INT32
+    ],
+    hca_ori_slot_mapping: pl.Tensor[[N_RANKS, T_DYN], pl.INT64],
+    hca_window_swa_indices: pl.Tensor[
+        [N_RANKS, T_DYN, WIN], pl.INT32
+    ],
+    hca_window_swa_lens: pl.Tensor[[N_RANKS, T_DYN], pl.INT32],
+    hca_cmp_slot_mapping: pl.Tensor[[N_RANKS, T_DYN], pl.INT64],
+    hca_state_slot_mapping: pl.Tensor[[N_RANKS, T_DYN], pl.INT64],
+    hca_kv_seq_lens: pl.Tensor[[N_RANKS, HCA_B_DYN], pl.INT32],
+    attn_sink: pl.Tensor[[N_RANKS, FWD_WEIGHT_BANK_SIZE * H], pl.FP32],
+    wo_a: pl.Tensor[
+        [
+            N_RANKS,
+            FWD_WEIGHT_BANK_SIZE * LOCAL_O_GROUPS,
+            O_LORA,
+            O_GROUP_IN,
+        ],
+        pl.BF16,
+    ],
+    wo_b: pl.Tensor[
+        [N_RANKS, FWD_WEIGHT_BANK_SIZE * D, LOCAL_O_WIDTH], pl.INT8
+    ],
+    wo_b_scale: pl.Tensor[
+        [N_RANKS, FWD_WEIGHT_BANK_SIZE * D], pl.FP32
+    ],
+    hc_ffn_fn: pl.Tensor[
+        [N_RANKS, FWD_WEIGHT_BANK_SIZE * HC_FN_STORAGE_ROWS, HC_DIM],
+        pl.FP32,
+    ],
+    hc_ffn_scale: pl.Tensor[
+        [N_RANKS, FWD_WEIGHT_BANK_SIZE * 3], pl.FP32
+    ],
+    hc_ffn_base: pl.Tensor[
+        [N_RANKS, FWD_WEIGHT_BANK_SIZE * MIX_HC], pl.FP32
+    ],
+    norm_w: pl.Tensor[[N_RANKS, FWD_WEIGHT_BANK_SIZE * D], pl.BF16],
+    gate_w: pl.Tensor[
+        [N_RANKS, FWD_WEIGHT_BANK_SIZE * N_EXPERTS_GLOBAL, D], pl.FP32
+    ],
+    gate_bias: pl.Tensor[
+        [N_RANKS, FWD_WEIGHT_BANK_SIZE * N_EXPERTS_GLOBAL], pl.FP32
+    ],
+    tid2eid: pl.Tensor[
+        [N_RANKS, FWD_WEIGHT_BANK_SIZE * VOCAB, TOPK], pl.INT32
+    ],
+    input_ids: pl.Tensor[[N_RANKS, MOE_TOKENS], pl.INT64],
+    routed_w1: pl.Tensor[
+        [N_RANKS, FWD_WEIGHT_BANK_SIZE * N_LOCAL, MOE_INTER, D], pl.INT8
+    ],
+    routed_w1_scale: pl.Tensor[
+        [N_RANKS, FWD_WEIGHT_BANK_SIZE * N_LOCAL, MOE_INTER], pl.FP32
+    ],
+    routed_w3: pl.Tensor[
+        [N_RANKS, FWD_WEIGHT_BANK_SIZE * N_LOCAL, MOE_INTER, D], pl.INT8
+    ],
+    routed_w3_scale: pl.Tensor[
+        [N_RANKS, FWD_WEIGHT_BANK_SIZE * N_LOCAL, MOE_INTER], pl.FP32
+    ],
+    routed_w2: pl.Tensor[
+        [N_RANKS, FWD_WEIGHT_BANK_SIZE * N_LOCAL, D, MOE_INTER], pl.INT8
+    ],
+    routed_w2_scale: pl.Tensor[
+        [N_RANKS, FWD_WEIGHT_BANK_SIZE * N_LOCAL, D], pl.FP32
+    ],
+    shared_w1: pl.Tensor[
+        [N_RANKS, FWD_WEIGHT_BANK_SIZE * MOE_INTER, D], pl.INT8
+    ],
+    shared_w1_scale: pl.Tensor[
+        [N_RANKS, FWD_WEIGHT_BANK_SIZE * MOE_INTER], pl.FP32
+    ],
+    shared_w3: pl.Tensor[
+        [N_RANKS, FWD_WEIGHT_BANK_SIZE * MOE_INTER, D], pl.INT8
+    ],
+    shared_w3_scale: pl.Tensor[
+        [N_RANKS, FWD_WEIGHT_BANK_SIZE * MOE_INTER], pl.FP32
+    ],
+    shared_w2: pl.Tensor[
+        [N_RANKS, FWD_WEIGHT_BANK_SIZE * D, MOE_INTER], pl.INT8
+    ],
+    shared_w2_scale: pl.Tensor[
+        [N_RANKS, FWD_WEIGHT_BANK_SIZE * D], pl.FP32
+    ],
+    x_ping: pl.InOut[
+        pl.Tensor[[N_RANKS, T_DYN, HC_MULT, D], pl.FP32]
+    ],
+    x_pong: pl.InOut[
+        pl.Tensor[[N_RANKS, T_DYN, HC_MULT, D], pl.FP32]
+    ],
+    x_attn_active: pl.InOut[
+        pl.Tensor[[N_RANKS, T_DYN, HC_MULT, D], pl.FP32]
+    ],
+    x_moe_next: pl.InOut[
+        pl.Tensor[[N_RANKS, MOE_TOKENS, HC_MULT, D], pl.FP32]
+    ],
+    x_out: pl.Out[
+        pl.Tensor[[N_RANKS, T_DYN, HC_MULT, D], pl.FP32]
+    ],
+):
+    """Allocate each communication window once and submit one Full43 child."""
+    x_ping.bind_dynamic(1, T_DYN)
+    raw_kv_pool.bind_dynamic(1, FWD_PACKED_RAW_BLOCKS_DYN)
+    freqs_cos.bind_dynamic(1, T_DYN)
+    freqs_sin.bind_dynamic(1, T_DYN)
+    swa_slot_mapping.bind_dynamic(1, T_DYN)
+    swa_indices.bind_dynamic(1, T_DYN)
+    swa_lens.bind_dynamic(1, T_DYN)
+    position_ids.bind_dynamic(1, T_DYN)
+    csa_cmp_freqs_cos.bind_dynamic(1, T_DYN)
+    csa_cmp_freqs_sin.bind_dynamic(1, T_DYN)
+    csa_compress_state.bind_dynamic(1, FWD_CSA_MAIN_STATE_BLOCKS_DYN)
+    csa_compress_state_block_table.bind_dynamic(1, CSA_B_DYN)
+    csa_inner_compress_state.bind_dynamic(
+        1, FWD_CSA_INNER_STATE_BLOCKS_DYN
+    )
+    csa_inner_compress_state_block_table.bind_dynamic(1, CSA_B_DYN)
+    csa_cmp_kv.bind_dynamic(1, FWD_CSA_CMP_BLOCKS_DYN)
+    csa_cmp_block_table.bind_dynamic(1, CSA_B_DYN)
+    csa_idx_kv_cache.bind_dynamic(1, FWD_CSA_IDX_BLOCKS_DYN)
+    csa_idx_kv_scale.bind_dynamic(1, FWD_CSA_IDX_BLOCKS_DYN)
+    csa_idx_block_table.bind_dynamic(1, CSA_B_DYN)
+    csa_ori_slot_mapping.bind_dynamic(1, T_DYN)
+    csa_window_swa_indices.bind_dynamic(1, T_DYN)
+    csa_window_swa_lens.bind_dynamic(1, T_DYN)
+    csa_cmp_slot_mapping.bind_dynamic(1, T_DYN)
+    csa_idx_slot_mapping.bind_dynamic(1, T_DYN)
+    csa_state_slot_mapping.bind_dynamic(1, T_DYN)
+    csa_inner_state_slot_mapping.bind_dynamic(1, T_DYN)
+    csa_kv_seq_lens.bind_dynamic(1, CSA_B_DYN)
+    hca_compress_state.bind_dynamic(1, FWD_HCA_STATE_BLOCKS_DYN)
+    hca_compress_state_block_table.bind_dynamic(1, HCA_B_DYN)
+    hca_cmp_kv.bind_dynamic(1, FWD_HCA_CMP_BLOCKS_DYN)
+    hca_cmp_block_table.bind_dynamic(1, HCA_B_DYN)
+    hca_cmp_block_table.bind_dynamic(2, HCA_CMP_TABLE_BLOCKS_DYN)
+    hca_ori_slot_mapping.bind_dynamic(1, T_DYN)
+    hca_window_swa_indices.bind_dynamic(1, T_DYN)
+    hca_window_swa_lens.bind_dynamic(1, T_DYN)
+    hca_cmp_slot_mapping.bind_dynamic(1, T_DYN)
+    hca_state_slot_mapping.bind_dynamic(1, T_DYN)
+    hca_kv_seq_lens.bind_dynamic(1, HCA_B_DYN)
+    x_pong.bind_dynamic(1, T_DYN)
+    x_attn_active.bind_dynamic(1, T_DYN)
+    x_out.bind_dynamic(1, T_DYN)
+
+    attention_window_buf = pld.alloc_window_buffer(
+        [ATTENTION_WINDOW_ROWS, O_GROUP_IN], dtype=pl.BF16
+    )
+    attention_signal_buf = pld.alloc_window_buffer(
+        [TP_SIZE, 1], dtype=pl.INT32
+    )
+    o_window_buf = pld.alloc_window_buffer(
+        [O_WINDOW_ROWS, D], dtype=pl.FP32
+    )
+    o_signal_buf = pld.alloc_window_buffer([TP_SIZE, 1], dtype=pl.INT32)
+    recv_meta_buf = pld.alloc_window_buffer(
+        [N_RANKS, N_LOCAL], dtype=pl.INT32
+    )
+    recv_x_buf = pld.alloc_window_buffer(
+        [N_LOCAL * RECV_MAX, D], dtype=pl.INT8
+    )
+    recv_aux_buf = pld.alloc_window_buffer(
+        [N_LOCAL * RECV_MAX, AUX_PAD], dtype=pl.FP32
+    )
+    recv_route_buf = pld.alloc_window_buffer(
+        [N_LOCAL * RECV_MAX, IDX_PAD], dtype=pl.INT32
+    )
+    arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
+    data_arrived_buf = pld.alloc_window_buffer(
+        [N_RANKS, 1], dtype=pl.INT32
+    )
+    routed_y_buf_buf = pld.alloc_window_buffer(
+        [N_ROUTES, D], dtype=pl.BF16
+    )
+    combine_arrived_buf = pld.alloc_window_buffer(
+        [N_RANKS, 1], dtype=pl.INT32
+    )
+
+    for rank in pl.range(pld.world_size()):
+        attention_window = pld.window(
+            attention_window_buf,
+            [ATTENTION_WINDOW_ROWS, O_GROUP_IN],
+            dtype=pl.BF16,
+        )
+        attention_signal = pld.window(
+            attention_signal_buf, [TP_SIZE, 1], dtype=pl.INT32
+        )
+        o_window = pld.window(
+            o_window_buf, [O_WINDOW_ROWS, D], dtype=pl.FP32
+        )
+        o_signal = pld.window(
+            o_signal_buf, [TP_SIZE, 1], dtype=pl.INT32
+        )
+        recv_meta = pld.window(
+            recv_meta_buf, [N_RANKS, N_LOCAL], dtype=pl.INT32
+        )
+        recv_x = pld.window(
+            recv_x_buf, [N_LOCAL * RECV_MAX, D], dtype=pl.INT8
+        )
+        recv_aux = pld.window(
+            recv_aux_buf,
+            [N_LOCAL * RECV_MAX, AUX_PAD],
+            dtype=pl.FP32,
+        )
+        recv_route = pld.window(
+            recv_route_buf,
+            [N_LOCAL * RECV_MAX, IDX_PAD],
+            dtype=pl.INT32,
+        )
+        arrived = pld.window(
+            arrived_buf, [N_RANKS, 1], dtype=pl.INT32
+        )
+        data_arrived = pld.window(
+            data_arrived_buf, [N_RANKS, 1], dtype=pl.INT32
+        )
+        routed_y_buf = pld.window(
+            routed_y_buf_buf, [N_ROUTES, D], dtype=pl.BF16
+        )
+        combine_arrived = pld.window(
+            combine_arrived_buf, [N_RANKS, 1], dtype=pl.INT32
+        )
+        tp_rank = rank % TP_SIZE
+        group_base = rank - tp_rank
+        decode_fwd_full43(
+            hc_attn_fn[rank], hc_attn_scale[rank], hc_attn_base[rank],
+            attn_norm_w[rank], wq_a[rank], wq_b[rank],
+            wq_b_scale[rank], wkv[rank], gamma_cq[rank], gamma_ckv[rank],
+            raw_kv_pool[rank], freqs_cos[rank], freqs_sin[rank],
+            swa_slot_mapping[rank], swa_indices[rank], swa_lens[rank],
+            position_ids[rank],
+            csa_cmp_freqs_cos[rank], csa_cmp_freqs_sin[rank],
+            csa_cmp_wkv[rank], csa_cmp_wgate[rank], csa_cmp_ape[rank],
+            csa_cmp_norm_w[rank], csa_compress_state[rank],
+            csa_compress_state_block_table[rank],
+            csa_idx_wq_b[rank], csa_idx_wq_b_scale[rank],
+            csa_weights_proj[rank], csa_hadamard_idx[rank],
+            csa_inner_wkv[rank], csa_inner_wgate[rank],
+            csa_inner_ape[rank], csa_inner_norm_w[rank],
+            csa_inner_compress_state[rank],
+            csa_inner_compress_state_block_table[rank],
+            csa_cmp_kv[rank], csa_cmp_block_table[rank],
+            csa_idx_kv_cache[rank], csa_idx_kv_scale[rank],
+            csa_idx_block_table[rank], csa_ori_slot_mapping[rank],
+            csa_window_swa_indices[rank], csa_window_swa_lens[rank],
+            csa_cmp_slot_mapping[rank], csa_idx_slot_mapping[rank],
+            csa_state_slot_mapping[rank],
+            csa_inner_state_slot_mapping[rank], csa_kv_seq_lens[rank],
+            hca_cmp_freqs_cos[rank], hca_cmp_freqs_sin[rank],
+            hca_cmp_wkv[rank], hca_cmp_wgate[rank], hca_cmp_ape[rank],
+            hca_cmp_norm_w[rank], hca_compress_state[rank],
+            hca_compress_state_block_table[rank],
+            hca_cmp_kv[rank], hca_cmp_block_table[rank],
+            hca_ori_slot_mapping[rank], hca_window_swa_indices[rank],
+            hca_window_swa_lens[rank], hca_cmp_slot_mapping[rank],
+            hca_state_slot_mapping[rank], hca_kv_seq_lens[rank],
+            attn_sink[rank], wo_a[rank], wo_b[rank],
+            wo_b_scale[rank],
+            hc_ffn_fn[rank], hc_ffn_scale[rank], hc_ffn_base[rank],
+            norm_w[rank], gate_w[rank], gate_bias[rank], tid2eid[rank],
+            input_ids[rank],
+            routed_w1[rank], routed_w1_scale[rank],
+            routed_w3[rank], routed_w3_scale[rank],
+            routed_w2[rank], routed_w2_scale[rank],
+            shared_w1[rank], shared_w1_scale[rank],
+            shared_w3[rank], shared_w3_scale[rank],
+            shared_w2[rank], shared_w2_scale[rank],
+            x_ping[rank], x_pong[rank],
+            x_attn_active[rank], x_moe_next[rank], x_out[rank],
+            attention_window, attention_signal, o_window, o_signal,
+            recv_meta, recv_x, recv_aux, recv_route,
+            arrived, data_arrived, routed_y_buf, combine_arrived,
+            group_base, tp_rank, rank,
+            device=rank,
+        )
+    return x_out
+
+
 _COMMON_ATTN_WEIGHT_NAMES = (
     "hc_attn_fn",
     "hc_attn_scale",
@@ -2212,6 +4132,468 @@ def build_mixed_prefix_tensor_specs(start_pos=None):
     return specs
 
 
+def _make_full43_weight_bank_spec(
+    name, source, bank_size, *, compile_only=False
+):
+    """Pack a static layer bank along the first rank-local data axis."""
+    from golden import TensorSpec
+
+    storage_shape = list(source.shape[1:])
+    pad_hc_fn = name in {"hc_attn_fn", "hc_ffn_fn"}
+    if pad_hc_fn:
+        if storage_shape[0] != MIX_HC:
+            raise ValueError(f"unexpected HC function shape for {name}")
+        storage_shape[0] = HC_FN_STORAGE_ROWS
+    shape = [
+        N_RANKS,
+        int(bank_size) * int(storage_shape[0]),
+        *storage_shape[1:],
+    ]
+
+    def init_value():
+        import torch
+
+        value = source.create_tensor()
+        if pad_hc_fn:
+            padded = torch.zeros(
+                N_RANKS, HC_FN_STORAGE_ROWS, HC_DIM, dtype=value.dtype
+            )
+            padded[:, :MIX_HC].copy_(value)
+            value = padded
+        repeats = [1, int(bank_size)] + [1] * (value.ndim - 2)
+        return value.repeat(*repeats).contiguous()
+
+    spec = TensorSpec(
+        name,
+        shape,
+        source.dtype,
+        init_value=0 if compile_only else init_value,
+    )
+    spec.resident = "stacked"
+    return spec
+
+
+def _make_full43_packed_pool_spec(
+    name, source, layer_count, *, sentinel=False
+):
+    """Pack identical layer-local allocator pools along the block axis."""
+    import torch
+    from golden import TensorSpec
+
+    shape = list(source.shape)
+    shape[1] *= int(layer_count)
+
+    def init_value():
+        value = source.create_tensor()
+        if not sentinel:
+            repeats = [1, int(layer_count)] + [1] * (value.ndim - 2)
+            return value.repeat(*repeats).contiguous()
+        packed = torch.empty(shape, dtype=source.dtype)
+        extent = int(source.shape[1])
+        for ordinal in range(layer_count):
+            packed[:, ordinal * extent : (ordinal + 1) * extent].fill_(
+                ordinal + 1
+            )
+        return packed
+
+    spec = TensorSpec(
+        name, shape, source.dtype, init_value=init_value, is_output=True
+    )
+    spec.resident = "stacked"
+    return spec
+
+
+def build_full43_tensor_specs(
+    start_pos=None,
+    *,
+    weight_bank_size=FULL43_RUNTIME_WEIGHT_BANK,
+    runtime_case="full_active",
+):
+    """Build the production or bounded-runtime Full43 L3 fixture."""
+    import inspect
+
+    import torch
+    from golden import TensorSpec
+
+    if weight_bank_size != FWD_WEIGHT_BANK_SIZE:
+        raise ValueError(
+            "weight bank froze at module import as "
+            f"{FWD_WEIGHT_BANK_SIZE}, got {weight_bank_size}"
+        )
+    compile_only = runtime_case is None
+    if not compile_only and weight_bank_size != FULL43_RUNTIME_WEIGHT_BANK:
+        raise ValueError("Full43 runtime witnesses use one reusable weight bank")
+    if runtime_case not in {
+        None,
+        "full_active",
+        "packed_pool_sentinel",
+        "long_context_tail",
+    }:
+        raise ValueError(f"unknown Full43 runtime case: {runtime_case!r}")
+
+    if runtime_case == "long_context_tail" and start_pos is None:
+        start_pos = [0, 0, 0, 1048568]
+
+    def tensor_specs(builder, layer_id):
+        return {
+            spec.name: spec
+            for spec in builder(start_pos=start_pos, layer_id=layer_id)
+            if isinstance(spec, TensorSpec)
+        }
+
+    swa_specs = tensor_specs(layer.build_swa_layer_specs, 0)
+    csa_specs = tensor_specs(layer.build_csa_layer_specs, 2)
+    hca_specs = tensor_specs(layer.build_hca_layer_specs, 3)
+    local_t = int(swa_specs["freqs_cos"].shape[1])
+    if int(csa_specs["freqs_cos"].shape[1]) != local_t:
+        raise ValueError("CSA and SWA Full43 fixtures disagree on active rows")
+    if int(hca_specs["freqs_cos"].shape[1]) != local_t:
+        raise ValueError("HCA and SWA Full43 fixtures disagree on active rows")
+
+    def zero_active():
+        return torch.zeros(
+            N_RANKS, local_t, HC_MULT, D, dtype=torch.float32
+        )
+
+    def init_input_ids():
+        value = swa_specs["input_ids"].create_tensor()
+        return torch.remainder(value, MIXED_PREFIX_TEST_VOCAB).contiguous()
+
+    sentinel = runtime_case == "packed_pool_sentinel"
+    specs_by_name = {
+        "raw_kv_pool": _make_full43_packed_pool_spec(
+            "raw_kv_pool",
+            swa_specs["kv_cache"],
+            MAIN_LAYER_COUNT,
+            sentinel=sentinel,
+        ),
+        "hca_compress_state": _make_full43_packed_pool_spec(
+            "hca_compress_state",
+            hca_specs["compress_state"],
+            HCA_LAYER_COUNT,
+            sentinel=sentinel,
+        ),
+        "hca_cmp_kv": _make_full43_packed_pool_spec(
+            "hca_cmp_kv",
+            hca_specs["cmp_kv"],
+            HCA_LAYER_COUNT,
+            sentinel=sentinel,
+        ),
+        "csa_compress_state": _make_full43_packed_pool_spec(
+            "csa_compress_state",
+            csa_specs["compress_state"],
+            CSA_LAYER_COUNT,
+            sentinel=sentinel,
+        ),
+        "csa_cmp_kv": _make_full43_packed_pool_spec(
+            "csa_cmp_kv",
+            csa_specs["cmp_kv"],
+            CSA_LAYER_COUNT,
+            sentinel=sentinel,
+        ),
+        "csa_inner_compress_state": _make_full43_packed_pool_spec(
+            "csa_inner_compress_state",
+            csa_specs["inner_compress_state"],
+            CSA_LAYER_COUNT,
+            sentinel=sentinel,
+        ),
+        "csa_idx_kv_cache": _make_full43_packed_pool_spec(
+            "csa_idx_kv_cache",
+            csa_specs["idx_kv_cache"],
+            CSA_LAYER_COUNT,
+            sentinel=sentinel,
+        ),
+        "csa_idx_kv_scale": _make_full43_packed_pool_spec(
+            "csa_idx_kv_scale",
+            csa_specs["idx_kv_scale"],
+            CSA_LAYER_COUNT,
+            sentinel=sentinel,
+        ),
+        "input_ids": TensorSpec(
+            "input_ids",
+            [N_RANKS, MOE_TOKENS],
+            torch.int64,
+            init_value=init_input_ids,
+        ),
+        "x_ping": TensorSpec(
+            "x_ping",
+            [N_RANKS, local_t, HC_MULT, D],
+            torch.float32,
+            init_value=swa_specs["x_hc"].init_value,
+            is_output=True,
+        ),
+        "x_pong": TensorSpec(
+            "x_pong",
+            [N_RANKS, local_t, HC_MULT, D],
+            torch.float32,
+            init_value=zero_active,
+            is_output=True,
+        ),
+        "x_attn_active": TensorSpec(
+            "x_attn_active",
+            [N_RANKS, local_t, HC_MULT, D],
+            torch.float32,
+            init_value=zero_active,
+            is_output=True,
+        ),
+        "x_moe_next": TensorSpec(
+            "x_moe_next",
+            [N_RANKS, MOE_TOKENS, HC_MULT, D],
+            torch.float32,
+            init_value=lambda: torch.zeros(
+                N_RANKS, MOE_TOKENS, HC_MULT, D, dtype=torch.float32
+            ),
+            is_output=True,
+        ),
+        "x_out": TensorSpec(
+            "x_out",
+            [N_RANKS, local_t, HC_MULT, D],
+            torch.float32,
+            is_output=True,
+        ),
+    }
+
+    for name in _MIXED_LAYERED_WEIGHT_NAMES:
+        specs_by_name[name] = _make_full43_weight_bank_spec(
+            name,
+            swa_specs[name],
+            weight_bank_size,
+            compile_only=compile_only,
+        )
+    for name in _SWA_METADATA_NAMES:
+        specs_by_name[name] = _copy_prefix_spec(name, swa_specs[name])
+
+    csa_weight_names = {
+        f"csa_{name}": name for name in _CSA_EXTRA_WEIGHT_NAMES
+    }
+    hca_weight_names = {
+        f"hca_{name}": name for name in _HCA_EXTRA_WEIGHT_NAMES
+    }
+    for public_name, source_name in csa_weight_names.items():
+        specs_by_name[public_name] = _make_full43_weight_bank_spec(
+            public_name,
+            csa_specs[source_name],
+            CSA_LAYER_COUNT if compile_only else FULL43_RUNTIME_WEIGHT_BANK,
+            compile_only=compile_only,
+        )
+    for public_name, source_name in hca_weight_names.items():
+        specs_by_name[public_name] = _make_full43_weight_bank_spec(
+            public_name,
+            hca_specs[source_name],
+            HCA_LAYER_COUNT if compile_only else FULL43_RUNTIME_WEIGHT_BANK,
+            compile_only=compile_only,
+        )
+
+    packed_names = set(PACKED_POOL_LAYER_COUNTS)
+    for public_name, source_name in _CSA_PREFIX_SOURCES.items():
+        if public_name in packed_names or public_name in csa_weight_names:
+            continue
+        specs_by_name[public_name] = _copy_prefix_spec(
+            public_name, csa_specs[source_name]
+        )
+    for public_name, source_name in _HCA_PREFIX_SOURCES.items():
+        if public_name in packed_names or public_name in hca_weight_names:
+            continue
+        specs_by_name[public_name] = _copy_prefix_spec(
+            public_name, hca_specs[source_name]
+        )
+
+    parameter_names = list(
+        inspect.signature(l3_decode_fwd_full43._func).parameters
+    )
+    missing = [name for name in parameter_names if name not in specs_by_name]
+    extra = [name for name in specs_by_name if name not in parameter_names]
+    if missing or extra:
+        raise ValueError(
+            f"Full43 spec/signature mismatch: missing={missing}, extra={extra}"
+        )
+    specs = [specs_by_name[name] for name in parameter_names]
+    for spec in specs:
+        if len(spec.shape) > MAX_PUBLIC_TENSOR_DIMS:
+            raise ValueError(
+                f"Full43 tensor {spec.name!r} exceeds "
+                f"{MAX_PUBLIC_TENSOR_DIMS} dimensions: {spec.shape}"
+            )
+    return specs
+
+
+def golden_full43_runtime(_tensors):
+    """Full43 is a topology/isolation witness; layer math is gated earlier."""
+
+
+def finite_full43_tensor_compare(actual, _expected, **_kwargs):
+    """Require a completed finite device result without duplicating 43 goldens."""
+    import torch
+
+    if actual.numel() == 0:
+        return False, "    Full43 output is empty"
+    if actual.is_floating_point() and not bool(torch.isfinite(actual).all()):
+        return False, "    Full43 output contains NaN or Inf"
+    return True, ""
+
+
+def _full43_pool_compare(layer_mappings, layer_count, block_size, pool_name):
+    """Check every packed layer slice and reject writes outside local slots."""
+    def compare(actual, expected, **kwargs):
+        import torch
+
+        if actual.shape != expected.shape:
+            return False, (
+                f"    {pool_name} shape mismatch: "
+                f"actual={tuple(actual.shape)} expected={tuple(expected.shape)}"
+            )
+        if actual.shape[1] % layer_count:
+            return False, f"    {pool_name} packed extent is not divisible"
+        if len(layer_mappings) != layer_count:
+            return False, f"    {pool_name} mapping count diverged"
+        inputs = kwargs.get("inputs", {})
+        extent = actual.shape[1] // layer_count
+        for ordinal, mapping_name in enumerate(layer_mappings):
+            mapping = inputs.get(mapping_name)
+            if mapping is None:
+                return False, f"    missing input {mapping_name!r}"
+            for rank in range(actual.shape[0]):
+                begin = ordinal * extent
+                actual_rows = actual[rank, begin : begin + extent].reshape(
+                    extent * block_size, *actual.shape[3:]
+                )
+                expected_rows = expected[rank, begin : begin + extent].reshape(
+                    extent * block_size, *expected.shape[3:]
+                )
+                slots = mapping[rank].to(dtype=torch.int64).reshape(-1)
+                invalid = (slots < -1) | (slots >= actual_rows.shape[0])
+                if bool(invalid.any()):
+                    first = int(slots[invalid][0])
+                    return False, (
+                        f"    {pool_name} layer={ordinal} rank={rank} "
+                        f"contains out-of-range slot {first}"
+                    )
+                slots = slots[slots >= 0]
+                target = torch.zeros(
+                    actual_rows.shape[0], dtype=torch.bool, device=actual.device
+                )
+                if slots.numel():
+                    target[slots] = True
+                if not torch.equal(actual_rows[~target], expected_rows[~target]):
+                    return False, (
+                        f"    {pool_name} layer={ordinal} rank={rank} "
+                        "modified an unmapped row"
+                    )
+                selected = actual_rows[target]
+                if selected.is_floating_point() and not bool(
+                    torch.isfinite(selected).all()
+                ):
+                    return False, (
+                        f"    {pool_name} layer={ordinal} rank={rank} "
+                        "wrote NaN or Inf"
+                    )
+                sentinel_value = ordinal + 1
+                if slots.numel() and bool(
+                    torch.all(expected_rows == sentinel_value)
+                ) and torch.equal(selected, expected_rows[target]):
+                    return False, (
+                        f"    {pool_name} layer={ordinal} rank={rank} "
+                        "did not update any mapped sentinel row"
+                    )
+        return True, ""
+
+    return compare
+
+
+def full43_compare_functions():
+    """Return the Full43 runtime isolation and completion comparators."""
+    raw_mappings = tuple(
+        "swa_slot_mapping"
+        if entry["kind"] == "swa"
+        else f"{entry['kind']}_ori_slot_mapping"
+        for entry in FULL43_LAYER_PLAN
+    )
+    csa_mappings = ("csa_state_slot_mapping",) * CSA_LAYER_COUNT
+    csa_cmp_mappings = ("csa_cmp_slot_mapping",) * CSA_LAYER_COUNT
+    csa_inner_mappings = (
+        "csa_inner_state_slot_mapping",
+    ) * CSA_LAYER_COUNT
+    csa_idx_mappings = ("csa_idx_slot_mapping",) * CSA_LAYER_COUNT
+    hca_state_mappings = ("hca_state_slot_mapping",) * HCA_LAYER_COUNT
+    hca_cmp_mappings = ("hca_cmp_slot_mapping",) * HCA_LAYER_COUNT
+    finite_names = {
+        "x_ping",
+        "x_pong",
+        "x_attn_active",
+        "x_moe_next",
+        "x_out",
+    }
+    compare = {name: finite_full43_tensor_compare for name in finite_names}
+    compare.update({
+        "raw_kv_pool": _full43_pool_compare(
+            raw_mappings, MAIN_LAYER_COUNT, BLOCK_SIZE, "Full43 raw KV"
+        ),
+        "hca_compress_state": _full43_pool_compare(
+            hca_state_mappings,
+            HCA_LAYER_COUNT,
+            HCA_COMPRESS_STATE_BLOCK_SIZE,
+            "Full43 HCA state",
+        ),
+        "hca_cmp_kv": _full43_pool_compare(
+            hca_cmp_mappings,
+            HCA_LAYER_COUNT,
+            BLOCK_SIZE,
+            "Full43 HCA compressed KV",
+        ),
+        "csa_compress_state": _full43_pool_compare(
+            csa_mappings,
+            CSA_LAYER_COUNT,
+            CSA_MAIN_STATE_BLOCK_SIZE,
+            "Full43 CSA main state",
+        ),
+        "csa_cmp_kv": _full43_pool_compare(
+            csa_cmp_mappings,
+            CSA_LAYER_COUNT,
+            BLOCK_SIZE,
+            "Full43 CSA compressed KV",
+        ),
+        "csa_inner_compress_state": _full43_pool_compare(
+            csa_inner_mappings,
+            CSA_LAYER_COUNT,
+            CSA_INNER_STATE_BLOCK_SIZE,
+            "Full43 CSA inner state",
+        ),
+        "csa_idx_kv_cache": _full43_pool_compare(
+            csa_idx_mappings,
+            CSA_LAYER_COUNT,
+            BLOCK_SIZE,
+            "Full43 CSA index KV",
+        ),
+        "csa_idx_kv_scale": _full43_pool_compare(
+            csa_idx_mappings,
+            CSA_LAYER_COUNT,
+            BLOCK_SIZE,
+            "Full43 CSA index scale",
+        ),
+    })
+    return compare
+
+
+def build_full43_shape_report(
+    start_pos=None, *, weight_bank_size=FWD_WEIGHT_BANK_SIZE
+):
+    """Return concrete Full43 device ABI shapes without materializing values."""
+    runtime_case = "full_active" if weight_bank_size == 1 else None
+    specs = build_full43_tensor_specs(
+        start_pos,
+        weight_bank_size=weight_bank_size,
+        runtime_case=runtime_case,
+    )
+    shapes = {spec.name: list(spec.shape) for spec in specs}
+    return {
+        "weight_bank_size": weight_bank_size,
+        "active_tokens": shapes["freqs_cos"][1],
+        "raw_blocks_per_layer": shapes["raw_kv_pool"][1] // MAIN_LAYER_COUNT,
+        "maximum_public_tensor_dims": max(len(shape) for shape in shapes.values()),
+        "shapes": shapes,
+    }
+
+
 def _mixed_layer_value(value, layer_ordinal):
     extent = value.shape[1] // MIXED_PREFIX_LAYER_COUNT
     begin = layer_ordinal * extent
@@ -2458,7 +4840,7 @@ def _parse_start_pos(raw):
 def main():
     import argparse
 
-    from golden import mapped_pool_ratio_allclose, ratio_reldiff, run_jit
+    from golden import run_jit
     from pypto.ir.distributed_compiled_program import DistributedConfig
 
     parser = argparse.ArgumentParser(
@@ -2483,6 +4865,23 @@ def main():
     parser.add_argument("--shape-only", action="store_true", default=False)
     parser.add_argument("--compile-only", action="store_true", default=False)
     parser.add_argument(
+        "--weight-bank-size",
+        type=int,
+        default=FWD_WEIGHT_BANK_SIZE,
+        choices=(1, MAIN_LAYER_COUNT),
+        help="1 reuses weights at runtime; 43 builds production layer banks",
+    )
+    parser.add_argument(
+        "--runtime-case",
+        type=str,
+        default="full_active",
+        choices=(
+            "full_active",
+            "packed_pool_sentinel",
+            "long_context_tail",
+        ),
+    )
+    parser.add_argument(
         "--enable-scope-stats", action="store_true", default=False
     )
     parser.add_argument("--runtime-dir", type=str, default=None)
@@ -2497,9 +4896,19 @@ def main():
             f"parallel sizes froze at import as TP={TP_SIZE}, EP={EP_SIZE}"
         )
     start_pos = _parse_start_pos(args.start_pos)
+    weight_bank_size = args.weight_bank_size
+    if weight_bank_size != FWD_WEIGHT_BANK_SIZE:
+        parser.error(
+            "weight bank froze at import as "
+            f"{FWD_WEIGHT_BANK_SIZE}, got {weight_bank_size}"
+        )
+    if not args.compile_only and not args.shape_only and weight_bank_size != 1:
+        parser.error("Full43 runtime requires --weight-bank-size 1")
     if args.shape_only:
         report = build_decode_fwd_shape_report(start_pos)
-        prefix_report = build_mixed_prefix_shape_report(start_pos)
+        full43_report = build_full43_shape_report(
+            start_pos, weight_bank_size=weight_bank_size
+        )
         packed_summary = ", ".join(
             f"{name}={entry['total_extent']}"
             for name, entry in report["packed_layout"].items()
@@ -2516,10 +4925,11 @@ def main():
             f"{report['packed_pool_bytes_per_rank'] / (1024 ** 3):.3f}"
         )
         print(
-            "mixed_prefix: "
-            f"active_t={prefix_report['active_tokens']} "
-            f"raw_blocks_per_layer={prefix_report['raw_blocks_per_layer']} "
-            f"max_dims={prefix_report['maximum_public_tensor_dims']}"
+            "full43_device: "
+            f"weight_bank={full43_report['weight_bank_size']} "
+            f"active_t={full43_report['active_tokens']} "
+            f"raw_blocks_per_layer={full43_report['raw_blocks_per_layer']} "
+            f"max_dims={full43_report['maximum_public_tensor_dims']}"
         )
         return
 
@@ -2541,12 +4951,16 @@ def main():
     ):
         parser.error(f"device IDs must be distinct and non-negative: {device_ids}")
 
-    specs = build_mixed_prefix_tensor_specs(start_pos=start_pos)
-    local_t = next(spec.shape[1] for spec in specs if spec.name == "x_out")
+    runtime_case = None if weight_bank_size == MAIN_LAYER_COUNT else args.runtime_case
+    specs = build_full43_tensor_specs(
+        start_pos=start_pos,
+        weight_bank_size=weight_bank_size,
+        runtime_case=runtime_case,
+    )
     result = run_jit(
-        fn=l3_decode_fwd,
+        fn=l3_decode_fwd_full43,
         specs=specs,
-        golden_fn=golden_mixed_prefix_decode_fwd,
+        golden_fn=golden_full43_runtime,
         golden_data=args.golden_data,
         save_data=args.save_data,
         compile_only=args.compile_only,
@@ -2564,91 +4978,7 @@ def main():
         ),
         rtol=1e-2,
         atol=1e-2,
-        compare_fn={
-            "raw_kv_pool": mixed_packed_raw_pool_compare,
-            "hca_compress_state": mapped_pool_ratio_allclose(
-                "hca_state_slot_mapping",
-                mapping_shape=(N_RANKS, local_t),
-                block_size=HCA_COMPRESS_STATE_BLOCK_SIZE,
-                leading_rank_axis=True,
-                pool_name="mixed HCA compressor state",
-                atol=0.01,
-                rtol=0.08,
-                max_error_ratio=0.08,
-            ),
-            "hca_cmp_kv": mapped_pool_ratio_allclose(
-                "hca_cmp_slot_mapping",
-                mapping_shape=(N_RANKS, local_t),
-                block_size=BLOCK_SIZE,
-                leading_rank_axis=True,
-                pool_name="mixed HCA compressed KV cache",
-                atol=0.01,
-                rtol=0.08,
-                max_error_ratio=0.08,
-            ),
-            "csa_compress_state": mapped_pool_ratio_allclose(
-                "csa_state_slot_mapping",
-                mapping_shape=(N_RANKS, local_t),
-                block_size=CSA_MAIN_STATE_BLOCK_SIZE,
-                leading_rank_axis=True,
-                pool_name="mixed CSA main compressor state",
-                atol=0.01,
-                rtol=0.08,
-                max_error_ratio=0.08,
-            ),
-            "csa_cmp_kv": mapped_pool_ratio_allclose(
-                "csa_cmp_slot_mapping",
-                mapping_shape=(N_RANKS, local_t),
-                block_size=BLOCK_SIZE,
-                leading_rank_axis=True,
-                pool_name="mixed CSA compressed KV cache",
-                atol=0.01,
-                rtol=0.08,
-                max_error_ratio=0.08,
-            ),
-            "csa_inner_compress_state": mapped_pool_ratio_allclose(
-                "csa_inner_state_slot_mapping",
-                mapping_shape=(N_RANKS, local_t),
-                block_size=CSA_INNER_STATE_BLOCK_SIZE,
-                leading_rank_axis=True,
-                pool_name="mixed CSA inner compressor state",
-                atol=0.01,
-                rtol=0.08,
-                max_error_ratio=0.08,
-            ),
-            "csa_idx_kv_cache": mapped_pool_ratio_allclose(
-                "csa_idx_slot_mapping",
-                mapping_shape=(N_RANKS, local_t),
-                block_size=BLOCK_SIZE,
-                leading_rank_axis=True,
-                pool_name="mixed CSA indexer KV cache",
-                atol=1,
-                rtol=0,
-                max_error_ratio=0.08,
-            ),
-            "csa_idx_kv_scale": mapped_pool_ratio_allclose(
-                "csa_idx_slot_mapping",
-                mapping_shape=(N_RANKS, local_t),
-                block_size=BLOCK_SIZE,
-                leading_rank_axis=True,
-                pool_name="mixed CSA indexer KV scale",
-                atol=0.01,
-                rtol=0.08,
-                max_error_ratio=0.08,
-            ),
-            "x_ping": ratio_reldiff(diff_thd=0.01, pct_thd=0.06),
-            "x_pong": ratio_reldiff(diff_thd=0.01, pct_thd=0.15),
-            "x_attn_active": ratio_reldiff(
-                diff_thd=0.01, pct_thd=0.15
-            ),
-            "x_moe_next": ratio_reldiff(
-                diff_thd=0.01,
-                pct_thd=0.22,
-                valid_rows=local_t,
-                valid_axis=1,
-            ),
-            "x_out": ratio_reldiff(diff_thd=0.01, pct_thd=0.22),
-        },
+        compare_fn=full43_compare_functions(),
     )
     if not result.passed:
         if result.error:

--- a/models/deepseek_v4_flash_dspark/decode_fwd.py
+++ b/models/deepseek_v4_flash_dspark/decode_fwd.py
@@ -151,6 +151,9 @@ CSA_IDX_MAX_BLOCKS = csa.IDX_MAX_BLOCKS
 RUNTIME_TEST_VOCAB = 256
 RUNTIME_WEIGHT_BANK = 1
 HC_FN_STORAGE_ROWS = 32
+DECODE_RING_TASK_WINDOW = 16384
+DECODE_RING_HEAP = 1 << 30
+DECODE_RING_DEP_POOL = 16384
 
 
 def _validate_import_contract():
@@ -2233,6 +2236,9 @@ def main():
             platform=args.platform,
             enable_scope_stats=args.enable_scope_stats,
             log_level=args.log_level,
+            ring_task_window=DECODE_RING_TASK_WINDOW,
+            ring_heap=DECODE_RING_HEAP,
+            ring_dep_pool=DECODE_RING_DEP_POOL,
         ),
         rtol=1e-2,
         atol=1e-2,

--- a/models/deepseek_v4_flash_dspark/decode_fwd.py
+++ b/models/deepseek_v4_flash_dspark/decode_fwd.py
@@ -6,7 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
-"""DeepSeek-V4 D-Spark 43-layer decode-forward integration."""
+"""DeepSeek-V4 D-Spark decode forward."""
 
 import sys
 
@@ -58,9 +58,21 @@ import moe as moe_module
 import pypto.language as pl
 import pypto.language.distributed as pld
 from decode_layer import decode_layer_csa, decode_layer_hca, decode_layer_swa
+from hc_head import hc_head
+from lm_head import (
+    GROUP_LOGIT_ROWS,
+    MAX_LOGIT_ROWS,
+    SAMPLED_IDS_PAD,
+    TP_SIZE as LM_HEAD_TP_SIZE,
+    VOCAB as LM_HEAD_VOCAB,
+    VOCAB_PER_TP,
+    greedy_sample,
+    lm_head,
+)
 from lookup_embedding import VOCAB_DYN as EMBED_VOCAB_DYN
 from lookup_embedding import lookup_embedding
 from moe import clear_moe_signals
+from rmsnorm import rms_norm
 
 
 MODEL_CONFIG = config.FLASH
@@ -78,9 +90,7 @@ MOE_TOKENS = layer.MOE_TOKENS
 D = layer.D
 HC_MULT = layer.HC_MULT
 HC_DIM = layer.HC_DIM
-MAX_LOGIT_ROWS = DECODE_TOKENS
-SAMPLED_IDS_PAD = 8
-VOCAB_PER_TP = MODEL_CONFIG.vocab_size // TP_SIZE
+LM_HEAD_COMM_EPOCH = 1
 
 T_DYN = layer.T_DYN
 FWD_PACKED_RAW_BLOCKS_DYN = pl.dynamic("FWD_PACKED_RAW_BLOCKS_DYN")
@@ -138,11 +148,8 @@ CSA_INNER_STATE_DIM = layer.CSA_INNER_STATE_DIM
 CSA_CMP_MAX_BLOCKS = layer.CSA_CMP_MAX_BLOCKS
 CSA_IDX_MAX_BLOCKS = layer.CSA_IDX_MAX_BLOCKS
 
-MIXED_PREFIX_LAYER_COUNT = 4
-MIXED_PREFIX_CSA_LAYER_COUNT = 1
-MIXED_PREFIX_HCA_LAYER_COUNT = 1
-MIXED_PREFIX_TEST_VOCAB = 256
-FULL43_RUNTIME_WEIGHT_BANK = 1
+RUNTIME_TEST_VOCAB = 256
+RUNTIME_WEIGHT_BANK = 1
 HC_FN_STORAGE_ROWS = 32
 
 
@@ -163,6 +170,20 @@ def _validate_import_contract():
         raise ValueError(
             f"vocab size {MODEL_CONFIG.vocab_size} must be divisible by TP={TP_SIZE}"
         )
+    if LM_HEAD_TP_SIZE != TP_SIZE:
+        raise ValueError(
+            f"LM-head TP={LM_HEAD_TP_SIZE} does not match forward TP={TP_SIZE}"
+        )
+    if LM_HEAD_VOCAB != MODEL_CONFIG.vocab_size:
+        raise ValueError(
+            f"LM-head vocab={LM_HEAD_VOCAB} does not match "
+            f"model vocab={MODEL_CONFIG.vocab_size}"
+        )
+    if MAX_LOGIT_ROWS != DECODE_TOKENS:
+        raise ValueError(
+            f"LM-head rows={MAX_LOGIT_ROWS} do not match decode "
+            f"capacity={DECODE_TOKENS}"
+        )
     if MOE_TOKENS > MAX_LOGIT_ROWS:
         raise ValueError(
             f"MoE capacity {MOE_TOKENS} exceeds LM-head rows {MAX_LOGIT_ROWS}"
@@ -172,7 +193,7 @@ def _validate_import_contract():
 _validate_import_contract()
 
 
-def build_full43_layer_plan():
+def build_layer_plan():
     """Return the fixed model-layer, kind-ordinal, and MoE-epoch mapping."""
     kind_ordinals = {"swa": 0, "csa": 0, "hca": 0}
     plan = []
@@ -196,7 +217,7 @@ def build_full43_layer_plan():
     }
     if kind_ordinals != expected_counts:
         raise ValueError(
-            f"full43 attention counts changed: {kind_ordinals} != {expected_counts}"
+            f"decode forward attention counts changed: {kind_ordinals} != {expected_counts}"
         )
     if plan[0]["kind"] != "swa" or plan[1]["kind"] != "swa":
         raise ValueError("model layers 0 and 1 must be SWA")
@@ -217,7 +238,7 @@ def build_full43_layer_plan():
     return tuple(plan)
 
 
-FULL43_LAYER_PLAN = build_full43_layer_plan()
+LAYER_PLAN = build_layer_plan()
 
 
 PACKED_POOL_LAYER_COUNTS = {
@@ -393,8 +414,17 @@ def decode_embedding_preamble(
     embed_weight: pl.Tensor[[EMBED_VOCAB_DYN, D], pl.BF16],
     hidden_states: pl.Tensor[[T_DYN, D], pl.BF16],
     x_hc: pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32],
+    moe_input_ids: pl.Tensor[[MOE_TOKENS], pl.INT64],
 ):
-    """Reuse the canonical lookup and emit the active Hyper-Connections rows."""
+    """Embed active rows and pad their token ids to the fixed MoE capacity."""
+    active_tokens = pl.tensor.dim(input_ids, 0)
+    for token_idx in pl.spmd(
+        MOE_TOKENS, name_hint="decode_fwd_pack_moe_input_ids"
+    ):
+        token_id = pl.cast(0, pl.INT64)
+        if token_idx < active_tokens:
+            token_id = pl.read(input_ids, [token_idx])
+        pl.write(moe_input_ids, [token_idx], token_id)
     lookup_embedding(input_ids, embed_weight, hidden_states, x_hc)
     return x_hc
 
@@ -415,1407 +445,7 @@ def mask_inactive_sample_rows(
 
 @pl.jit(auto_scope=False)
 def decode_fwd(
-    hc_attn_fn: pl.Tensor[[MIXED_PREFIX_LAYER_COUNT * MIX_HC, HC_DIM], pl.FP32],
-    hc_attn_scale: pl.Tensor[[MIXED_PREFIX_LAYER_COUNT * 3], pl.FP32],
-    hc_attn_base: pl.Tensor[[MIXED_PREFIX_LAYER_COUNT * MIX_HC], pl.FP32],
-    attn_norm_w: pl.Tensor[[MIXED_PREFIX_LAYER_COUNT * D], pl.BF16],
-    wq_a: pl.Tensor[[MIXED_PREFIX_LAYER_COUNT * D, Q_LORA], pl.BF16],
-    wq_b: pl.Tensor[
-        [MIXED_PREFIX_LAYER_COUNT * Q_LORA, H * HEAD_DIM], pl.INT8
-    ],
-    wq_b_scale: pl.Tensor[
-        [MIXED_PREFIX_LAYER_COUNT * H * HEAD_DIM], pl.FP32
-    ],
-    wkv: pl.Tensor[[MIXED_PREFIX_LAYER_COUNT * D, HEAD_DIM], pl.BF16],
-    gamma_cq: pl.Tensor[[MIXED_PREFIX_LAYER_COUNT * Q_LORA], pl.BF16],
-    gamma_ckv: pl.Tensor[[MIXED_PREFIX_LAYER_COUNT * HEAD_DIM], pl.BF16],
-    raw_kv_pool: pl.InOut[
-        pl.Tensor[
-            [FWD_PACKED_RAW_BLOCKS_DYN, BLOCK_SIZE, 1, HEAD_DIM],
-            pl.BF16,
-        ]
-    ],
-    freqs_cos: pl.Tensor[[T_DYN, ROPE_HEAD_DIM], pl.BF16],
-    freqs_sin: pl.Tensor[[T_DYN, ROPE_HEAD_DIM], pl.BF16],
-    swa_slot_mapping: pl.Tensor[[T_DYN], pl.INT64],
-    swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
-    swa_lens: pl.Tensor[[T_DYN], pl.INT32],
-    position_ids: pl.Tensor[[T_DYN], pl.INT32],
-    csa_cmp_freqs_cos: pl.Tensor[[T_DYN, ROPE_HEAD_DIM], pl.BF16],
-    csa_cmp_freqs_sin: pl.Tensor[[T_DYN, ROPE_HEAD_DIM], pl.BF16],
-    csa_cmp_wkv: pl.Tensor[[CSA_MAIN_OUT_DIM, D], pl.BF16],
-    csa_cmp_wgate: pl.Tensor[[CSA_MAIN_OUT_DIM, D], pl.BF16],
-    csa_cmp_ape: pl.Tensor[
-        [CSA_COMPRESS_RATIO, CSA_MAIN_OUT_DIM], pl.FP32
-    ],
-    csa_cmp_norm_w: pl.Tensor[[HEAD_DIM], pl.BF16],
-    csa_compress_state: pl.InOut[
-        pl.Tensor[
-            [
-                FWD_CSA_MAIN_STATE_BLOCKS_DYN,
-                CSA_MAIN_STATE_BLOCK_SIZE,
-                CSA_MAIN_STATE_DIM,
-            ],
-            pl.FP32,
-        ]
-    ],
-    csa_compress_state_block_table: pl.Tensor[
-        [CSA_B_DYN, CSA_MAIN_STATE_MAX_BLOCKS], pl.INT32
-    ],
-    csa_idx_wq_b: pl.Tensor[
-        [Q_LORA, CSA_IDX_N_HEADS * CSA_IDX_HEAD_DIM], pl.INT8
-    ],
-    csa_idx_wq_b_scale: pl.Tensor[
-        [CSA_IDX_N_HEADS * CSA_IDX_HEAD_DIM], pl.FP32
-    ],
-    csa_weights_proj: pl.Tensor[[D, CSA_IDX_N_HEADS], pl.BF16],
-    csa_hadamard_idx: pl.Tensor[
-        [CSA_IDX_HEAD_DIM, CSA_IDX_HEAD_DIM], pl.BF16
-    ],
-    csa_inner_wkv: pl.Tensor[[CSA_INNER_OUT_DIM, D], pl.BF16],
-    csa_inner_wgate: pl.Tensor[[CSA_INNER_OUT_DIM, D], pl.BF16],
-    csa_inner_ape: pl.Tensor[
-        [CSA_COMPRESS_RATIO, CSA_INNER_OUT_DIM], pl.FP32
-    ],
-    csa_inner_norm_w: pl.Tensor[[CSA_IDX_HEAD_DIM], pl.BF16],
-    csa_inner_compress_state: pl.InOut[
-        pl.Tensor[
-            [
-                FWD_CSA_INNER_STATE_BLOCKS_DYN,
-                CSA_INNER_STATE_BLOCK_SIZE,
-                CSA_INNER_STATE_DIM,
-            ],
-            pl.FP32,
-        ]
-    ],
-    csa_inner_compress_state_block_table: pl.Tensor[
-        [CSA_B_DYN, CSA_INNER_STATE_MAX_BLOCKS], pl.INT32
-    ],
-    csa_cmp_kv: pl.InOut[
-        pl.Tensor[
-            [FWD_CSA_CMP_BLOCKS_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16
-        ]
-    ],
-    csa_cmp_block_table: pl.Tensor[
-        [CSA_B_DYN, CSA_CMP_MAX_BLOCKS], pl.INT32
-    ],
-    csa_idx_kv_cache: pl.InOut[
-        pl.Tensor[
-            [FWD_CSA_IDX_BLOCKS_DYN, BLOCK_SIZE, 1, CSA_IDX_HEAD_DIM],
-            pl.INT8,
-        ]
-    ],
-    csa_idx_kv_scale: pl.InOut[
-        pl.Tensor[
-            [FWD_CSA_IDX_BLOCKS_DYN, BLOCK_SIZE, 1, 1], pl.FP32
-        ]
-    ],
-    csa_idx_block_table: pl.Tensor[
-        [CSA_B_DYN, CSA_IDX_MAX_BLOCKS], pl.INT32
-    ],
-    csa_ori_slot_mapping: pl.Tensor[[T_DYN], pl.INT64],
-    csa_window_swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
-    csa_window_swa_lens: pl.Tensor[[T_DYN], pl.INT32],
-    csa_cmp_slot_mapping: pl.Tensor[[T_DYN], pl.INT64],
-    csa_idx_slot_mapping: pl.Tensor[[T_DYN], pl.INT64],
-    csa_state_slot_mapping: pl.Tensor[[T_DYN], pl.INT64],
-    csa_inner_state_slot_mapping: pl.Tensor[[T_DYN], pl.INT64],
-    csa_kv_seq_lens: pl.Tensor[[CSA_B_DYN], pl.INT32],
-    hca_cmp_freqs_cos: pl.Tensor[[HCA_B, ROPE_HEAD_DIM // 2], pl.FP32],
-    hca_cmp_freqs_sin: pl.Tensor[[HCA_B, ROPE_HEAD_DIM // 2], pl.FP32],
-    hca_cmp_wkv: pl.Tensor[[HCA_MAIN_OUT_DIM, D], pl.BF16],
-    hca_cmp_wgate: pl.Tensor[[HCA_MAIN_OUT_DIM, D], pl.BF16],
-    hca_cmp_ape: pl.Tensor[
-        [HCA_COMPRESS_RATIO, HCA_MAIN_OUT_DIM], pl.FP32
-    ],
-    hca_cmp_norm_w: pl.Tensor[[HEAD_DIM], pl.BF16],
-    hca_compress_state: pl.InOut[
-        pl.Tensor[
-            [
-                FWD_HCA_STATE_BLOCKS_DYN,
-                HCA_COMPRESS_STATE_BLOCK_SIZE,
-                HCA_COMPRESS_STATE_DIM,
-            ],
-            pl.FP32,
-        ]
-    ],
-    hca_compress_state_block_table: pl.Tensor[
-        [HCA_B_DYN, HCA_COMPRESS_STATE_MAX_BLOCKS], pl.INT32
-    ],
-    hca_cmp_kv: pl.InOut[
-        pl.Tensor[
-            [FWD_HCA_CMP_BLOCKS_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16
-        ]
-    ],
-    hca_cmp_block_table: pl.Tensor[
-        [HCA_B_DYN, HCA_CMP_TABLE_BLOCKS_DYN], pl.INT32
-    ],
-    hca_ori_slot_mapping: pl.Tensor[[T_DYN], pl.INT64],
-    hca_window_swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
-    hca_window_swa_lens: pl.Tensor[[T_DYN], pl.INT32],
-    hca_cmp_slot_mapping: pl.Tensor[[T_DYN], pl.INT64],
-    hca_state_slot_mapping: pl.Tensor[[T_DYN], pl.INT64],
-    hca_kv_seq_lens: pl.Tensor[[HCA_B_DYN], pl.INT32],
-    attn_sink: pl.Tensor[[MIXED_PREFIX_LAYER_COUNT * H], pl.FP32],
-    wo_a: pl.Tensor[
-        [MIXED_PREFIX_LAYER_COUNT * LOCAL_O_GROUPS, O_LORA, O_GROUP_IN],
-        pl.BF16,
-    ],
-    wo_b: pl.Tensor[
-        [MIXED_PREFIX_LAYER_COUNT * D, LOCAL_O_WIDTH], pl.INT8
-    ],
-    wo_b_scale: pl.Tensor[[MIXED_PREFIX_LAYER_COUNT * D], pl.FP32],
-    hc_ffn_fn: pl.Tensor[
-        [MIXED_PREFIX_LAYER_COUNT * MIX_HC, HC_DIM], pl.FP32
-    ],
-    hc_ffn_scale: pl.Tensor[[MIXED_PREFIX_LAYER_COUNT * 3], pl.FP32],
-    hc_ffn_base: pl.Tensor[[MIXED_PREFIX_LAYER_COUNT * MIX_HC], pl.FP32],
-    norm_w: pl.Tensor[[MIXED_PREFIX_LAYER_COUNT * D], pl.BF16],
-    gate_w: pl.Tensor[
-        [MIXED_PREFIX_LAYER_COUNT * N_EXPERTS_GLOBAL, D], pl.FP32
-    ],
-    gate_bias: pl.Tensor[
-        [MIXED_PREFIX_LAYER_COUNT * N_EXPERTS_GLOBAL], pl.FP32
-    ],
-    tid2eid: pl.Tensor[[MIXED_PREFIX_LAYER_COUNT * VOCAB, TOPK], pl.INT32],
-    input_ids: pl.Tensor[[MOE_TOKENS], pl.INT64],
-    routed_w1: pl.Tensor[
-        [MIXED_PREFIX_LAYER_COUNT * N_LOCAL, MOE_INTER, D], pl.INT8
-    ],
-    routed_w1_scale: pl.Tensor[
-        [MIXED_PREFIX_LAYER_COUNT * N_LOCAL, MOE_INTER], pl.FP32
-    ],
-    routed_w3: pl.Tensor[
-        [MIXED_PREFIX_LAYER_COUNT * N_LOCAL, MOE_INTER, D], pl.INT8
-    ],
-    routed_w3_scale: pl.Tensor[
-        [MIXED_PREFIX_LAYER_COUNT * N_LOCAL, MOE_INTER], pl.FP32
-    ],
-    routed_w2: pl.Tensor[
-        [MIXED_PREFIX_LAYER_COUNT * N_LOCAL, D, MOE_INTER], pl.INT8
-    ],
-    routed_w2_scale: pl.Tensor[
-        [MIXED_PREFIX_LAYER_COUNT * N_LOCAL, D], pl.FP32
-    ],
-    shared_w1: pl.Tensor[
-        [MIXED_PREFIX_LAYER_COUNT * MOE_INTER, D], pl.INT8
-    ],
-    shared_w1_scale: pl.Tensor[
-        [MIXED_PREFIX_LAYER_COUNT * MOE_INTER], pl.FP32
-    ],
-    shared_w3: pl.Tensor[
-        [MIXED_PREFIX_LAYER_COUNT * MOE_INTER, D], pl.INT8
-    ],
-    shared_w3_scale: pl.Tensor[
-        [MIXED_PREFIX_LAYER_COUNT * MOE_INTER], pl.FP32
-    ],
-    shared_w2: pl.Tensor[
-        [MIXED_PREFIX_LAYER_COUNT * D, MOE_INTER], pl.INT8
-    ],
-    shared_w2_scale: pl.Tensor[[MIXED_PREFIX_LAYER_COUNT * D], pl.FP32],
-    x_ping: pl.InOut[pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32]],
-    x_pong: pl.InOut[pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32]],
-    x_attn_active: pl.InOut[
-        pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32]
-    ],
-    x_moe_next: pl.InOut[
-        pl.Tensor[[MOE_TOKENS, HC_MULT, D], pl.FP32]
-    ],
-    x_out: pl.Out[pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32]],
-    attention_window: pld.DistributedTensor[
-        [ATTENTION_WINDOW_ROWS, O_GROUP_IN], pl.BF16
-    ],
-    attention_signal: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
-    o_window: pld.DistributedTensor[[O_WINDOW_ROWS, D], pl.FP32],
-    o_signal: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
-    recv_meta: pld.DistributedTensor[[N_RANKS, N_LOCAL], pl.INT32],
-    recv_x: pld.DistributedTensor[[N_LOCAL * RECV_MAX, D], pl.INT8],
-    recv_aux: pld.DistributedTensor[
-        [N_LOCAL * RECV_MAX, AUX_PAD], pl.FP32
-    ],
-    recv_route: pld.DistributedTensor[
-        [N_LOCAL * RECV_MAX, IDX_PAD], pl.INT32
-    ],
-    arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
-    data_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
-    routed_y_buf: pld.DistributedTensor[[N_ROUTES, D], pl.BF16],
-    combine_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
-    group_base: pl.Scalar[pl.INT32],
-    tp_rank: pl.Scalar[pl.INT32],
-    my_rank: pl.Scalar[pl.INT32],
-):
-    """Run SWA, SWA, CSA, and HCA with shared windows and ping-pong."""
-    x_ping.bind_dynamic(0, T_DYN)
-    raw_kv_pool.bind_dynamic(0, FWD_PACKED_RAW_BLOCKS_DYN)
-    freqs_cos.bind_dynamic(0, T_DYN)
-    freqs_sin.bind_dynamic(0, T_DYN)
-    swa_slot_mapping.bind_dynamic(0, T_DYN)
-    swa_indices.bind_dynamic(0, T_DYN)
-    swa_lens.bind_dynamic(0, T_DYN)
-    position_ids.bind_dynamic(0, T_DYN)
-    csa_cmp_freqs_cos.bind_dynamic(0, T_DYN)
-    csa_cmp_freqs_sin.bind_dynamic(0, T_DYN)
-    csa_compress_state.bind_dynamic(0, FWD_CSA_MAIN_STATE_BLOCKS_DYN)
-    csa_compress_state_block_table.bind_dynamic(0, CSA_B_DYN)
-    csa_inner_compress_state.bind_dynamic(
-        0, FWD_CSA_INNER_STATE_BLOCKS_DYN
-    )
-    csa_inner_compress_state_block_table.bind_dynamic(0, CSA_B_DYN)
-    csa_cmp_kv.bind_dynamic(0, FWD_CSA_CMP_BLOCKS_DYN)
-    csa_cmp_block_table.bind_dynamic(0, CSA_B_DYN)
-    csa_idx_kv_cache.bind_dynamic(0, FWD_CSA_IDX_BLOCKS_DYN)
-    csa_idx_kv_scale.bind_dynamic(0, FWD_CSA_IDX_BLOCKS_DYN)
-    csa_idx_block_table.bind_dynamic(0, CSA_B_DYN)
-    csa_ori_slot_mapping.bind_dynamic(0, T_DYN)
-    csa_window_swa_indices.bind_dynamic(0, T_DYN)
-    csa_window_swa_lens.bind_dynamic(0, T_DYN)
-    csa_cmp_slot_mapping.bind_dynamic(0, T_DYN)
-    csa_idx_slot_mapping.bind_dynamic(0, T_DYN)
-    csa_state_slot_mapping.bind_dynamic(0, T_DYN)
-    csa_inner_state_slot_mapping.bind_dynamic(0, T_DYN)
-    csa_kv_seq_lens.bind_dynamic(0, CSA_B_DYN)
-    hca_compress_state.bind_dynamic(0, FWD_HCA_STATE_BLOCKS_DYN)
-    hca_compress_state_block_table.bind_dynamic(0, HCA_B_DYN)
-    hca_cmp_kv.bind_dynamic(0, FWD_HCA_CMP_BLOCKS_DYN)
-    hca_cmp_block_table.bind_dynamic(0, HCA_B_DYN)
-    hca_cmp_block_table.bind_dynamic(1, HCA_CMP_TABLE_BLOCKS_DYN)
-    hca_ori_slot_mapping.bind_dynamic(0, T_DYN)
-    hca_window_swa_indices.bind_dynamic(0, T_DYN)
-    hca_window_swa_lens.bind_dynamic(0, T_DYN)
-    hca_cmp_slot_mapping.bind_dynamic(0, T_DYN)
-    hca_state_slot_mapping.bind_dynamic(0, T_DYN)
-    hca_kv_seq_lens.bind_dynamic(0, HCA_B_DYN)
-    x_pong.bind_dynamic(0, T_DYN)
-    x_attn_active.bind_dynamic(0, T_DYN)
-    x_out.bind_dynamic(0, T_DYN)
-
-    local_t = pl.cast(pl.tensor.dim(x_ping, 0), pl.INT32)
-    raw_blocks_per_layer = (
-        pl.tensor.dim(raw_kv_pool, 0) // MIXED_PREFIX_LAYER_COUNT
-    )
-    with pl.scope():
-        raw_kv_l0 = pl.slice(
-            raw_kv_pool,
-            [raw_blocks_per_layer, BLOCK_SIZE, 1, HEAD_DIM],
-            [0, 0, 0, 0],
-        )
-        hc_attn_fn_l0: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32] = pl.slice(
-            hc_attn_fn, [MIX_HC, HC_DIM], [0, 0]
-        )
-        hc_attn_scale_l0: pl.Tensor[[3], pl.FP32] = pl.slice(
-            hc_attn_scale, [3], [0]
-        )
-        hc_attn_base_l0: pl.Tensor[[MIX_HC], pl.FP32] = pl.slice(
-            hc_attn_base, [MIX_HC], [0]
-        )
-        attn_norm_w_l0: pl.Tensor[[D], pl.BF16] = pl.slice(
-            attn_norm_w, [D], [0]
-        )
-        wq_a_l0: pl.Tensor[[D, Q_LORA], pl.BF16] = pl.slice(
-            wq_a, [D, Q_LORA], [0, 0]
-        )
-        wq_b_l0: pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8] = pl.slice(
-            wq_b, [Q_LORA, H * HEAD_DIM], [0, 0]
-        )
-        wq_b_scale_l0: pl.Tensor[[H * HEAD_DIM], pl.FP32] = pl.slice(
-            wq_b_scale, [H * HEAD_DIM], [0]
-        )
-        wkv_l0: pl.Tensor[[D, HEAD_DIM], pl.BF16] = pl.slice(
-            wkv, [D, HEAD_DIM], [0, 0]
-        )
-        gamma_cq_l0: pl.Tensor[[Q_LORA], pl.BF16] = pl.slice(
-            gamma_cq, [Q_LORA], [0]
-        )
-        gamma_ckv_l0: pl.Tensor[[HEAD_DIM], pl.BF16] = pl.slice(
-            gamma_ckv, [HEAD_DIM], [0]
-        )
-        attn_sink_l0: pl.Tensor[[H], pl.FP32] = pl.slice(
-            attn_sink, [H], [0]
-        )
-        wo_a_l0: pl.Tensor[
-            [LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16
-        ] = pl.slice(
-            wo_a, [LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], [0, 0, 0]
-        )
-        wo_b_l0: pl.Tensor[[D, LOCAL_O_WIDTH], pl.INT8] = pl.slice(
-            wo_b, [D, LOCAL_O_WIDTH], [0, 0]
-        )
-        wo_b_scale_l0: pl.Tensor[[D], pl.FP32] = pl.slice(
-            wo_b_scale, [D], [0]
-        )
-        hc_ffn_fn_l0: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32] = pl.slice(
-            hc_ffn_fn, [MIX_HC, HC_DIM], [0, 0]
-        )
-        hc_ffn_scale_l0: pl.Tensor[[3], pl.FP32] = pl.slice(
-            hc_ffn_scale, [3], [0]
-        )
-        hc_ffn_base_l0: pl.Tensor[[MIX_HC], pl.FP32] = pl.slice(
-            hc_ffn_base, [MIX_HC], [0]
-        )
-        norm_w_l0: pl.Tensor[[D], pl.BF16] = pl.slice(norm_w, [D], [0])
-        gate_w_l0: pl.Tensor[[N_EXPERTS_GLOBAL, D], pl.FP32] = pl.slice(
-            gate_w, [N_EXPERTS_GLOBAL, D], [0, 0]
-        )
-        gate_bias_l0: pl.Tensor[[N_EXPERTS_GLOBAL], pl.FP32] = pl.slice(
-            gate_bias, [N_EXPERTS_GLOBAL], [0]
-        )
-        tid2eid_l0: pl.Tensor[[VOCAB, TOPK], pl.INT32] = pl.slice(
-            tid2eid, [VOCAB, TOPK], [0, 0]
-        )
-        routed_w1_l0: pl.Tensor[
-            [N_LOCAL, MOE_INTER, D], pl.INT8
-        ] = pl.slice(routed_w1, [N_LOCAL, MOE_INTER, D], [0, 0, 0])
-        routed_w1_scale_l0: pl.Tensor[
-            [N_LOCAL, MOE_INTER], pl.FP32
-        ] = pl.slice(routed_w1_scale, [N_LOCAL, MOE_INTER], [0, 0])
-        routed_w3_l0: pl.Tensor[
-            [N_LOCAL, MOE_INTER, D], pl.INT8
-        ] = pl.slice(routed_w3, [N_LOCAL, MOE_INTER, D], [0, 0, 0])
-        routed_w3_scale_l0: pl.Tensor[
-            [N_LOCAL, MOE_INTER], pl.FP32
-        ] = pl.slice(routed_w3_scale, [N_LOCAL, MOE_INTER], [0, 0])
-        routed_w2_l0: pl.Tensor[
-            [N_LOCAL, D, MOE_INTER], pl.INT8
-        ] = pl.slice(routed_w2, [N_LOCAL, D, MOE_INTER], [0, 0, 0])
-        routed_w2_scale_l0: pl.Tensor[[N_LOCAL, D], pl.FP32] = pl.slice(
-            routed_w2_scale, [N_LOCAL, D], [0, 0]
-        )
-        shared_w1_l0: pl.Tensor[[MOE_INTER, D], pl.INT8] = pl.slice(
-            shared_w1, [MOE_INTER, D], [0, 0]
-        )
-        shared_w1_scale_l0: pl.Tensor[[MOE_INTER], pl.FP32] = pl.slice(
-            shared_w1_scale, [MOE_INTER], [0]
-        )
-        shared_w3_l0: pl.Tensor[[MOE_INTER, D], pl.INT8] = pl.slice(
-            shared_w3, [MOE_INTER, D], [0, 0]
-        )
-        shared_w3_scale_l0: pl.Tensor[[MOE_INTER], pl.FP32] = pl.slice(
-            shared_w3_scale, [MOE_INTER], [0]
-        )
-        shared_w2_l0: pl.Tensor[[D, MOE_INTER], pl.INT8] = pl.slice(
-            shared_w2, [D, MOE_INTER], [0, 0]
-        )
-        shared_w2_scale_l0: pl.Tensor[[D], pl.FP32] = pl.slice(
-            shared_w2_scale, [D], [0]
-        )
-        decode_layer_swa(
-            x_ping,
-            hc_attn_fn_l0, hc_attn_scale_l0, hc_attn_base_l0,
-            attn_norm_w_l0, wq_a_l0, wq_b_l0, wq_b_scale_l0,
-            wkv_l0, gamma_cq_l0, gamma_ckv_l0,
-            freqs_cos, freqs_sin, raw_kv_l0,
-            swa_slot_mapping, swa_indices, swa_lens, position_ids,
-            attn_sink_l0, wo_a_l0, wo_b_l0, wo_b_scale_l0,
-            hc_ffn_fn_l0, hc_ffn_scale_l0, hc_ffn_base_l0,
-            norm_w_l0, gate_w_l0, gate_bias_l0, tid2eid_l0, input_ids,
-            routed_w1_l0, routed_w1_scale_l0,
-            routed_w3_l0, routed_w3_scale_l0,
-            routed_w2_l0, routed_w2_scale_l0,
-            shared_w1_l0, shared_w1_scale_l0,
-            shared_w3_l0, shared_w3_scale_l0,
-            shared_w2_l0, shared_w2_scale_l0,
-            x_attn_active, x_moe_next, x_pong,
-            attention_window, attention_signal, o_window, o_signal,
-            recv_meta, recv_x, recv_aux, recv_route,
-            arrived, data_arrived, routed_y_buf, combine_arrived,
-            pl.const(0, pl.INT32), group_base, tp_rank, local_t, my_rank,
-            pl.const(1, pl.INT32),
-        )
-
-    with pl.scope():
-        raw_kv_l1 = pl.slice(
-            raw_kv_pool,
-            [raw_blocks_per_layer, BLOCK_SIZE, 1, HEAD_DIM],
-            [raw_blocks_per_layer, 0, 0, 0],
-        )
-        hc_attn_fn_l1: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32] = pl.slice(
-            hc_attn_fn, [MIX_HC, HC_DIM], [MIX_HC, 0]
-        )
-        hc_attn_scale_l1: pl.Tensor[[3], pl.FP32] = pl.slice(
-            hc_attn_scale, [3], [3]
-        )
-        hc_attn_base_l1: pl.Tensor[[MIX_HC], pl.FP32] = pl.slice(
-            hc_attn_base, [MIX_HC], [MIX_HC]
-        )
-        attn_norm_w_l1: pl.Tensor[[D], pl.BF16] = pl.slice(
-            attn_norm_w, [D], [D]
-        )
-        wq_a_l1: pl.Tensor[[D, Q_LORA], pl.BF16] = pl.slice(
-            wq_a, [D, Q_LORA], [D, 0]
-        )
-        wq_b_l1: pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8] = pl.slice(
-            wq_b, [Q_LORA, H * HEAD_DIM], [Q_LORA, 0]
-        )
-        wq_b_scale_l1: pl.Tensor[[H * HEAD_DIM], pl.FP32] = pl.slice(
-            wq_b_scale, [H * HEAD_DIM], [H * HEAD_DIM]
-        )
-        wkv_l1: pl.Tensor[[D, HEAD_DIM], pl.BF16] = pl.slice(
-            wkv, [D, HEAD_DIM], [D, 0]
-        )
-        gamma_cq_l1: pl.Tensor[[Q_LORA], pl.BF16] = pl.slice(
-            gamma_cq, [Q_LORA], [Q_LORA]
-        )
-        gamma_ckv_l1: pl.Tensor[[HEAD_DIM], pl.BF16] = pl.slice(
-            gamma_ckv, [HEAD_DIM], [HEAD_DIM]
-        )
-        attn_sink_l1: pl.Tensor[[H], pl.FP32] = pl.slice(
-            attn_sink, [H], [H]
-        )
-        wo_a_l1: pl.Tensor[
-            [LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16
-        ] = pl.slice(
-            wo_a,
-            [LOCAL_O_GROUPS, O_LORA, O_GROUP_IN],
-            [LOCAL_O_GROUPS, 0, 0],
-        )
-        wo_b_l1: pl.Tensor[[D, LOCAL_O_WIDTH], pl.INT8] = pl.slice(
-            wo_b, [D, LOCAL_O_WIDTH], [D, 0]
-        )
-        wo_b_scale_l1: pl.Tensor[[D], pl.FP32] = pl.slice(
-            wo_b_scale, [D], [D]
-        )
-        hc_ffn_fn_l1: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32] = pl.slice(
-            hc_ffn_fn, [MIX_HC, HC_DIM], [MIX_HC, 0]
-        )
-        hc_ffn_scale_l1: pl.Tensor[[3], pl.FP32] = pl.slice(
-            hc_ffn_scale, [3], [3]
-        )
-        hc_ffn_base_l1: pl.Tensor[[MIX_HC], pl.FP32] = pl.slice(
-            hc_ffn_base, [MIX_HC], [MIX_HC]
-        )
-        norm_w_l1: pl.Tensor[[D], pl.BF16] = pl.slice(norm_w, [D], [D])
-        gate_w_l1: pl.Tensor[[N_EXPERTS_GLOBAL, D], pl.FP32] = pl.slice(
-            gate_w, [N_EXPERTS_GLOBAL, D], [N_EXPERTS_GLOBAL, 0]
-        )
-        gate_bias_l1: pl.Tensor[[N_EXPERTS_GLOBAL], pl.FP32] = pl.slice(
-            gate_bias, [N_EXPERTS_GLOBAL], [N_EXPERTS_GLOBAL]
-        )
-        tid2eid_l1: pl.Tensor[[VOCAB, TOPK], pl.INT32] = pl.slice(
-            tid2eid, [VOCAB, TOPK], [VOCAB, 0]
-        )
-        routed_w1_l1: pl.Tensor[
-            [N_LOCAL, MOE_INTER, D], pl.INT8
-        ] = pl.slice(routed_w1, [N_LOCAL, MOE_INTER, D], [N_LOCAL, 0, 0])
-        routed_w1_scale_l1: pl.Tensor[
-            [N_LOCAL, MOE_INTER], pl.FP32
-        ] = pl.slice(routed_w1_scale, [N_LOCAL, MOE_INTER], [N_LOCAL, 0])
-        routed_w3_l1: pl.Tensor[
-            [N_LOCAL, MOE_INTER, D], pl.INT8
-        ] = pl.slice(routed_w3, [N_LOCAL, MOE_INTER, D], [N_LOCAL, 0, 0])
-        routed_w3_scale_l1: pl.Tensor[
-            [N_LOCAL, MOE_INTER], pl.FP32
-        ] = pl.slice(routed_w3_scale, [N_LOCAL, MOE_INTER], [N_LOCAL, 0])
-        routed_w2_l1: pl.Tensor[
-            [N_LOCAL, D, MOE_INTER], pl.INT8
-        ] = pl.slice(routed_w2, [N_LOCAL, D, MOE_INTER], [N_LOCAL, 0, 0])
-        routed_w2_scale_l1: pl.Tensor[[N_LOCAL, D], pl.FP32] = pl.slice(
-            routed_w2_scale, [N_LOCAL, D], [N_LOCAL, 0]
-        )
-        shared_w1_l1: pl.Tensor[[MOE_INTER, D], pl.INT8] = pl.slice(
-            shared_w1, [MOE_INTER, D], [MOE_INTER, 0]
-        )
-        shared_w1_scale_l1: pl.Tensor[[MOE_INTER], pl.FP32] = pl.slice(
-            shared_w1_scale, [MOE_INTER], [MOE_INTER]
-        )
-        shared_w3_l1: pl.Tensor[[MOE_INTER, D], pl.INT8] = pl.slice(
-            shared_w3, [MOE_INTER, D], [MOE_INTER, 0]
-        )
-        shared_w3_scale_l1: pl.Tensor[[MOE_INTER], pl.FP32] = pl.slice(
-            shared_w3_scale, [MOE_INTER], [MOE_INTER]
-        )
-        shared_w2_l1: pl.Tensor[[D, MOE_INTER], pl.INT8] = pl.slice(
-            shared_w2, [D, MOE_INTER], [D, 0]
-        )
-        shared_w2_scale_l1: pl.Tensor[[D], pl.FP32] = pl.slice(
-            shared_w2_scale, [D], [D]
-        )
-        decode_layer_swa(
-            x_pong,
-            hc_attn_fn_l1, hc_attn_scale_l1, hc_attn_base_l1,
-            attn_norm_w_l1, wq_a_l1, wq_b_l1, wq_b_scale_l1,
-            wkv_l1, gamma_cq_l1, gamma_ckv_l1,
-            freqs_cos, freqs_sin, raw_kv_l1,
-            swa_slot_mapping, swa_indices, swa_lens, position_ids,
-            attn_sink_l1, wo_a_l1, wo_b_l1, wo_b_scale_l1,
-            hc_ffn_fn_l1, hc_ffn_scale_l1, hc_ffn_base_l1,
-            norm_w_l1, gate_w_l1, gate_bias_l1, tid2eid_l1, input_ids,
-            routed_w1_l1, routed_w1_scale_l1,
-            routed_w3_l1, routed_w3_scale_l1,
-            routed_w2_l1, routed_w2_scale_l1,
-            shared_w1_l1, shared_w1_scale_l1,
-            shared_w3_l1, shared_w3_scale_l1,
-            shared_w2_l1, shared_w2_scale_l1,
-            x_attn_active, x_moe_next, x_ping,
-            attention_window, attention_signal, o_window, o_signal,
-            recv_meta, recv_x, recv_aux, recv_route,
-            arrived, data_arrived, routed_y_buf, combine_arrived,
-            pl.const(1, pl.INT32), group_base, tp_rank, local_t, my_rank,
-            pl.const(2, pl.INT32),
-        )
-    csa_state_blocks_per_layer = (
-        pl.tensor.dim(csa_compress_state, 0) // MIXED_PREFIX_CSA_LAYER_COUNT
-    )
-    csa_cmp_blocks_per_layer = (
-        pl.tensor.dim(csa_cmp_kv, 0) // MIXED_PREFIX_CSA_LAYER_COUNT
-    )
-    csa_inner_state_blocks_per_layer = (
-        pl.tensor.dim(csa_inner_compress_state, 0)
-        // MIXED_PREFIX_CSA_LAYER_COUNT
-    )
-    csa_idx_blocks_per_layer = (
-        pl.tensor.dim(csa_idx_kv_cache, 0) // MIXED_PREFIX_CSA_LAYER_COUNT
-    )
-    with pl.scope():
-        raw_kv_l2 = pl.slice(
-            raw_kv_pool,
-            [raw_blocks_per_layer, BLOCK_SIZE, 1, HEAD_DIM],
-            [2 * raw_blocks_per_layer, 0, 0, 0],
-        )
-        csa_compress_state_l0 = pl.slice(
-            csa_compress_state,
-            [
-                csa_state_blocks_per_layer,
-                CSA_MAIN_STATE_BLOCK_SIZE,
-                CSA_MAIN_STATE_DIM,
-            ],
-            [0, 0, 0],
-        )
-        csa_cmp_kv_l0 = pl.slice(
-            csa_cmp_kv,
-            [csa_cmp_blocks_per_layer, BLOCK_SIZE, 1, HEAD_DIM],
-            [0, 0, 0, 0],
-        )
-        csa_inner_compress_state_l0 = pl.slice(
-            csa_inner_compress_state,
-            [
-                csa_inner_state_blocks_per_layer,
-                CSA_INNER_STATE_BLOCK_SIZE,
-                CSA_INNER_STATE_DIM,
-            ],
-            [0, 0, 0],
-        )
-        csa_idx_kv_cache_l0 = pl.slice(
-            csa_idx_kv_cache,
-            [csa_idx_blocks_per_layer, BLOCK_SIZE, 1, CSA_IDX_HEAD_DIM],
-            [0, 0, 0, 0],
-        )
-        csa_idx_kv_scale_l0 = pl.slice(
-            csa_idx_kv_scale,
-            [csa_idx_blocks_per_layer, BLOCK_SIZE, 1, 1],
-            [0, 0, 0, 0],
-        )
-        hc_attn_fn_l2: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32] = pl.slice(
-            hc_attn_fn, [MIX_HC, HC_DIM], [2 * MIX_HC, 0]
-        )
-        hc_attn_scale_l2: pl.Tensor[[3], pl.FP32] = pl.slice(
-            hc_attn_scale, [3], [6]
-        )
-        hc_attn_base_l2: pl.Tensor[[MIX_HC], pl.FP32] = pl.slice(
-            hc_attn_base, [MIX_HC], [2 * MIX_HC]
-        )
-        attn_norm_w_l2: pl.Tensor[[D], pl.BF16] = pl.slice(
-            attn_norm_w, [D], [2 * D]
-        )
-        wq_a_l2: pl.Tensor[[D, Q_LORA], pl.BF16] = pl.slice(
-            wq_a, [D, Q_LORA], [2 * D, 0]
-        )
-        wq_b_l2: pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8] = pl.slice(
-            wq_b, [Q_LORA, H * HEAD_DIM], [2 * Q_LORA, 0]
-        )
-        wq_b_scale_l2: pl.Tensor[[H * HEAD_DIM], pl.FP32] = pl.slice(
-            wq_b_scale, [H * HEAD_DIM], [2 * H * HEAD_DIM]
-        )
-        wkv_l2: pl.Tensor[[D, HEAD_DIM], pl.BF16] = pl.slice(
-            wkv, [D, HEAD_DIM], [2 * D, 0]
-        )
-        gamma_cq_l2: pl.Tensor[[Q_LORA], pl.BF16] = pl.slice(
-            gamma_cq, [Q_LORA], [2 * Q_LORA]
-        )
-        gamma_ckv_l2: pl.Tensor[[HEAD_DIM], pl.BF16] = pl.slice(
-            gamma_ckv, [HEAD_DIM], [2 * HEAD_DIM]
-        )
-        attn_sink_l2: pl.Tensor[[H], pl.FP32] = pl.slice(
-            attn_sink, [H], [2 * H]
-        )
-        wo_a_l2: pl.Tensor[
-            [LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16
-        ] = pl.slice(
-            wo_a,
-            [LOCAL_O_GROUPS, O_LORA, O_GROUP_IN],
-            [2 * LOCAL_O_GROUPS, 0, 0],
-        )
-        wo_b_l2: pl.Tensor[[D, LOCAL_O_WIDTH], pl.INT8] = pl.slice(
-            wo_b, [D, LOCAL_O_WIDTH], [2 * D, 0]
-        )
-        wo_b_scale_l2: pl.Tensor[[D], pl.FP32] = pl.slice(
-            wo_b_scale, [D], [2 * D]
-        )
-        hc_ffn_fn_l2: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32] = pl.slice(
-            hc_ffn_fn, [MIX_HC, HC_DIM], [2 * MIX_HC, 0]
-        )
-        hc_ffn_scale_l2: pl.Tensor[[3], pl.FP32] = pl.slice(
-            hc_ffn_scale, [3], [6]
-        )
-        hc_ffn_base_l2: pl.Tensor[[MIX_HC], pl.FP32] = pl.slice(
-            hc_ffn_base, [MIX_HC], [2 * MIX_HC]
-        )
-        norm_w_l2: pl.Tensor[[D], pl.BF16] = pl.slice(
-            norm_w, [D], [2 * D]
-        )
-        gate_w_l2: pl.Tensor[[N_EXPERTS_GLOBAL, D], pl.FP32] = pl.slice(
-            gate_w, [N_EXPERTS_GLOBAL, D], [2 * N_EXPERTS_GLOBAL, 0]
-        )
-        gate_bias_l2: pl.Tensor[[N_EXPERTS_GLOBAL], pl.FP32] = pl.slice(
-            gate_bias, [N_EXPERTS_GLOBAL], [2 * N_EXPERTS_GLOBAL]
-        )
-        tid2eid_l2: pl.Tensor[[VOCAB, TOPK], pl.INT32] = pl.slice(
-            tid2eid, [VOCAB, TOPK], [2 * VOCAB, 0]
-        )
-        routed_w1_l2: pl.Tensor[
-            [N_LOCAL, MOE_INTER, D], pl.INT8
-        ] = pl.slice(
-            routed_w1, [N_LOCAL, MOE_INTER, D], [2 * N_LOCAL, 0, 0]
-        )
-        routed_w1_scale_l2: pl.Tensor[
-            [N_LOCAL, MOE_INTER], pl.FP32
-        ] = pl.slice(
-            routed_w1_scale, [N_LOCAL, MOE_INTER], [2 * N_LOCAL, 0]
-        )
-        routed_w3_l2: pl.Tensor[
-            [N_LOCAL, MOE_INTER, D], pl.INT8
-        ] = pl.slice(
-            routed_w3, [N_LOCAL, MOE_INTER, D], [2 * N_LOCAL, 0, 0]
-        )
-        routed_w3_scale_l2: pl.Tensor[
-            [N_LOCAL, MOE_INTER], pl.FP32
-        ] = pl.slice(
-            routed_w3_scale, [N_LOCAL, MOE_INTER], [2 * N_LOCAL, 0]
-        )
-        routed_w2_l2: pl.Tensor[
-            [N_LOCAL, D, MOE_INTER], pl.INT8
-        ] = pl.slice(
-            routed_w2, [N_LOCAL, D, MOE_INTER], [2 * N_LOCAL, 0, 0]
-        )
-        routed_w2_scale_l2: pl.Tensor[[N_LOCAL, D], pl.FP32] = pl.slice(
-            routed_w2_scale, [N_LOCAL, D], [2 * N_LOCAL, 0]
-        )
-        shared_w1_l2: pl.Tensor[[MOE_INTER, D], pl.INT8] = pl.slice(
-            shared_w1, [MOE_INTER, D], [2 * MOE_INTER, 0]
-        )
-        shared_w1_scale_l2: pl.Tensor[[MOE_INTER], pl.FP32] = pl.slice(
-            shared_w1_scale, [MOE_INTER], [2 * MOE_INTER]
-        )
-        shared_w3_l2: pl.Tensor[[MOE_INTER, D], pl.INT8] = pl.slice(
-            shared_w3, [MOE_INTER, D], [2 * MOE_INTER, 0]
-        )
-        shared_w3_scale_l2: pl.Tensor[[MOE_INTER], pl.FP32] = pl.slice(
-            shared_w3_scale, [MOE_INTER], [2 * MOE_INTER]
-        )
-        shared_w2_l2: pl.Tensor[[D, MOE_INTER], pl.INT8] = pl.slice(
-            shared_w2, [D, MOE_INTER], [2 * D, 0]
-        )
-        shared_w2_scale_l2: pl.Tensor[[D], pl.FP32] = pl.slice(
-            shared_w2_scale, [D], [2 * D]
-        )
-        decode_layer_csa(
-            x_ping,
-            hc_attn_fn_l2, hc_attn_scale_l2, hc_attn_base_l2,
-            attn_norm_w_l2, wq_a_l2, wq_b_l2, wq_b_scale_l2,
-            wkv_l2, gamma_cq_l2, gamma_ckv_l2,
-            freqs_cos, freqs_sin,
-            csa_cmp_freqs_cos, csa_cmp_freqs_sin,
-            csa_cmp_wkv, csa_cmp_wgate, csa_cmp_ape, csa_cmp_norm_w,
-            csa_compress_state_l0, csa_compress_state_block_table,
-            csa_idx_wq_b, csa_idx_wq_b_scale,
-            csa_weights_proj, csa_hadamard_idx,
-            csa_inner_wkv, csa_inner_wgate,
-            csa_inner_ape, csa_inner_norm_w,
-            csa_inner_compress_state_l0,
-            csa_inner_compress_state_block_table,
-            raw_kv_l2, csa_cmp_kv_l0, csa_cmp_block_table,
-            csa_idx_kv_cache_l0, csa_idx_kv_scale_l0,
-            csa_idx_block_table,
-            csa_ori_slot_mapping, csa_window_swa_indices,
-            csa_window_swa_lens, csa_cmp_slot_mapping,
-            csa_idx_slot_mapping, csa_state_slot_mapping,
-            csa_inner_state_slot_mapping, position_ids,
-            csa_kv_seq_lens, attn_sink_l2,
-            wo_a_l2, wo_b_l2, wo_b_scale_l2,
-            hc_ffn_fn_l2, hc_ffn_scale_l2, hc_ffn_base_l2,
-            norm_w_l2, gate_w_l2, gate_bias_l2, tid2eid_l2, input_ids,
-            routed_w1_l2, routed_w1_scale_l2,
-            routed_w3_l2, routed_w3_scale_l2,
-            routed_w2_l2, routed_w2_scale_l2,
-            shared_w1_l2, shared_w1_scale_l2,
-            shared_w3_l2, shared_w3_scale_l2,
-            shared_w2_l2, shared_w2_scale_l2,
-            x_attn_active, x_moe_next, x_pong,
-            attention_window, attention_signal, o_window, o_signal,
-            recv_meta, recv_x, recv_aux, recv_route,
-            arrived, data_arrived, routed_y_buf, combine_arrived,
-            pl.const(2, pl.INT32), group_base, tp_rank, local_t, my_rank,
-            pl.const(3, pl.INT32),
-        )
-
-    hca_state_blocks_per_layer = (
-        pl.tensor.dim(hca_compress_state, 0) // MIXED_PREFIX_HCA_LAYER_COUNT
-    )
-    hca_cmp_blocks_per_layer = (
-        pl.tensor.dim(hca_cmp_kv, 0) // MIXED_PREFIX_HCA_LAYER_COUNT
-    )
-    with pl.scope():
-        raw_kv_l3 = pl.slice(
-            raw_kv_pool,
-            [raw_blocks_per_layer, BLOCK_SIZE, 1, HEAD_DIM],
-            [3 * raw_blocks_per_layer, 0, 0, 0],
-        )
-        hca_compress_state_l0 = pl.slice(
-            hca_compress_state,
-            [
-                hca_state_blocks_per_layer,
-                HCA_COMPRESS_STATE_BLOCK_SIZE,
-                HCA_COMPRESS_STATE_DIM,
-            ],
-            [0, 0, 0],
-        )
-        hca_cmp_kv_l0 = pl.slice(
-            hca_cmp_kv,
-            [hca_cmp_blocks_per_layer, BLOCK_SIZE, 1, HEAD_DIM],
-            [0, 0, 0, 0],
-        )
-        hc_attn_fn_l3: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32] = pl.slice(
-            hc_attn_fn, [MIX_HC, HC_DIM], [3 * MIX_HC, 0]
-        )
-        hc_attn_scale_l3: pl.Tensor[[3], pl.FP32] = pl.slice(
-            hc_attn_scale, [3], [9]
-        )
-        hc_attn_base_l3: pl.Tensor[[MIX_HC], pl.FP32] = pl.slice(
-            hc_attn_base, [MIX_HC], [3 * MIX_HC]
-        )
-        attn_norm_w_l3: pl.Tensor[[D], pl.BF16] = pl.slice(
-            attn_norm_w, [D], [3 * D]
-        )
-        wq_a_l3: pl.Tensor[[D, Q_LORA], pl.BF16] = pl.slice(
-            wq_a, [D, Q_LORA], [3 * D, 0]
-        )
-        wq_b_l3: pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8] = pl.slice(
-            wq_b, [Q_LORA, H * HEAD_DIM], [3 * Q_LORA, 0]
-        )
-        wq_b_scale_l3: pl.Tensor[[H * HEAD_DIM], pl.FP32] = pl.slice(
-            wq_b_scale, [H * HEAD_DIM], [3 * H * HEAD_DIM]
-        )
-        wkv_l3: pl.Tensor[[D, HEAD_DIM], pl.BF16] = pl.slice(
-            wkv, [D, HEAD_DIM], [3 * D, 0]
-        )
-        gamma_cq_l3: pl.Tensor[[Q_LORA], pl.BF16] = pl.slice(
-            gamma_cq, [Q_LORA], [3 * Q_LORA]
-        )
-        gamma_ckv_l3: pl.Tensor[[HEAD_DIM], pl.BF16] = pl.slice(
-            gamma_ckv, [HEAD_DIM], [3 * HEAD_DIM]
-        )
-        attn_sink_l3: pl.Tensor[[H], pl.FP32] = pl.slice(
-            attn_sink, [H], [3 * H]
-        )
-        wo_a_l3: pl.Tensor[
-            [LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16
-        ] = pl.slice(
-            wo_a,
-            [LOCAL_O_GROUPS, O_LORA, O_GROUP_IN],
-            [3 * LOCAL_O_GROUPS, 0, 0],
-        )
-        wo_b_l3: pl.Tensor[[D, LOCAL_O_WIDTH], pl.INT8] = pl.slice(
-            wo_b, [D, LOCAL_O_WIDTH], [3 * D, 0]
-        )
-        wo_b_scale_l3: pl.Tensor[[D], pl.FP32] = pl.slice(
-            wo_b_scale, [D], [3 * D]
-        )
-        hc_ffn_fn_l3: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32] = pl.slice(
-            hc_ffn_fn, [MIX_HC, HC_DIM], [3 * MIX_HC, 0]
-        )
-        hc_ffn_scale_l3: pl.Tensor[[3], pl.FP32] = pl.slice(
-            hc_ffn_scale, [3], [9]
-        )
-        hc_ffn_base_l3: pl.Tensor[[MIX_HC], pl.FP32] = pl.slice(
-            hc_ffn_base, [MIX_HC], [3 * MIX_HC]
-        )
-        norm_w_l3: pl.Tensor[[D], pl.BF16] = pl.slice(
-            norm_w, [D], [3 * D]
-        )
-        gate_w_l3: pl.Tensor[[N_EXPERTS_GLOBAL, D], pl.FP32] = pl.slice(
-            gate_w, [N_EXPERTS_GLOBAL, D], [3 * N_EXPERTS_GLOBAL, 0]
-        )
-        gate_bias_l3: pl.Tensor[[N_EXPERTS_GLOBAL], pl.FP32] = pl.slice(
-            gate_bias, [N_EXPERTS_GLOBAL], [3 * N_EXPERTS_GLOBAL]
-        )
-        tid2eid_l3: pl.Tensor[[VOCAB, TOPK], pl.INT32] = pl.slice(
-            tid2eid, [VOCAB, TOPK], [3 * VOCAB, 0]
-        )
-        routed_w1_l3: pl.Tensor[
-            [N_LOCAL, MOE_INTER, D], pl.INT8
-        ] = pl.slice(
-            routed_w1, [N_LOCAL, MOE_INTER, D], [3 * N_LOCAL, 0, 0]
-        )
-        routed_w1_scale_l3: pl.Tensor[
-            [N_LOCAL, MOE_INTER], pl.FP32
-        ] = pl.slice(
-            routed_w1_scale, [N_LOCAL, MOE_INTER], [3 * N_LOCAL, 0]
-        )
-        routed_w3_l3: pl.Tensor[
-            [N_LOCAL, MOE_INTER, D], pl.INT8
-        ] = pl.slice(
-            routed_w3, [N_LOCAL, MOE_INTER, D], [3 * N_LOCAL, 0, 0]
-        )
-        routed_w3_scale_l3: pl.Tensor[
-            [N_LOCAL, MOE_INTER], pl.FP32
-        ] = pl.slice(
-            routed_w3_scale, [N_LOCAL, MOE_INTER], [3 * N_LOCAL, 0]
-        )
-        routed_w2_l3: pl.Tensor[
-            [N_LOCAL, D, MOE_INTER], pl.INT8
-        ] = pl.slice(
-            routed_w2, [N_LOCAL, D, MOE_INTER], [3 * N_LOCAL, 0, 0]
-        )
-        routed_w2_scale_l3: pl.Tensor[[N_LOCAL, D], pl.FP32] = pl.slice(
-            routed_w2_scale, [N_LOCAL, D], [3 * N_LOCAL, 0]
-        )
-        shared_w1_l3: pl.Tensor[[MOE_INTER, D], pl.INT8] = pl.slice(
-            shared_w1, [MOE_INTER, D], [3 * MOE_INTER, 0]
-        )
-        shared_w1_scale_l3: pl.Tensor[[MOE_INTER], pl.FP32] = pl.slice(
-            shared_w1_scale, [MOE_INTER], [3 * MOE_INTER]
-        )
-        shared_w3_l3: pl.Tensor[[MOE_INTER, D], pl.INT8] = pl.slice(
-            shared_w3, [MOE_INTER, D], [3 * MOE_INTER, 0]
-        )
-        shared_w3_scale_l3: pl.Tensor[[MOE_INTER], pl.FP32] = pl.slice(
-            shared_w3_scale, [MOE_INTER], [3 * MOE_INTER]
-        )
-        shared_w2_l3: pl.Tensor[[D, MOE_INTER], pl.INT8] = pl.slice(
-            shared_w2, [D, MOE_INTER], [3 * D, 0]
-        )
-        shared_w2_scale_l3: pl.Tensor[[D], pl.FP32] = pl.slice(
-            shared_w2_scale, [D], [3 * D]
-        )
-        decode_layer_hca(
-            x_pong,
-            hc_attn_fn_l3, hc_attn_scale_l3, hc_attn_base_l3,
-            attn_norm_w_l3, wq_a_l3, wq_b_l3, wq_b_scale_l3,
-            wkv_l3, gamma_cq_l3, gamma_ckv_l3,
-            freqs_cos, freqs_sin,
-            hca_cmp_freqs_cos, hca_cmp_freqs_sin,
-            hca_cmp_wkv, hca_cmp_wgate, hca_cmp_ape, hca_cmp_norm_w,
-            hca_compress_state_l0, hca_compress_state_block_table,
-            raw_kv_l3, hca_cmp_kv_l0, hca_cmp_block_table,
-            hca_ori_slot_mapping, hca_window_swa_indices,
-            hca_window_swa_lens, hca_cmp_slot_mapping,
-            hca_state_slot_mapping, position_ids, hca_kv_seq_lens,
-            attn_sink_l3, wo_a_l3, wo_b_l3, wo_b_scale_l3,
-            hc_ffn_fn_l3, hc_ffn_scale_l3, hc_ffn_base_l3,
-            norm_w_l3, gate_w_l3, gate_bias_l3, tid2eid_l3, input_ids,
-            routed_w1_l3, routed_w1_scale_l3,
-            routed_w3_l3, routed_w3_scale_l3,
-            routed_w2_l3, routed_w2_scale_l3,
-            shared_w1_l3, shared_w1_scale_l3,
-            shared_w3_l3, shared_w3_scale_l3,
-            shared_w2_l3, shared_w2_scale_l3,
-            x_attn_active, x_moe_next, x_out,
-            attention_window, attention_signal, o_window, o_signal,
-            recv_meta, recv_x, recv_aux, recv_route,
-            arrived, data_arrived, routed_y_buf, combine_arrived,
-            pl.const(3, pl.INT32), group_base, tp_rank, local_t, my_rank,
-            pl.const(4, pl.INT32),
-        )
-        clear_moe_signals(
-            x_moe_next, arrived, data_arrived, combine_arrived
-        )
-    return x_out
-
-
-@pl.jit.host
-def l3_decode_fwd(
-    hc_attn_fn: pl.Tensor[
-        [N_RANKS, MIXED_PREFIX_LAYER_COUNT * MIX_HC, HC_DIM], pl.FP32
-    ],
-    hc_attn_scale: pl.Tensor[
-        [N_RANKS, MIXED_PREFIX_LAYER_COUNT * 3], pl.FP32
-    ],
-    hc_attn_base: pl.Tensor[
-        [N_RANKS, MIXED_PREFIX_LAYER_COUNT * MIX_HC], pl.FP32
-    ],
-    attn_norm_w: pl.Tensor[
-        [N_RANKS, MIXED_PREFIX_LAYER_COUNT * D], pl.BF16
-    ],
-    wq_a: pl.Tensor[
-        [N_RANKS, MIXED_PREFIX_LAYER_COUNT * D, Q_LORA], pl.BF16
-    ],
-    wq_b: pl.Tensor[
-        [N_RANKS, MIXED_PREFIX_LAYER_COUNT * Q_LORA, H * HEAD_DIM], pl.INT8
-    ],
-    wq_b_scale: pl.Tensor[
-        [N_RANKS, MIXED_PREFIX_LAYER_COUNT * H * HEAD_DIM], pl.FP32
-    ],
-    wkv: pl.Tensor[
-        [N_RANKS, MIXED_PREFIX_LAYER_COUNT * D, HEAD_DIM], pl.BF16
-    ],
-    gamma_cq: pl.Tensor[
-        [N_RANKS, MIXED_PREFIX_LAYER_COUNT * Q_LORA], pl.BF16
-    ],
-    gamma_ckv: pl.Tensor[
-        [N_RANKS, MIXED_PREFIX_LAYER_COUNT * HEAD_DIM], pl.BF16
-    ],
-    raw_kv_pool: pl.InOut[
-        pl.Tensor[
-            [
-                N_RANKS,
-                FWD_PACKED_RAW_BLOCKS_DYN,
-                BLOCK_SIZE,
-                1,
-                HEAD_DIM,
-            ],
-            pl.BF16,
-        ]
-    ],
-    freqs_cos: pl.Tensor[
-        [N_RANKS, T_DYN, ROPE_HEAD_DIM], pl.BF16
-    ],
-    freqs_sin: pl.Tensor[
-        [N_RANKS, T_DYN, ROPE_HEAD_DIM], pl.BF16
-    ],
-    swa_slot_mapping: pl.Tensor[[N_RANKS, T_DYN], pl.INT64],
-    swa_indices: pl.Tensor[[N_RANKS, T_DYN, WIN], pl.INT32],
-    swa_lens: pl.Tensor[[N_RANKS, T_DYN], pl.INT32],
-    position_ids: pl.Tensor[[N_RANKS, T_DYN], pl.INT32],
-    csa_cmp_freqs_cos: pl.Tensor[
-        [N_RANKS, T_DYN, ROPE_HEAD_DIM], pl.BF16
-    ],
-    csa_cmp_freqs_sin: pl.Tensor[
-        [N_RANKS, T_DYN, ROPE_HEAD_DIM], pl.BF16
-    ],
-    csa_cmp_wkv: pl.Tensor[[N_RANKS, CSA_MAIN_OUT_DIM, D], pl.BF16],
-    csa_cmp_wgate: pl.Tensor[
-        [N_RANKS, CSA_MAIN_OUT_DIM, D], pl.BF16
-    ],
-    csa_cmp_ape: pl.Tensor[
-        [N_RANKS, CSA_COMPRESS_RATIO, CSA_MAIN_OUT_DIM], pl.FP32
-    ],
-    csa_cmp_norm_w: pl.Tensor[[N_RANKS, HEAD_DIM], pl.BF16],
-    csa_compress_state: pl.InOut[
-        pl.Tensor[
-            [
-                N_RANKS,
-                FWD_CSA_MAIN_STATE_BLOCKS_DYN,
-                CSA_MAIN_STATE_BLOCK_SIZE,
-                CSA_MAIN_STATE_DIM,
-            ],
-            pl.FP32,
-        ]
-    ],
-    csa_compress_state_block_table: pl.Tensor[
-        [N_RANKS, CSA_B_DYN, CSA_MAIN_STATE_MAX_BLOCKS], pl.INT32
-    ],
-    csa_idx_wq_b: pl.Tensor[
-        [N_RANKS, Q_LORA, CSA_IDX_N_HEADS * CSA_IDX_HEAD_DIM], pl.INT8
-    ],
-    csa_idx_wq_b_scale: pl.Tensor[
-        [N_RANKS, CSA_IDX_N_HEADS * CSA_IDX_HEAD_DIM], pl.FP32
-    ],
-    csa_weights_proj: pl.Tensor[
-        [N_RANKS, D, CSA_IDX_N_HEADS], pl.BF16
-    ],
-    csa_hadamard_idx: pl.Tensor[
-        [N_RANKS, CSA_IDX_HEAD_DIM, CSA_IDX_HEAD_DIM], pl.BF16
-    ],
-    csa_inner_wkv: pl.Tensor[
-        [N_RANKS, CSA_INNER_OUT_DIM, D], pl.BF16
-    ],
-    csa_inner_wgate: pl.Tensor[
-        [N_RANKS, CSA_INNER_OUT_DIM, D], pl.BF16
-    ],
-    csa_inner_ape: pl.Tensor[
-        [N_RANKS, CSA_COMPRESS_RATIO, CSA_INNER_OUT_DIM], pl.FP32
-    ],
-    csa_inner_norm_w: pl.Tensor[
-        [N_RANKS, CSA_IDX_HEAD_DIM], pl.BF16
-    ],
-    csa_inner_compress_state: pl.InOut[
-        pl.Tensor[
-            [
-                N_RANKS,
-                FWD_CSA_INNER_STATE_BLOCKS_DYN,
-                CSA_INNER_STATE_BLOCK_SIZE,
-                CSA_INNER_STATE_DIM,
-            ],
-            pl.FP32,
-        ]
-    ],
-    csa_inner_compress_state_block_table: pl.Tensor[
-        [N_RANKS, CSA_B_DYN, CSA_INNER_STATE_MAX_BLOCKS], pl.INT32
-    ],
-    csa_cmp_kv: pl.InOut[
-        pl.Tensor[
-            [
-                N_RANKS,
-                FWD_CSA_CMP_BLOCKS_DYN,
-                BLOCK_SIZE,
-                1,
-                HEAD_DIM,
-            ],
-            pl.BF16,
-        ]
-    ],
-    csa_cmp_block_table: pl.Tensor[
-        [N_RANKS, CSA_B_DYN, CSA_CMP_MAX_BLOCKS], pl.INT32
-    ],
-    csa_idx_kv_cache: pl.InOut[
-        pl.Tensor[
-            [
-                N_RANKS,
-                FWD_CSA_IDX_BLOCKS_DYN,
-                BLOCK_SIZE,
-                1,
-                CSA_IDX_HEAD_DIM,
-            ],
-            pl.INT8,
-        ]
-    ],
-    csa_idx_kv_scale: pl.InOut[
-        pl.Tensor[
-            [N_RANKS, FWD_CSA_IDX_BLOCKS_DYN, BLOCK_SIZE, 1, 1],
-            pl.FP32,
-        ]
-    ],
-    csa_idx_block_table: pl.Tensor[
-        [N_RANKS, CSA_B_DYN, CSA_IDX_MAX_BLOCKS], pl.INT32
-    ],
-    csa_ori_slot_mapping: pl.Tensor[[N_RANKS, T_DYN], pl.INT64],
-    csa_window_swa_indices: pl.Tensor[
-        [N_RANKS, T_DYN, WIN], pl.INT32
-    ],
-    csa_window_swa_lens: pl.Tensor[[N_RANKS, T_DYN], pl.INT32],
-    csa_cmp_slot_mapping: pl.Tensor[[N_RANKS, T_DYN], pl.INT64],
-    csa_idx_slot_mapping: pl.Tensor[[N_RANKS, T_DYN], pl.INT64],
-    csa_state_slot_mapping: pl.Tensor[[N_RANKS, T_DYN], pl.INT64],
-    csa_inner_state_slot_mapping: pl.Tensor[
-        [N_RANKS, T_DYN], pl.INT64
-    ],
-    csa_kv_seq_lens: pl.Tensor[[N_RANKS, CSA_B_DYN], pl.INT32],
-    hca_cmp_freqs_cos: pl.Tensor[
-        [N_RANKS, HCA_B, ROPE_HEAD_DIM // 2], pl.FP32
-    ],
-    hca_cmp_freqs_sin: pl.Tensor[
-        [N_RANKS, HCA_B, ROPE_HEAD_DIM // 2], pl.FP32
-    ],
-    hca_cmp_wkv: pl.Tensor[[N_RANKS, HCA_MAIN_OUT_DIM, D], pl.BF16],
-    hca_cmp_wgate: pl.Tensor[
-        [N_RANKS, HCA_MAIN_OUT_DIM, D], pl.BF16
-    ],
-    hca_cmp_ape: pl.Tensor[
-        [N_RANKS, HCA_COMPRESS_RATIO, HCA_MAIN_OUT_DIM], pl.FP32
-    ],
-    hca_cmp_norm_w: pl.Tensor[[N_RANKS, HEAD_DIM], pl.BF16],
-    hca_compress_state: pl.InOut[
-        pl.Tensor[
-            [
-                N_RANKS,
-                FWD_HCA_STATE_BLOCKS_DYN,
-                HCA_COMPRESS_STATE_BLOCK_SIZE,
-                HCA_COMPRESS_STATE_DIM,
-            ],
-            pl.FP32,
-        ]
-    ],
-    hca_compress_state_block_table: pl.Tensor[
-        [N_RANKS, HCA_B_DYN, HCA_COMPRESS_STATE_MAX_BLOCKS], pl.INT32
-    ],
-    hca_cmp_kv: pl.InOut[
-        pl.Tensor[
-            [N_RANKS, FWD_HCA_CMP_BLOCKS_DYN, BLOCK_SIZE, 1, HEAD_DIM],
-            pl.BF16,
-        ]
-    ],
-    hca_cmp_block_table: pl.Tensor[
-        [N_RANKS, HCA_B_DYN, HCA_CMP_TABLE_BLOCKS_DYN], pl.INT32
-    ],
-    hca_ori_slot_mapping: pl.Tensor[[N_RANKS, T_DYN], pl.INT64],
-    hca_window_swa_indices: pl.Tensor[
-        [N_RANKS, T_DYN, WIN], pl.INT32
-    ],
-    hca_window_swa_lens: pl.Tensor[[N_RANKS, T_DYN], pl.INT32],
-    hca_cmp_slot_mapping: pl.Tensor[[N_RANKS, T_DYN], pl.INT64],
-    hca_state_slot_mapping: pl.Tensor[[N_RANKS, T_DYN], pl.INT64],
-    hca_kv_seq_lens: pl.Tensor[[N_RANKS, HCA_B_DYN], pl.INT32],
-    attn_sink: pl.Tensor[
-        [N_RANKS, MIXED_PREFIX_LAYER_COUNT * H], pl.FP32
-    ],
-    wo_a: pl.Tensor[
-        [
-            N_RANKS,
-            MIXED_PREFIX_LAYER_COUNT * LOCAL_O_GROUPS,
-            O_LORA,
-            O_GROUP_IN,
-        ],
-        pl.BF16,
-    ],
-    wo_b: pl.Tensor[
-        [N_RANKS, MIXED_PREFIX_LAYER_COUNT * D, LOCAL_O_WIDTH], pl.INT8
-    ],
-    wo_b_scale: pl.Tensor[
-        [N_RANKS, MIXED_PREFIX_LAYER_COUNT * D], pl.FP32
-    ],
-    hc_ffn_fn: pl.Tensor[
-        [N_RANKS, MIXED_PREFIX_LAYER_COUNT * MIX_HC, HC_DIM], pl.FP32
-    ],
-    hc_ffn_scale: pl.Tensor[
-        [N_RANKS, MIXED_PREFIX_LAYER_COUNT * 3], pl.FP32
-    ],
-    hc_ffn_base: pl.Tensor[
-        [N_RANKS, MIXED_PREFIX_LAYER_COUNT * MIX_HC], pl.FP32
-    ],
-    norm_w: pl.Tensor[
-        [N_RANKS, MIXED_PREFIX_LAYER_COUNT * D], pl.BF16
-    ],
-    gate_w: pl.Tensor[
-        [N_RANKS, MIXED_PREFIX_LAYER_COUNT * N_EXPERTS_GLOBAL, D], pl.FP32
-    ],
-    gate_bias: pl.Tensor[
-        [N_RANKS, MIXED_PREFIX_LAYER_COUNT * N_EXPERTS_GLOBAL], pl.FP32
-    ],
-    tid2eid: pl.Tensor[
-        [N_RANKS, MIXED_PREFIX_LAYER_COUNT * VOCAB, TOPK], pl.INT32
-    ],
-    input_ids: pl.Tensor[[N_RANKS, MOE_TOKENS], pl.INT64],
-    routed_w1: pl.Tensor[
-        [N_RANKS, MIXED_PREFIX_LAYER_COUNT * N_LOCAL, MOE_INTER, D], pl.INT8
-    ],
-    routed_w1_scale: pl.Tensor[
-        [N_RANKS, MIXED_PREFIX_LAYER_COUNT * N_LOCAL, MOE_INTER], pl.FP32
-    ],
-    routed_w3: pl.Tensor[
-        [N_RANKS, MIXED_PREFIX_LAYER_COUNT * N_LOCAL, MOE_INTER, D], pl.INT8
-    ],
-    routed_w3_scale: pl.Tensor[
-        [N_RANKS, MIXED_PREFIX_LAYER_COUNT * N_LOCAL, MOE_INTER], pl.FP32
-    ],
-    routed_w2: pl.Tensor[
-        [N_RANKS, MIXED_PREFIX_LAYER_COUNT * N_LOCAL, D, MOE_INTER], pl.INT8
-    ],
-    routed_w2_scale: pl.Tensor[
-        [N_RANKS, MIXED_PREFIX_LAYER_COUNT * N_LOCAL, D], pl.FP32
-    ],
-    shared_w1: pl.Tensor[
-        [N_RANKS, MIXED_PREFIX_LAYER_COUNT * MOE_INTER, D], pl.INT8
-    ],
-    shared_w1_scale: pl.Tensor[
-        [N_RANKS, MIXED_PREFIX_LAYER_COUNT * MOE_INTER], pl.FP32
-    ],
-    shared_w3: pl.Tensor[
-        [N_RANKS, MIXED_PREFIX_LAYER_COUNT * MOE_INTER, D], pl.INT8
-    ],
-    shared_w3_scale: pl.Tensor[
-        [N_RANKS, MIXED_PREFIX_LAYER_COUNT * MOE_INTER], pl.FP32
-    ],
-    shared_w2: pl.Tensor[
-        [N_RANKS, MIXED_PREFIX_LAYER_COUNT * D, MOE_INTER], pl.INT8
-    ],
-    shared_w2_scale: pl.Tensor[
-        [N_RANKS, MIXED_PREFIX_LAYER_COUNT * D], pl.FP32
-    ],
-    x_ping: pl.InOut[
-        pl.Tensor[[N_RANKS, T_DYN, HC_MULT, D], pl.FP32]
-    ],
-    x_pong: pl.InOut[
-        pl.Tensor[[N_RANKS, T_DYN, HC_MULT, D], pl.FP32]
-    ],
-    x_attn_active: pl.InOut[
-        pl.Tensor[[N_RANKS, T_DYN, HC_MULT, D], pl.FP32]
-    ],
-    x_moe_next: pl.InOut[
-        pl.Tensor[[N_RANKS, MOE_TOKENS, HC_MULT, D], pl.FP32]
-    ],
-    x_out: pl.Out[
-        pl.Tensor[[N_RANKS, T_DYN, HC_MULT, D], pl.FP32]
-    ],
-):
-    """Allocate shared windows once and launch one four-layer child per rank."""
-    x_ping.bind_dynamic(1, T_DYN)
-    raw_kv_pool.bind_dynamic(1, FWD_PACKED_RAW_BLOCKS_DYN)
-    freqs_cos.bind_dynamic(1, T_DYN)
-    freqs_sin.bind_dynamic(1, T_DYN)
-    swa_slot_mapping.bind_dynamic(1, T_DYN)
-    swa_indices.bind_dynamic(1, T_DYN)
-    swa_lens.bind_dynamic(1, T_DYN)
-    position_ids.bind_dynamic(1, T_DYN)
-    csa_cmp_freqs_cos.bind_dynamic(1, T_DYN)
-    csa_cmp_freqs_sin.bind_dynamic(1, T_DYN)
-    csa_compress_state.bind_dynamic(1, FWD_CSA_MAIN_STATE_BLOCKS_DYN)
-    csa_compress_state_block_table.bind_dynamic(1, CSA_B_DYN)
-    csa_inner_compress_state.bind_dynamic(
-        1, FWD_CSA_INNER_STATE_BLOCKS_DYN
-    )
-    csa_inner_compress_state_block_table.bind_dynamic(1, CSA_B_DYN)
-    csa_cmp_kv.bind_dynamic(1, FWD_CSA_CMP_BLOCKS_DYN)
-    csa_cmp_block_table.bind_dynamic(1, CSA_B_DYN)
-    csa_idx_kv_cache.bind_dynamic(1, FWD_CSA_IDX_BLOCKS_DYN)
-    csa_idx_kv_scale.bind_dynamic(1, FWD_CSA_IDX_BLOCKS_DYN)
-    csa_idx_block_table.bind_dynamic(1, CSA_B_DYN)
-    csa_ori_slot_mapping.bind_dynamic(1, T_DYN)
-    csa_window_swa_indices.bind_dynamic(1, T_DYN)
-    csa_window_swa_lens.bind_dynamic(1, T_DYN)
-    csa_cmp_slot_mapping.bind_dynamic(1, T_DYN)
-    csa_idx_slot_mapping.bind_dynamic(1, T_DYN)
-    csa_state_slot_mapping.bind_dynamic(1, T_DYN)
-    csa_inner_state_slot_mapping.bind_dynamic(1, T_DYN)
-    csa_kv_seq_lens.bind_dynamic(1, CSA_B_DYN)
-    hca_compress_state.bind_dynamic(1, FWD_HCA_STATE_BLOCKS_DYN)
-    hca_compress_state_block_table.bind_dynamic(1, HCA_B_DYN)
-    hca_cmp_kv.bind_dynamic(1, FWD_HCA_CMP_BLOCKS_DYN)
-    hca_cmp_block_table.bind_dynamic(1, HCA_B_DYN)
-    hca_cmp_block_table.bind_dynamic(2, HCA_CMP_TABLE_BLOCKS_DYN)
-    hca_ori_slot_mapping.bind_dynamic(1, T_DYN)
-    hca_window_swa_indices.bind_dynamic(1, T_DYN)
-    hca_window_swa_lens.bind_dynamic(1, T_DYN)
-    hca_cmp_slot_mapping.bind_dynamic(1, T_DYN)
-    hca_state_slot_mapping.bind_dynamic(1, T_DYN)
-    hca_kv_seq_lens.bind_dynamic(1, HCA_B_DYN)
-    x_pong.bind_dynamic(1, T_DYN)
-    x_attn_active.bind_dynamic(1, T_DYN)
-    x_out.bind_dynamic(1, T_DYN)
-
-    attention_window_buf = pld.alloc_window_buffer(
-        [ATTENTION_WINDOW_ROWS, O_GROUP_IN], dtype=pl.BF16
-    )
-    attention_signal_buf = pld.alloc_window_buffer(
-        [TP_SIZE, 1], dtype=pl.INT32
-    )
-    o_window_buf = pld.alloc_window_buffer(
-        [O_WINDOW_ROWS, D], dtype=pl.FP32
-    )
-    o_signal_buf = pld.alloc_window_buffer([TP_SIZE, 1], dtype=pl.INT32)
-
-    recv_meta_buf = pld.alloc_window_buffer(
-        [N_RANKS, N_LOCAL], dtype=pl.INT32
-    )
-    recv_x_buf = pld.alloc_window_buffer(
-        [N_LOCAL * RECV_MAX, D], dtype=pl.INT8
-    )
-    recv_aux_buf = pld.alloc_window_buffer(
-        [N_LOCAL * RECV_MAX, AUX_PAD], dtype=pl.FP32
-    )
-    recv_route_buf = pld.alloc_window_buffer(
-        [N_LOCAL * RECV_MAX, IDX_PAD], dtype=pl.INT32
-    )
-    arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
-    data_arrived_buf = pld.alloc_window_buffer(
-        [N_RANKS, 1], dtype=pl.INT32
-    )
-    routed_y_buf_buf = pld.alloc_window_buffer(
-        [N_ROUTES, D], dtype=pl.BF16
-    )
-    combine_arrived_buf = pld.alloc_window_buffer(
-        [N_RANKS, 1], dtype=pl.INT32
-    )
-
-    for rank in pl.range(pld.world_size()):
-        attention_window = pld.window(
-            attention_window_buf,
-            [ATTENTION_WINDOW_ROWS, O_GROUP_IN],
-            dtype=pl.BF16,
-        )
-        attention_signal = pld.window(
-            attention_signal_buf, [TP_SIZE, 1], dtype=pl.INT32
-        )
-        o_window = pld.window(
-            o_window_buf, [O_WINDOW_ROWS, D], dtype=pl.FP32
-        )
-        o_signal = pld.window(
-            o_signal_buf, [TP_SIZE, 1], dtype=pl.INT32
-        )
-        recv_meta = pld.window(
-            recv_meta_buf, [N_RANKS, N_LOCAL], dtype=pl.INT32
-        )
-        recv_x = pld.window(
-            recv_x_buf, [N_LOCAL * RECV_MAX, D], dtype=pl.INT8
-        )
-        recv_aux = pld.window(
-            recv_aux_buf,
-            [N_LOCAL * RECV_MAX, AUX_PAD],
-            dtype=pl.FP32,
-        )
-        recv_route = pld.window(
-            recv_route_buf,
-            [N_LOCAL * RECV_MAX, IDX_PAD],
-            dtype=pl.INT32,
-        )
-        arrived = pld.window(
-            arrived_buf, [N_RANKS, 1], dtype=pl.INT32
-        )
-        data_arrived = pld.window(
-            data_arrived_buf, [N_RANKS, 1], dtype=pl.INT32
-        )
-        routed_y_buf = pld.window(
-            routed_y_buf_buf, [N_ROUTES, D], dtype=pl.BF16
-        )
-        combine_arrived = pld.window(
-            combine_arrived_buf, [N_RANKS, 1], dtype=pl.INT32
-        )
-        tp_rank = rank % TP_SIZE
-        group_base = rank - tp_rank
-        decode_fwd(
-            hc_attn_fn[rank], hc_attn_scale[rank], hc_attn_base[rank],
-            attn_norm_w[rank], wq_a[rank], wq_b[rank],
-            wq_b_scale[rank], wkv[rank], gamma_cq[rank], gamma_ckv[rank],
-            raw_kv_pool[rank], freqs_cos[rank], freqs_sin[rank],
-            swa_slot_mapping[rank], swa_indices[rank], swa_lens[rank],
-            position_ids[rank],
-            csa_cmp_freqs_cos[rank], csa_cmp_freqs_sin[rank],
-            csa_cmp_wkv[rank], csa_cmp_wgate[rank], csa_cmp_ape[rank],
-            csa_cmp_norm_w[rank], csa_compress_state[rank],
-            csa_compress_state_block_table[rank],
-            csa_idx_wq_b[rank], csa_idx_wq_b_scale[rank],
-            csa_weights_proj[rank], csa_hadamard_idx[rank],
-            csa_inner_wkv[rank], csa_inner_wgate[rank],
-            csa_inner_ape[rank], csa_inner_norm_w[rank],
-            csa_inner_compress_state[rank],
-            csa_inner_compress_state_block_table[rank],
-            csa_cmp_kv[rank], csa_cmp_block_table[rank],
-            csa_idx_kv_cache[rank], csa_idx_kv_scale[rank],
-            csa_idx_block_table[rank], csa_ori_slot_mapping[rank],
-            csa_window_swa_indices[rank], csa_window_swa_lens[rank],
-            csa_cmp_slot_mapping[rank], csa_idx_slot_mapping[rank],
-            csa_state_slot_mapping[rank],
-            csa_inner_state_slot_mapping[rank], csa_kv_seq_lens[rank],
-            hca_cmp_freqs_cos[rank], hca_cmp_freqs_sin[rank],
-            hca_cmp_wkv[rank], hca_cmp_wgate[rank], hca_cmp_ape[rank],
-            hca_cmp_norm_w[rank], hca_compress_state[rank],
-            hca_compress_state_block_table[rank],
-            hca_cmp_kv[rank], hca_cmp_block_table[rank],
-            hca_ori_slot_mapping[rank], hca_window_swa_indices[rank],
-            hca_window_swa_lens[rank], hca_cmp_slot_mapping[rank],
-            hca_state_slot_mapping[rank], hca_kv_seq_lens[rank],
-            attn_sink[rank], wo_a[rank], wo_b[rank],
-            wo_b_scale[rank],
-            hc_ffn_fn[rank], hc_ffn_scale[rank], hc_ffn_base[rank],
-            norm_w[rank], gate_w[rank], gate_bias[rank], tid2eid[rank],
-            input_ids[rank],
-            routed_w1[rank], routed_w1_scale[rank],
-            routed_w3[rank], routed_w3_scale[rank],
-            routed_w2[rank], routed_w2_scale[rank],
-            shared_w1[rank], shared_w1_scale[rank],
-            shared_w3[rank], shared_w3_scale[rank],
-            shared_w2[rank], shared_w2_scale[rank],
-            x_ping[rank], x_pong[rank],
-            x_attn_active[rank], x_moe_next[rank], x_out[rank],
-            attention_window, attention_signal, o_window, o_signal,
-            recv_meta, recv_x, recv_aux, recv_route,
-            arrived, data_arrived, routed_y_buf, combine_arrived,
-            group_base, tp_rank, rank,
-            device=rank,
-        )
-    return x_out
-
-
-@pl.jit(auto_scope=False)
-def decode_fwd_full43(
+    embed_weight: pl.Tensor[[EMBED_VOCAB_DYN, D], pl.BF16],
     hc_attn_fn: pl.Tensor[
         [FWD_WEIGHT_BANK_SIZE * HC_FN_STORAGE_ROWS, HC_DIM], pl.FP32
     ],
@@ -2010,7 +640,13 @@ def decode_fwd_full43(
         [FWD_WEIGHT_BANK_SIZE * N_EXPERTS_GLOBAL], pl.FP32
     ],
     tid2eid: pl.Tensor[[FWD_WEIGHT_BANK_SIZE * VOCAB, TOPK], pl.INT32],
-    input_ids: pl.Tensor[[MOE_TOKENS], pl.INT64],
+    input_ids: pl.Tensor[[T_DYN], pl.INT64],
+    hc_head_fn: pl.Tensor[[HC_MULT, HC_DIM], pl.FP32],
+    hc_head_scale: pl.Tensor[[1], pl.FP32],
+    hc_head_base: pl.Tensor[[HC_MULT], pl.FP32],
+    final_norm_w: pl.Tensor[[D], pl.BF16],
+    lm_head_weight: pl.Tensor[[VOCAB_PER_TP, D], pl.BF16],
+    logit_row_indices: pl.Tensor[[MAX_LOGIT_ROWS], pl.INT32],
     routed_w1: pl.Tensor[
         [FWD_WEIGHT_BANK_SIZE * N_LOCAL, MOE_INTER, D], pl.INT8
     ],
@@ -2045,6 +681,7 @@ def decode_fwd_full43(
         [FWD_WEIGHT_BANK_SIZE * D, MOE_INTER], pl.INT8
     ],
     shared_w2_scale: pl.Tensor[[FWD_WEIGHT_BANK_SIZE * D], pl.FP32],
+    hidden_workspace: pl.Out[pl.Tensor[[T_DYN, D], pl.BF16]],
     x_ping: pl.InOut[pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32]],
     x_pong: pl.InOut[pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32]],
     x_attn_active: pl.InOut[
@@ -2053,7 +690,16 @@ def decode_fwd_full43(
     x_moe_next: pl.InOut[
         pl.Tensor[[MOE_TOKENS, HC_MULT, D], pl.FP32]
     ],
-    x_out: pl.Out[pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32]],
+    pre_hc_hidden_out: pl.Out[
+        pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32]
+    ],
+    x_out: pl.Out[pl.Tensor[[T_DYN, D], pl.BF16]],
+    logits: pl.Out[
+        pl.Tensor[[MAX_LOGIT_ROWS, LM_HEAD_VOCAB], pl.FP32]
+    ],
+    sampled_ids: pl.Out[
+        pl.Tensor[[MAX_LOGIT_ROWS, SAMPLED_IDS_PAD], pl.INT32]
+    ],
     attention_window: pld.DistributedTensor[
         [ATTENTION_WINDOW_ROWS, O_GROUP_IN], pl.BF16
     ],
@@ -2072,11 +718,26 @@ def decode_fwd_full43(
     data_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
     routed_y_buf: pld.DistributedTensor[[N_ROUTES, D], pl.BF16],
     combine_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
+    lm_head_hidden_window: pld.DistributedTensor[
+        [GROUP_LOGIT_ROWS, D], pl.BF16
+    ],
+    lm_head_hidden_done: pld.DistributedTensor[
+        [LM_HEAD_TP_SIZE, 1], pl.INT32
+    ],
+    lm_head_logits_window: pld.DistributedTensor[
+        [MAX_LOGIT_ROWS, LM_HEAD_VOCAB], pl.FP32
+    ],
+    lm_head_logits_done: pld.DistributedTensor[
+        [LM_HEAD_TP_SIZE, 1], pl.INT32
+    ],
     group_base: pl.Scalar[pl.INT32],
     tp_rank: pl.Scalar[pl.INT32],
     my_rank: pl.Scalar[pl.INT32],
 ):
     """Run the fixed 2-SWA, 21-CSA, 20-HCA model in one rank child."""
+    embed_weight.bind_dynamic(0, EMBED_VOCAB_DYN)
+    input_ids.bind_dynamic(0, T_DYN)
+    hidden_workspace.bind_dynamic(0, T_DYN)
     x_ping.bind_dynamic(0, T_DYN)
     raw_kv_pool.bind_dynamic(0, FWD_PACKED_RAW_BLOCKS_DYN)
     freqs_cos.bind_dynamic(0, T_DYN)
@@ -2119,9 +780,20 @@ def decode_fwd_full43(
     hca_kv_seq_lens.bind_dynamic(0, HCA_B_DYN)
     x_pong.bind_dynamic(0, T_DYN)
     x_attn_active.bind_dynamic(0, T_DYN)
+    pre_hc_hidden_out.bind_dynamic(0, T_DYN)
     x_out.bind_dynamic(0, T_DYN)
 
-    local_t = pl.cast(pl.tensor.dim(x_ping, 0), pl.INT32)
+    moe_input_ids = pl.create_tensor([MOE_TOKENS], dtype=pl.INT64)
+    with pl.scope():
+        decode_embedding_preamble(
+            input_ids,
+            embed_weight,
+            hidden_workspace,
+            x_ping,
+            moe_input_ids,
+        )
+
+    local_t = pl.cast(pl.tensor.dim(input_ids, 0), pl.INT32)
     raw_blocks_per_layer = (
         pl.tensor.dim(raw_kv_pool, 0) // MAIN_LAYER_COUNT
     )
@@ -2247,7 +919,7 @@ def decode_fwd_full43(
             attn_sink_layer_swa0, wo_a_layer_swa0, wo_b_layer_swa0, wo_b_scale_layer_swa0,
             hc_ffn_fn_layer_swa0, hc_ffn_scale_layer_swa0,
             hc_ffn_base_layer_swa0, norm_w_layer_swa0,
-            gate_w_layer_swa0, gate_bias_layer_swa0, tid2eid_layer_swa0, input_ids,
+            gate_w_layer_swa0, gate_bias_layer_swa0, tid2eid_layer_swa0, moe_input_ids,
             routed_w1_layer_swa0, routed_w1_scale_layer_swa0,
             routed_w3_layer_swa0, routed_w3_scale_layer_swa0,
             routed_w2_layer_swa0, routed_w2_scale_layer_swa0,
@@ -2407,7 +1079,7 @@ def decode_fwd_full43(
             attn_sink_layer_swa1, wo_a_layer_swa1, wo_b_layer_swa1, wo_b_scale_layer_swa1,
             hc_ffn_fn_layer_swa1, hc_ffn_scale_layer_swa1,
             hc_ffn_base_layer_swa1, norm_w_layer_swa1,
-            gate_w_layer_swa1, gate_bias_layer_swa1, tid2eid_layer_swa1, input_ids,
+            gate_w_layer_swa1, gate_bias_layer_swa1, tid2eid_layer_swa1, moe_input_ids,
             routed_w1_layer_swa1, routed_w1_scale_layer_swa1,
             routed_w3_layer_swa1, routed_w3_scale_layer_swa1,
             routed_w2_layer_swa1, routed_w2_scale_layer_swa1,
@@ -2705,7 +1377,7 @@ def decode_fwd_full43(
                 wo_a_layer_csa, wo_b_layer_csa, wo_b_scale_layer_csa,
                 hc_ffn_fn_layer_csa, hc_ffn_scale_layer_csa,
                 hc_ffn_base_layer_csa, norm_w_layer_csa,
-                gate_w_layer_csa, gate_bias_layer_csa, tid2eid_layer_csa, input_ids,
+                gate_w_layer_csa, gate_bias_layer_csa, tid2eid_layer_csa, moe_input_ids,
                 routed_w1_layer_csa, routed_w1_scale_layer_csa,
                 routed_w3_layer_csa, routed_w3_scale_layer_csa,
                 routed_w2_layer_csa, routed_w2_scale_layer_csa,
@@ -2921,7 +1593,7 @@ def decode_fwd_full43(
                 attn_sink_layer_hca, wo_a_layer_hca, wo_b_layer_hca, wo_b_scale_layer_hca,
                 hc_ffn_fn_layer_hca, hc_ffn_scale_layer_hca,
                 hc_ffn_base_layer_hca, norm_w_layer_hca,
-                gate_w_layer_hca, gate_bias_layer_hca, tid2eid_layer_hca, input_ids,
+                gate_w_layer_hca, gate_bias_layer_hca, tid2eid_layer_hca, moe_input_ids,
                 routed_w1_layer_hca, routed_w1_scale_layer_hca,
                 routed_w3_layer_hca, routed_w3_scale_layer_hca,
                 routed_w2_layer_hca, routed_w2_scale_layer_hca,
@@ -3195,28 +1867,56 @@ def decode_fwd_full43(
             wo_a_layer_last, wo_b_layer_last, wo_b_scale_layer_last,
             hc_ffn_fn_layer_last, hc_ffn_scale_layer_last,
             hc_ffn_base_layer_last, norm_w_layer_last,
-            gate_w_layer_last, gate_bias_layer_last, tid2eid_layer_last, input_ids,
+            gate_w_layer_last, gate_bias_layer_last, tid2eid_layer_last, moe_input_ids,
             routed_w1_layer_last, routed_w1_scale_layer_last,
             routed_w3_layer_last, routed_w3_scale_layer_last,
             routed_w2_layer_last, routed_w2_scale_layer_last,
             shared_w1_layer_last, shared_w1_scale_layer_last,
             shared_w3_layer_last, shared_w3_scale_layer_last,
             shared_w2_layer_last, shared_w2_scale_layer_last,
-            x_attn_active, x_moe_next, x_out,
+            x_attn_active, x_moe_next, pre_hc_hidden_out,
             attention_window, attention_signal, o_window, o_signal,
             recv_meta, recv_x, recv_aux, recv_route,
             arrived, data_arrived, routed_y_buf, combine_arrived,
             model_layer_last, group_base, tp_rank, local_t, my_rank,
             pl.const(43, pl.INT32),
         )
-        clear_moe_signals(
-            x_moe_next, arrived, data_arrived, combine_arrived
+    clear_moe_signals(
+        x_moe_next, arrived, data_arrived, combine_arrived
+    )
+
+    with pl.scope():
+        hc_head(
+            pre_hc_hidden_out,
+            hc_head_fn,
+            hc_head_scale,
+            hc_head_base,
+            hidden_workspace,
         )
+        rms_norm(hidden_workspace, final_norm_w, x_out)
+        lm_head(
+            x_out,
+            lm_head_weight,
+            logit_row_indices,
+            logits,
+            lm_head_hidden_window,
+            lm_head_hidden_done,
+            lm_head_logits_window,
+            lm_head_logits_done,
+            group_base,
+            tp_rank,
+            pl.const(LM_HEAD_COMM_EPOCH, pl.INT32),
+        )
+        greedy_sample(logits, sampled_ids)
+        mask_inactive_sample_rows(logit_row_indices, sampled_ids)
     return x_out
 
 
 @pl.jit.host
-def l3_decode_fwd_full43(
+def l3_decode_fwd(
+    embed_weight: pl.Tensor[
+        [N_RANKS, EMBED_VOCAB_DYN, D], pl.BF16
+    ],
     hc_attn_fn: pl.Tensor[
         [N_RANKS, FWD_WEIGHT_BANK_SIZE * HC_FN_STORAGE_ROWS, HC_DIM],
         pl.FP32,
@@ -3496,7 +2196,19 @@ def l3_decode_fwd_full43(
     tid2eid: pl.Tensor[
         [N_RANKS, FWD_WEIGHT_BANK_SIZE * VOCAB, TOPK], pl.INT32
     ],
-    input_ids: pl.Tensor[[N_RANKS, MOE_TOKENS], pl.INT64],
+    input_ids: pl.Tensor[[N_RANKS, T_DYN], pl.INT64],
+    hc_head_fn: pl.Tensor[
+        [N_RANKS, HC_MULT, HC_DIM], pl.FP32
+    ],
+    hc_head_scale: pl.Tensor[[N_RANKS, 1], pl.FP32],
+    hc_head_base: pl.Tensor[[N_RANKS, HC_MULT], pl.FP32],
+    final_norm_w: pl.Tensor[[N_RANKS, D], pl.BF16],
+    lm_head_weight: pl.Tensor[
+        [N_RANKS, VOCAB_PER_TP, D], pl.BF16
+    ],
+    logit_row_indices: pl.Tensor[
+        [N_RANKS, MAX_LOGIT_ROWS], pl.INT32
+    ],
     routed_w1: pl.Tensor[
         [N_RANKS, FWD_WEIGHT_BANK_SIZE * N_LOCAL, MOE_INTER, D], pl.INT8
     ],
@@ -3533,6 +2245,9 @@ def l3_decode_fwd_full43(
     shared_w2_scale: pl.Tensor[
         [N_RANKS, FWD_WEIGHT_BANK_SIZE * D], pl.FP32
     ],
+    hidden_workspace: pl.Out[
+        pl.Tensor[[N_RANKS, T_DYN, D], pl.BF16]
+    ],
     x_ping: pl.InOut[
         pl.Tensor[[N_RANKS, T_DYN, HC_MULT, D], pl.FP32]
     ],
@@ -3545,11 +2260,25 @@ def l3_decode_fwd_full43(
     x_moe_next: pl.InOut[
         pl.Tensor[[N_RANKS, MOE_TOKENS, HC_MULT, D], pl.FP32]
     ],
-    x_out: pl.Out[
+    pre_hc_hidden_out: pl.Out[
         pl.Tensor[[N_RANKS, T_DYN, HC_MULT, D], pl.FP32]
     ],
+    x_out: pl.Out[
+        pl.Tensor[[N_RANKS, T_DYN, D], pl.BF16]
+    ],
+    logits: pl.Out[
+        pl.Tensor[[N_RANKS, MAX_LOGIT_ROWS, LM_HEAD_VOCAB], pl.FP32]
+    ],
+    sampled_ids: pl.Out[
+        pl.Tensor[
+            [N_RANKS, MAX_LOGIT_ROWS, SAMPLED_IDS_PAD], pl.INT32
+        ]
+    ],
 ):
-    """Allocate each communication window once and submit one Full43 child."""
+    """Allocate each communication window once and submit one decode forward child."""
+    embed_weight.bind_dynamic(1, EMBED_VOCAB_DYN)
+    input_ids.bind_dynamic(1, T_DYN)
+    hidden_workspace.bind_dynamic(1, T_DYN)
     x_ping.bind_dynamic(1, T_DYN)
     raw_kv_pool.bind_dynamic(1, FWD_PACKED_RAW_BLOCKS_DYN)
     freqs_cos.bind_dynamic(1, T_DYN)
@@ -3592,6 +2321,7 @@ def l3_decode_fwd_full43(
     hca_kv_seq_lens.bind_dynamic(1, HCA_B_DYN)
     x_pong.bind_dynamic(1, T_DYN)
     x_attn_active.bind_dynamic(1, T_DYN)
+    pre_hc_hidden_out.bind_dynamic(1, T_DYN)
     x_out.bind_dynamic(1, T_DYN)
 
     attention_window_buf = pld.alloc_window_buffer(
@@ -3625,6 +2355,18 @@ def l3_decode_fwd_full43(
     )
     combine_arrived_buf = pld.alloc_window_buffer(
         [N_RANKS, 1], dtype=pl.INT32
+    )
+    lm_head_hidden_window_buf = pld.alloc_window_buffer(
+        [GROUP_LOGIT_ROWS, D], dtype=pl.BF16
+    )
+    lm_head_hidden_done_buf = pld.alloc_window_buffer(
+        [LM_HEAD_TP_SIZE, 1], dtype=pl.INT32
+    )
+    lm_head_logits_window_buf = pld.alloc_window_buffer(
+        [MAX_LOGIT_ROWS, LM_HEAD_VOCAB], dtype=pl.FP32
+    )
+    lm_head_logits_done_buf = pld.alloc_window_buffer(
+        [LM_HEAD_TP_SIZE, 1], dtype=pl.INT32
     )
 
     for rank in pl.range(pld.world_size()):
@@ -3670,9 +2412,30 @@ def l3_decode_fwd_full43(
         combine_arrived = pld.window(
             combine_arrived_buf, [N_RANKS, 1], dtype=pl.INT32
         )
+        lm_head_hidden_window = pld.window(
+            lm_head_hidden_window_buf,
+            [GROUP_LOGIT_ROWS, D],
+            dtype=pl.BF16,
+        )
+        lm_head_hidden_done = pld.window(
+            lm_head_hidden_done_buf,
+            [LM_HEAD_TP_SIZE, 1],
+            dtype=pl.INT32,
+        )
+        lm_head_logits_window = pld.window(
+            lm_head_logits_window_buf,
+            [MAX_LOGIT_ROWS, LM_HEAD_VOCAB],
+            dtype=pl.FP32,
+        )
+        lm_head_logits_done = pld.window(
+            lm_head_logits_done_buf,
+            [LM_HEAD_TP_SIZE, 1],
+            dtype=pl.INT32,
+        )
         tp_rank = rank % TP_SIZE
         group_base = rank - tp_rank
-        decode_fwd_full43(
+        decode_fwd(
+            embed_weight[rank],
             hc_attn_fn[rank], hc_attn_scale[rank], hc_attn_base[rank],
             attn_norm_w[rank], wq_a[rank], wq_b[rank],
             wq_b_scale[rank], wkv[rank], gamma_cq[rank], gamma_ckv[rank],
@@ -3709,21 +2472,29 @@ def l3_decode_fwd_full43(
             hc_ffn_fn[rank], hc_ffn_scale[rank], hc_ffn_base[rank],
             norm_w[rank], gate_w[rank], gate_bias[rank], tid2eid[rank],
             input_ids[rank],
+            hc_head_fn[rank], hc_head_scale[rank], hc_head_base[rank],
+            final_norm_w[rank], lm_head_weight[rank],
+            logit_row_indices[rank],
             routed_w1[rank], routed_w1_scale[rank],
             routed_w3[rank], routed_w3_scale[rank],
             routed_w2[rank], routed_w2_scale[rank],
             shared_w1[rank], shared_w1_scale[rank],
             shared_w3[rank], shared_w3_scale[rank],
             shared_w2[rank], shared_w2_scale[rank],
+            hidden_workspace[rank],
             x_ping[rank], x_pong[rank],
-            x_attn_active[rank], x_moe_next[rank], x_out[rank],
+            x_attn_active[rank], x_moe_next[rank],
+            pre_hc_hidden_out[rank], x_out[rank], logits[rank],
+            sampled_ids[rank],
             attention_window, attention_signal, o_window, o_signal,
             recv_meta, recv_x, recv_aux, recv_route,
             arrived, data_arrived, routed_y_buf, combine_arrived,
+            lm_head_hidden_window, lm_head_hidden_done,
+            lm_head_logits_window, lm_head_logits_done,
             group_base, tp_rank, rank,
             device=rank,
         )
-    return x_out
+    return x_out, logits, sampled_ids
 
 
 _COMMON_ATTN_WEIGHT_NAMES = (
@@ -3765,9 +2536,7 @@ _CSA_EXTRA_WEIGHT_NAMES = (
     "inner_norm_w",
 )
 
-_MOE_NON_WEIGHT_NAMES = {"x_attn_moe", "x_moe_next", "input_ids"}
-
-_MIXED_LAYERED_WEIGHT_NAMES = (
+_LAYER_WEIGHT_NAMES = (
     *_COMMON_ATTN_WEIGHT_NAMES,
     "hc_ffn_fn",
     "hc_ffn_scale",
@@ -3799,7 +2568,7 @@ _SWA_METADATA_NAMES = (
     "position_ids",
 )
 
-_CSA_PREFIX_SOURCES = {
+_CSA_SOURCES = {
     "csa_cmp_freqs_cos": "cmp_freqs_cos",
     "csa_cmp_freqs_sin": "cmp_freqs_sin",
     "csa_cmp_wkv": "cmp_wkv",
@@ -3835,7 +2604,7 @@ _CSA_PREFIX_SOURCES = {
     "csa_kv_seq_lens": "kv_seq_lens",
 }
 
-_HCA_PREFIX_SOURCES = {
+_HCA_SOURCES = {
     "hca_cmp_freqs_cos": "cmp_freqs_cos",
     "hca_cmp_freqs_sin": "cmp_freqs_sin",
     "hca_cmp_wkv": "cmp_wkv",
@@ -3854,132 +2623,7 @@ _HCA_PREFIX_SOURCES = {
     "hca_kv_seq_lens": "kv_seq_lens",
 }
 
-_METADATA_EXCLUDES = {
-    "x_hc",
-    "x_out",
-    "kv_cache",
-    "compress_state",
-    "cmp_kv",
-    "inner_compress_state",
-    "idx_kv_cache",
-    "idx_kv_scale",
-    *_COMMON_ATTN_WEIGHT_NAMES,
-    *_HCA_EXTRA_WEIGHT_NAMES,
-    *_CSA_EXTRA_WEIGHT_NAMES,
-}
-
-
-def _stack_rank_shape(shape, layer_count):
-    stacked = [int(dim) for dim in shape]
-    if len(stacked) < 2 or stacked[0] != N_RANKS:
-        raise ValueError(f"layer-stacked tensor must start with rank: {stacked}")
-    stacked[1] *= int(layer_count)
-    return stacked
-
-
-def _collect_weight_shapes(reports, common_count, hca_count, csa_count):
-    swa_shapes = reports["swa"]["distributed_shapes"]
-    hca_shapes = reports["hca"]["distributed_shapes"]
-    csa_shapes = reports["csa"]["distributed_shapes"]
-
-    common = {}
-    for name in _COMMON_ATTN_WEIGHT_NAMES:
-        reference = swa_shapes[name]
-        if hca_shapes[name] != reference or csa_shapes[name] != reference:
-            raise ValueError(f"common attention weight shape diverged for {name}")
-        common[name] = _stack_rank_shape(reference, common_count)
-
-    moe_shapes = reports["swa"]["moe_shapes"]
-    for name, shape in moe_shapes.items():
-        if name not in _MOE_NON_WEIGHT_NAMES:
-            common[name] = _stack_rank_shape(shape, common_count)
-
-    return {
-        "common": common,
-        "hca": {
-            name: _stack_rank_shape(hca_shapes[name], hca_count)
-            for name in _HCA_EXTRA_WEIGHT_NAMES
-        },
-        "csa": {
-            name: _stack_rank_shape(csa_shapes[name], csa_count)
-            for name in _CSA_EXTRA_WEIGHT_NAMES
-        },
-    }
-
-
-def _collect_metadata_shapes(reports):
-    metadata = {}
-    for kind, report in reports.items():
-        for name, shape in report["distributed_shapes"].items():
-            if name not in _METADATA_EXCLUDES:
-                metadata[f"{kind}_{name}"] = list(shape)
-    return metadata
-
-
-def _collect_per_layer_pool_shapes(reports):
-    raw_shapes = tuple(
-        reports[kind]["distributed_shapes"]["kv_cache"]
-        for kind in ("swa", "hca", "csa")
-    )
-    if raw_shapes[1:] != raw_shapes[:-1]:
-        raise ValueError(f"raw KV pool shapes diverged by attention kind: {raw_shapes}")
-
-    hca_shapes = reports["hca"]["distributed_shapes"]
-    csa_shapes = reports["csa"]["distributed_shapes"]
-    return {
-        "raw_kv_pool": list(raw_shapes[0]),
-        "hca_compress_state": list(hca_shapes["compress_state"]),
-        "hca_cmp_kv": list(hca_shapes["cmp_kv"]),
-        "csa_compress_state": list(csa_shapes["compress_state"]),
-        "csa_cmp_kv": list(csa_shapes["cmp_kv"]),
-        "csa_inner_compress_state": list(csa_shapes["inner_compress_state"]),
-        "csa_idx_kv_cache": list(csa_shapes["idx_kv_cache"]),
-        "csa_idx_kv_scale": list(csa_shapes["idx_kv_scale"]),
-    }
-
-
-def _validate_public_shapes(sections):
-    maximum_dims = 0
-    for section_name, shapes in sections.items():
-        for name, shape in shapes.items():
-            dims = len(shape)
-            maximum_dims = max(maximum_dims, dims)
-            if dims > MAX_PUBLIC_TENSOR_DIMS:
-                raise ValueError(
-                    f"{section_name} tensor {name!r} has {dims} dimensions: "
-                    f"{shape}"
-                )
-            if any(int(dim) <= 0 for dim in shape):
-                raise ValueError(
-                    f"{section_name} tensor {name!r} has an invalid shape: {shape}"
-                )
-    return maximum_dims
-
-
-def _make_mixed_layered_spec(name, source_specs):
-    """Pack the four real layer fixtures along the rank-local data axis."""
-    from golden import TensorSpec
-
-    shape = list(source_specs[0].shape)
-    shape[1] = sum(int(spec.shape[1]) for spec in source_specs)
-    reference_tail = tuple(source_specs[0].shape[2:])
-    for spec in source_specs:
-        if spec.shape[0] != N_RANKS or tuple(spec.shape[2:]) != reference_tail:
-            raise ValueError(f"mixed layer weight shape diverged for {name}")
-
-    def init_value():
-        import torch
-
-        return torch.cat(
-            [spec.create_tensor() for spec in source_specs], dim=1
-        ).contiguous()
-
-    packed = TensorSpec(name, shape, source_specs[0].dtype, init_value=init_value)
-    packed.resident = "stacked"
-    return packed
-
-
-def _copy_prefix_spec(name, source, *, is_output=None):
+def _copy_spec(name, source, *, is_output=None):
     from golden import TensorSpec
 
     copied = TensorSpec(
@@ -3993,146 +2637,7 @@ def _copy_prefix_spec(name, source, *, is_output=None):
     return copied
 
 
-def build_mixed_prefix_tensor_specs(start_pos=None):
-    """Build the rank-stacked SWA/SWA/CSA/HCA fixture in L3 ABI order."""
-    import inspect
-
-    import torch
-    from golden import TensorSpec
-
-    builders = (
-        (layer.build_swa_layer_specs, 0),
-        (layer.build_swa_layer_specs, 1),
-        (layer.build_csa_layer_specs, 2),
-        (layer.build_hca_layer_specs, 3),
-    )
-    layer_specs = []
-    for builder, layer_id in builders:
-        layer_specs.append({
-            spec.name: spec
-            for spec in builder(start_pos=start_pos, layer_id=layer_id)
-            if isinstance(spec, TensorSpec)
-        })
-    swa0_specs, _swa1_specs, csa_specs, hca_specs = layer_specs
-    local_t = int(swa0_specs["freqs_cos"].shape[1])
-    if any(int(specs["freqs_cos"].shape[1]) != local_t for specs in layer_specs):
-        raise ValueError("mixed attention fixtures disagree on active tokens")
-
-    def init_raw_kv_pool():
-        layers = []
-        for ordinal, specs in enumerate(layer_specs):
-            value = specs["kv_cache"].create_tensor()
-            value = (value.float() + ordinal * 0.125).to(torch.bfloat16)
-            layers.append(value)
-        return torch.cat(layers, dim=1).contiguous()
-
-    def init_input_ids():
-        value = swa0_specs["input_ids"].create_tensor()
-        return torch.remainder(value, MIXED_PREFIX_TEST_VOCAB).contiguous()
-
-    def zero_active():
-        return torch.zeros(
-            N_RANKS, local_t, HC_MULT, D, dtype=torch.float32
-        )
-
-    specs_by_name = {
-        "raw_kv_pool": TensorSpec(
-            "raw_kv_pool",
-            [
-                N_RANKS,
-                MIXED_PREFIX_LAYER_COUNT * swa0_specs["kv_cache"].shape[1],
-                BLOCK_SIZE,
-                1,
-                HEAD_DIM,
-            ],
-            torch.bfloat16,
-            init_value=init_raw_kv_pool,
-            is_output=True,
-        ),
-        "input_ids": TensorSpec(
-            "input_ids",
-            [N_RANKS, MOE_TOKENS],
-            torch.int64,
-            init_value=init_input_ids,
-        ),
-        "x_ping": TensorSpec(
-            "x_ping",
-            [N_RANKS, local_t, HC_MULT, D],
-            torch.float32,
-            init_value=swa0_specs["x_hc"].init_value,
-            is_output=True,
-        ),
-        "x_pong": TensorSpec(
-            "x_pong",
-            [N_RANKS, local_t, HC_MULT, D],
-            torch.float32,
-            init_value=zero_active,
-            is_output=True,
-        ),
-        "x_attn_active": TensorSpec(
-            "x_attn_active",
-            [N_RANKS, local_t, HC_MULT, D],
-            torch.float32,
-            init_value=zero_active,
-            is_output=True,
-        ),
-        "x_moe_next": TensorSpec(
-            "x_moe_next",
-            [N_RANKS, MOE_TOKENS, HC_MULT, D],
-            torch.float32,
-            init_value=lambda: torch.zeros(
-                N_RANKS, MOE_TOKENS, HC_MULT, D, dtype=torch.float32
-            ),
-            is_output=True,
-        ),
-        "x_out": TensorSpec(
-            "x_out",
-            [N_RANKS, local_t, HC_MULT, D],
-            torch.float32,
-            is_output=True,
-        ),
-    }
-    specs_by_name["raw_kv_pool"].resident = "stacked"
-
-    for name in _MIXED_LAYERED_WEIGHT_NAMES:
-        specs_by_name[name] = _make_mixed_layered_spec(
-            name, [specs[name] for specs in layer_specs]
-        )
-    for name in _SWA_METADATA_NAMES:
-        specs_by_name[name] = _copy_prefix_spec(name, swa0_specs[name])
-    for public_name, source_name in _CSA_PREFIX_SOURCES.items():
-        specs_by_name[public_name] = _copy_prefix_spec(
-            public_name, csa_specs[source_name]
-        )
-    for public_name, source_name in _HCA_PREFIX_SOURCES.items():
-        specs_by_name[public_name] = _copy_prefix_spec(
-            public_name, hca_specs[source_name]
-        )
-
-    parameter_names = [
-        name
-        for name, parameter in inspect.signature(
-            l3_decode_fwd._func
-        ).parameters.items()
-        if parameter.default is inspect.Parameter.empty
-    ]
-    missing = [name for name in parameter_names if name not in specs_by_name]
-    extra = [name for name in specs_by_name if name not in parameter_names]
-    if missing or extra:
-        raise ValueError(
-            f"mixed-prefix spec/signature mismatch: missing={missing}, extra={extra}"
-        )
-    specs = [specs_by_name[name] for name in parameter_names]
-    for spec in specs:
-        if isinstance(spec, TensorSpec) and len(spec.shape) > MAX_PUBLIC_TENSOR_DIMS:
-            raise ValueError(
-                f"mixed-prefix tensor {spec.name!r} exceeds "
-                f"{MAX_PUBLIC_TENSOR_DIMS} dimensions: {spec.shape}"
-            )
-    return specs
-
-
-def _make_full43_weight_bank_spec(
+def _make_weight_bank_spec(
     name, source, bank_size, *, compile_only=False
 ):
     """Pack a static layer bank along the first rank-local data axis."""
@@ -4173,7 +2678,7 @@ def _make_full43_weight_bank_spec(
     return spec
 
 
-def _make_full43_packed_pool_spec(
+def _make_packed_pool_spec(
     name, source, layer_count, *, sentinel=False
 ):
     """Pack identical layer-local allocator pools along the block axis."""
@@ -4203,13 +2708,13 @@ def _make_full43_packed_pool_spec(
     return spec
 
 
-def build_full43_tensor_specs(
+def build_tensor_specs(
     start_pos=None,
     *,
-    weight_bank_size=FULL43_RUNTIME_WEIGHT_BANK,
+    weight_bank_size=RUNTIME_WEIGHT_BANK,
     runtime_case="full_active",
 ):
-    """Build the production or bounded-runtime Full43 L3 fixture."""
+    """Build the production or bounded-runtime decode forward L3 fixture."""
     import inspect
 
     import torch
@@ -4221,15 +2726,15 @@ def build_full43_tensor_specs(
             f"{FWD_WEIGHT_BANK_SIZE}, got {weight_bank_size}"
         )
     compile_only = runtime_case is None
-    if not compile_only and weight_bank_size != FULL43_RUNTIME_WEIGHT_BANK:
-        raise ValueError("Full43 runtime witnesses use one reusable weight bank")
+    if not compile_only and weight_bank_size != RUNTIME_WEIGHT_BANK:
+        raise ValueError("decode forward runtime witnesses use one reusable weight bank")
     if runtime_case not in {
         None,
         "full_active",
         "packed_pool_sentinel",
         "long_context_tail",
     }:
-        raise ValueError(f"unknown Full43 runtime case: {runtime_case!r}")
+        raise ValueError(f"unknown decode forward runtime case: {runtime_case!r}")
 
     if runtime_case == "long_context_tail" and start_pos is None:
         start_pos = [0, 0, 0, 1048568]
@@ -4246,9 +2751,9 @@ def build_full43_tensor_specs(
     hca_specs = tensor_specs(layer.build_hca_layer_specs, 3)
     local_t = int(swa_specs["freqs_cos"].shape[1])
     if int(csa_specs["freqs_cos"].shape[1]) != local_t:
-        raise ValueError("CSA and SWA Full43 fixtures disagree on active rows")
+        raise ValueError("CSA and SWA decode forward fixtures disagree on active rows")
     if int(hca_specs["freqs_cos"].shape[1]) != local_t:
-        raise ValueError("HCA and SWA Full43 fixtures disagree on active rows")
+        raise ValueError("HCA and SWA decode forward fixtures disagree on active rows")
 
     def zero_active():
         return torch.zeros(
@@ -4257,53 +2762,70 @@ def build_full43_tensor_specs(
 
     def init_input_ids():
         value = swa_specs["input_ids"].create_tensor()
-        return torch.remainder(value, MIXED_PREFIX_TEST_VOCAB).contiguous()
+        return torch.remainder(
+            value[:, :local_t], RUNTIME_TEST_VOCAB
+        ).contiguous()
+
+    embedding_vocab = (
+        MODEL_CONFIG.vocab_size if compile_only else RUNTIME_TEST_VOCAB
+    )
+
+    def init_embed_weight():
+        return (
+            torch.randn(N_RANKS, embedding_vocab, D) * 0.05
+        ).to(torch.bfloat16)
 
     sentinel = runtime_case == "packed_pool_sentinel"
     specs_by_name = {
-        "raw_kv_pool": _make_full43_packed_pool_spec(
+        "embed_weight": TensorSpec(
+            "embed_weight",
+            [N_RANKS, embedding_vocab, D],
+            torch.bfloat16,
+            init_value=0 if compile_only else init_embed_weight,
+        ),
+        "raw_kv_pool": _make_packed_pool_spec(
             "raw_kv_pool",
             swa_specs["kv_cache"],
             MAIN_LAYER_COUNT,
             sentinel=sentinel,
         ),
-        "hca_compress_state": _make_full43_packed_pool_spec(
+        "hca_compress_state": _make_packed_pool_spec(
             "hca_compress_state",
             hca_specs["compress_state"],
             HCA_LAYER_COUNT,
             sentinel=sentinel,
         ),
-        "hca_cmp_kv": _make_full43_packed_pool_spec(
+        "hca_cmp_kv": _make_packed_pool_spec(
             "hca_cmp_kv",
             hca_specs["cmp_kv"],
             HCA_LAYER_COUNT,
             sentinel=sentinel,
         ),
-        "csa_compress_state": _make_full43_packed_pool_spec(
+        "csa_compress_state": _make_packed_pool_spec(
             "csa_compress_state",
             csa_specs["compress_state"],
             CSA_LAYER_COUNT,
             sentinel=sentinel,
         ),
-        "csa_cmp_kv": _make_full43_packed_pool_spec(
+        "csa_cmp_kv": _make_packed_pool_spec(
             "csa_cmp_kv",
             csa_specs["cmp_kv"],
             CSA_LAYER_COUNT,
             sentinel=sentinel,
         ),
-        "csa_inner_compress_state": _make_full43_packed_pool_spec(
+        "csa_inner_compress_state": _make_packed_pool_spec(
             "csa_inner_compress_state",
             csa_specs["inner_compress_state"],
             CSA_LAYER_COUNT,
             sentinel=sentinel,
         ),
-        "csa_idx_kv_cache": _make_full43_packed_pool_spec(
+        "csa_idx_kv_cache": _make_packed_pool_spec(
             "csa_idx_kv_cache",
             csa_specs["idx_kv_cache"],
             CSA_LAYER_COUNT,
             sentinel=sentinel,
         ),
-        "csa_idx_kv_scale": _make_full43_packed_pool_spec(
+        "csa_idx_kv_scale": _make_packed_pool_spec(
             "csa_idx_kv_scale",
             csa_specs["idx_kv_scale"],
             CSA_LAYER_COUNT,
@@ -4311,15 +2833,54 @@ def build_full43_tensor_specs(
         ),
         "input_ids": TensorSpec(
             "input_ids",
-            [N_RANKS, MOE_TOKENS],
+            [N_RANKS, local_t],
             torch.int64,
             init_value=init_input_ids,
+        ),
+        "hc_head_fn": TensorSpec(
+            "hc_head_fn",
+            [N_RANKS, HC_MULT, HC_DIM],
+            torch.float32,
+            init_value=0,
+        ),
+        "hc_head_scale": TensorSpec(
+            "hc_head_scale", [N_RANKS, 1], torch.float32, init_value=1.0
+        ),
+        "hc_head_base": TensorSpec(
+            "hc_head_base",
+            [N_RANKS, HC_MULT],
+            torch.float32,
+            init_value=0,
+        ),
+        "final_norm_w": TensorSpec(
+            "final_norm_w",
+            [N_RANKS, D],
+            torch.bfloat16,
+            init_value=1.0,
+        ),
+        "lm_head_weight": TensorSpec(
+            "lm_head_weight",
+            [N_RANKS, VOCAB_PER_TP, D],
+            torch.bfloat16,
+            init_value=0,
+        ),
+        "logit_row_indices": TensorSpec(
+            "logit_row_indices",
+            [N_RANKS, MAX_LOGIT_ROWS],
+            torch.int32,
+            init_value=lambda: build_active_logit_row_indices_host(local_t),
+        ),
+        "hidden_workspace": TensorSpec(
+            "hidden_workspace",
+            [N_RANKS, local_t, D],
+            torch.bfloat16,
+            is_output=True,
         ),
         "x_ping": TensorSpec(
             "x_ping",
             [N_RANKS, local_t, HC_MULT, D],
             torch.float32,
-            init_value=swa_specs["x_hc"].init_value,
+            init_value=zero_active,
             is_output=True,
         ),
         "x_pong": TensorSpec(
@@ -4345,23 +2906,41 @@ def build_full43_tensor_specs(
             ),
             is_output=True,
         ),
-        "x_out": TensorSpec(
-            "x_out",
+        "pre_hc_hidden_out": TensorSpec(
+            "pre_hc_hidden_out",
             [N_RANKS, local_t, HC_MULT, D],
             torch.float32,
             is_output=True,
         ),
+        "x_out": TensorSpec(
+            "x_out",
+            [N_RANKS, local_t, D],
+            torch.bfloat16,
+            is_output=True,
+        ),
+        "logits": TensorSpec(
+            "logits",
+            [N_RANKS, MAX_LOGIT_ROWS, LM_HEAD_VOCAB],
+            torch.float32,
+            is_output=True,
+        ),
+        "sampled_ids": TensorSpec(
+            "sampled_ids",
+            [N_RANKS, MAX_LOGIT_ROWS, SAMPLED_IDS_PAD],
+            torch.int32,
+            is_output=True,
+        ),
     }
 
-    for name in _MIXED_LAYERED_WEIGHT_NAMES:
-        specs_by_name[name] = _make_full43_weight_bank_spec(
+    for name in _LAYER_WEIGHT_NAMES:
+        specs_by_name[name] = _make_weight_bank_spec(
             name,
             swa_specs[name],
             weight_bank_size,
             compile_only=compile_only,
         )
     for name in _SWA_METADATA_NAMES:
-        specs_by_name[name] = _copy_prefix_spec(name, swa_specs[name])
+        specs_by_name[name] = _copy_spec(name, swa_specs[name])
 
     csa_weight_names = {
         f"csa_{name}": name for name in _CSA_EXTRA_WEIGHT_NAMES
@@ -4370,69 +2949,92 @@ def build_full43_tensor_specs(
         f"hca_{name}": name for name in _HCA_EXTRA_WEIGHT_NAMES
     }
     for public_name, source_name in csa_weight_names.items():
-        specs_by_name[public_name] = _make_full43_weight_bank_spec(
+        specs_by_name[public_name] = _make_weight_bank_spec(
             public_name,
             csa_specs[source_name],
-            CSA_LAYER_COUNT if compile_only else FULL43_RUNTIME_WEIGHT_BANK,
+            CSA_LAYER_COUNT if compile_only else RUNTIME_WEIGHT_BANK,
             compile_only=compile_only,
         )
     for public_name, source_name in hca_weight_names.items():
-        specs_by_name[public_name] = _make_full43_weight_bank_spec(
+        specs_by_name[public_name] = _make_weight_bank_spec(
             public_name,
             hca_specs[source_name],
-            HCA_LAYER_COUNT if compile_only else FULL43_RUNTIME_WEIGHT_BANK,
+            HCA_LAYER_COUNT if compile_only else RUNTIME_WEIGHT_BANK,
             compile_only=compile_only,
         )
 
     packed_names = set(PACKED_POOL_LAYER_COUNTS)
-    for public_name, source_name in _CSA_PREFIX_SOURCES.items():
+    for public_name, source_name in _CSA_SOURCES.items():
         if public_name in packed_names or public_name in csa_weight_names:
             continue
-        specs_by_name[public_name] = _copy_prefix_spec(
+        specs_by_name[public_name] = _copy_spec(
             public_name, csa_specs[source_name]
         )
-    for public_name, source_name in _HCA_PREFIX_SOURCES.items():
+    for public_name, source_name in _HCA_SOURCES.items():
         if public_name in packed_names or public_name in hca_weight_names:
             continue
-        specs_by_name[public_name] = _copy_prefix_spec(
+        specs_by_name[public_name] = _copy_spec(
             public_name, hca_specs[source_name]
         )
 
     parameter_names = list(
-        inspect.signature(l3_decode_fwd_full43._func).parameters
+        inspect.signature(l3_decode_fwd._func).parameters
     )
     missing = [name for name in parameter_names if name not in specs_by_name]
     extra = [name for name in specs_by_name if name not in parameter_names]
     if missing or extra:
         raise ValueError(
-            f"Full43 spec/signature mismatch: missing={missing}, extra={extra}"
+            f"decode forward spec/signature mismatch: missing={missing}, extra={extra}"
         )
     specs = [specs_by_name[name] for name in parameter_names]
     for spec in specs:
         if len(spec.shape) > MAX_PUBLIC_TENSOR_DIMS:
             raise ValueError(
-                f"Full43 tensor {spec.name!r} exceeds "
+                f"decode forward tensor {spec.name!r} exceeds "
                 f"{MAX_PUBLIC_TENSOR_DIMS} dimensions: {spec.shape}"
             )
     return specs
 
 
-def golden_full43_runtime(_tensors):
-    """Full43 is a topology/isolation witness; layer math is gated earlier."""
+def golden_decode_fwd(_tensors):
+    """decode forward is a topology/isolation witness; layer math is gated earlier."""
 
 
-def finite_full43_tensor_compare(actual, _expected, **_kwargs):
+def finite_tensor_compare(actual, _expected, **_kwargs):
     """Require a completed finite device result without duplicating 43 goldens."""
     import torch
 
     if actual.numel() == 0:
-        return False, "    Full43 output is empty"
+        return False, "    decode forward output is empty"
     if actual.is_floating_point() and not bool(torch.isfinite(actual).all()):
-        return False, "    Full43 output contains NaN or Inf"
+        return False, "    decode forward output contains NaN or Inf"
     return True, ""
 
 
-def _full43_pool_compare(layer_mappings, layer_count, block_size, pool_name):
+def sampled_ids_compare(actual, _expected, **kwargs):
+    """Validate active greedy ids and the inactive-row -1 contract."""
+    import torch
+
+    row_indices = kwargs.get("inputs", {}).get("logit_row_indices")
+    if row_indices is None:
+        return False, "    missing logit_row_indices input"
+    active = row_indices >= 0
+    inactive_values = actual.masked_select(
+        (~active).unsqueeze(-1).expand_as(actual)
+    )
+    if inactive_values.numel() and not bool(
+        torch.all(inactive_values == -1)
+    ):
+        return False, "    inactive sampled-id rows are not -1"
+    active_ids = actual[..., 0].masked_select(active)
+    if active_ids.numel() and bool(
+        ((active_ids < 0) | (active_ids >= LM_HEAD_VOCAB)).any()
+    ):
+        return False, "    active sampled token id is outside the vocabulary"
+    return True, ""
+
+
+def _packed_pool_compare(layer_mappings, layer_count, block_size, pool_name):
     """Check every packed layer slice and reject writes outside local slots."""
     def compare(actual, expected, **kwargs):
         import torch
@@ -4500,13 +3102,13 @@ def _full43_pool_compare(layer_mappings, layer_count, block_size, pool_name):
     return compare
 
 
-def full43_compare_functions():
-    """Return the Full43 runtime isolation and completion comparators."""
+def compare_functions():
+    """Return the decode forward runtime isolation and completion comparators."""
     raw_mappings = tuple(
         "swa_slot_mapping"
         if entry["kind"] == "swa"
         else f"{entry['kind']}_ori_slot_mapping"
-        for entry in FULL43_LAYER_PLAN
+        for entry in LAYER_PLAN
     )
     csa_mappings = ("csa_state_slot_mapping",) * CSA_LAYER_COUNT
     csa_cmp_mappings = ("csa_cmp_slot_mapping",) * CSA_LAYER_COUNT
@@ -4517,69 +3119,73 @@ def full43_compare_functions():
     hca_state_mappings = ("hca_state_slot_mapping",) * HCA_LAYER_COUNT
     hca_cmp_mappings = ("hca_cmp_slot_mapping",) * HCA_LAYER_COUNT
     finite_names = {
+        "hidden_workspace",
         "x_ping",
         "x_pong",
         "x_attn_active",
         "x_moe_next",
+        "pre_hc_hidden_out",
         "x_out",
+        "logits",
     }
-    compare = {name: finite_full43_tensor_compare for name in finite_names}
+    compare = {name: finite_tensor_compare for name in finite_names}
+    compare["sampled_ids"] = sampled_ids_compare
     compare.update({
-        "raw_kv_pool": _full43_pool_compare(
-            raw_mappings, MAIN_LAYER_COUNT, BLOCK_SIZE, "Full43 raw KV"
+        "raw_kv_pool": _packed_pool_compare(
+            raw_mappings, MAIN_LAYER_COUNT, BLOCK_SIZE, "decode forward raw KV"
         ),
-        "hca_compress_state": _full43_pool_compare(
+        "hca_compress_state": _packed_pool_compare(
             hca_state_mappings,
             HCA_LAYER_COUNT,
             HCA_COMPRESS_STATE_BLOCK_SIZE,
-            "Full43 HCA state",
+            "decode forward HCA state",
         ),
-        "hca_cmp_kv": _full43_pool_compare(
+        "hca_cmp_kv": _packed_pool_compare(
             hca_cmp_mappings,
             HCA_LAYER_COUNT,
             BLOCK_SIZE,
-            "Full43 HCA compressed KV",
+            "decode forward HCA compressed KV",
         ),
-        "csa_compress_state": _full43_pool_compare(
+        "csa_compress_state": _packed_pool_compare(
             csa_mappings,
             CSA_LAYER_COUNT,
             CSA_MAIN_STATE_BLOCK_SIZE,
-            "Full43 CSA main state",
+            "decode forward CSA main state",
         ),
-        "csa_cmp_kv": _full43_pool_compare(
+        "csa_cmp_kv": _packed_pool_compare(
             csa_cmp_mappings,
             CSA_LAYER_COUNT,
             BLOCK_SIZE,
-            "Full43 CSA compressed KV",
+            "decode forward CSA compressed KV",
         ),
-        "csa_inner_compress_state": _full43_pool_compare(
+        "csa_inner_compress_state": _packed_pool_compare(
             csa_inner_mappings,
             CSA_LAYER_COUNT,
             CSA_INNER_STATE_BLOCK_SIZE,
-            "Full43 CSA inner state",
+            "decode forward CSA inner state",
         ),
-        "csa_idx_kv_cache": _full43_pool_compare(
+        "csa_idx_kv_cache": _packed_pool_compare(
             csa_idx_mappings,
             CSA_LAYER_COUNT,
             BLOCK_SIZE,
-            "Full43 CSA index KV",
+            "decode forward CSA index KV",
         ),
-        "csa_idx_kv_scale": _full43_pool_compare(
+        "csa_idx_kv_scale": _packed_pool_compare(
             csa_idx_mappings,
             CSA_LAYER_COUNT,
             BLOCK_SIZE,
-            "Full43 CSA index scale",
+            "decode forward CSA index scale",
         ),
     })
     return compare
 
 
-def build_full43_shape_report(
+def build_shape_report(
     start_pos=None, *, weight_bank_size=FWD_WEIGHT_BANK_SIZE
 ):
-    """Return concrete Full43 device ABI shapes without materializing values."""
+    """Return concrete decode forward device ABI shapes without materializing values."""
     runtime_case = "full_active" if weight_bank_size == 1 else None
-    specs = build_full43_tensor_specs(
+    specs = build_tensor_specs(
         start_pos,
         weight_bank_size=weight_bank_size,
         runtime_case=runtime_case,
@@ -4591,240 +3197,6 @@ def build_full43_shape_report(
         "raw_blocks_per_layer": shapes["raw_kv_pool"][1] // MAIN_LAYER_COUNT,
         "maximum_public_tensor_dims": max(len(shape) for shape in shapes.values()),
         "shapes": shapes,
-    }
-
-
-def _mixed_layer_value(value, layer_ordinal):
-    extent = value.shape[1] // MIXED_PREFIX_LAYER_COUNT
-    begin = layer_ordinal * extent
-    return value[:, begin : begin + extent]
-
-
-def golden_mixed_prefix_decode_fwd(tensors):
-    """Compose the unchanged four production layer goldens in model order."""
-    import torch
-
-    local_t = int(tensors["freqs_cos"].shape[1])
-    current = tensors["x_ping"].clone()
-    raw_blocks_per_layer = (
-        tensors["raw_kv_pool"].shape[1] // MIXED_PREFIX_LAYER_COUNT
-    )
-    layer_kinds = ("swa", "swa", "csa", "hca")
-    kind_sources = {"csa": _CSA_PREFIX_SOURCES, "hca": _HCA_PREFIX_SOURCES}
-    golden_fns = {
-        "swa": layer.golden_decode_layer_swa,
-        "csa": layer.golden_decode_layer_csa,
-        "hca": layer.golden_decode_layer_hca,
-    }
-
-    for layer_ordinal, kind in enumerate(layer_kinds):
-        raw_begin = layer_ordinal * raw_blocks_per_layer
-        x_attn_active = torch.zeros_like(current)
-        x_moe_next = torch.zeros(
-            N_RANKS, MOE_TOKENS, HC_MULT, D, dtype=torch.float32
-        )
-        x_next = torch.zeros_like(current)
-        layer_tensors = {
-            name: _mixed_layer_value(tensors[name], layer_ordinal)
-            for name in _MIXED_LAYERED_WEIGHT_NAMES
-        }
-        layer_tensors.update({
-            "x_hc": current,
-            "freqs_cos": tensors["freqs_cos"],
-            "freqs_sin": tensors["freqs_sin"],
-            "position_ids": tensors["position_ids"],
-            "kv_cache": tensors["raw_kv_pool"][
-                :, raw_begin : raw_begin + raw_blocks_per_layer
-            ],
-            "input_ids": tensors["input_ids"],
-            "x_attn_active": x_attn_active,
-            "x_moe_next": x_moe_next,
-            "x_next": x_next,
-            "layer_id": layer_ordinal,
-            "local_t": local_t,
-        })
-        if kind == "swa":
-            layer_tensors.update({
-                name: tensors[name]
-                for name in ("swa_slot_mapping", "swa_indices", "swa_lens")
-            })
-        else:
-            layer_tensors.update({
-                source_name: tensors[public_name]
-                for public_name, source_name in kind_sources[kind].items()
-            })
-        golden_fns[kind](layer_tensors)
-        current = x_next.clone()
-        tensors["x_attn_active"].copy_(x_attn_active)
-        tensors["x_moe_next"].copy_(x_moe_next)
-        if layer_ordinal == 0:
-            tensors["x_pong"].copy_(current)
-        elif layer_ordinal == 1:
-            tensors["x_ping"].copy_(current)
-        elif layer_ordinal == 2:
-            tensors["x_pong"].copy_(current)
-    tensors["x_out"].copy_(current)
-
-
-def mixed_packed_raw_pool_compare(actual, expected, **kwargs):
-    """Check all four local raw mappings and every untouched cache row."""
-    from golden import mapped_pool_ratio_allclose
-
-    if actual.shape != expected.shape:
-        return False, (
-            f"    raw pool shape mismatch: actual={tuple(actual.shape)} "
-            f"expected={tuple(expected.shape)}"
-        )
-    if actual.shape[1] % MIXED_PREFIX_LAYER_COUNT:
-        return False, "    packed raw pool is not divisible by four layers"
-
-    per_layer_blocks = actual.shape[1] // MIXED_PREFIX_LAYER_COUNT
-    mapping_names = (
-        "swa_slot_mapping",
-        "swa_slot_mapping",
-        "csa_ori_slot_mapping",
-        "hca_ori_slot_mapping",
-    )
-    inputs = kwargs.get("inputs", {})
-    for layer_ordinal, mapping_name in enumerate(mapping_names):
-        mapping = inputs.get(mapping_name)
-        if mapping is None:
-            return False, f"    compare_fn missing input {mapping_name!r}"
-        compare_layer = mapped_pool_ratio_allclose(
-            mapping_name,
-            mapping_shape=tuple(mapping.shape),
-            block_size=BLOCK_SIZE,
-            leading_rank_axis=True,
-            pool_name=f"mixed layer {layer_ordinal} raw KV cache",
-            atol=1e-4 if layer_ordinal == 0 else 0.01,
-            rtol=1.0 / 128 if layer_ordinal == 0 else 0.08,
-            max_error_ratio=0.005 if layer_ordinal == 0 else 0.08,
-        )
-        begin = layer_ordinal * per_layer_blocks
-        ok, detail = compare_layer(
-            actual[:, begin : begin + per_layer_blocks],
-            expected[:, begin : begin + per_layer_blocks],
-            **kwargs,
-        )
-        if not ok:
-            return False, f"    layer {layer_ordinal}:\n{detail}"
-    return True, ""
-
-
-def build_mixed_prefix_shape_report(start_pos=None):
-    """Return concrete mixed-prefix L3 shapes without materializing tensors."""
-    specs = build_mixed_prefix_tensor_specs(start_pos=start_pos)
-    shapes = {
-        spec.name: list(spec.shape)
-        for spec in specs
-        if hasattr(spec, "shape")
-    }
-    return {
-        "tp": TP_SIZE,
-        "ep": EP_SIZE,
-        "active_tokens": shapes["freqs_cos"][1],
-        "raw_blocks_per_layer": (
-            shapes["raw_kv_pool"][1] // MIXED_PREFIX_LAYER_COUNT
-        ),
-        "maximum_public_tensor_dims": max(len(shape) for shape in shapes.values()),
-        "shapes": shapes,
-    }
-
-
-def build_decode_fwd_shape_report(start_pos=None):
-    """Build production/runtime shape skeletons without building a device graph."""
-    reports = {
-        "swa": layer.build_layer_shape_report(0, start_pos=start_pos),
-        "csa": layer.build_layer_shape_report(2, start_pos=start_pos),
-        "hca": layer.build_layer_shape_report(3, start_pos=start_pos),
-    }
-    active_tokens = reports["swa"]["active_tokens"]
-    if any(report["active_tokens"] != active_tokens for report in reports.values()):
-        raise ValueError("attention kinds disagree on the active-token extent")
-
-    per_layer_pool_shapes = _collect_per_layer_pool_shapes(reports)
-    packed_layout = build_packed_pool_layout(per_layer_pool_shapes)
-    packed_pool_shapes = {
-        name: entry["packed_shape"] for name, entry in packed_layout.items()
-    }
-    metadata_shapes = _collect_metadata_shapes(reports)
-
-    preamble_shapes = {
-        "input_ids": [N_RANKS, MOE_TOKENS],
-        "embed_weight": [N_RANKS, MODEL_CONFIG.vocab_size, D],
-    }
-    workspace_shapes = {
-        "embedding_hidden": [N_RANKS, active_tokens, D],
-        "x_ping": [N_RANKS, active_tokens, HC_MULT, D],
-        "x_pong": [N_RANKS, active_tokens, HC_MULT, D],
-        "x_attn_active": [N_RANKS, active_tokens, HC_MULT, D],
-        "x_moe_next": [N_RANKS, MOE_TOKENS, HC_MULT, D],
-    }
-    terminal_shapes = {
-        "hc_head_fn": [N_RANKS, HC_MULT, HC_DIM],
-        "hc_head_scale": [N_RANKS, 1],
-        "hc_head_base": [N_RANKS, HC_MULT],
-        "final_norm_w": [N_RANKS, D],
-        "lm_head_weight": [N_RANKS, VOCAB_PER_TP, D],
-        "hidden_out": [N_RANKS, active_tokens, D],
-        "logit_row_indices": [N_RANKS, MAX_LOGIT_ROWS],
-        "logits": [N_RANKS, MAX_LOGIT_ROWS, MODEL_CONFIG.vocab_size],
-        "sampled_ids": [N_RANKS, MAX_LOGIT_ROWS, SAMPLED_IDS_PAD],
-    }
-
-    production_weights = _collect_weight_shapes(
-        reports,
-        MAIN_LAYER_COUNT,
-        HCA_LAYER_COUNT,
-        CSA_LAYER_COUNT,
-    )
-    runtime_weights = _collect_weight_shapes(reports, 1, 1, 1)
-
-    common_sections = {
-        "preamble": preamble_shapes,
-        "metadata": metadata_shapes,
-        "packed_pools": packed_pool_shapes,
-        "workspaces": workspace_shapes,
-        "terminal": terminal_shapes,
-    }
-    production_sections = {
-        **common_sections,
-        "common_weights": production_weights["common"],
-        "hca_weights": production_weights["hca"],
-        "csa_weights": production_weights["csa"],
-    }
-    runtime_sections = {
-        **common_sections,
-        "common_weights": runtime_weights["common"],
-        "hca_weights": runtime_weights["hca"],
-        "csa_weights": runtime_weights["csa"],
-    }
-    maximum_dims = max(
-        _validate_public_shapes(production_sections),
-        _validate_public_shapes(runtime_sections),
-    )
-
-    return {
-        "tp": TP_SIZE,
-        "ep": EP_SIZE,
-        "active_batch": reports["swa"]["active_batch"],
-        "active_tokens": active_tokens,
-        "layer_plan": FULL43_LAYER_PLAN,
-        "packed_layout": packed_layout,
-        "packed_pool_bytes_per_rank": sum(
-            entry["bytes_per_rank"] for entry in packed_layout.values()
-        ),
-        "weight_bank_layers": {
-            "production": {
-                "common": MAIN_LAYER_COUNT,
-                "hca": HCA_LAYER_COUNT,
-                "csa": CSA_LAYER_COUNT,
-            },
-            "runtime": {"common": 1, "hca": 1, "csa": 1},
-        },
-        "production": production_sections,
-        "runtime": runtime_sections,
-        "maximum_public_tensor_dims": maximum_dims,
     }
 
 
@@ -4903,33 +3275,18 @@ def main():
             f"{FWD_WEIGHT_BANK_SIZE}, got {weight_bank_size}"
         )
     if not args.compile_only and not args.shape_only and weight_bank_size != 1:
-        parser.error("Full43 runtime requires --weight-bank-size 1")
+        parser.error("decode forward runtime requires --weight-bank-size 1")
     if args.shape_only:
-        report = build_decode_fwd_shape_report(start_pos)
-        full43_report = build_full43_shape_report(
+        report = build_shape_report(
             start_pos, weight_bank_size=weight_bank_size
         )
-        packed_summary = ", ".join(
-            f"{name}={entry['total_extent']}"
-            for name, entry in report["packed_layout"].items()
-        )
         print(
-            f"TP={report['tp']} EP={report['ep']} "
-            f"batch={report['active_batch']} active_t={report['active_tokens']} "
-            f"layers={len(report['layer_plan'])} "
+            f"TP={TP_SIZE} EP={EP_SIZE} "
+            f"weight_bank={report['weight_bank_size']} "
+            f"active_t={report['active_tokens']} "
+            f"layers={len(LAYER_PLAN)} "
+            f"raw_blocks_per_layer={report['raw_blocks_per_layer']} "
             f"max_dims={report['maximum_public_tensor_dims']}"
-        )
-        print(f"packed_blocks: {packed_summary}")
-        print(
-            "packed_pool_gib_per_rank: "
-            f"{report['packed_pool_bytes_per_rank'] / (1024 ** 3):.3f}"
-        )
-        print(
-            "full43_device: "
-            f"weight_bank={full43_report['weight_bank_size']} "
-            f"active_t={full43_report['active_tokens']} "
-            f"raw_blocks_per_layer={full43_report['raw_blocks_per_layer']} "
-            f"max_dims={full43_report['maximum_public_tensor_dims']}"
         )
         return
 
@@ -4952,15 +3309,15 @@ def main():
         parser.error(f"device IDs must be distinct and non-negative: {device_ids}")
 
     runtime_case = None if weight_bank_size == MAIN_LAYER_COUNT else args.runtime_case
-    specs = build_full43_tensor_specs(
+    specs = build_tensor_specs(
         start_pos=start_pos,
         weight_bank_size=weight_bank_size,
         runtime_case=runtime_case,
     )
     result = run_jit(
-        fn=l3_decode_fwd_full43,
+        fn=l3_decode_fwd,
         specs=specs,
-        golden_fn=golden_full43_runtime,
+        golden_fn=golden_decode_fwd,
         golden_data=args.golden_data,
         save_data=args.save_data,
         compile_only=args.compile_only,
@@ -4978,7 +3335,7 @@ def main():
         ),
         rtol=1e-2,
         atol=1e-2,
-        compare_fn=full43_compare_functions(),
+        compare_fn=compare_functions(),
     )
     if not result.passed:
         if result.error:

--- a/models/deepseek_v4_flash_dspark/decode_fwd.py
+++ b/models/deepseek_v4_flash_dspark/decode_fwd.py
@@ -725,7 +725,7 @@ def decode_fwd(
         [LM_HEAD_TP_SIZE, 1], pl.INT32
     ],
     lm_head_logits_window: pld.DistributedTensor[
-        [MAX_LOGIT_ROWS, LM_HEAD_VOCAB], pl.FP32
+        [MAX_LOGIT_ROWS * LM_HEAD_VOCAB], pl.FP32
     ],
     lm_head_logits_done: pld.DistributedTensor[
         [LM_HEAD_TP_SIZE, 1], pl.INT32
@@ -1893,8 +1893,8 @@ def decode_fwd(
             hc_head_base,
             hidden_workspace,
         )
-        rms_norm(hidden_workspace, final_norm_w, x_out)
-        lm_head(
+        final_norm_tid = rms_norm(hidden_workspace, final_norm_w, x_out)
+        logits, _lm_head_done_tid = lm_head(
             x_out,
             lm_head_weight,
             logit_row_indices,
@@ -1906,6 +1906,7 @@ def decode_fwd(
             group_base,
             tp_rank,
             pl.const(LM_HEAD_COMM_EPOCH, pl.INT32),
+            final_norm_tid,
         )
         greedy_sample(logits, sampled_ids)
         mask_inactive_sample_rows(logit_row_indices, sampled_ids)
@@ -2363,7 +2364,7 @@ def l3_decode_fwd(
         [LM_HEAD_TP_SIZE, 1], dtype=pl.INT32
     )
     lm_head_logits_window_buf = pld.alloc_window_buffer(
-        [MAX_LOGIT_ROWS, LM_HEAD_VOCAB], dtype=pl.FP32
+        [MAX_LOGIT_ROWS * LM_HEAD_VOCAB], dtype=pl.FP32
     )
     lm_head_logits_done_buf = pld.alloc_window_buffer(
         [LM_HEAD_TP_SIZE, 1], dtype=pl.INT32
@@ -2424,7 +2425,7 @@ def l3_decode_fwd(
         )
         lm_head_logits_window = pld.window(
             lm_head_logits_window_buf,
-            [MAX_LOGIT_ROWS, LM_HEAD_VOCAB],
+            [MAX_LOGIT_ROWS * LM_HEAD_VOCAB],
             dtype=pl.FP32,
         )
         lm_head_logits_done = pld.window(

--- a/models/deepseek_v4_flash_dspark/decode_fwd.py
+++ b/models/deepseek_v4_flash_dspark/decode_fwd.py
@@ -6,6 +6,7 @@
 # INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
+# ci: devices=2  # CI: EP2/TP2 full decode forward
 """DeepSeek-V4 D-Spark decode forward."""
 
 import sys
@@ -54,7 +55,6 @@ import decode_csa as csa
 import decode_hca as hca
 import decode_layer as layer
 import decode_swa as swa
-import moe as moe_module
 import pypto.language as pl
 import pypto.language.distributed as pld
 from decode_layer import decode_layer_csa, decode_layer_hca, decode_layer_swa

--- a/models/deepseek_v4_flash_dspark/decode_fwd.py
+++ b/models/deepseek_v4_flash_dspark/decode_fwd.py
@@ -151,9 +151,7 @@ CSA_IDX_MAX_BLOCKS = csa.IDX_MAX_BLOCKS
 RUNTIME_TEST_VOCAB = 256
 RUNTIME_WEIGHT_BANK = 1
 HC_FN_STORAGE_ROWS = 32
-DECODE_RING_TASK_WINDOW = 16384
 DECODE_RING_HEAP = 1 << 30
-DECODE_RING_DEP_POOL = 16384
 
 
 def _validate_import_contract():
@@ -2236,9 +2234,7 @@ def main():
             platform=args.platform,
             enable_scope_stats=args.enable_scope_stats,
             log_level=args.log_level,
-            ring_task_window=DECODE_RING_TASK_WINDOW,
             ring_heap=DECODE_RING_HEAP,
-            ring_dep_pool=DECODE_RING_DEP_POOL,
         ),
         rtol=1e-2,
         atol=1e-2,

--- a/models/deepseek_v4_flash_dspark/decode_fwd.py
+++ b/models/deepseek_v4_flash_dspark/decode_fwd.py
@@ -1,0 +1,1764 @@
+# Copyright (c) PyPTO Contributors.
+# This program is free software, you can redistribute it and/or modify it under the terms and conditions of
+# CANN Open Software License Agreement Version 2.0 (the "License").
+# Please refer to the License for details. You may not use this file except in compliance with the License.
+# THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS, WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED,
+# INCLUDING BUT NOT LIMITED TO NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE.
+# See LICENSE in the root of the software repository for the full text of the License.
+# -----------------------------------------------------------------------------------------------------------
+"""DeepSeek-V4 D-Spark 43-layer decode-forward integration."""
+
+import sys
+
+import config
+
+
+_TP_CHOICES = (1, 2, 4)
+_EP_CHOICES = (2, 4, 8, 16)
+_TP_DEFAULT = 2
+_EP_DEFAULT = 2
+
+
+def _parse_parallel_arg(name, default):
+    flag = f"--{name}"
+    prefix = f"{flag}="
+    for index, arg in enumerate(sys.argv):
+        if arg == flag and index + 1 < len(sys.argv):
+            return int(sys.argv[index + 1])
+        if arg.startswith(prefix):
+            return int(arg.split("=", 1)[1])
+    return default
+
+
+# TP/EP-dependent leaf shapes freeze at import time. Select both worlds before
+# importing attention, MoE, or output-projection modules.
+TP_SIZE = _parse_parallel_arg("tp", _TP_DEFAULT)
+EP_SIZE = _parse_parallel_arg("ep", _EP_DEFAULT)
+if TP_SIZE not in _TP_CHOICES:
+    raise ValueError(f"--tp must be one of {_TP_CHOICES} (got {TP_SIZE})")
+if EP_SIZE not in _EP_CHOICES:
+    raise ValueError(f"--ep must be one of {_EP_CHOICES} (got {EP_SIZE})")
+if EP_SIZE % TP_SIZE != 0:
+    raise ValueError(f"EP={EP_SIZE} must be divisible by TP={TP_SIZE}")
+
+config.TP = TP_SIZE
+config.EP = EP_SIZE
+
+import decode_csa as csa
+import decode_hca as hca
+import decode_layer as layer
+import decode_swa as swa
+import moe as moe_module
+import pypto.language as pl
+import pypto.language.distributed as pld
+from decode_layer import decode_layer_swa
+from lookup_embedding import VOCAB_DYN as EMBED_VOCAB_DYN
+from lookup_embedding import lookup_embedding
+from moe import clear_moe_signals
+
+
+MODEL_CONFIG = config.FLASH
+DECODE_TOKENS = config.DECODE_TOKENS
+
+MAIN_LAYER_COUNT = MODEL_CONFIG.num_hidden_layers
+SWA_LAYER_COUNT = 2
+CSA_LAYER_COUNT = 21
+HCA_LAYER_COUNT = 20
+LAST_MODEL_LAYER = MAIN_LAYER_COUNT - 1
+MAX_PUBLIC_TENSOR_DIMS = 5
+
+N_RANKS = layer.N_RANKS
+MOE_TOKENS = layer.MOE_TOKENS
+D = layer.D
+HC_MULT = layer.HC_MULT
+HC_DIM = layer.HC_DIM
+MAX_LOGIT_ROWS = DECODE_TOKENS
+SAMPLED_IDS_PAD = 8
+VOCAB_PER_TP = MODEL_CONFIG.vocab_size // TP_SIZE
+
+T_DYN = layer.T_DYN
+FWD_PACKED_RAW_BLOCKS_DYN = pl.dynamic("FWD_PACKED_RAW_BLOCKS_DYN")
+
+MIX_HC = layer.MIX_HC
+Q_LORA = layer.Q_LORA
+H = layer.H
+HEAD_DIM = layer.HEAD_DIM
+ROPE_HEAD_DIM = layer.ROPE_HEAD_DIM
+WIN = layer.WIN
+O_LORA = layer.O_LORA
+O_GROUP_IN = layer.O_GROUP_IN
+LOCAL_O_GROUPS = layer.LOCAL_O_GROUPS
+LOCAL_O_WIDTH = layer.LOCAL_O_WIDTH
+BLOCK_SIZE = layer.BLOCK_SIZE
+ATTENTION_WINDOW_ROWS = layer.ATTENTION_WINDOW_ROWS
+O_WINDOW_ROWS = layer.O_WINDOW_ROWS
+N_EXPERTS_GLOBAL = layer.N_EXPERTS_GLOBAL
+N_LOCAL = layer.N_LOCAL
+MOE_INTER = layer.MOE_INTER
+VOCAB = layer.VOCAB
+TOPK = layer.TOPK
+RECV_MAX = layer.RECV_MAX
+AUX_PAD = layer.AUX_PAD
+IDX_PAD = layer.IDX_PAD
+N_ROUTES = layer.N_ROUTES
+
+TWO_SWA_LAYER_COUNT = 2
+TWO_SWA_TEST_VOCAB = 256
+
+
+def _validate_import_contract():
+    if layer.TP_SIZE != TP_SIZE or layer.EP_SIZE != EP_SIZE:
+        raise ValueError(
+            "decode_layer parallel configuration diverged from decode_fwd: "
+            f"layer TP/EP={layer.TP_SIZE}/{layer.EP_SIZE}, "
+            f"forward TP/EP={TP_SIZE}/{EP_SIZE}"
+        )
+    if N_RANKS != EP_SIZE:
+        raise ValueError(f"MoE world size {N_RANKS} does not match EP={EP_SIZE}")
+    if MAIN_LAYER_COUNT != 43:
+        raise ValueError(
+            f"D-Spark decode forward expects 43 layers, got {MAIN_LAYER_COUNT}"
+        )
+    if MODEL_CONFIG.vocab_size % TP_SIZE:
+        raise ValueError(
+            f"vocab size {MODEL_CONFIG.vocab_size} must be divisible by TP={TP_SIZE}"
+        )
+    if MOE_TOKENS > MAX_LOGIT_ROWS:
+        raise ValueError(
+            f"MoE capacity {MOE_TOKENS} exceeds LM-head rows {MAX_LOGIT_ROWS}"
+        )
+
+
+_validate_import_contract()
+
+
+def build_full43_layer_plan():
+    """Return the fixed model-layer, kind-ordinal, and MoE-epoch mapping."""
+    kind_ordinals = {"swa": 0, "csa": 0, "hca": 0}
+    plan = []
+    for model_layer in range(MAIN_LAYER_COUNT):
+        kind = layer.attention_kind_for_layer(model_layer)
+        ordinal = kind_ordinals[kind]
+        kind_ordinals[kind] += 1
+        plan.append(
+            {
+                "model_layer": model_layer,
+                "kind": kind,
+                "kind_ordinal": ordinal,
+                "moe_epoch": model_layer + 1,
+            }
+        )
+
+    expected_counts = {
+        "swa": SWA_LAYER_COUNT,
+        "csa": CSA_LAYER_COUNT,
+        "hca": HCA_LAYER_COUNT,
+    }
+    if kind_ordinals != expected_counts:
+        raise ValueError(
+            f"full43 attention counts changed: {kind_ordinals} != {expected_counts}"
+        )
+    if plan[0]["kind"] != "swa" or plan[1]["kind"] != "swa":
+        raise ValueError("model layers 0 and 1 must be SWA")
+    for model_layer in range(2, MAIN_LAYER_COUNT):
+        expected_kind = "csa" if model_layer % 2 == 0 else "hca"
+        if plan[model_layer]["kind"] != expected_kind:
+            raise ValueError(
+                f"model layer {model_layer} must be {expected_kind}, "
+                f"got {plan[model_layer]['kind']}"
+            )
+    if plan[LAST_MODEL_LAYER] != {
+        "model_layer": 42,
+        "kind": "csa",
+        "kind_ordinal": 20,
+        "moe_epoch": 43,
+    }:
+        raise ValueError(f"unexpected terminal layer mapping: {plan[-1]}")
+    return tuple(plan)
+
+
+FULL43_LAYER_PLAN = build_full43_layer_plan()
+
+
+PACKED_POOL_LAYER_COUNTS = {
+    "raw_kv_pool": MAIN_LAYER_COUNT,
+    "hca_compress_state": HCA_LAYER_COUNT,
+    "hca_cmp_kv": HCA_LAYER_COUNT,
+    "csa_compress_state": CSA_LAYER_COUNT,
+    "csa_cmp_kv": CSA_LAYER_COUNT,
+    "csa_inner_compress_state": CSA_LAYER_COUNT,
+    "csa_idx_kv_cache": CSA_LAYER_COUNT,
+    "csa_idx_kv_scale": CSA_LAYER_COUNT,
+}
+
+PACKED_POOL_BLOCK_SIZES = {
+    "raw_kv_pool": swa.BLOCK_SIZE,
+    "hca_compress_state": hca.COMPRESS_STATE_BLOCK_SIZE,
+    "hca_cmp_kv": hca.BLOCK_SIZE,
+    "csa_compress_state": csa.MAIN_STATE_BLOCK_SIZE,
+    "csa_cmp_kv": csa.BLOCK_SIZE,
+    "csa_inner_compress_state": csa.INNER_STATE_BLOCK_SIZE,
+    "csa_idx_kv_cache": csa.BLOCK_SIZE,
+    "csa_idx_kv_scale": csa.BLOCK_SIZE,
+}
+
+PACKED_POOL_ELEMENT_BYTES = {
+    "raw_kv_pool": 2,
+    "hca_compress_state": 4,
+    "hca_cmp_kv": 2,
+    "csa_compress_state": 4,
+    "csa_cmp_kv": 2,
+    "csa_inner_compress_state": 4,
+    "csa_idx_kv_cache": 1,
+    "csa_idx_kv_scale": 4,
+}
+
+
+def build_packed_pool_layout(per_layer_shapes):
+    """Pack each persistent pool along its block axis without a layer axis."""
+    expected_names = set(PACKED_POOL_LAYER_COUNTS)
+    provided_names = set(per_layer_shapes)
+    missing = expected_names - provided_names
+    unknown = provided_names - expected_names
+    if missing or unknown:
+        raise ValueError(
+            f"packed pool names mismatch: missing={sorted(missing)}, "
+            f"unknown={sorted(unknown)}"
+        )
+
+    layout = {}
+    for name, layer_count in PACKED_POOL_LAYER_COUNTS.items():
+        leaf_shape = [int(dim) for dim in per_layer_shapes[name]]
+        if len(leaf_shape) not in (4, 5):
+            raise ValueError(
+                f"{name} rank-stacked leaf pool must be 4D or 5D, "
+                f"got {leaf_shape}"
+            )
+        if leaf_shape[0] != N_RANKS:
+            raise ValueError(
+                f"{name} must have leading rank extent {N_RANKS}, "
+                f"got {leaf_shape}"
+            )
+        per_layer_extent = leaf_shape[1]
+        if per_layer_extent <= 0:
+            raise ValueError(
+                f"{name} per-layer block extent must be positive, "
+                f"got {per_layer_extent}"
+            )
+        expected_block_size = PACKED_POOL_BLOCK_SIZES[name]
+        if leaf_shape[2] != expected_block_size:
+            raise ValueError(
+                f"{name} block size {leaf_shape[2]} does not match "
+                f"{expected_block_size}"
+            )
+
+        packed_shape = list(leaf_shape)
+        packed_shape[1] = layer_count * per_layer_extent
+        elements_per_rank = 1
+        for dim in packed_shape[1:]:
+            elements_per_rank *= dim
+        slices = tuple(
+            (ordinal * per_layer_extent, (ordinal + 1) * per_layer_extent)
+            for ordinal in range(layer_count)
+        )
+        layout[name] = {
+            "layer_count": layer_count,
+            "per_layer_extent": per_layer_extent,
+            "total_extent": packed_shape[1],
+            "block_size": expected_block_size,
+            "leaf_shape": leaf_shape,
+            "packed_shape": packed_shape,
+            "bytes_per_rank": (
+                elements_per_rank * PACKED_POOL_ELEMENT_BYTES[name]
+            ),
+            "slices": slices,
+        }
+    validate_packed_pool_layout(layout)
+    return layout
+
+
+def validate_packed_pool_layout(layout):
+    """Fail closed on dimension, extent, and layer-slice contract errors."""
+    if set(layout) != set(PACKED_POOL_LAYER_COUNTS):
+        raise ValueError("packed layout must describe every persistent pool")
+    for name, entry in layout.items():
+        layer_count = PACKED_POOL_LAYER_COUNTS[name]
+        total_extent = int(entry["total_extent"])
+        if total_extent % layer_count:
+            raise ValueError(
+                f"{name} packed extent {total_extent} is not divisible by "
+                f"{layer_count}"
+            )
+        if len(entry["packed_shape"]) > MAX_PUBLIC_TENSOR_DIMS:
+            raise ValueError(
+                f"{name} has {len(entry['packed_shape'])} dimensions; "
+                f"maximum is {MAX_PUBLIC_TENSOR_DIMS}"
+            )
+        if entry["packed_shape"][1] != total_extent:
+            raise ValueError(f"{name} packed shape and extent diverged")
+
+        previous_end = 0
+        for begin, end in entry["slices"]:
+            if begin != previous_end or begin >= end or end > total_extent:
+                raise ValueError(f"{name} layer slices overlap or leave a gap")
+            previous_end = end
+        if previous_end != total_extent:
+            raise ValueError(f"{name} layer slices do not cover the packed axis")
+    return layout
+
+
+def validate_local_write_slots(name, slots, per_layer_capacity, active_mask=None):
+    """Validate layer-local write slots and the inactive-row -1 contract."""
+    import torch
+
+    values = torch.as_tensor(slots)
+    capacity = int(per_layer_capacity)
+    if capacity <= 0:
+        raise ValueError(f"{name} capacity must be positive, got {capacity}")
+    if bool((values < -1).any().item()):
+        raise ValueError(f"{name} contains a write slot below -1")
+    if bool((values >= capacity).any().item()):
+        raise ValueError(
+            f"{name} contains a non-local write slot for capacity {capacity}"
+        )
+    if active_mask is not None:
+        active = torch.as_tensor(active_mask, dtype=torch.bool)
+        while active.ndim < values.ndim:
+            active = active.unsqueeze(-1)
+        if bool((values.masked_select(~active) != -1).any().item()):
+            raise ValueError(f"{name} retains a write slot for an inactive row")
+    return values
+
+
+def build_active_logit_row_indices_host(active_tokens):
+    """Build the host fixture for the terminal active-prefix row contract."""
+    import torch
+
+    active_tokens = int(active_tokens)
+    if active_tokens < 0 or active_tokens > min(MOE_TOKENS, MAX_LOGIT_ROWS):
+        raise ValueError(
+            f"active token count must be in [0, {min(MOE_TOKENS, MAX_LOGIT_ROWS)}], "
+            f"got {active_tokens}"
+        )
+    indices = torch.full((N_RANKS, MAX_LOGIT_ROWS), -1, dtype=torch.int32)
+    if active_tokens:
+        active_rows = torch.arange(active_tokens, dtype=torch.int32)
+        indices[:, :active_tokens] = active_rows
+    return indices
+
+
+@pl.jit.inline
+def decode_embedding_preamble(
+    input_ids: pl.Tensor[[T_DYN], pl.INT64],
+    embed_weight: pl.Tensor[[EMBED_VOCAB_DYN, D], pl.BF16],
+    hidden_states: pl.Tensor[[T_DYN, D], pl.BF16],
+    x_hc: pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32],
+):
+    """Reuse the canonical lookup and emit the active Hyper-Connections rows."""
+    lookup_embedding(input_ids, embed_weight, hidden_states, x_hc)
+    return x_hc
+
+
+@pl.jit.inline
+def mask_inactive_sample_rows(
+    logit_row_indices: pl.Tensor[[MAX_LOGIT_ROWS], pl.INT32],
+    sampled_ids: pl.Tensor[[MAX_LOGIT_ROWS, SAMPLED_IDS_PAD], pl.INT32],
+):
+    """Make inactive terminal rows observable as -1 after greedy sampling."""
+    for row in pl.spmd(MAX_LOGIT_ROWS, name_hint="decode_fwd_sample_mask"):
+        if pl.read(logit_row_indices, [row]) < 0:
+            sampled_ids[row : row + 1, :] = pl.full(
+                [1, SAMPLED_IDS_PAD], dtype=pl.INT32, value=-1
+            )
+    return sampled_ids
+
+
+@pl.jit(auto_scope=False)
+def decode_fwd(
+    hc_attn_fn: pl.Tensor[[TWO_SWA_LAYER_COUNT * MIX_HC, HC_DIM], pl.FP32],
+    hc_attn_scale: pl.Tensor[[TWO_SWA_LAYER_COUNT * 3], pl.FP32],
+    hc_attn_base: pl.Tensor[[TWO_SWA_LAYER_COUNT * MIX_HC], pl.FP32],
+    attn_norm_w: pl.Tensor[[TWO_SWA_LAYER_COUNT * D], pl.BF16],
+    wq_a: pl.Tensor[[TWO_SWA_LAYER_COUNT * D, Q_LORA], pl.BF16],
+    wq_b: pl.Tensor[
+        [TWO_SWA_LAYER_COUNT * Q_LORA, H * HEAD_DIM], pl.INT8
+    ],
+    wq_b_scale: pl.Tensor[
+        [TWO_SWA_LAYER_COUNT * H * HEAD_DIM], pl.FP32
+    ],
+    wkv: pl.Tensor[[TWO_SWA_LAYER_COUNT * D, HEAD_DIM], pl.BF16],
+    gamma_cq: pl.Tensor[[TWO_SWA_LAYER_COUNT * Q_LORA], pl.BF16],
+    gamma_ckv: pl.Tensor[[TWO_SWA_LAYER_COUNT * HEAD_DIM], pl.BF16],
+    raw_kv_pool: pl.InOut[
+        pl.Tensor[
+            [FWD_PACKED_RAW_BLOCKS_DYN, BLOCK_SIZE, 1, HEAD_DIM],
+            pl.BF16,
+        ]
+    ],
+    freqs_cos: pl.Tensor[[T_DYN, ROPE_HEAD_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[T_DYN, ROPE_HEAD_DIM], pl.BF16],
+    swa_slot_mapping: pl.Tensor[[T_DYN], pl.INT64],
+    swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
+    swa_lens: pl.Tensor[[T_DYN], pl.INT32],
+    position_ids: pl.Tensor[[T_DYN], pl.INT32],
+    attn_sink: pl.Tensor[[TWO_SWA_LAYER_COUNT * H], pl.FP32],
+    wo_a: pl.Tensor[
+        [TWO_SWA_LAYER_COUNT * LOCAL_O_GROUPS, O_LORA, O_GROUP_IN],
+        pl.BF16,
+    ],
+    wo_b: pl.Tensor[
+        [TWO_SWA_LAYER_COUNT * D, LOCAL_O_WIDTH], pl.INT8
+    ],
+    wo_b_scale: pl.Tensor[[TWO_SWA_LAYER_COUNT * D], pl.FP32],
+    hc_ffn_fn: pl.Tensor[
+        [TWO_SWA_LAYER_COUNT * MIX_HC, HC_DIM], pl.FP32
+    ],
+    hc_ffn_scale: pl.Tensor[[TWO_SWA_LAYER_COUNT * 3], pl.FP32],
+    hc_ffn_base: pl.Tensor[[TWO_SWA_LAYER_COUNT * MIX_HC], pl.FP32],
+    norm_w: pl.Tensor[[TWO_SWA_LAYER_COUNT * D], pl.BF16],
+    gate_w: pl.Tensor[
+        [TWO_SWA_LAYER_COUNT * N_EXPERTS_GLOBAL, D], pl.FP32
+    ],
+    gate_bias: pl.Tensor[
+        [TWO_SWA_LAYER_COUNT * N_EXPERTS_GLOBAL], pl.FP32
+    ],
+    tid2eid: pl.Tensor[[TWO_SWA_LAYER_COUNT * VOCAB, TOPK], pl.INT32],
+    input_ids: pl.Tensor[[MOE_TOKENS], pl.INT64],
+    routed_w1: pl.Tensor[
+        [TWO_SWA_LAYER_COUNT * N_LOCAL, MOE_INTER, D], pl.INT8
+    ],
+    routed_w1_scale: pl.Tensor[
+        [TWO_SWA_LAYER_COUNT * N_LOCAL, MOE_INTER], pl.FP32
+    ],
+    routed_w3: pl.Tensor[
+        [TWO_SWA_LAYER_COUNT * N_LOCAL, MOE_INTER, D], pl.INT8
+    ],
+    routed_w3_scale: pl.Tensor[
+        [TWO_SWA_LAYER_COUNT * N_LOCAL, MOE_INTER], pl.FP32
+    ],
+    routed_w2: pl.Tensor[
+        [TWO_SWA_LAYER_COUNT * N_LOCAL, D, MOE_INTER], pl.INT8
+    ],
+    routed_w2_scale: pl.Tensor[
+        [TWO_SWA_LAYER_COUNT * N_LOCAL, D], pl.FP32
+    ],
+    shared_w1: pl.Tensor[
+        [TWO_SWA_LAYER_COUNT * MOE_INTER, D], pl.INT8
+    ],
+    shared_w1_scale: pl.Tensor[
+        [TWO_SWA_LAYER_COUNT * MOE_INTER], pl.FP32
+    ],
+    shared_w3: pl.Tensor[
+        [TWO_SWA_LAYER_COUNT * MOE_INTER, D], pl.INT8
+    ],
+    shared_w3_scale: pl.Tensor[
+        [TWO_SWA_LAYER_COUNT * MOE_INTER], pl.FP32
+    ],
+    shared_w2: pl.Tensor[
+        [TWO_SWA_LAYER_COUNT * D, MOE_INTER], pl.INT8
+    ],
+    shared_w2_scale: pl.Tensor[[TWO_SWA_LAYER_COUNT * D], pl.FP32],
+    x_ping: pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32],
+    x_pong: pl.InOut[pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32]],
+    x_attn_active: pl.InOut[
+        pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32]
+    ],
+    x_moe_next: pl.InOut[
+        pl.Tensor[[MOE_TOKENS, HC_MULT, D], pl.FP32]
+    ],
+    x_out: pl.Out[pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32]],
+    attention_window: pld.DistributedTensor[
+        [ATTENTION_WINDOW_ROWS, O_GROUP_IN], pl.BF16
+    ],
+    attention_signal: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
+    o_window: pld.DistributedTensor[[O_WINDOW_ROWS, D], pl.FP32],
+    o_signal: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
+    recv_meta: pld.DistributedTensor[[N_RANKS, N_LOCAL], pl.INT32],
+    recv_x: pld.DistributedTensor[[N_LOCAL * RECV_MAX, D], pl.INT8],
+    recv_aux: pld.DistributedTensor[
+        [N_LOCAL * RECV_MAX, AUX_PAD], pl.FP32
+    ],
+    recv_route: pld.DistributedTensor[
+        [N_LOCAL * RECV_MAX, IDX_PAD], pl.INT32
+    ],
+    arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
+    data_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
+    routed_y_buf: pld.DistributedTensor[[N_ROUTES, D], pl.BF16],
+    combine_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
+    group_base: pl.Scalar[pl.INT32],
+    tp_rank: pl.Scalar[pl.INT32],
+    my_rank: pl.Scalar[pl.INT32],
+):
+    """Run the first two model layers with shared windows and ping-pong."""
+    x_ping.bind_dynamic(0, T_DYN)
+    raw_kv_pool.bind_dynamic(0, FWD_PACKED_RAW_BLOCKS_DYN)
+    freqs_cos.bind_dynamic(0, T_DYN)
+    freqs_sin.bind_dynamic(0, T_DYN)
+    swa_slot_mapping.bind_dynamic(0, T_DYN)
+    swa_indices.bind_dynamic(0, T_DYN)
+    swa_lens.bind_dynamic(0, T_DYN)
+    position_ids.bind_dynamic(0, T_DYN)
+    x_pong.bind_dynamic(0, T_DYN)
+    x_attn_active.bind_dynamic(0, T_DYN)
+    x_out.bind_dynamic(0, T_DYN)
+
+    local_t = pl.cast(pl.tensor.dim(x_ping, 0), pl.INT32)
+    raw_blocks_per_layer = (
+        pl.tensor.dim(raw_kv_pool, 0) // TWO_SWA_LAYER_COUNT
+    )
+    with pl.scope():
+        raw_kv_l0 = pl.slice(
+            raw_kv_pool,
+            [raw_blocks_per_layer, BLOCK_SIZE, 1, HEAD_DIM],
+            [0, 0, 0, 0],
+        )
+        hc_attn_fn_l0: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32] = pl.slice(
+            hc_attn_fn, [MIX_HC, HC_DIM], [0, 0]
+        )
+        hc_attn_scale_l0: pl.Tensor[[3], pl.FP32] = pl.slice(
+            hc_attn_scale, [3], [0]
+        )
+        hc_attn_base_l0: pl.Tensor[[MIX_HC], pl.FP32] = pl.slice(
+            hc_attn_base, [MIX_HC], [0]
+        )
+        attn_norm_w_l0: pl.Tensor[[D], pl.BF16] = pl.slice(
+            attn_norm_w, [D], [0]
+        )
+        wq_a_l0: pl.Tensor[[D, Q_LORA], pl.BF16] = pl.slice(
+            wq_a, [D, Q_LORA], [0, 0]
+        )
+        wq_b_l0: pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8] = pl.slice(
+            wq_b, [Q_LORA, H * HEAD_DIM], [0, 0]
+        )
+        wq_b_scale_l0: pl.Tensor[[H * HEAD_DIM], pl.FP32] = pl.slice(
+            wq_b_scale, [H * HEAD_DIM], [0]
+        )
+        wkv_l0: pl.Tensor[[D, HEAD_DIM], pl.BF16] = pl.slice(
+            wkv, [D, HEAD_DIM], [0, 0]
+        )
+        gamma_cq_l0: pl.Tensor[[Q_LORA], pl.BF16] = pl.slice(
+            gamma_cq, [Q_LORA], [0]
+        )
+        gamma_ckv_l0: pl.Tensor[[HEAD_DIM], pl.BF16] = pl.slice(
+            gamma_ckv, [HEAD_DIM], [0]
+        )
+        attn_sink_l0: pl.Tensor[[H], pl.FP32] = pl.slice(
+            attn_sink, [H], [0]
+        )
+        wo_a_l0: pl.Tensor[
+            [LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16
+        ] = pl.slice(
+            wo_a, [LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], [0, 0, 0]
+        )
+        wo_b_l0: pl.Tensor[[D, LOCAL_O_WIDTH], pl.INT8] = pl.slice(
+            wo_b, [D, LOCAL_O_WIDTH], [0, 0]
+        )
+        wo_b_scale_l0: pl.Tensor[[D], pl.FP32] = pl.slice(
+            wo_b_scale, [D], [0]
+        )
+        hc_ffn_fn_l0: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32] = pl.slice(
+            hc_ffn_fn, [MIX_HC, HC_DIM], [0, 0]
+        )
+        hc_ffn_scale_l0: pl.Tensor[[3], pl.FP32] = pl.slice(
+            hc_ffn_scale, [3], [0]
+        )
+        hc_ffn_base_l0: pl.Tensor[[MIX_HC], pl.FP32] = pl.slice(
+            hc_ffn_base, [MIX_HC], [0]
+        )
+        norm_w_l0: pl.Tensor[[D], pl.BF16] = pl.slice(norm_w, [D], [0])
+        gate_w_l0: pl.Tensor[[N_EXPERTS_GLOBAL, D], pl.FP32] = pl.slice(
+            gate_w, [N_EXPERTS_GLOBAL, D], [0, 0]
+        )
+        gate_bias_l0: pl.Tensor[[N_EXPERTS_GLOBAL], pl.FP32] = pl.slice(
+            gate_bias, [N_EXPERTS_GLOBAL], [0]
+        )
+        tid2eid_l0: pl.Tensor[[VOCAB, TOPK], pl.INT32] = pl.slice(
+            tid2eid, [VOCAB, TOPK], [0, 0]
+        )
+        routed_w1_l0: pl.Tensor[
+            [N_LOCAL, MOE_INTER, D], pl.INT8
+        ] = pl.slice(routed_w1, [N_LOCAL, MOE_INTER, D], [0, 0, 0])
+        routed_w1_scale_l0: pl.Tensor[
+            [N_LOCAL, MOE_INTER], pl.FP32
+        ] = pl.slice(routed_w1_scale, [N_LOCAL, MOE_INTER], [0, 0])
+        routed_w3_l0: pl.Tensor[
+            [N_LOCAL, MOE_INTER, D], pl.INT8
+        ] = pl.slice(routed_w3, [N_LOCAL, MOE_INTER, D], [0, 0, 0])
+        routed_w3_scale_l0: pl.Tensor[
+            [N_LOCAL, MOE_INTER], pl.FP32
+        ] = pl.slice(routed_w3_scale, [N_LOCAL, MOE_INTER], [0, 0])
+        routed_w2_l0: pl.Tensor[
+            [N_LOCAL, D, MOE_INTER], pl.INT8
+        ] = pl.slice(routed_w2, [N_LOCAL, D, MOE_INTER], [0, 0, 0])
+        routed_w2_scale_l0: pl.Tensor[[N_LOCAL, D], pl.FP32] = pl.slice(
+            routed_w2_scale, [N_LOCAL, D], [0, 0]
+        )
+        shared_w1_l0: pl.Tensor[[MOE_INTER, D], pl.INT8] = pl.slice(
+            shared_w1, [MOE_INTER, D], [0, 0]
+        )
+        shared_w1_scale_l0: pl.Tensor[[MOE_INTER], pl.FP32] = pl.slice(
+            shared_w1_scale, [MOE_INTER], [0]
+        )
+        shared_w3_l0: pl.Tensor[[MOE_INTER, D], pl.INT8] = pl.slice(
+            shared_w3, [MOE_INTER, D], [0, 0]
+        )
+        shared_w3_scale_l0: pl.Tensor[[MOE_INTER], pl.FP32] = pl.slice(
+            shared_w3_scale, [MOE_INTER], [0]
+        )
+        shared_w2_l0: pl.Tensor[[D, MOE_INTER], pl.INT8] = pl.slice(
+            shared_w2, [D, MOE_INTER], [0, 0]
+        )
+        shared_w2_scale_l0: pl.Tensor[[D], pl.FP32] = pl.slice(
+            shared_w2_scale, [D], [0]
+        )
+        decode_layer_swa(
+            x_ping,
+            hc_attn_fn_l0, hc_attn_scale_l0, hc_attn_base_l0,
+            attn_norm_w_l0, wq_a_l0, wq_b_l0, wq_b_scale_l0,
+            wkv_l0, gamma_cq_l0, gamma_ckv_l0,
+            freqs_cos, freqs_sin, raw_kv_l0,
+            swa_slot_mapping, swa_indices, swa_lens, position_ids,
+            attn_sink_l0, wo_a_l0, wo_b_l0, wo_b_scale_l0,
+            hc_ffn_fn_l0, hc_ffn_scale_l0, hc_ffn_base_l0,
+            norm_w_l0, gate_w_l0, gate_bias_l0, tid2eid_l0, input_ids,
+            routed_w1_l0, routed_w1_scale_l0,
+            routed_w3_l0, routed_w3_scale_l0,
+            routed_w2_l0, routed_w2_scale_l0,
+            shared_w1_l0, shared_w1_scale_l0,
+            shared_w3_l0, shared_w3_scale_l0,
+            shared_w2_l0, shared_w2_scale_l0,
+            x_attn_active, x_moe_next, x_pong,
+            attention_window, attention_signal, o_window, o_signal,
+            recv_meta, recv_x, recv_aux, recv_route,
+            arrived, data_arrived, routed_y_buf, combine_arrived,
+            pl.const(0, pl.INT32), group_base, tp_rank, local_t, my_rank,
+            pl.const(1, pl.INT32),
+        )
+
+    with pl.scope():
+        raw_kv_l1 = pl.slice(
+            raw_kv_pool,
+            [raw_blocks_per_layer, BLOCK_SIZE, 1, HEAD_DIM],
+            [raw_blocks_per_layer, 0, 0, 0],
+        )
+        hc_attn_fn_l1: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32] = pl.slice(
+            hc_attn_fn, [MIX_HC, HC_DIM], [MIX_HC, 0]
+        )
+        hc_attn_scale_l1: pl.Tensor[[3], pl.FP32] = pl.slice(
+            hc_attn_scale, [3], [3]
+        )
+        hc_attn_base_l1: pl.Tensor[[MIX_HC], pl.FP32] = pl.slice(
+            hc_attn_base, [MIX_HC], [MIX_HC]
+        )
+        attn_norm_w_l1: pl.Tensor[[D], pl.BF16] = pl.slice(
+            attn_norm_w, [D], [D]
+        )
+        wq_a_l1: pl.Tensor[[D, Q_LORA], pl.BF16] = pl.slice(
+            wq_a, [D, Q_LORA], [D, 0]
+        )
+        wq_b_l1: pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8] = pl.slice(
+            wq_b, [Q_LORA, H * HEAD_DIM], [Q_LORA, 0]
+        )
+        wq_b_scale_l1: pl.Tensor[[H * HEAD_DIM], pl.FP32] = pl.slice(
+            wq_b_scale, [H * HEAD_DIM], [H * HEAD_DIM]
+        )
+        wkv_l1: pl.Tensor[[D, HEAD_DIM], pl.BF16] = pl.slice(
+            wkv, [D, HEAD_DIM], [D, 0]
+        )
+        gamma_cq_l1: pl.Tensor[[Q_LORA], pl.BF16] = pl.slice(
+            gamma_cq, [Q_LORA], [Q_LORA]
+        )
+        gamma_ckv_l1: pl.Tensor[[HEAD_DIM], pl.BF16] = pl.slice(
+            gamma_ckv, [HEAD_DIM], [HEAD_DIM]
+        )
+        attn_sink_l1: pl.Tensor[[H], pl.FP32] = pl.slice(
+            attn_sink, [H], [H]
+        )
+        wo_a_l1: pl.Tensor[
+            [LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16
+        ] = pl.slice(
+            wo_a,
+            [LOCAL_O_GROUPS, O_LORA, O_GROUP_IN],
+            [LOCAL_O_GROUPS, 0, 0],
+        )
+        wo_b_l1: pl.Tensor[[D, LOCAL_O_WIDTH], pl.INT8] = pl.slice(
+            wo_b, [D, LOCAL_O_WIDTH], [D, 0]
+        )
+        wo_b_scale_l1: pl.Tensor[[D], pl.FP32] = pl.slice(
+            wo_b_scale, [D], [D]
+        )
+        hc_ffn_fn_l1: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32] = pl.slice(
+            hc_ffn_fn, [MIX_HC, HC_DIM], [MIX_HC, 0]
+        )
+        hc_ffn_scale_l1: pl.Tensor[[3], pl.FP32] = pl.slice(
+            hc_ffn_scale, [3], [3]
+        )
+        hc_ffn_base_l1: pl.Tensor[[MIX_HC], pl.FP32] = pl.slice(
+            hc_ffn_base, [MIX_HC], [MIX_HC]
+        )
+        norm_w_l1: pl.Tensor[[D], pl.BF16] = pl.slice(norm_w, [D], [D])
+        gate_w_l1: pl.Tensor[[N_EXPERTS_GLOBAL, D], pl.FP32] = pl.slice(
+            gate_w, [N_EXPERTS_GLOBAL, D], [N_EXPERTS_GLOBAL, 0]
+        )
+        gate_bias_l1: pl.Tensor[[N_EXPERTS_GLOBAL], pl.FP32] = pl.slice(
+            gate_bias, [N_EXPERTS_GLOBAL], [N_EXPERTS_GLOBAL]
+        )
+        tid2eid_l1: pl.Tensor[[VOCAB, TOPK], pl.INT32] = pl.slice(
+            tid2eid, [VOCAB, TOPK], [VOCAB, 0]
+        )
+        routed_w1_l1: pl.Tensor[
+            [N_LOCAL, MOE_INTER, D], pl.INT8
+        ] = pl.slice(routed_w1, [N_LOCAL, MOE_INTER, D], [N_LOCAL, 0, 0])
+        routed_w1_scale_l1: pl.Tensor[
+            [N_LOCAL, MOE_INTER], pl.FP32
+        ] = pl.slice(routed_w1_scale, [N_LOCAL, MOE_INTER], [N_LOCAL, 0])
+        routed_w3_l1: pl.Tensor[
+            [N_LOCAL, MOE_INTER, D], pl.INT8
+        ] = pl.slice(routed_w3, [N_LOCAL, MOE_INTER, D], [N_LOCAL, 0, 0])
+        routed_w3_scale_l1: pl.Tensor[
+            [N_LOCAL, MOE_INTER], pl.FP32
+        ] = pl.slice(routed_w3_scale, [N_LOCAL, MOE_INTER], [N_LOCAL, 0])
+        routed_w2_l1: pl.Tensor[
+            [N_LOCAL, D, MOE_INTER], pl.INT8
+        ] = pl.slice(routed_w2, [N_LOCAL, D, MOE_INTER], [N_LOCAL, 0, 0])
+        routed_w2_scale_l1: pl.Tensor[[N_LOCAL, D], pl.FP32] = pl.slice(
+            routed_w2_scale, [N_LOCAL, D], [N_LOCAL, 0]
+        )
+        shared_w1_l1: pl.Tensor[[MOE_INTER, D], pl.INT8] = pl.slice(
+            shared_w1, [MOE_INTER, D], [MOE_INTER, 0]
+        )
+        shared_w1_scale_l1: pl.Tensor[[MOE_INTER], pl.FP32] = pl.slice(
+            shared_w1_scale, [MOE_INTER], [MOE_INTER]
+        )
+        shared_w3_l1: pl.Tensor[[MOE_INTER, D], pl.INT8] = pl.slice(
+            shared_w3, [MOE_INTER, D], [MOE_INTER, 0]
+        )
+        shared_w3_scale_l1: pl.Tensor[[MOE_INTER], pl.FP32] = pl.slice(
+            shared_w3_scale, [MOE_INTER], [MOE_INTER]
+        )
+        shared_w2_l1: pl.Tensor[[D, MOE_INTER], pl.INT8] = pl.slice(
+            shared_w2, [D, MOE_INTER], [D, 0]
+        )
+        shared_w2_scale_l1: pl.Tensor[[D], pl.FP32] = pl.slice(
+            shared_w2_scale, [D], [D]
+        )
+        decode_layer_swa(
+            x_pong,
+            hc_attn_fn_l1, hc_attn_scale_l1, hc_attn_base_l1,
+            attn_norm_w_l1, wq_a_l1, wq_b_l1, wq_b_scale_l1,
+            wkv_l1, gamma_cq_l1, gamma_ckv_l1,
+            freqs_cos, freqs_sin, raw_kv_l1,
+            swa_slot_mapping, swa_indices, swa_lens, position_ids,
+            attn_sink_l1, wo_a_l1, wo_b_l1, wo_b_scale_l1,
+            hc_ffn_fn_l1, hc_ffn_scale_l1, hc_ffn_base_l1,
+            norm_w_l1, gate_w_l1, gate_bias_l1, tid2eid_l1, input_ids,
+            routed_w1_l1, routed_w1_scale_l1,
+            routed_w3_l1, routed_w3_scale_l1,
+            routed_w2_l1, routed_w2_scale_l1,
+            shared_w1_l1, shared_w1_scale_l1,
+            shared_w3_l1, shared_w3_scale_l1,
+            shared_w2_l1, shared_w2_scale_l1,
+            x_attn_active, x_moe_next, x_out,
+            attention_window, attention_signal, o_window, o_signal,
+            recv_meta, recv_x, recv_aux, recv_route,
+            arrived, data_arrived, routed_y_buf, combine_arrived,
+            pl.const(1, pl.INT32), group_base, tp_rank, local_t, my_rank,
+            pl.const(2, pl.INT32),
+        )
+        clear_moe_signals(
+            x_moe_next, arrived, data_arrived, combine_arrived
+        )
+    return x_out
+
+
+@pl.jit.host
+def l3_decode_fwd(
+    hc_attn_fn: pl.Tensor[
+        [N_RANKS, TWO_SWA_LAYER_COUNT * MIX_HC, HC_DIM], pl.FP32
+    ],
+    hc_attn_scale: pl.Tensor[
+        [N_RANKS, TWO_SWA_LAYER_COUNT * 3], pl.FP32
+    ],
+    hc_attn_base: pl.Tensor[
+        [N_RANKS, TWO_SWA_LAYER_COUNT * MIX_HC], pl.FP32
+    ],
+    attn_norm_w: pl.Tensor[
+        [N_RANKS, TWO_SWA_LAYER_COUNT * D], pl.BF16
+    ],
+    wq_a: pl.Tensor[
+        [N_RANKS, TWO_SWA_LAYER_COUNT * D, Q_LORA], pl.BF16
+    ],
+    wq_b: pl.Tensor[
+        [N_RANKS, TWO_SWA_LAYER_COUNT * Q_LORA, H * HEAD_DIM], pl.INT8
+    ],
+    wq_b_scale: pl.Tensor[
+        [N_RANKS, TWO_SWA_LAYER_COUNT * H * HEAD_DIM], pl.FP32
+    ],
+    wkv: pl.Tensor[
+        [N_RANKS, TWO_SWA_LAYER_COUNT * D, HEAD_DIM], pl.BF16
+    ],
+    gamma_cq: pl.Tensor[
+        [N_RANKS, TWO_SWA_LAYER_COUNT * Q_LORA], pl.BF16
+    ],
+    gamma_ckv: pl.Tensor[
+        [N_RANKS, TWO_SWA_LAYER_COUNT * HEAD_DIM], pl.BF16
+    ],
+    raw_kv_pool: pl.InOut[
+        pl.Tensor[
+            [
+                N_RANKS,
+                FWD_PACKED_RAW_BLOCKS_DYN,
+                BLOCK_SIZE,
+                1,
+                HEAD_DIM,
+            ],
+            pl.BF16,
+        ]
+    ],
+    freqs_cos: pl.Tensor[
+        [N_RANKS, T_DYN, ROPE_HEAD_DIM], pl.BF16
+    ],
+    freqs_sin: pl.Tensor[
+        [N_RANKS, T_DYN, ROPE_HEAD_DIM], pl.BF16
+    ],
+    swa_slot_mapping: pl.Tensor[[N_RANKS, T_DYN], pl.INT64],
+    swa_indices: pl.Tensor[[N_RANKS, T_DYN, WIN], pl.INT32],
+    swa_lens: pl.Tensor[[N_RANKS, T_DYN], pl.INT32],
+    position_ids: pl.Tensor[[N_RANKS, T_DYN], pl.INT32],
+    attn_sink: pl.Tensor[
+        [N_RANKS, TWO_SWA_LAYER_COUNT * H], pl.FP32
+    ],
+    wo_a: pl.Tensor[
+        [
+            N_RANKS,
+            TWO_SWA_LAYER_COUNT * LOCAL_O_GROUPS,
+            O_LORA,
+            O_GROUP_IN,
+        ],
+        pl.BF16,
+    ],
+    wo_b: pl.Tensor[
+        [N_RANKS, TWO_SWA_LAYER_COUNT * D, LOCAL_O_WIDTH], pl.INT8
+    ],
+    wo_b_scale: pl.Tensor[
+        [N_RANKS, TWO_SWA_LAYER_COUNT * D], pl.FP32
+    ],
+    hc_ffn_fn: pl.Tensor[
+        [N_RANKS, TWO_SWA_LAYER_COUNT * MIX_HC, HC_DIM], pl.FP32
+    ],
+    hc_ffn_scale: pl.Tensor[
+        [N_RANKS, TWO_SWA_LAYER_COUNT * 3], pl.FP32
+    ],
+    hc_ffn_base: pl.Tensor[
+        [N_RANKS, TWO_SWA_LAYER_COUNT * MIX_HC], pl.FP32
+    ],
+    norm_w: pl.Tensor[
+        [N_RANKS, TWO_SWA_LAYER_COUNT * D], pl.BF16
+    ],
+    gate_w: pl.Tensor[
+        [N_RANKS, TWO_SWA_LAYER_COUNT * N_EXPERTS_GLOBAL, D], pl.FP32
+    ],
+    gate_bias: pl.Tensor[
+        [N_RANKS, TWO_SWA_LAYER_COUNT * N_EXPERTS_GLOBAL], pl.FP32
+    ],
+    tid2eid: pl.Tensor[
+        [N_RANKS, TWO_SWA_LAYER_COUNT * VOCAB, TOPK], pl.INT32
+    ],
+    input_ids: pl.Tensor[[N_RANKS, MOE_TOKENS], pl.INT64],
+    routed_w1: pl.Tensor[
+        [N_RANKS, TWO_SWA_LAYER_COUNT * N_LOCAL, MOE_INTER, D], pl.INT8
+    ],
+    routed_w1_scale: pl.Tensor[
+        [N_RANKS, TWO_SWA_LAYER_COUNT * N_LOCAL, MOE_INTER], pl.FP32
+    ],
+    routed_w3: pl.Tensor[
+        [N_RANKS, TWO_SWA_LAYER_COUNT * N_LOCAL, MOE_INTER, D], pl.INT8
+    ],
+    routed_w3_scale: pl.Tensor[
+        [N_RANKS, TWO_SWA_LAYER_COUNT * N_LOCAL, MOE_INTER], pl.FP32
+    ],
+    routed_w2: pl.Tensor[
+        [N_RANKS, TWO_SWA_LAYER_COUNT * N_LOCAL, D, MOE_INTER], pl.INT8
+    ],
+    routed_w2_scale: pl.Tensor[
+        [N_RANKS, TWO_SWA_LAYER_COUNT * N_LOCAL, D], pl.FP32
+    ],
+    shared_w1: pl.Tensor[
+        [N_RANKS, TWO_SWA_LAYER_COUNT * MOE_INTER, D], pl.INT8
+    ],
+    shared_w1_scale: pl.Tensor[
+        [N_RANKS, TWO_SWA_LAYER_COUNT * MOE_INTER], pl.FP32
+    ],
+    shared_w3: pl.Tensor[
+        [N_RANKS, TWO_SWA_LAYER_COUNT * MOE_INTER, D], pl.INT8
+    ],
+    shared_w3_scale: pl.Tensor[
+        [N_RANKS, TWO_SWA_LAYER_COUNT * MOE_INTER], pl.FP32
+    ],
+    shared_w2: pl.Tensor[
+        [N_RANKS, TWO_SWA_LAYER_COUNT * D, MOE_INTER], pl.INT8
+    ],
+    shared_w2_scale: pl.Tensor[
+        [N_RANKS, TWO_SWA_LAYER_COUNT * D], pl.FP32
+    ],
+    x_ping: pl.Tensor[[N_RANKS, T_DYN, HC_MULT, D], pl.FP32],
+    x_pong: pl.InOut[
+        pl.Tensor[[N_RANKS, T_DYN, HC_MULT, D], pl.FP32]
+    ],
+    x_attn_active: pl.InOut[
+        pl.Tensor[[N_RANKS, T_DYN, HC_MULT, D], pl.FP32]
+    ],
+    x_moe_next: pl.InOut[
+        pl.Tensor[[N_RANKS, MOE_TOKENS, HC_MULT, D], pl.FP32]
+    ],
+    x_out: pl.Out[
+        pl.Tensor[[N_RANKS, T_DYN, HC_MULT, D], pl.FP32]
+    ],
+):
+    """Allocate shared windows once and launch one two-SWA child per rank."""
+    x_ping.bind_dynamic(1, T_DYN)
+    raw_kv_pool.bind_dynamic(1, FWD_PACKED_RAW_BLOCKS_DYN)
+    freqs_cos.bind_dynamic(1, T_DYN)
+    freqs_sin.bind_dynamic(1, T_DYN)
+    swa_slot_mapping.bind_dynamic(1, T_DYN)
+    swa_indices.bind_dynamic(1, T_DYN)
+    swa_lens.bind_dynamic(1, T_DYN)
+    position_ids.bind_dynamic(1, T_DYN)
+    x_pong.bind_dynamic(1, T_DYN)
+    x_attn_active.bind_dynamic(1, T_DYN)
+    x_out.bind_dynamic(1, T_DYN)
+
+    attention_window_buf = pld.alloc_window_buffer(
+        [ATTENTION_WINDOW_ROWS, O_GROUP_IN], dtype=pl.BF16
+    )
+    attention_signal_buf = pld.alloc_window_buffer(
+        [TP_SIZE, 1], dtype=pl.INT32
+    )
+    o_window_buf = pld.alloc_window_buffer(
+        [O_WINDOW_ROWS, D], dtype=pl.FP32
+    )
+    o_signal_buf = pld.alloc_window_buffer([TP_SIZE, 1], dtype=pl.INT32)
+
+    recv_meta_buf = pld.alloc_window_buffer(
+        [N_RANKS, N_LOCAL], dtype=pl.INT32
+    )
+    recv_x_buf = pld.alloc_window_buffer(
+        [N_LOCAL * RECV_MAX, D], dtype=pl.INT8
+    )
+    recv_aux_buf = pld.alloc_window_buffer(
+        [N_LOCAL * RECV_MAX, AUX_PAD], dtype=pl.FP32
+    )
+    recv_route_buf = pld.alloc_window_buffer(
+        [N_LOCAL * RECV_MAX, IDX_PAD], dtype=pl.INT32
+    )
+    arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
+    data_arrived_buf = pld.alloc_window_buffer(
+        [N_RANKS, 1], dtype=pl.INT32
+    )
+    routed_y_buf_buf = pld.alloc_window_buffer(
+        [N_ROUTES, D], dtype=pl.BF16
+    )
+    combine_arrived_buf = pld.alloc_window_buffer(
+        [N_RANKS, 1], dtype=pl.INT32
+    )
+
+    for rank in pl.range(pld.world_size()):
+        attention_window = pld.window(
+            attention_window_buf,
+            [ATTENTION_WINDOW_ROWS, O_GROUP_IN],
+            dtype=pl.BF16,
+        )
+        attention_signal = pld.window(
+            attention_signal_buf, [TP_SIZE, 1], dtype=pl.INT32
+        )
+        o_window = pld.window(
+            o_window_buf, [O_WINDOW_ROWS, D], dtype=pl.FP32
+        )
+        o_signal = pld.window(
+            o_signal_buf, [TP_SIZE, 1], dtype=pl.INT32
+        )
+        recv_meta = pld.window(
+            recv_meta_buf, [N_RANKS, N_LOCAL], dtype=pl.INT32
+        )
+        recv_x = pld.window(
+            recv_x_buf, [N_LOCAL * RECV_MAX, D], dtype=pl.INT8
+        )
+        recv_aux = pld.window(
+            recv_aux_buf,
+            [N_LOCAL * RECV_MAX, AUX_PAD],
+            dtype=pl.FP32,
+        )
+        recv_route = pld.window(
+            recv_route_buf,
+            [N_LOCAL * RECV_MAX, IDX_PAD],
+            dtype=pl.INT32,
+        )
+        arrived = pld.window(
+            arrived_buf, [N_RANKS, 1], dtype=pl.INT32
+        )
+        data_arrived = pld.window(
+            data_arrived_buf, [N_RANKS, 1], dtype=pl.INT32
+        )
+        routed_y_buf = pld.window(
+            routed_y_buf_buf, [N_ROUTES, D], dtype=pl.BF16
+        )
+        combine_arrived = pld.window(
+            combine_arrived_buf, [N_RANKS, 1], dtype=pl.INT32
+        )
+        tp_rank = rank % TP_SIZE
+        group_base = rank - tp_rank
+        decode_fwd(
+            hc_attn_fn[rank], hc_attn_scale[rank], hc_attn_base[rank],
+            attn_norm_w[rank], wq_a[rank], wq_b[rank],
+            wq_b_scale[rank], wkv[rank], gamma_cq[rank], gamma_ckv[rank],
+            raw_kv_pool[rank], freqs_cos[rank], freqs_sin[rank],
+            swa_slot_mapping[rank], swa_indices[rank], swa_lens[rank],
+            position_ids[rank], attn_sink[rank], wo_a[rank], wo_b[rank],
+            wo_b_scale[rank],
+            hc_ffn_fn[rank], hc_ffn_scale[rank], hc_ffn_base[rank],
+            norm_w[rank], gate_w[rank], gate_bias[rank], tid2eid[rank],
+            input_ids[rank],
+            routed_w1[rank], routed_w1_scale[rank],
+            routed_w3[rank], routed_w3_scale[rank],
+            routed_w2[rank], routed_w2_scale[rank],
+            shared_w1[rank], shared_w1_scale[rank],
+            shared_w3[rank], shared_w3_scale[rank],
+            shared_w2[rank], shared_w2_scale[rank],
+            x_ping[rank], x_pong[rank],
+            x_attn_active[rank], x_moe_next[rank], x_out[rank],
+            attention_window, attention_signal, o_window, o_signal,
+            recv_meta, recv_x, recv_aux, recv_route,
+            arrived, data_arrived, routed_y_buf, combine_arrived,
+            group_base, tp_rank, rank,
+            device=rank,
+        )
+    return x_out
+
+
+_COMMON_ATTN_WEIGHT_NAMES = (
+    "hc_attn_fn",
+    "hc_attn_scale",
+    "hc_attn_base",
+    "attn_norm_w",
+    "wq_a",
+    "wq_b",
+    "wq_b_scale",
+    "wkv",
+    "gamma_cq",
+    "gamma_ckv",
+    "attn_sink",
+    "wo_a",
+    "wo_b",
+    "wo_b_scale",
+)
+
+_HCA_EXTRA_WEIGHT_NAMES = (
+    "cmp_wkv",
+    "cmp_wgate",
+    "cmp_ape",
+    "cmp_norm_w",
+)
+
+_CSA_EXTRA_WEIGHT_NAMES = (
+    "cmp_wkv",
+    "cmp_wgate",
+    "cmp_ape",
+    "cmp_norm_w",
+    "idx_wq_b",
+    "idx_wq_b_scale",
+    "weights_proj",
+    "hadamard_idx",
+    "inner_wkv",
+    "inner_wgate",
+    "inner_ape",
+    "inner_norm_w",
+)
+
+_MOE_NON_WEIGHT_NAMES = {"x_attn_moe", "x_moe_next", "input_ids"}
+
+_TWO_SWA_LAYERED_WEIGHT_NAMES = (
+    *_COMMON_ATTN_WEIGHT_NAMES,
+    "hc_ffn_fn",
+    "hc_ffn_scale",
+    "hc_ffn_base",
+    "norm_w",
+    "gate_w",
+    "gate_bias",
+    "tid2eid",
+    "routed_w1",
+    "routed_w1_scale",
+    "routed_w3",
+    "routed_w3_scale",
+    "routed_w2",
+    "routed_w2_scale",
+    "shared_w1",
+    "shared_w1_scale",
+    "shared_w3",
+    "shared_w3_scale",
+    "shared_w2",
+    "shared_w2_scale",
+)
+
+_TWO_SWA_METADATA_NAMES = (
+    "freqs_cos",
+    "freqs_sin",
+    "swa_slot_mapping",
+    "swa_indices",
+    "swa_lens",
+    "position_ids",
+)
+
+_TWO_SWA_ATTN_INPUT_NAMES = (
+    "x_hc",
+    "hc_attn_fn",
+    "hc_attn_scale",
+    "hc_attn_base",
+    "attn_norm_w",
+    "wq_a",
+    "wq_b",
+    "wq_b_scale",
+    "wkv",
+    "gamma_cq",
+    "gamma_ckv",
+    "freqs_cos",
+    "freqs_sin",
+    "kv_cache",
+    "swa_slot_mapping",
+    "swa_indices",
+    "swa_lens",
+    "position_ids",
+    "attn_sink",
+    "wo_a",
+    "wo_b",
+    "wo_b_scale",
+)
+
+_METADATA_EXCLUDES = {
+    "x_hc",
+    "x_out",
+    "kv_cache",
+    "compress_state",
+    "cmp_kv",
+    "inner_compress_state",
+    "idx_kv_cache",
+    "idx_kv_scale",
+    *_COMMON_ATTN_WEIGHT_NAMES,
+    *_HCA_EXTRA_WEIGHT_NAMES,
+    *_CSA_EXTRA_WEIGHT_NAMES,
+}
+
+
+def _stack_rank_shape(shape, layer_count):
+    stacked = [int(dim) for dim in shape]
+    if len(stacked) < 2 or stacked[0] != N_RANKS:
+        raise ValueError(f"layer-stacked tensor must start with rank: {stacked}")
+    stacked[1] *= int(layer_count)
+    return stacked
+
+
+def _collect_weight_shapes(reports, common_count, hca_count, csa_count):
+    swa_shapes = reports["swa"]["distributed_shapes"]
+    hca_shapes = reports["hca"]["distributed_shapes"]
+    csa_shapes = reports["csa"]["distributed_shapes"]
+
+    common = {}
+    for name in _COMMON_ATTN_WEIGHT_NAMES:
+        reference = swa_shapes[name]
+        if hca_shapes[name] != reference or csa_shapes[name] != reference:
+            raise ValueError(f"common attention weight shape diverged for {name}")
+        common[name] = _stack_rank_shape(reference, common_count)
+
+    moe_shapes = reports["swa"]["moe_shapes"]
+    for name, shape in moe_shapes.items():
+        if name not in _MOE_NON_WEIGHT_NAMES:
+            common[name] = _stack_rank_shape(shape, common_count)
+
+    return {
+        "common": common,
+        "hca": {
+            name: _stack_rank_shape(hca_shapes[name], hca_count)
+            for name in _HCA_EXTRA_WEIGHT_NAMES
+        },
+        "csa": {
+            name: _stack_rank_shape(csa_shapes[name], csa_count)
+            for name in _CSA_EXTRA_WEIGHT_NAMES
+        },
+    }
+
+
+def _collect_metadata_shapes(reports):
+    metadata = {}
+    for kind, report in reports.items():
+        for name, shape in report["distributed_shapes"].items():
+            if name not in _METADATA_EXCLUDES:
+                metadata[f"{kind}_{name}"] = list(shape)
+    return metadata
+
+
+def _collect_per_layer_pool_shapes(reports):
+    raw_shapes = tuple(
+        reports[kind]["distributed_shapes"]["kv_cache"]
+        for kind in ("swa", "hca", "csa")
+    )
+    if raw_shapes[1:] != raw_shapes[:-1]:
+        raise ValueError(f"raw KV pool shapes diverged by attention kind: {raw_shapes}")
+
+    hca_shapes = reports["hca"]["distributed_shapes"]
+    csa_shapes = reports["csa"]["distributed_shapes"]
+    return {
+        "raw_kv_pool": list(raw_shapes[0]),
+        "hca_compress_state": list(hca_shapes["compress_state"]),
+        "hca_cmp_kv": list(hca_shapes["cmp_kv"]),
+        "csa_compress_state": list(csa_shapes["compress_state"]),
+        "csa_cmp_kv": list(csa_shapes["cmp_kv"]),
+        "csa_inner_compress_state": list(csa_shapes["inner_compress_state"]),
+        "csa_idx_kv_cache": list(csa_shapes["idx_kv_cache"]),
+        "csa_idx_kv_scale": list(csa_shapes["idx_kv_scale"]),
+    }
+
+
+def _validate_public_shapes(sections):
+    maximum_dims = 0
+    for section_name, shapes in sections.items():
+        for name, shape in shapes.items():
+            dims = len(shape)
+            maximum_dims = max(maximum_dims, dims)
+            if dims > MAX_PUBLIC_TENSOR_DIMS:
+                raise ValueError(
+                    f"{section_name} tensor {name!r} has {dims} dimensions: "
+                    f"{shape}"
+                )
+            if any(int(dim) <= 0 for dim in shape):
+                raise ValueError(
+                    f"{section_name} tensor {name!r} has an invalid shape: {shape}"
+                )
+    return maximum_dims
+
+
+def _make_two_swa_layered_spec(name, spec):
+    """Pack two copies of one rank-stacked layer weight along axis one."""
+    from golden import TensorSpec
+
+    shape = list(spec.shape)
+    shape[1] *= TWO_SWA_LAYER_COUNT
+
+    def init_value():
+        value = spec.create_tensor()
+        return value.repeat(
+            1, TWO_SWA_LAYER_COUNT, *([1] * (value.ndim - 2))
+        )
+
+    packed = TensorSpec(
+        name,
+        shape,
+        spec.dtype,
+        init_value=init_value,
+    )
+    packed.resident = "stacked"
+    return packed
+
+
+def build_two_swa_tensor_specs(start_pos=None):
+    """Build the rank-stacked two-SWA prefix fixture in L3 ABI order."""
+    import inspect
+
+    import torch
+    from golden import TensorSpec
+
+    base_specs = {
+        spec.name: spec
+        for spec in layer.build_swa_layer_specs(start_pos=start_pos, layer_id=0)
+        if isinstance(spec, TensorSpec)
+    }
+    local_t = int(base_specs["freqs_cos"].shape[1])
+
+    def init_raw_kv_pool():
+        first = base_specs["kv_cache"].create_tensor()
+        second = (first.float() + 0.125).to(torch.bfloat16)
+        return torch.cat((first, second), dim=1)
+
+    def init_input_ids():
+        value = base_specs["input_ids"].create_tensor()
+        return torch.remainder(value, TWO_SWA_TEST_VOCAB).contiguous()
+
+    specs_by_name = {
+        "raw_kv_pool": TensorSpec(
+            "raw_kv_pool",
+            [
+                N_RANKS,
+                TWO_SWA_LAYER_COUNT * base_specs["kv_cache"].shape[1],
+                BLOCK_SIZE,
+                1,
+                HEAD_DIM,
+            ],
+            torch.bfloat16,
+            init_value=init_raw_kv_pool,
+            is_output=True,
+        ),
+        "input_ids": TensorSpec(
+            "input_ids",
+            [N_RANKS, MOE_TOKENS],
+            torch.int64,
+            init_value=init_input_ids,
+        ),
+        "x_ping": TensorSpec(
+            "x_ping",
+            [N_RANKS, local_t, HC_MULT, D],
+            torch.float32,
+            init_value=base_specs["x_hc"].init_value,
+        ),
+        "x_pong": TensorSpec(
+            "x_pong",
+            [N_RANKS, local_t, HC_MULT, D],
+            torch.float32,
+            init_value=lambda: torch.zeros(
+                N_RANKS, local_t, HC_MULT, D, dtype=torch.float32
+            ),
+            is_output=True,
+        ),
+        "x_attn_active": TensorSpec(
+            "x_attn_active",
+            [N_RANKS, local_t, HC_MULT, D],
+            torch.float32,
+            init_value=lambda: torch.zeros(
+                N_RANKS, local_t, HC_MULT, D, dtype=torch.float32
+            ),
+            is_output=True,
+        ),
+        "x_moe_next": TensorSpec(
+            "x_moe_next",
+            [N_RANKS, MOE_TOKENS, HC_MULT, D],
+            torch.float32,
+            init_value=lambda: torch.zeros(
+                N_RANKS, MOE_TOKENS, HC_MULT, D, dtype=torch.float32
+            ),
+            is_output=True,
+        ),
+        "x_out": TensorSpec(
+            "x_out",
+            [N_RANKS, local_t, HC_MULT, D],
+            torch.float32,
+            is_output=True,
+        ),
+    }
+    specs_by_name["raw_kv_pool"].resident = "stacked"
+
+    for name in _TWO_SWA_LAYERED_WEIGHT_NAMES:
+        specs_by_name[name] = _make_two_swa_layered_spec(
+            name, base_specs[name]
+        )
+
+    for name in _TWO_SWA_METADATA_NAMES:
+        source = base_specs[name]
+        copied = TensorSpec(
+            name,
+            list(source.shape),
+            source.dtype,
+            init_value=source.init_value,
+        )
+        copied.resident = source.resident
+        specs_by_name[name] = copied
+
+    parameter_names = [
+        name
+        for name, parameter in inspect.signature(
+            l3_decode_fwd._func
+        ).parameters.items()
+        if parameter.default is inspect.Parameter.empty
+    ]
+    missing = [name for name in parameter_names if name not in specs_by_name]
+    extra = [name for name in specs_by_name if name not in parameter_names]
+    if missing or extra:
+        raise ValueError(
+            f"two-SWA spec/signature mismatch: missing={missing}, extra={extra}"
+        )
+    specs = [specs_by_name[name] for name in parameter_names]
+    for spec in specs:
+        if isinstance(spec, TensorSpec) and len(spec.shape) > MAX_PUBLIC_TENSOR_DIMS:
+            raise ValueError(
+                f"two-SWA tensor {spec.name!r} exceeds "
+                f"{MAX_PUBLIC_TENSOR_DIMS} dimensions: {spec.shape}"
+            )
+    return specs
+
+
+def _two_swa_layer_value(value, layer_ordinal):
+    extent = value.shape[1] // TWO_SWA_LAYER_COUNT
+    begin = layer_ordinal * extent
+    return value[:, begin : begin + extent]
+
+
+def golden_two_swa_decode_fwd(tensors):
+    """Compose two unchanged SWA+MoE goldens after the embedding preamble."""
+    import torch
+
+    local_t = int(tensors["freqs_cos"].shape[1])
+    current = tensors["x_ping"].clone()
+    raw_blocks_per_layer = (
+        tensors["raw_kv_pool"].shape[1] // TWO_SWA_LAYER_COUNT
+    )
+
+    for layer_ordinal in range(TWO_SWA_LAYER_COUNT):
+        raw_begin = layer_ordinal * raw_blocks_per_layer
+        raw_layer = tensors["raw_kv_pool"][
+            :, raw_begin : raw_begin + raw_blocks_per_layer
+        ]
+        x_attn_active = torch.zeros_like(current)
+        for group in range(layer.TP_GROUPS):
+            group_begin = group * TP_SIZE
+            group_end = group_begin + TP_SIZE
+            group_tensors = {}
+            for name in _TWO_SWA_ATTN_INPUT_NAMES:
+                if name == "x_hc":
+                    value = current
+                elif name == "kv_cache":
+                    value = raw_layer
+                elif name in _TWO_SWA_LAYERED_WEIGHT_NAMES:
+                    value = _two_swa_layer_value(
+                        tensors[name], layer_ordinal
+                    )
+                else:
+                    value = tensors[name]
+                group_tensors[name] = value[group_begin:group_end]
+            group_tensors["x_out"] = x_attn_active[group_begin:group_end]
+            group_tensors["local_t"] = local_t
+            swa.golden_decode_swa(group_tensors)
+
+        x_attn_moe = torch.zeros(
+            N_RANKS, MOE_TOKENS, HC_MULT, D, dtype=torch.float32
+        )
+        x_attn_moe[:, :local_t].copy_(x_attn_active)
+        x_moe_next = torch.zeros_like(x_attn_moe)
+        moe_tensors = dict(tensors)
+        for name in _TWO_SWA_LAYERED_WEIGHT_NAMES:
+            if name not in _COMMON_ATTN_WEIGHT_NAMES:
+                moe_tensors[name] = _two_swa_layer_value(
+                    tensors[name], layer_ordinal
+                )
+        moe_tensors.update(
+            {
+                "x_hc": x_attn_moe,
+                "x_next": x_moe_next,
+                "layer_id": layer_ordinal,
+                "num_tokens": local_t,
+            }
+        )
+        moe_module.golden_moe(moe_tensors)
+        current = x_moe_next[:, :local_t].clone()
+        tensors["x_attn_active"].copy_(x_attn_active)
+        tensors["x_moe_next"].copy_(x_moe_next)
+        if layer_ordinal == 0:
+            tensors["x_pong"].copy_(current)
+
+    tensors["x_out"].copy_(current)
+
+
+def two_swa_packed_raw_pool_compare(
+    actual, expected, **kwargs
+):
+    """Check both local layer mappings and require all other rows unchanged."""
+    from golden import mapped_pool_ratio_allclose
+
+    if actual.shape != expected.shape:
+        return False, (
+            f"    raw pool shape mismatch: actual={tuple(actual.shape)} "
+            f"expected={tuple(expected.shape)}"
+        )
+    if actual.shape[1] % TWO_SWA_LAYER_COUNT:
+        return False, "    packed raw pool is not divisible by two SWA layers"
+
+    per_layer_blocks = actual.shape[1] // TWO_SWA_LAYER_COUNT
+    mapping = kwargs.get("inputs", {}).get("swa_slot_mapping")
+    if mapping is None:
+        return False, "    compare_fn missing input 'swa_slot_mapping'"
+    compare_layer0 = mapped_pool_ratio_allclose(
+        "swa_slot_mapping",
+        mapping_shape=tuple(mapping.shape),
+        block_size=BLOCK_SIZE,
+        leading_rank_axis=True,
+        pool_name="two-SWA raw KV cache",
+        atol=1e-4,
+        rtol=1.0 / 128,
+        max_error_ratio=0.005,
+    )
+    compare_layer1 = mapped_pool_ratio_allclose(
+        "swa_slot_mapping",
+        mapping_shape=tuple(mapping.shape),
+        block_size=BLOCK_SIZE,
+        leading_rank_axis=True,
+        pool_name="two-SWA raw KV cache",
+        atol=0.01,
+        rtol=0.05,
+        max_error_ratio=0.05,
+    )
+    for layer_ordinal in range(TWO_SWA_LAYER_COUNT):
+        begin = layer_ordinal * per_layer_blocks
+        compare_layer = compare_layer0 if layer_ordinal == 0 else compare_layer1
+        ok, detail = compare_layer(
+            actual[:, begin : begin + per_layer_blocks],
+            expected[:, begin : begin + per_layer_blocks],
+            **kwargs,
+        )
+        if not ok:
+            return False, f"    layer {layer_ordinal}:\n{detail}"
+    return True, ""
+
+
+def build_two_swa_shape_report(start_pos=None):
+    """Return the concrete Phase B L3 shapes without materializing tensors."""
+    specs = build_two_swa_tensor_specs(start_pos=start_pos)
+    shapes = {
+        spec.name: list(spec.shape)
+        for spec in specs
+        if hasattr(spec, "shape")
+    }
+    return {
+        "tp": TP_SIZE,
+        "ep": EP_SIZE,
+        "active_tokens": shapes["freqs_cos"][1],
+        "raw_blocks_per_layer": (
+            shapes["raw_kv_pool"][1] // TWO_SWA_LAYER_COUNT
+        ),
+        "maximum_public_tensor_dims": max(len(shape) for shape in shapes.values()),
+        "shapes": shapes,
+    }
+
+
+def build_decode_fwd_shape_report(start_pos=None):
+    """Build production/runtime shape skeletons without building a device graph."""
+    reports = {
+        "swa": layer.build_layer_shape_report(0, start_pos=start_pos),
+        "csa": layer.build_layer_shape_report(2, start_pos=start_pos),
+        "hca": layer.build_layer_shape_report(3, start_pos=start_pos),
+    }
+    active_tokens = reports["swa"]["active_tokens"]
+    if any(report["active_tokens"] != active_tokens for report in reports.values()):
+        raise ValueError("attention kinds disagree on the active-token extent")
+
+    per_layer_pool_shapes = _collect_per_layer_pool_shapes(reports)
+    packed_layout = build_packed_pool_layout(per_layer_pool_shapes)
+    packed_pool_shapes = {
+        name: entry["packed_shape"] for name, entry in packed_layout.items()
+    }
+    metadata_shapes = _collect_metadata_shapes(reports)
+
+    preamble_shapes = {
+        "input_ids": [N_RANKS, MOE_TOKENS],
+        "embed_weight": [N_RANKS, MODEL_CONFIG.vocab_size, D],
+    }
+    workspace_shapes = {
+        "embedding_hidden": [N_RANKS, active_tokens, D],
+        "x_ping": [N_RANKS, active_tokens, HC_MULT, D],
+        "x_pong": [N_RANKS, active_tokens, HC_MULT, D],
+        "x_attn_active": [N_RANKS, active_tokens, HC_MULT, D],
+        "x_moe_next": [N_RANKS, MOE_TOKENS, HC_MULT, D],
+    }
+    terminal_shapes = {
+        "hc_head_fn": [N_RANKS, HC_MULT, HC_DIM],
+        "hc_head_scale": [N_RANKS, 1],
+        "hc_head_base": [N_RANKS, HC_MULT],
+        "final_norm_w": [N_RANKS, D],
+        "lm_head_weight": [N_RANKS, VOCAB_PER_TP, D],
+        "hidden_out": [N_RANKS, active_tokens, D],
+        "logit_row_indices": [N_RANKS, MAX_LOGIT_ROWS],
+        "logits": [N_RANKS, MAX_LOGIT_ROWS, MODEL_CONFIG.vocab_size],
+        "sampled_ids": [N_RANKS, MAX_LOGIT_ROWS, SAMPLED_IDS_PAD],
+    }
+
+    production_weights = _collect_weight_shapes(
+        reports,
+        MAIN_LAYER_COUNT,
+        HCA_LAYER_COUNT,
+        CSA_LAYER_COUNT,
+    )
+    runtime_weights = _collect_weight_shapes(reports, 1, 1, 1)
+
+    common_sections = {
+        "preamble": preamble_shapes,
+        "metadata": metadata_shapes,
+        "packed_pools": packed_pool_shapes,
+        "workspaces": workspace_shapes,
+        "terminal": terminal_shapes,
+    }
+    production_sections = {
+        **common_sections,
+        "common_weights": production_weights["common"],
+        "hca_weights": production_weights["hca"],
+        "csa_weights": production_weights["csa"],
+    }
+    runtime_sections = {
+        **common_sections,
+        "common_weights": runtime_weights["common"],
+        "hca_weights": runtime_weights["hca"],
+        "csa_weights": runtime_weights["csa"],
+    }
+    maximum_dims = max(
+        _validate_public_shapes(production_sections),
+        _validate_public_shapes(runtime_sections),
+    )
+
+    return {
+        "tp": TP_SIZE,
+        "ep": EP_SIZE,
+        "active_batch": reports["swa"]["active_batch"],
+        "active_tokens": active_tokens,
+        "layer_plan": FULL43_LAYER_PLAN,
+        "packed_layout": packed_layout,
+        "packed_pool_bytes_per_rank": sum(
+            entry["bytes_per_rank"] for entry in packed_layout.values()
+        ),
+        "weight_bank_layers": {
+            "production": {
+                "common": MAIN_LAYER_COUNT,
+                "hca": HCA_LAYER_COUNT,
+                "csa": CSA_LAYER_COUNT,
+            },
+            "runtime": {"common": 1, "hca": 1, "csa": 1},
+        },
+        "production": production_sections,
+        "runtime": runtime_sections,
+        "maximum_public_tensor_dims": maximum_dims,
+    }
+
+
+def _parse_start_pos(raw):
+    if raw is None:
+        return None
+    values = [int(part.strip()) for part in raw.split(",") if part.strip()]
+    if not values:
+        raise ValueError("--start-pos must contain at least one integer")
+    return values[0] if len(values) == 1 else values
+
+
+def main():
+    import argparse
+
+    from golden import ratio_reldiff, run_jit
+    from pypto.ir.distributed_compiled_program import DistributedConfig
+
+    parser = argparse.ArgumentParser(
+        description="DeepSeek-V4 D-Spark decode-forward integration"
+    )
+    parser.add_argument(
+        "-p", "--platform", type=str, default="a2a3",
+        choices=("a2a3", "a2a3sim", "a5", "a5sim"),
+    )
+    parser.add_argument("--tp", type=int, default=TP_SIZE, choices=_TP_CHOICES)
+    parser.add_argument("--ep", type=int, default=EP_SIZE, choices=_EP_CHOICES)
+    parser.add_argument(
+        "-d", "--device", type=str, default=None,
+        help=f"comma-separated device ids; EP={EP_SIZE} needs {EP_SIZE}",
+    )
+    parser.add_argument(
+        "--start-pos",
+        type=str,
+        default=None,
+        help="a scalar selects batch=1; a comma-separated list sets the batch",
+    )
+    parser.add_argument("--shape-only", action="store_true", default=False)
+    parser.add_argument("--compile-only", action="store_true", default=False)
+    parser.add_argument(
+        "--enable-scope-stats", action="store_true", default=False
+    )
+    parser.add_argument("--runtime-dir", type=str, default=None)
+    parser.add_argument("--golden-data", type=str, default=None)
+    parser.add_argument("--save-data", action="store_true", default=False)
+    parser.add_argument("--dump-passes", action="store_true", default=False)
+    parser.add_argument("--log-level", type=str, default=None)
+    args = parser.parse_args()
+
+    if args.tp != TP_SIZE or args.ep != EP_SIZE:
+        parser.error(
+            f"parallel sizes froze at import as TP={TP_SIZE}, EP={EP_SIZE}"
+        )
+    start_pos = _parse_start_pos(args.start_pos)
+    if args.shape_only:
+        report = build_decode_fwd_shape_report(start_pos)
+        prefix_report = build_two_swa_shape_report(start_pos)
+        packed_summary = ", ".join(
+            f"{name}={entry['total_extent']}"
+            for name, entry in report["packed_layout"].items()
+        )
+        print(
+            f"TP={report['tp']} EP={report['ep']} "
+            f"batch={report['active_batch']} active_t={report['active_tokens']} "
+            f"layers={len(report['layer_plan'])} "
+            f"max_dims={report['maximum_public_tensor_dims']}"
+        )
+        print(f"packed_blocks: {packed_summary}")
+        print(
+            "packed_pool_gib_per_rank: "
+            f"{report['packed_pool_bytes_per_rank'] / (1024 ** 3):.3f}"
+        )
+        print(
+            "two_swa: "
+            f"active_t={prefix_report['active_tokens']} "
+            f"raw_blocks_per_layer={prefix_report['raw_blocks_per_layer']} "
+            f"max_dims={prefix_report['maximum_public_tensor_dims']}"
+        )
+        return
+
+    if args.device is None:
+        args.device = ",".join(str(rank) for rank in range(EP_SIZE))
+    try:
+        device_ids = [int(device) for device in args.device.split(",")]
+    except ValueError:
+        parser.error(
+            f"--device must be a comma-separated integer list, got "
+            f"{args.device!r}"
+        )
+    if len(device_ids) != EP_SIZE:
+        parser.error(
+            f"EP={EP_SIZE} needs exactly {EP_SIZE} devices, got {device_ids}"
+        )
+    if len(set(device_ids)) != len(device_ids) or any(
+        device < 0 for device in device_ids
+    ):
+        parser.error(f"device IDs must be distinct and non-negative: {device_ids}")
+
+    specs = build_two_swa_tensor_specs(start_pos=start_pos)
+    local_t = next(spec.shape[1] for spec in specs if spec.name == "x_out")
+    result = run_jit(
+        fn=l3_decode_fwd,
+        specs=specs,
+        golden_fn=golden_two_swa_decode_fwd,
+        golden_data=args.golden_data,
+        save_data=args.save_data,
+        compile_only=args.compile_only,
+        runtime_dir=args.runtime_dir,
+        compile_cfg=dict(
+            dump_passes=args.dump_passes,
+            distributed_config=DistributedConfig(
+                device_ids=device_ids, num_sub_workers=0
+            ),
+        ),
+        runtime_cfg=dict(
+            platform=args.platform,
+            enable_scope_stats=args.enable_scope_stats,
+            log_level=args.log_level,
+        ),
+        rtol=1e-2,
+        atol=1e-2,
+        compare_fn={
+            "raw_kv_pool": two_swa_packed_raw_pool_compare,
+            "x_pong": ratio_reldiff(diff_thd=0.01, pct_thd=0.05),
+            "x_attn_active": ratio_reldiff(
+                diff_thd=0.01, pct_thd=0.05
+            ),
+            "x_moe_next": ratio_reldiff(
+                diff_thd=0.01,
+                pct_thd=0.06,
+                valid_rows=local_t,
+                valid_axis=1,
+            ),
+            "x_out": ratio_reldiff(diff_thd=0.01, pct_thd=0.06),
+        },
+    )
+    if not result.passed:
+        if result.error:
+            print(result.error)
+        raise SystemExit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/models/deepseek_v4_flash_dspark/decode_fwd.py
+++ b/models/deepseek_v4_flash_dspark/decode_fwd.py
@@ -31,8 +31,7 @@ def _parse_parallel_arg(name, default):
     return default
 
 
-# TP/EP-dependent leaf shapes freeze at import time. Select both worlds before
-# importing attention, MoE, or output-projection modules.
+# Parallel configuration for shape-specialized kernel imports.
 TP_SIZE = _parse_parallel_arg("tp", _TP_DEFAULT)
 EP_SIZE = _parse_parallel_arg("ep", _EP_DEFAULT)
 FWD_WEIGHT_BANK_SIZE = _parse_parallel_arg("weight-bank-size", 1)
@@ -53,11 +52,13 @@ config.EP = EP_SIZE
 
 import decode_csa as csa
 import decode_hca as hca
-import decode_layer as layer
 import decode_swa as swa
+import moe as moe_module
 import pypto.language as pl
 import pypto.language.distributed as pld
-from decode_layer import decode_layer_csa, decode_layer_hca, decode_layer_swa
+from decode_csa import decode_csa, decode_csa_tp1
+from decode_hca import decode_hca, decode_hca_tp1
+from decode_swa import decode_swa, decode_swa_tp1
 from hc_head import hc_head
 from lm_head import (
     GROUP_LOGIT_ROWS,
@@ -71,28 +72,12 @@ from lm_head import (
 )
 from lookup_embedding import VOCAB_DYN as EMBED_VOCAB_DYN
 from lookup_embedding import lookup_embedding
-from moe import clear_moe_signals
+from moe import clear_moe_signals, moe
 from rmsnorm import rms_norm
 
 
-MODEL_CONFIG = config.FLASH
-DECODE_TOKENS = config.DECODE_TOKENS
-
-MAIN_LAYER_COUNT = MODEL_CONFIG.num_hidden_layers
-SWA_LAYER_COUNT = 2
-CSA_LAYER_COUNT = 21
-HCA_LAYER_COUNT = 20
-LAST_MODEL_LAYER = MAIN_LAYER_COUNT - 1
-MAX_PUBLIC_TENSOR_DIMS = 5
-
-N_RANKS = layer.N_RANKS
-MOE_TOKENS = layer.MOE_TOKENS
-D = layer.D
-HC_MULT = layer.HC_MULT
-HC_DIM = layer.HC_DIM
-LM_HEAD_COMM_EPOCH = 1
-
-T_DYN = layer.T_DYN
+# Dynamic shape variables.
+T_DYN = swa.T_DYN
 FWD_PACKED_RAW_BLOCKS_DYN = pl.dynamic("FWD_PACKED_RAW_BLOCKS_DYN")
 FWD_HCA_STATE_BLOCKS_DYN = pl.dynamic("FWD_HCA_STATE_BLOCKS_DYN")
 FWD_HCA_CMP_BLOCKS_DYN = pl.dynamic("FWD_HCA_CMP_BLOCKS_DYN")
@@ -101,52 +86,66 @@ FWD_CSA_CMP_BLOCKS_DYN = pl.dynamic("FWD_CSA_CMP_BLOCKS_DYN")
 FWD_CSA_INNER_STATE_BLOCKS_DYN = pl.dynamic("FWD_CSA_INNER_STATE_BLOCKS_DYN")
 FWD_CSA_IDX_BLOCKS_DYN = pl.dynamic("FWD_CSA_IDX_BLOCKS_DYN")
 
-MIX_HC = layer.MIX_HC
-Q_LORA = layer.Q_LORA
-H = layer.H
-HEAD_DIM = layer.HEAD_DIM
-ROPE_HEAD_DIM = layer.ROPE_HEAD_DIM
-WIN = layer.WIN
-O_LORA = layer.O_LORA
-O_GROUP_IN = layer.O_GROUP_IN
-LOCAL_O_GROUPS = layer.LOCAL_O_GROUPS
-LOCAL_O_WIDTH = layer.LOCAL_O_WIDTH
-BLOCK_SIZE = layer.BLOCK_SIZE
-ATTENTION_WINDOW_ROWS = layer.ATTENTION_WINDOW_ROWS
-O_WINDOW_ROWS = layer.O_WINDOW_ROWS
-N_EXPERTS_GLOBAL = layer.N_EXPERTS_GLOBAL
-N_LOCAL = layer.N_LOCAL
-MOE_INTER = layer.MOE_INTER
-VOCAB = layer.VOCAB
-TOPK = layer.TOPK
-RECV_MAX = layer.RECV_MAX
-AUX_PAD = layer.AUX_PAD
-IDX_PAD = layer.IDX_PAD
-N_ROUTES = layer.N_ROUTES
+# model config
+MODEL_CONFIG = config.FLASH
+DECODE_TOKENS = config.DECODE_TOKENS
+MAIN_LAYER_COUNT = MODEL_CONFIG.num_hidden_layers
+SWA_LAYER_COUNT = 2
+CSA_LAYER_COUNT = 21
+HCA_LAYER_COUNT = 20
+MAX_PUBLIC_TENSOR_DIMS = 5
+N_RANKS = moe_module.N_RANKS
+MOE_TOKENS = moe_module.T
+D = swa.D
+HC_MULT = swa.HC_MULT
+HC_DIM = swa.HC_DIM
+LM_HEAD_COMM_EPOCH = 1
+MIX_HC = swa.MIX_HC
+Q_LORA = swa.Q_LORA
+H = swa.H
+HEAD_DIM = swa.HEAD_DIM
+ROPE_HEAD_DIM = swa.ROPE_HEAD_DIM
+WIN = swa.WIN
+O_LORA = swa.O_LORA
+O_GROUP_IN = swa.O_GROUP_IN
+LOCAL_O_GROUPS = swa.LOCAL_O_GROUPS
+LOCAL_O_WIDTH = swa.LOCAL_O_WIDTH
+BLOCK_SIZE = swa.BLOCK_SIZE
+ATTENTION_WINDOW_ROWS = swa.ATTENTION_WINDOW_ROWS
+O_WINDOW_ROWS = swa.O_WINDOW_ROWS
+N_EXPERTS_GLOBAL = moe_module.N_EXPERTS_GLOBAL
+N_LOCAL = moe_module.N_LOCAL
+MOE_INTER = moe_module.MOE_INTER
+VOCAB = moe_module.VOCAB
+TOPK = moe_module.TOPK
+RECV_MAX = moe_module.RECV_MAX
+AUX_PAD = moe_module.AUX_PAD
+IDX_PAD = moe_module.IDX_PAD
+N_ROUTES = moe_module.N_ROUTES
 
-HCA_B_DYN = layer.HCA_B_DYN
-HCA_CMP_TABLE_BLOCKS_DYN = layer.HCA_CMP_TABLE_BLOCKS_DYN
-HCA_B = layer.HCA_B
-HCA_MAIN_OUT_DIM = layer.HCA_MAIN_OUT_DIM
-HCA_COMPRESS_RATIO = layer.HCA_COMPRESS_RATIO
-HCA_COMPRESS_STATE_BLOCK_SIZE = layer.HCA_COMPRESS_STATE_BLOCK_SIZE
-HCA_COMPRESS_STATE_MAX_BLOCKS = layer.HCA_COMPRESS_STATE_MAX_BLOCKS
-HCA_COMPRESS_STATE_DIM = layer.HCA_COMPRESS_STATE_DIM
+HCA_B_DYN = hca.B_DYN
+HCA_CMP_TABLE_BLOCKS_DYN = hca.CMP_TABLE_BLOCKS_DYN
+HCA_B = hca.B
+HCA_MAIN_OUT_DIM = hca.MAIN_OUT_DIM
+HCA_COMPRESS_RATIO = hca.COMPRESS_RATIO
+HCA_COMPRESS_STATE_BLOCK_SIZE = hca.COMPRESS_STATE_BLOCK_SIZE
+HCA_COMPRESS_STATE_MAX_BLOCKS = hca.COMPRESS_STATE_MAX_BLOCKS
+HCA_COMPRESS_STATE_DIM = hca.COMPRESS_STATE_DIM
 
-CSA_B_DYN = layer.CSA_B_DYN
-CSA_MAIN_OUT_DIM = layer.CSA_MAIN_OUT_DIM
-CSA_COMPRESS_RATIO = layer.CSA_COMPRESS_RATIO
-CSA_MAIN_STATE_BLOCK_SIZE = layer.CSA_MAIN_STATE_BLOCK_SIZE
-CSA_MAIN_STATE_MAX_BLOCKS = layer.CSA_MAIN_STATE_MAX_BLOCKS
-CSA_MAIN_STATE_DIM = layer.CSA_MAIN_STATE_DIM
-CSA_IDX_N_HEADS = layer.CSA_IDX_N_HEADS
-CSA_IDX_HEAD_DIM = layer.CSA_IDX_HEAD_DIM
-CSA_INNER_OUT_DIM = layer.CSA_INNER_OUT_DIM
-CSA_INNER_STATE_BLOCK_SIZE = layer.CSA_INNER_STATE_BLOCK_SIZE
-CSA_INNER_STATE_MAX_BLOCKS = layer.CSA_INNER_STATE_MAX_BLOCKS
-CSA_INNER_STATE_DIM = layer.CSA_INNER_STATE_DIM
-CSA_CMP_MAX_BLOCKS = layer.CSA_CMP_MAX_BLOCKS
-CSA_IDX_MAX_BLOCKS = layer.CSA_IDX_MAX_BLOCKS
+CSA_B_DYN = csa.B_DYN
+CSA_MAIN_OUT_DIM = csa.MAIN_OUT_DIM
+CSA_COMPRESS_RATIO = csa.COMPRESS_RATIO
+CSA_MAIN_STATE_BLOCK_SIZE = csa.MAIN_STATE_BLOCK_SIZE
+CSA_MAIN_STATE_MAX_BLOCKS = csa.MAIN_STATE_MAX_BLOCKS
+CSA_MAIN_STATE_DIM = csa.MAIN_STATE_DIM
+CSA_IDX_N_HEADS = csa.IDX_N_HEADS
+CSA_IDX_HEAD_DIM = csa.IDX_HEAD_DIM
+CSA_INNER_OUT_DIM = csa.INNER_OUT_DIM
+CSA_INNER_STATE_BLOCK_SIZE = csa.INNER_STATE_BLOCK_SIZE
+CSA_INNER_STATE_MAX_BLOCKS = csa.INNER_STATE_MAX_BLOCKS
+CSA_INNER_STATE_DIM = csa.INNER_STATE_DIM
+CSA_CMP_MAX_BLOCKS = csa.CMP_MAX_BLOCKS
+CSA_IDX_MAX_BLOCKS = csa.IDX_MAX_BLOCKS
 
 RUNTIME_TEST_VOCAB = 256
 RUNTIME_WEIGHT_BANK = 1
@@ -154,91 +153,28 @@ HC_FN_STORAGE_ROWS = 32
 
 
 def _validate_import_contract():
-    if layer.TP_SIZE != TP_SIZE or layer.EP_SIZE != EP_SIZE:
-        raise ValueError(
-            "decode_layer parallel configuration diverged from decode_fwd: "
-            f"layer TP/EP={layer.TP_SIZE}/{layer.EP_SIZE}, "
-            f"forward TP/EP={TP_SIZE}/{EP_SIZE}"
-        )
+    for module in (swa, hca, csa):
+        if module.TP_SIZE != TP_SIZE:
+            raise ValueError(f"{module.__name__} TP={module.TP_SIZE} does not match forward TP={TP_SIZE}")
+    if moe_module.EP != EP_SIZE:
+        raise ValueError(f"MoE EP={moe_module.EP} does not match forward EP={EP_SIZE}")
     if N_RANKS != EP_SIZE:
         raise ValueError(f"MoE world size {N_RANKS} does not match EP={EP_SIZE}")
     if MAIN_LAYER_COUNT != 43:
-        raise ValueError(
-            f"D-Spark decode forward expects 43 layers, got {MAIN_LAYER_COUNT}"
-        )
+        raise ValueError(f"D-Spark decode forward expects 43 layers, got {MAIN_LAYER_COUNT}")
     if MODEL_CONFIG.vocab_size % TP_SIZE:
-        raise ValueError(
-            f"vocab size {MODEL_CONFIG.vocab_size} must be divisible by TP={TP_SIZE}"
-        )
+        raise ValueError(f"vocab size {MODEL_CONFIG.vocab_size} must be divisible by TP={TP_SIZE}")
     if LM_HEAD_TP_SIZE != TP_SIZE:
-        raise ValueError(
-            f"LM-head TP={LM_HEAD_TP_SIZE} does not match forward TP={TP_SIZE}"
-        )
+        raise ValueError(f"LM-head TP={LM_HEAD_TP_SIZE} does not match forward TP={TP_SIZE}")
     if LM_HEAD_VOCAB != MODEL_CONFIG.vocab_size:
-        raise ValueError(
-            f"LM-head vocab={LM_HEAD_VOCAB} does not match "
-            f"model vocab={MODEL_CONFIG.vocab_size}"
-        )
+        raise ValueError(f"LM-head vocab={LM_HEAD_VOCAB} does not match model vocab={MODEL_CONFIG.vocab_size}")
     if MAX_LOGIT_ROWS != DECODE_TOKENS:
-        raise ValueError(
-            f"LM-head rows={MAX_LOGIT_ROWS} do not match decode "
-            f"capacity={DECODE_TOKENS}"
-        )
+        raise ValueError(f"LM-head rows={MAX_LOGIT_ROWS} do not match decode capacity={DECODE_TOKENS}")
     if MOE_TOKENS > MAX_LOGIT_ROWS:
-        raise ValueError(
-            f"MoE capacity {MOE_TOKENS} exceeds LM-head rows {MAX_LOGIT_ROWS}"
-        )
+        raise ValueError(f"MoE capacity {MOE_TOKENS} exceeds LM-head rows {MAX_LOGIT_ROWS}")
 
 
 _validate_import_contract()
-
-
-def build_layer_plan():
-    """Return the fixed model-layer, kind-ordinal, and MoE-epoch mapping."""
-    kind_ordinals = {"swa": 0, "csa": 0, "hca": 0}
-    plan = []
-    for model_layer in range(MAIN_LAYER_COUNT):
-        kind = layer.attention_kind_for_layer(model_layer)
-        ordinal = kind_ordinals[kind]
-        kind_ordinals[kind] += 1
-        plan.append(
-            {
-                "model_layer": model_layer,
-                "kind": kind,
-                "kind_ordinal": ordinal,
-                "moe_epoch": model_layer + 1,
-            }
-        )
-
-    expected_counts = {
-        "swa": SWA_LAYER_COUNT,
-        "csa": CSA_LAYER_COUNT,
-        "hca": HCA_LAYER_COUNT,
-    }
-    if kind_ordinals != expected_counts:
-        raise ValueError(
-            f"decode forward attention counts changed: {kind_ordinals} != {expected_counts}"
-        )
-    if plan[0]["kind"] != "swa" or plan[1]["kind"] != "swa":
-        raise ValueError("model layers 0 and 1 must be SWA")
-    for model_layer in range(2, MAIN_LAYER_COUNT):
-        expected_kind = "csa" if model_layer % 2 == 0 else "hca"
-        if plan[model_layer]["kind"] != expected_kind:
-            raise ValueError(
-                f"model layer {model_layer} must be {expected_kind}, "
-                f"got {plan[model_layer]['kind']}"
-            )
-    if plan[LAST_MODEL_LAYER] != {
-        "model_layer": 42,
-        "kind": "csa",
-        "kind_ordinal": 20,
-        "moe_epoch": 43,
-    }:
-        raise ValueError(f"unexpected terminal layer mapping: {plan[-1]}")
-    return tuple(plan)
-
-
-LAYER_PLAN = build_layer_plan()
 
 
 PACKED_POOL_LAYER_COUNTS = {
@@ -252,144 +188,6 @@ PACKED_POOL_LAYER_COUNTS = {
     "csa_idx_kv_scale": CSA_LAYER_COUNT,
 }
 
-PACKED_POOL_BLOCK_SIZES = {
-    "raw_kv_pool": swa.BLOCK_SIZE,
-    "hca_compress_state": hca.COMPRESS_STATE_BLOCK_SIZE,
-    "hca_cmp_kv": hca.BLOCK_SIZE,
-    "csa_compress_state": csa.MAIN_STATE_BLOCK_SIZE,
-    "csa_cmp_kv": csa.BLOCK_SIZE,
-    "csa_inner_compress_state": csa.INNER_STATE_BLOCK_SIZE,
-    "csa_idx_kv_cache": csa.BLOCK_SIZE,
-    "csa_idx_kv_scale": csa.BLOCK_SIZE,
-}
-
-PACKED_POOL_ELEMENT_BYTES = {
-    "raw_kv_pool": 2,
-    "hca_compress_state": 4,
-    "hca_cmp_kv": 2,
-    "csa_compress_state": 4,
-    "csa_cmp_kv": 2,
-    "csa_inner_compress_state": 4,
-    "csa_idx_kv_cache": 1,
-    "csa_idx_kv_scale": 4,
-}
-
-
-def build_packed_pool_layout(per_layer_shapes):
-    """Pack each persistent pool along its block axis without a layer axis."""
-    expected_names = set(PACKED_POOL_LAYER_COUNTS)
-    provided_names = set(per_layer_shapes)
-    missing = expected_names - provided_names
-    unknown = provided_names - expected_names
-    if missing or unknown:
-        raise ValueError(
-            f"packed pool names mismatch: missing={sorted(missing)}, "
-            f"unknown={sorted(unknown)}"
-        )
-
-    layout = {}
-    for name, layer_count in PACKED_POOL_LAYER_COUNTS.items():
-        leaf_shape = [int(dim) for dim in per_layer_shapes[name]]
-        if len(leaf_shape) not in (4, 5):
-            raise ValueError(
-                f"{name} rank-stacked leaf pool must be 4D or 5D, "
-                f"got {leaf_shape}"
-            )
-        if leaf_shape[0] != N_RANKS:
-            raise ValueError(
-                f"{name} must have leading rank extent {N_RANKS}, "
-                f"got {leaf_shape}"
-            )
-        per_layer_extent = leaf_shape[1]
-        if per_layer_extent <= 0:
-            raise ValueError(
-                f"{name} per-layer block extent must be positive, "
-                f"got {per_layer_extent}"
-            )
-        expected_block_size = PACKED_POOL_BLOCK_SIZES[name]
-        if leaf_shape[2] != expected_block_size:
-            raise ValueError(
-                f"{name} block size {leaf_shape[2]} does not match "
-                f"{expected_block_size}"
-            )
-
-        packed_shape = list(leaf_shape)
-        packed_shape[1] = layer_count * per_layer_extent
-        elements_per_rank = 1
-        for dim in packed_shape[1:]:
-            elements_per_rank *= dim
-        slices = tuple(
-            (ordinal * per_layer_extent, (ordinal + 1) * per_layer_extent)
-            for ordinal in range(layer_count)
-        )
-        layout[name] = {
-            "layer_count": layer_count,
-            "per_layer_extent": per_layer_extent,
-            "total_extent": packed_shape[1],
-            "block_size": expected_block_size,
-            "leaf_shape": leaf_shape,
-            "packed_shape": packed_shape,
-            "bytes_per_rank": (
-                elements_per_rank * PACKED_POOL_ELEMENT_BYTES[name]
-            ),
-            "slices": slices,
-        }
-    validate_packed_pool_layout(layout)
-    return layout
-
-
-def validate_packed_pool_layout(layout):
-    """Fail closed on dimension, extent, and layer-slice contract errors."""
-    if set(layout) != set(PACKED_POOL_LAYER_COUNTS):
-        raise ValueError("packed layout must describe every persistent pool")
-    for name, entry in layout.items():
-        layer_count = PACKED_POOL_LAYER_COUNTS[name]
-        total_extent = int(entry["total_extent"])
-        if total_extent % layer_count:
-            raise ValueError(
-                f"{name} packed extent {total_extent} is not divisible by "
-                f"{layer_count}"
-            )
-        if len(entry["packed_shape"]) > MAX_PUBLIC_TENSOR_DIMS:
-            raise ValueError(
-                f"{name} has {len(entry['packed_shape'])} dimensions; "
-                f"maximum is {MAX_PUBLIC_TENSOR_DIMS}"
-            )
-        if entry["packed_shape"][1] != total_extent:
-            raise ValueError(f"{name} packed shape and extent diverged")
-
-        previous_end = 0
-        for begin, end in entry["slices"]:
-            if begin != previous_end or begin >= end or end > total_extent:
-                raise ValueError(f"{name} layer slices overlap or leave a gap")
-            previous_end = end
-        if previous_end != total_extent:
-            raise ValueError(f"{name} layer slices do not cover the packed axis")
-    return layout
-
-
-def validate_local_write_slots(name, slots, per_layer_capacity, active_mask=None):
-    """Validate layer-local write slots and the inactive-row -1 contract."""
-    import torch
-
-    values = torch.as_tensor(slots)
-    capacity = int(per_layer_capacity)
-    if capacity <= 0:
-        raise ValueError(f"{name} capacity must be positive, got {capacity}")
-    if bool((values < -1).any().item()):
-        raise ValueError(f"{name} contains a write slot below -1")
-    if bool((values >= capacity).any().item()):
-        raise ValueError(
-            f"{name} contains a non-local write slot for capacity {capacity}"
-        )
-    if active_mask is not None:
-        active = torch.as_tensor(active_mask, dtype=torch.bool)
-        while active.ndim < values.ndim:
-            active = active.unsqueeze(-1)
-        if bool((values.masked_select(~active) != -1).any().item()):
-            raise ValueError(f"{name} retains a write slot for an inactive row")
-    return values
-
 
 def build_active_logit_row_indices_host(active_tokens):
     """Build the host fixture for the terminal active-prefix row contract."""
@@ -397,10 +195,8 @@ def build_active_logit_row_indices_host(active_tokens):
 
     active_tokens = int(active_tokens)
     if active_tokens < 0 or active_tokens > min(MOE_TOKENS, MAX_LOGIT_ROWS):
-        raise ValueError(
-            f"active token count must be in [0, {min(MOE_TOKENS, MAX_LOGIT_ROWS)}], "
-            f"got {active_tokens}"
-        )
+        max_active_tokens = min(MOE_TOKENS, MAX_LOGIT_ROWS)
+        raise ValueError(f"active token count must be in [0, {max_active_tokens}], got {active_tokens}")
     indices = torch.full((N_RANKS, MAX_LOGIT_ROWS), -1, dtype=torch.int32)
     if active_tokens:
         active_rows = torch.arange(active_tokens, dtype=torch.int32)
@@ -418,9 +214,7 @@ def decode_embedding_preamble(
 ):
     """Embed active rows and pad their token ids to the fixed MoE capacity."""
     active_tokens = pl.tensor.dim(input_ids, 0)
-    for token_idx in pl.spmd(
-        MOE_TOKENS, name_hint="decode_fwd_pack_moe_input_ids"
-    ):
+    for token_idx in pl.spmd(MOE_TOKENS, name_hint="decode_fwd_pack_moe_input_ids"):
         token_id = pl.cast(0, pl.INT64)
         if token_idx < active_tokens:
             token_id = pl.read(input_ids, [token_idx])
@@ -437,9 +231,7 @@ def mask_inactive_sample_rows(
     """Make inactive terminal rows observable as -1 after greedy sampling."""
     for row in pl.spmd(MAX_LOGIT_ROWS, name_hint="decode_fwd_sample_mask"):
         if pl.read(logit_row_indices, [row]) < 0:
-            sampled_ids[row : row + 1, :] = pl.full(
-                [1, SAMPLED_IDS_PAD], dtype=pl.INT32, value=-1
-            )
+            sampled_ids[row:row + 1, :] = pl.full([1, SAMPLED_IDS_PAD], dtype=pl.INT32, value=-1)
     return sampled_ids
 
 
@@ -750,9 +542,7 @@ def decode_fwd(
     csa_cmp_freqs_sin.bind_dynamic(0, T_DYN)
     csa_compress_state.bind_dynamic(0, FWD_CSA_MAIN_STATE_BLOCKS_DYN)
     csa_compress_state_block_table.bind_dynamic(0, CSA_B_DYN)
-    csa_inner_compress_state.bind_dynamic(
-        0, FWD_CSA_INNER_STATE_BLOCKS_DYN
-    )
+    csa_inner_compress_state.bind_dynamic(0, FWD_CSA_INNER_STATE_BLOCKS_DYN)
     csa_inner_compress_state_block_table.bind_dynamic(0, CSA_B_DYN)
     csa_cmp_kv.bind_dynamic(0, FWD_CSA_CMP_BLOCKS_DYN)
     csa_cmp_block_table.bind_dynamic(0, CSA_B_DYN)
@@ -785,77 +575,29 @@ def decode_fwd(
 
     moe_input_ids = pl.create_tensor([MOE_TOKENS], dtype=pl.INT64)
     with pl.scope():
-        decode_embedding_preamble(
-            input_ids,
-            embed_weight,
-            hidden_workspace,
-            x_ping,
-            moe_input_ids,
-        )
+        decode_embedding_preamble(input_ids, embed_weight, hidden_workspace, x_ping, moe_input_ids)
 
     local_t = pl.cast(pl.tensor.dim(input_ids, 0), pl.INT32)
-    raw_blocks_per_layer = (
-        pl.tensor.dim(raw_kv_pool, 0) // MAIN_LAYER_COUNT
-    )
-    csa_state_blocks_per_layer = (
-        pl.tensor.dim(csa_compress_state, 0) // CSA_LAYER_COUNT
-    )
-    csa_cmp_blocks_per_layer = (
-        pl.tensor.dim(csa_cmp_kv, 0) // CSA_LAYER_COUNT
-    )
-    csa_inner_state_blocks_per_layer = (
-        pl.tensor.dim(csa_inner_compress_state, 0) // CSA_LAYER_COUNT
-    )
-    csa_idx_blocks_per_layer = (
-        pl.tensor.dim(csa_idx_kv_cache, 0) // CSA_LAYER_COUNT
-    )
-    hca_state_blocks_per_layer = (
-        pl.tensor.dim(hca_compress_state, 0) // HCA_LAYER_COUNT
-    )
-    hca_cmp_blocks_per_layer = (
-        pl.tensor.dim(hca_cmp_kv, 0) // HCA_LAYER_COUNT
-    )
+    raw_blocks_per_layer = pl.tensor.dim(raw_kv_pool, 0) // MAIN_LAYER_COUNT
+    csa_state_blocks_per_layer = pl.tensor.dim(csa_compress_state, 0) // CSA_LAYER_COUNT
+    csa_cmp_blocks_per_layer = pl.tensor.dim(csa_cmp_kv, 0) // CSA_LAYER_COUNT
+    csa_inner_state_blocks_per_layer = pl.tensor.dim(csa_inner_compress_state, 0) // CSA_LAYER_COUNT
+    csa_idx_blocks_per_layer = pl.tensor.dim(csa_idx_kv_cache, 0) // CSA_LAYER_COUNT
+    hca_state_blocks_per_layer = pl.tensor.dim(hca_compress_state, 0) // HCA_LAYER_COUNT
+    hca_cmp_blocks_per_layer = pl.tensor.dim(hca_cmp_kv, 0) // HCA_LAYER_COUNT
 
     with pl.scope():
         weight_layer_swa0 = pl.const(0, pl.INT32)
-        hc_attn_fn_layer_swa0 = pl.slice(
-            hc_attn_fn, [MIX_HC, HC_DIM], [0, 0]
-        )
-        hc_ffn_fn_layer_swa0 = pl.slice(
-            hc_ffn_fn, [MIX_HC, HC_DIM], [0, 0]
-        )
-        wq_a_layer_swa0: pl.Tensor[[D, Q_LORA], pl.BF16] = pl.slice(
-            wq_a, [D, Q_LORA], [0, 0]
-        )
-        wq_b_layer_swa0: pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8] = pl.slice(
-            wq_b, [Q_LORA, H * HEAD_DIM], [0, 0]
-        )
-        wq_b_scale_layer_swa0: pl.Tensor[[H * HEAD_DIM], pl.FP32] = pl.slice(
-            wq_b_scale, [H * HEAD_DIM], [0]
-        )
-        wkv_layer_swa0: pl.Tensor[[D, HEAD_DIM], pl.BF16] = pl.slice(
-            wkv, [D, HEAD_DIM], [0, 0]
-        )
-        gamma_cq_layer_swa0: pl.Tensor[[Q_LORA], pl.BF16] = pl.slice(
-            gamma_cq, [Q_LORA], [0]
-        )
-        gamma_ckv_layer_swa0: pl.Tensor[[HEAD_DIM], pl.BF16] = pl.slice(
-            gamma_ckv, [HEAD_DIM], [0]
-        )
-        wo_a_layer_swa0: pl.Tensor[
-            [LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16
-        ] = pl.slice(
-            wo_a,
-            [LOCAL_O_GROUPS, O_LORA, O_GROUP_IN],
-            [weight_layer_swa0 * LOCAL_O_GROUPS, 0, 0],
-        )
-        routed_w1_layer_swa0: pl.Tensor[
-            [N_LOCAL, MOE_INTER, D], pl.INT8
-        ] = pl.slice(
-            routed_w1,
-            [N_LOCAL, MOE_INTER, D],
-            [weight_layer_swa0 * N_LOCAL, 0, 0],
-        )
+        hc_attn_fn_layer_swa0 = pl.slice(hc_attn_fn, [MIX_HC, HC_DIM], [0, 0])
+        hc_ffn_fn_layer_swa0 = pl.slice(hc_ffn_fn, [MIX_HC, HC_DIM], [0, 0])
+        wq_a_layer_swa0: pl.Tensor[[D, Q_LORA], pl.BF16] = pl.slice(wq_a, [D, Q_LORA], [0, 0])
+        wq_b_layer_swa0: pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8] = pl.slice(wq_b, [Q_LORA, H * HEAD_DIM], [0, 0])
+        wq_b_scale_layer_swa0: pl.Tensor[[H * HEAD_DIM], pl.FP32] = pl.slice(wq_b_scale, [H * HEAD_DIM], [0])
+        wkv_layer_swa0: pl.Tensor[[D, HEAD_DIM], pl.BF16] = pl.slice(wkv, [D, HEAD_DIM], [0, 0])
+        gamma_cq_layer_swa0: pl.Tensor[[Q_LORA], pl.BF16] = pl.slice(gamma_cq, [Q_LORA], [0])
+        gamma_ckv_layer_swa0: pl.Tensor[[HEAD_DIM], pl.BF16] = pl.slice(gamma_ckv, [HEAD_DIM], [0])
+        wo_a_layer_swa0: pl.Tensor[[LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16] = pl.slice(wo_a, [LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], [weight_layer_swa0 * LOCAL_O_GROUPS, 0, 0])
+        routed_w1_layer_swa0: pl.Tensor[[N_LOCAL, MOE_INTER, D], pl.INT8] = pl.slice(routed_w1, [N_LOCAL, MOE_INTER, D], [weight_layer_swa0 * N_LOCAL, 0, 0])
         hc_attn_scale_layer_swa0 = pl.slice(hc_attn_scale, [3], [0])
         hc_attn_base_layer_swa0 = pl.slice(hc_attn_base, [MIX_HC], [0])
         attn_norm_w_layer_swa0 = pl.slice(attn_norm_w, [D], [0])
@@ -865,234 +607,172 @@ def decode_fwd(
         hc_ffn_scale_layer_swa0 = pl.slice(hc_ffn_scale, [3], [0])
         hc_ffn_base_layer_swa0 = pl.slice(hc_ffn_base, [MIX_HC], [0])
         norm_w_layer_swa0 = pl.slice(norm_w, [D], [0])
-        gate_w_layer_swa0 = pl.slice(
-            gate_w, [N_EXPERTS_GLOBAL, D], [0, 0]
-        )
+        gate_w_layer_swa0 = pl.slice(gate_w, [N_EXPERTS_GLOBAL, D], [0, 0])
         gate_bias_layer_swa0 = pl.slice(gate_bias, [N_EXPERTS_GLOBAL], [0])
         tid2eid_layer_swa0 = pl.slice(tid2eid, [VOCAB, TOPK], [0, 0])
-        routed_w1_scale_layer_swa0 = pl.slice(
-            routed_w1_scale, [N_LOCAL, MOE_INTER], [0, 0]
-        )
-        routed_w3_scale_layer_swa0 = pl.slice(
-            routed_w3_scale, [N_LOCAL, MOE_INTER], [0, 0]
-        )
-        routed_w2_scale_layer_swa0 = pl.slice(
-            routed_w2_scale, [N_LOCAL, D], [0, 0]
-        )
+        routed_w1_scale_layer_swa0 = pl.slice(routed_w1_scale, [N_LOCAL, MOE_INTER], [0, 0])
+        routed_w3_scale_layer_swa0 = pl.slice(routed_w3_scale, [N_LOCAL, MOE_INTER], [0, 0])
+        routed_w2_scale_layer_swa0 = pl.slice(routed_w2_scale, [N_LOCAL, D], [0, 0])
         shared_w1_layer_swa0 = pl.slice(shared_w1, [MOE_INTER, D], [0, 0])
-        shared_w1_scale_layer_swa0 = pl.slice(
-            shared_w1_scale, [MOE_INTER], [0]
-        )
+        shared_w1_scale_layer_swa0 = pl.slice(shared_w1_scale, [MOE_INTER], [0])
         shared_w3_layer_swa0 = pl.slice(shared_w3, [MOE_INTER, D], [0, 0])
-        shared_w3_scale_layer_swa0 = pl.slice(
-            shared_w3_scale, [MOE_INTER], [0]
-        )
+        shared_w3_scale_layer_swa0 = pl.slice(shared_w3_scale, [MOE_INTER], [0])
         shared_w2_layer_swa0 = pl.slice(shared_w2, [D, MOE_INTER], [0, 0])
         shared_w2_scale_layer_swa0 = pl.slice(shared_w2_scale, [D], [0])
-        routed_w3_layer_swa0: pl.Tensor[
-            [N_LOCAL, MOE_INTER, D], pl.INT8
-        ] = pl.slice(
-            routed_w3,
-            [N_LOCAL, MOE_INTER, D],
-            [weight_layer_swa0 * N_LOCAL, 0, 0],
-        )
-        routed_w2_layer_swa0: pl.Tensor[
-            [N_LOCAL, D, MOE_INTER], pl.INT8
-        ] = pl.slice(
-            routed_w2,
-            [N_LOCAL, D, MOE_INTER],
-            [weight_layer_swa0 * N_LOCAL, 0, 0],
-        )
-        raw_kv_layer_swa0 = pl.slice(
-            raw_kv_pool,
-            [raw_blocks_per_layer, BLOCK_SIZE, 1, HEAD_DIM],
-            [0, 0, 0, 0],
-        )
-        decode_layer_swa(
-            x_ping,
-            hc_attn_fn_layer_swa0, hc_attn_scale_layer_swa0,
-            hc_attn_base_layer_swa0, attn_norm_w_layer_swa0,
-            wq_a_layer_swa0, wq_b_layer_swa0, wq_b_scale_layer_swa0, wkv_layer_swa0,
-            gamma_cq_layer_swa0, gamma_ckv_layer_swa0,
-            freqs_cos, freqs_sin, raw_kv_layer_swa0,
-            swa_slot_mapping, swa_indices, swa_lens, position_ids,
-            attn_sink_layer_swa0, wo_a_layer_swa0, wo_b_layer_swa0, wo_b_scale_layer_swa0,
-            hc_ffn_fn_layer_swa0, hc_ffn_scale_layer_swa0,
-            hc_ffn_base_layer_swa0, norm_w_layer_swa0,
-            gate_w_layer_swa0, gate_bias_layer_swa0, tid2eid_layer_swa0, moe_input_ids,
-            routed_w1_layer_swa0, routed_w1_scale_layer_swa0,
-            routed_w3_layer_swa0, routed_w3_scale_layer_swa0,
-            routed_w2_layer_swa0, routed_w2_scale_layer_swa0,
-            shared_w1_layer_swa0, shared_w1_scale_layer_swa0,
-            shared_w3_layer_swa0, shared_w3_scale_layer_swa0,
-            shared_w2_layer_swa0, shared_w2_scale_layer_swa0,
-            x_attn_active, x_moe_next, x_pong,
-            attention_window, attention_signal, o_window, o_signal,
-            recv_meta, recv_x, recv_aux, recv_route,
-            arrived, data_arrived, routed_y_buf, combine_arrived,
-            pl.const(0, pl.INT32), group_base, tp_rank, local_t, my_rank,
-            pl.const(1, pl.INT32),
-        )
+        routed_w3_layer_swa0: pl.Tensor[[N_LOCAL, MOE_INTER, D], pl.INT8] = pl.slice(routed_w3, [N_LOCAL, MOE_INTER, D], [weight_layer_swa0 * N_LOCAL, 0, 0])
+        routed_w2_layer_swa0: pl.Tensor[[N_LOCAL, D, MOE_INTER], pl.INT8] = pl.slice(routed_w2, [N_LOCAL, D, MOE_INTER], [weight_layer_swa0 * N_LOCAL, 0, 0])
+        raw_kv_layer_swa0 = pl.slice(raw_kv_pool, [raw_blocks_per_layer, BLOCK_SIZE, 1, HEAD_DIM], [0, 0, 0, 0])
+        with pl.scope():
+            if TP_SIZE == 1:
+                decode_swa_tp1(
+                    x_ping,
+                    hc_attn_fn_layer_swa0, hc_attn_scale_layer_swa0, hc_attn_base_layer_swa0,
+                    attn_norm_w_layer_swa0, wq_a_layer_swa0, wq_b_layer_swa0, wq_b_scale_layer_swa0,
+                    wkv_layer_swa0, gamma_cq_layer_swa0, gamma_ckv_layer_swa0,
+                    freqs_cos, freqs_sin,
+                    raw_kv_layer_swa0, swa_slot_mapping, swa_indices, swa_lens, position_ids,
+                    attn_sink_layer_swa0, wo_a_layer_swa0, wo_b_layer_swa0, wo_b_scale_layer_swa0,
+                    x_attn_active,
+                )
+            else:
+                decode_swa(
+                    x_ping,
+                    hc_attn_fn_layer_swa0, hc_attn_scale_layer_swa0, hc_attn_base_layer_swa0,
+                    attn_norm_w_layer_swa0, wq_a_layer_swa0, wq_b_layer_swa0, wq_b_scale_layer_swa0,
+                    wkv_layer_swa0, gamma_cq_layer_swa0, gamma_ckv_layer_swa0,
+                    freqs_cos, freqs_sin,
+                    raw_kv_layer_swa0, swa_slot_mapping, swa_indices, swa_lens, position_ids,
+                    attn_sink_layer_swa0, wo_a_layer_swa0, wo_b_layer_swa0, wo_b_scale_layer_swa0,
+                    x_attn_active,
+                    attention_window, attention_signal, o_window, o_signal,
+                    group_base, tp_rank, local_t,
+                )
+
+        with pl.scope():
+            x_attn_moe_swa0 = pl.create_tensor([MOE_TOKENS, HC_MULT, D], dtype=pl.FP32)
+            for token in pl.spmd(MOE_TOKENS, name_hint="decode_fwd_swa0_attn_pack"):
+                if token < local_t:
+                    x_attn_moe_swa0[token : token + 1, 0 : HC_MULT, 0 : D] = x_attn_active[
+                        token : token + 1, 0 : HC_MULT, 0 : D
+                    ]
+                else:
+                    zero_moe_row_swa0 = pl.full([1, HC_MULT, D], dtype=pl.FP32, value=0.0)
+                    x_attn_moe_swa0[token : token + 1, 0 : HC_MULT, 0 : D] = zero_moe_row_swa0
+            moe(
+                x_attn_moe_swa0,
+                hc_ffn_fn_layer_swa0, hc_ffn_scale_layer_swa0, hc_ffn_base_layer_swa0,
+                norm_w_layer_swa0, gate_w_layer_swa0, gate_bias_layer_swa0, tid2eid_layer_swa0,
+                moe_input_ids,
+                routed_w1_layer_swa0, routed_w1_scale_layer_swa0,
+                routed_w3_layer_swa0, routed_w3_scale_layer_swa0,
+                routed_w2_layer_swa0, routed_w2_scale_layer_swa0,
+                shared_w1_layer_swa0, shared_w1_scale_layer_swa0,
+                shared_w3_layer_swa0, shared_w3_scale_layer_swa0,
+                shared_w2_layer_swa0, shared_w2_scale_layer_swa0,
+                x_moe_next,
+                recv_meta, recv_x, recv_aux, recv_route, arrived, data_arrived,
+                routed_y_buf, combine_arrived,
+                pl.const(0, pl.INT32), local_t, my_rank, pl.const(1, pl.INT32),
+            )
+            for token in pl.spmd(MOE_TOKENS, name_hint="decode_fwd_swa0_active_trim"):
+                if token < local_t:
+                    x_pong[token : token + 1, 0 : HC_MULT, 0 : D] = x_moe_next[
+                        token : token + 1, 0 : HC_MULT, 0 : D
+                    ]
 
     with pl.scope():
         weight_layer_swa1 = pl.const(1, pl.INT32) % FWD_WEIGHT_BANK_SIZE
-        hc_attn_fn_layer_swa1 = pl.slice(
-            hc_attn_fn,
-            [MIX_HC, HC_DIM],
-            [weight_layer_swa1 * HC_FN_STORAGE_ROWS, 0],
-        )
-        hc_ffn_fn_layer_swa1 = pl.slice(
-            hc_ffn_fn,
-            [MIX_HC, HC_DIM],
-            [weight_layer_swa1 * HC_FN_STORAGE_ROWS, 0],
-        )
-        wq_a_layer_swa1: pl.Tensor[[D, Q_LORA], pl.BF16] = pl.slice(
-            wq_a, [D, Q_LORA], [weight_layer_swa1 * D, 0]
-        )
-        wq_b_layer_swa1: pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8] = pl.slice(
-            wq_b, [Q_LORA, H * HEAD_DIM], [weight_layer_swa1 * Q_LORA, 0]
-        )
-        wq_b_scale_layer_swa1: pl.Tensor[[H * HEAD_DIM], pl.FP32] = pl.slice(
-            wq_b_scale,
-            [H * HEAD_DIM],
-            [weight_layer_swa1 * H * HEAD_DIM],
-        )
-        wkv_layer_swa1: pl.Tensor[[D, HEAD_DIM], pl.BF16] = pl.slice(
-            wkv, [D, HEAD_DIM], [weight_layer_swa1 * D, 0]
-        )
-        gamma_cq_layer_swa1: pl.Tensor[[Q_LORA], pl.BF16] = pl.slice(
-            gamma_cq, [Q_LORA], [weight_layer_swa1 * Q_LORA]
-        )
-        gamma_ckv_layer_swa1: pl.Tensor[[HEAD_DIM], pl.BF16] = pl.slice(
-            gamma_ckv, [HEAD_DIM], [weight_layer_swa1 * HEAD_DIM]
-        )
-        wo_a_layer_swa1: pl.Tensor[
-            [LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16
-        ] = pl.slice(
-            wo_a,
-            [LOCAL_O_GROUPS, O_LORA, O_GROUP_IN],
-            [weight_layer_swa1 * LOCAL_O_GROUPS, 0, 0],
-        )
-        routed_w1_layer_swa1: pl.Tensor[
-            [N_LOCAL, MOE_INTER, D], pl.INT8
-        ] = pl.slice(
-            routed_w1,
-            [N_LOCAL, MOE_INTER, D],
-            [weight_layer_swa1 * N_LOCAL, 0, 0],
-        )
-        hc_attn_scale_layer_swa1 = pl.slice(
-            hc_attn_scale, [3], [weight_layer_swa1 * 3]
-        )
-        hc_attn_base_layer_swa1 = pl.slice(
-            hc_attn_base, [MIX_HC], [weight_layer_swa1 * MIX_HC]
-        )
-        attn_norm_w_layer_swa1 = pl.slice(
-            attn_norm_w, [D], [weight_layer_swa1 * D]
-        )
+        hc_attn_fn_layer_swa1 = pl.slice(hc_attn_fn, [MIX_HC, HC_DIM], [weight_layer_swa1 * HC_FN_STORAGE_ROWS, 0])
+        hc_ffn_fn_layer_swa1 = pl.slice(hc_ffn_fn, [MIX_HC, HC_DIM], [weight_layer_swa1 * HC_FN_STORAGE_ROWS, 0])
+        wq_a_layer_swa1: pl.Tensor[[D, Q_LORA], pl.BF16] = pl.slice(wq_a, [D, Q_LORA], [weight_layer_swa1 * D, 0])
+        wq_b_layer_swa1: pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8] = pl.slice(wq_b, [Q_LORA, H * HEAD_DIM], [weight_layer_swa1 * Q_LORA, 0])
+        wq_b_scale_layer_swa1: pl.Tensor[[H * HEAD_DIM], pl.FP32] = pl.slice(wq_b_scale, [H * HEAD_DIM], [weight_layer_swa1 * H * HEAD_DIM])
+        wkv_layer_swa1: pl.Tensor[[D, HEAD_DIM], pl.BF16] = pl.slice(wkv, [D, HEAD_DIM], [weight_layer_swa1 * D, 0])
+        gamma_cq_layer_swa1: pl.Tensor[[Q_LORA], pl.BF16] = pl.slice(gamma_cq, [Q_LORA], [weight_layer_swa1 * Q_LORA])
+        gamma_ckv_layer_swa1: pl.Tensor[[HEAD_DIM], pl.BF16] = pl.slice(gamma_ckv, [HEAD_DIM], [weight_layer_swa1 * HEAD_DIM])
+        wo_a_layer_swa1: pl.Tensor[[LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16] = pl.slice(wo_a, [LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], [weight_layer_swa1 * LOCAL_O_GROUPS, 0, 0])
+        routed_w1_layer_swa1: pl.Tensor[[N_LOCAL, MOE_INTER, D], pl.INT8] = pl.slice(routed_w1, [N_LOCAL, MOE_INTER, D], [weight_layer_swa1 * N_LOCAL, 0, 0])
+        hc_attn_scale_layer_swa1 = pl.slice(hc_attn_scale, [3], [weight_layer_swa1 * 3])
+        hc_attn_base_layer_swa1 = pl.slice(hc_attn_base, [MIX_HC], [weight_layer_swa1 * MIX_HC])
+        attn_norm_w_layer_swa1 = pl.slice(attn_norm_w, [D], [weight_layer_swa1 * D])
         attn_sink_layer_swa1 = pl.slice(attn_sink, [H], [weight_layer_swa1 * H])
-        wo_b_layer_swa1 = pl.slice(
-            wo_b, [D, LOCAL_O_WIDTH], [weight_layer_swa1 * D, 0]
-        )
-        wo_b_scale_layer_swa1 = pl.slice(
-            wo_b_scale, [D], [weight_layer_swa1 * D]
-        )
-        hc_ffn_scale_layer_swa1 = pl.slice(
-            hc_ffn_scale, [3], [weight_layer_swa1 * 3]
-        )
-        hc_ffn_base_layer_swa1 = pl.slice(
-            hc_ffn_base, [MIX_HC], [weight_layer_swa1 * MIX_HC]
-        )
+        wo_b_layer_swa1 = pl.slice(wo_b, [D, LOCAL_O_WIDTH], [weight_layer_swa1 * D, 0])
+        wo_b_scale_layer_swa1 = pl.slice(wo_b_scale, [D], [weight_layer_swa1 * D])
+        hc_ffn_scale_layer_swa1 = pl.slice(hc_ffn_scale, [3], [weight_layer_swa1 * 3])
+        hc_ffn_base_layer_swa1 = pl.slice(hc_ffn_base, [MIX_HC], [weight_layer_swa1 * MIX_HC])
         norm_w_layer_swa1 = pl.slice(norm_w, [D], [weight_layer_swa1 * D])
-        gate_w_layer_swa1 = pl.slice(
-            gate_w,
-            [N_EXPERTS_GLOBAL, D],
-            [weight_layer_swa1 * N_EXPERTS_GLOBAL, 0],
-        )
-        gate_bias_layer_swa1 = pl.slice(
-            gate_bias,
-            [N_EXPERTS_GLOBAL],
-            [weight_layer_swa1 * N_EXPERTS_GLOBAL],
-        )
-        tid2eid_layer_swa1 = pl.slice(
-            tid2eid, [VOCAB, TOPK], [weight_layer_swa1 * VOCAB, 0]
-        )
-        routed_w1_scale_layer_swa1 = pl.slice(
-            routed_w1_scale,
-            [N_LOCAL, MOE_INTER],
-            [weight_layer_swa1 * N_LOCAL, 0],
-        )
-        routed_w3_scale_layer_swa1 = pl.slice(
-            routed_w3_scale,
-            [N_LOCAL, MOE_INTER],
-            [weight_layer_swa1 * N_LOCAL, 0],
-        )
-        routed_w2_scale_layer_swa1 = pl.slice(
-            routed_w2_scale,
-            [N_LOCAL, D],
-            [weight_layer_swa1 * N_LOCAL, 0],
-        )
-        shared_w1_layer_swa1 = pl.slice(
-            shared_w1, [MOE_INTER, D], [weight_layer_swa1 * MOE_INTER, 0]
-        )
-        shared_w1_scale_layer_swa1 = pl.slice(
-            shared_w1_scale, [MOE_INTER], [weight_layer_swa1 * MOE_INTER]
-        )
-        shared_w3_layer_swa1 = pl.slice(
-            shared_w3, [MOE_INTER, D], [weight_layer_swa1 * MOE_INTER, 0]
-        )
-        shared_w3_scale_layer_swa1 = pl.slice(
-            shared_w3_scale, [MOE_INTER], [weight_layer_swa1 * MOE_INTER]
-        )
-        shared_w2_layer_swa1 = pl.slice(
-            shared_w2, [D, MOE_INTER], [weight_layer_swa1 * D, 0]
-        )
-        shared_w2_scale_layer_swa1 = pl.slice(
-            shared_w2_scale, [D], [weight_layer_swa1 * D]
-        )
-        routed_w3_layer_swa1: pl.Tensor[
-            [N_LOCAL, MOE_INTER, D], pl.INT8
-        ] = pl.slice(
-            routed_w3,
-            [N_LOCAL, MOE_INTER, D],
-            [weight_layer_swa1 * N_LOCAL, 0, 0],
-        )
-        routed_w2_layer_swa1: pl.Tensor[
-            [N_LOCAL, D, MOE_INTER], pl.INT8
-        ] = pl.slice(
-            routed_w2,
-            [N_LOCAL, D, MOE_INTER],
-            [weight_layer_swa1 * N_LOCAL, 0, 0],
-        )
-        raw_kv_layer_swa1 = pl.slice(
-            raw_kv_pool,
-            [raw_blocks_per_layer, BLOCK_SIZE, 1, HEAD_DIM],
-            [raw_blocks_per_layer, 0, 0, 0],
-        )
-        decode_layer_swa(
-            x_pong,
-            hc_attn_fn_layer_swa1, hc_attn_scale_layer_swa1,
-            hc_attn_base_layer_swa1, attn_norm_w_layer_swa1,
-            wq_a_layer_swa1, wq_b_layer_swa1, wq_b_scale_layer_swa1, wkv_layer_swa1,
-            gamma_cq_layer_swa1, gamma_ckv_layer_swa1,
-            freqs_cos, freqs_sin, raw_kv_layer_swa1,
-            swa_slot_mapping, swa_indices, swa_lens, position_ids,
-            attn_sink_layer_swa1, wo_a_layer_swa1, wo_b_layer_swa1, wo_b_scale_layer_swa1,
-            hc_ffn_fn_layer_swa1, hc_ffn_scale_layer_swa1,
-            hc_ffn_base_layer_swa1, norm_w_layer_swa1,
-            gate_w_layer_swa1, gate_bias_layer_swa1, tid2eid_layer_swa1, moe_input_ids,
-            routed_w1_layer_swa1, routed_w1_scale_layer_swa1,
-            routed_w3_layer_swa1, routed_w3_scale_layer_swa1,
-            routed_w2_layer_swa1, routed_w2_scale_layer_swa1,
-            shared_w1_layer_swa1, shared_w1_scale_layer_swa1,
-            shared_w3_layer_swa1, shared_w3_scale_layer_swa1,
-            shared_w2_layer_swa1, shared_w2_scale_layer_swa1,
-            x_attn_active, x_moe_next, x_ping,
-            attention_window, attention_signal, o_window, o_signal,
-            recv_meta, recv_x, recv_aux, recv_route,
-            arrived, data_arrived, routed_y_buf, combine_arrived,
-            pl.const(1, pl.INT32), group_base, tp_rank, local_t, my_rank,
-            pl.const(2, pl.INT32),
-        )
+        gate_w_layer_swa1 = pl.slice(gate_w, [N_EXPERTS_GLOBAL, D], [weight_layer_swa1 * N_EXPERTS_GLOBAL, 0])
+        gate_bias_layer_swa1 = pl.slice(gate_bias, [N_EXPERTS_GLOBAL], [weight_layer_swa1 * N_EXPERTS_GLOBAL])
+        tid2eid_layer_swa1 = pl.slice(tid2eid, [VOCAB, TOPK], [weight_layer_swa1 * VOCAB, 0])
+        routed_w1_scale_layer_swa1 = pl.slice(routed_w1_scale, [N_LOCAL, MOE_INTER], [weight_layer_swa1 * N_LOCAL, 0])
+        routed_w3_scale_layer_swa1 = pl.slice(routed_w3_scale, [N_LOCAL, MOE_INTER], [weight_layer_swa1 * N_LOCAL, 0])
+        routed_w2_scale_layer_swa1 = pl.slice(routed_w2_scale, [N_LOCAL, D], [weight_layer_swa1 * N_LOCAL, 0])
+        shared_w1_layer_swa1 = pl.slice(shared_w1, [MOE_INTER, D], [weight_layer_swa1 * MOE_INTER, 0])
+        shared_w1_scale_layer_swa1 = pl.slice(shared_w1_scale, [MOE_INTER], [weight_layer_swa1 * MOE_INTER])
+        shared_w3_layer_swa1 = pl.slice(shared_w3, [MOE_INTER, D], [weight_layer_swa1 * MOE_INTER, 0])
+        shared_w3_scale_layer_swa1 = pl.slice(shared_w3_scale, [MOE_INTER], [weight_layer_swa1 * MOE_INTER])
+        shared_w2_layer_swa1 = pl.slice(shared_w2, [D, MOE_INTER], [weight_layer_swa1 * D, 0])
+        shared_w2_scale_layer_swa1 = pl.slice(shared_w2_scale, [D], [weight_layer_swa1 * D])
+        routed_w3_layer_swa1: pl.Tensor[[N_LOCAL, MOE_INTER, D], pl.INT8] = pl.slice(routed_w3, [N_LOCAL, MOE_INTER, D], [weight_layer_swa1 * N_LOCAL, 0, 0])
+        routed_w2_layer_swa1: pl.Tensor[[N_LOCAL, D, MOE_INTER], pl.INT8] = pl.slice(routed_w2, [N_LOCAL, D, MOE_INTER], [weight_layer_swa1 * N_LOCAL, 0, 0])
+        raw_kv_layer_swa1 = pl.slice(raw_kv_pool, [raw_blocks_per_layer, BLOCK_SIZE, 1, HEAD_DIM], [raw_blocks_per_layer, 0, 0, 0])
+        with pl.scope():
+            if TP_SIZE == 1:
+                decode_swa_tp1(
+                    x_pong,
+                    hc_attn_fn_layer_swa1, hc_attn_scale_layer_swa1, hc_attn_base_layer_swa1,
+                    attn_norm_w_layer_swa1, wq_a_layer_swa1, wq_b_layer_swa1, wq_b_scale_layer_swa1,
+                    wkv_layer_swa1, gamma_cq_layer_swa1, gamma_ckv_layer_swa1,
+                    freqs_cos, freqs_sin,
+                    raw_kv_layer_swa1, swa_slot_mapping, swa_indices, swa_lens, position_ids,
+                    attn_sink_layer_swa1, wo_a_layer_swa1, wo_b_layer_swa1, wo_b_scale_layer_swa1,
+                    x_attn_active,
+                )
+            else:
+                decode_swa(
+                    x_pong,
+                    hc_attn_fn_layer_swa1, hc_attn_scale_layer_swa1, hc_attn_base_layer_swa1,
+                    attn_norm_w_layer_swa1, wq_a_layer_swa1, wq_b_layer_swa1, wq_b_scale_layer_swa1,
+                    wkv_layer_swa1, gamma_cq_layer_swa1, gamma_ckv_layer_swa1,
+                    freqs_cos, freqs_sin,
+                    raw_kv_layer_swa1, swa_slot_mapping, swa_indices, swa_lens, position_ids,
+                    attn_sink_layer_swa1, wo_a_layer_swa1, wo_b_layer_swa1, wo_b_scale_layer_swa1,
+                    x_attn_active,
+                    attention_window, attention_signal, o_window, o_signal,
+                    group_base, tp_rank, local_t,
+                )
+
+        with pl.scope():
+            x_attn_moe_swa1 = pl.create_tensor([MOE_TOKENS, HC_MULT, D], dtype=pl.FP32)
+            for token in pl.spmd(MOE_TOKENS, name_hint="decode_fwd_swa1_attn_pack"):
+                if token < local_t:
+                    x_attn_moe_swa1[token : token + 1, 0 : HC_MULT, 0 : D] = x_attn_active[
+                        token : token + 1, 0 : HC_MULT, 0 : D
+                    ]
+                else:
+                    zero_moe_row_swa1 = pl.full([1, HC_MULT, D], dtype=pl.FP32, value=0.0)
+                    x_attn_moe_swa1[token : token + 1, 0 : HC_MULT, 0 : D] = zero_moe_row_swa1
+            moe(
+                x_attn_moe_swa1,
+                hc_ffn_fn_layer_swa1, hc_ffn_scale_layer_swa1, hc_ffn_base_layer_swa1,
+                norm_w_layer_swa1, gate_w_layer_swa1, gate_bias_layer_swa1, tid2eid_layer_swa1,
+                moe_input_ids,
+                routed_w1_layer_swa1, routed_w1_scale_layer_swa1,
+                routed_w3_layer_swa1, routed_w3_scale_layer_swa1,
+                routed_w2_layer_swa1, routed_w2_scale_layer_swa1,
+                shared_w1_layer_swa1, shared_w1_scale_layer_swa1,
+                shared_w3_layer_swa1, shared_w3_scale_layer_swa1,
+                shared_w2_layer_swa1, shared_w2_scale_layer_swa1,
+                x_moe_next,
+                recv_meta, recv_x, recv_aux, recv_route, arrived, data_arrived,
+                routed_y_buf, combine_arrived,
+                pl.const(1, pl.INT32), local_t, my_rank, pl.const(2, pl.INT32),
+            )
+            for token in pl.spmd(MOE_TOKENS, name_hint="decode_fwd_swa1_active_trim"):
+                if token < local_t:
+                    x_ping[token : token + 1, 0 : HC_MULT, 0 : D] = x_moe_next[
+                        token : token + 1, 0 : HC_MULT, 0 : D
+                    ]
 
     for ordinal in pl.range(HCA_LAYER_COUNT):
         csa_model_layer = pl.cast(ordinal * 2 + 2, pl.INT32)
@@ -1103,798 +783,397 @@ def decode_fwd(
         hca_extra_layer = ordinal % FWD_HCA_WEIGHT_BANK_SIZE
 
         with pl.scope():
-            hc_attn_fn_layer_csa = pl.slice(
-                hc_attn_fn,
-                [MIX_HC, HC_DIM],
-                [csa_weight_layer * HC_FN_STORAGE_ROWS, 0],
-            )
-            hc_ffn_fn_layer_csa = pl.slice(
-                hc_ffn_fn,
-                [MIX_HC, HC_DIM],
-                [csa_weight_layer * HC_FN_STORAGE_ROWS, 0],
-            )
-            wq_a_layer_csa: pl.Tensor[[D, Q_LORA], pl.BF16] = pl.slice(
-                wq_a, [D, Q_LORA], [csa_weight_layer * D, 0]
-            )
-            wq_b_layer_csa: pl.Tensor[
-                [Q_LORA, H * HEAD_DIM], pl.INT8
-            ] = pl.slice(
-                wq_b,
-                [Q_LORA, H * HEAD_DIM],
-                [csa_weight_layer * Q_LORA, 0],
-            )
-            wq_b_scale_layer_csa: pl.Tensor[
-                [H * HEAD_DIM], pl.FP32
-            ] = pl.slice(
-                wq_b_scale,
-                [H * HEAD_DIM],
-                [csa_weight_layer * H * HEAD_DIM],
-            )
-            wkv_layer_csa: pl.Tensor[[D, HEAD_DIM], pl.BF16] = pl.slice(
-                wkv, [D, HEAD_DIM], [csa_weight_layer * D, 0]
-            )
-            gamma_cq_layer_csa: pl.Tensor[[Q_LORA], pl.BF16] = pl.slice(
-                gamma_cq, [Q_LORA], [csa_weight_layer * Q_LORA]
-            )
-            gamma_ckv_layer_csa: pl.Tensor[[HEAD_DIM], pl.BF16] = pl.slice(
-                gamma_ckv, [HEAD_DIM], [csa_weight_layer * HEAD_DIM]
-            )
-            wo_a_layer_csa: pl.Tensor[
-                [LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16
-            ] = pl.slice(
-                wo_a,
-                [LOCAL_O_GROUPS, O_LORA, O_GROUP_IN],
-                [csa_weight_layer * LOCAL_O_GROUPS, 0, 0],
-            )
-            routed_w1_layer_csa: pl.Tensor[
-                [N_LOCAL, MOE_INTER, D], pl.INT8
-            ] = pl.slice(
-                routed_w1,
-                [N_LOCAL, MOE_INTER, D],
-                [csa_weight_layer * N_LOCAL, 0, 0],
-            )
-            routed_w3_layer_csa: pl.Tensor[
-                [N_LOCAL, MOE_INTER, D], pl.INT8
-            ] = pl.slice(
-                routed_w3,
-                [N_LOCAL, MOE_INTER, D],
-                [csa_weight_layer * N_LOCAL, 0, 0],
-            )
-            routed_w2_layer_csa: pl.Tensor[
-                [N_LOCAL, D, MOE_INTER], pl.INT8
-            ] = pl.slice(
-                routed_w2,
-                [N_LOCAL, D, MOE_INTER],
-                [csa_weight_layer * N_LOCAL, 0, 0],
-            )
-            raw_kv_layer_csa = pl.slice(
-                raw_kv_pool,
-                [raw_blocks_per_layer, BLOCK_SIZE, 1, HEAD_DIM],
-                [csa_model_layer * raw_blocks_per_layer, 0, 0, 0],
-            )
-            csa_state_layer_csa = pl.slice(
-                csa_compress_state,
-                [
-                    csa_state_blocks_per_layer,
-                    CSA_MAIN_STATE_BLOCK_SIZE,
-                    CSA_MAIN_STATE_DIM,
-                ],
-                [ordinal * csa_state_blocks_per_layer, 0, 0],
-            )
-            csa_cmp_kv_layer_csa = pl.slice(
-                csa_cmp_kv,
-                [csa_cmp_blocks_per_layer, BLOCK_SIZE, 1, HEAD_DIM],
-                [ordinal * csa_cmp_blocks_per_layer, 0, 0, 0],
-            )
-            csa_inner_state_layer_csa = pl.slice(
-                csa_inner_compress_state,
-                [
-                    csa_inner_state_blocks_per_layer,
-                    CSA_INNER_STATE_BLOCK_SIZE,
-                    CSA_INNER_STATE_DIM,
-                ],
-                [ordinal * csa_inner_state_blocks_per_layer, 0, 0],
-            )
-            csa_idx_cache_layer_csa = pl.slice(
-                csa_idx_kv_cache,
-                [
-                    csa_idx_blocks_per_layer,
-                    BLOCK_SIZE,
-                    1,
-                    CSA_IDX_HEAD_DIM,
-                ],
-                [ordinal * csa_idx_blocks_per_layer, 0, 0, 0],
-            )
-            csa_idx_scale_layer_csa = pl.slice(
-                csa_idx_kv_scale,
-                [csa_idx_blocks_per_layer, BLOCK_SIZE, 1, 1],
-                [ordinal * csa_idx_blocks_per_layer, 0, 0, 0],
-            )
-            hc_attn_scale_layer_csa = pl.slice(
-                hc_attn_scale, [3], [csa_weight_layer * 3]
-            )
-            hc_attn_base_layer_csa = pl.slice(
-                hc_attn_base, [MIX_HC], [csa_weight_layer * MIX_HC]
-            )
-            attn_norm_w_layer_csa = pl.slice(
-                attn_norm_w, [D], [csa_weight_layer * D]
-            )
-            csa_cmp_wkv_layer_csa = pl.slice(
-                csa_cmp_wkv,
-                [CSA_MAIN_OUT_DIM, D],
-                [csa_extra_layer * CSA_MAIN_OUT_DIM, 0],
-            )
-            csa_cmp_wgate_layer_csa = pl.slice(
-                csa_cmp_wgate,
-                [CSA_MAIN_OUT_DIM, D],
-                [csa_extra_layer * CSA_MAIN_OUT_DIM, 0],
-            )
-            csa_cmp_ape_layer_csa = pl.slice(
-                csa_cmp_ape,
-                [CSA_COMPRESS_RATIO, CSA_MAIN_OUT_DIM],
-                [csa_extra_layer * CSA_COMPRESS_RATIO, 0],
-            )
-            csa_cmp_norm_w_layer_csa = pl.slice(
-                csa_cmp_norm_w,
-                [HEAD_DIM],
-                [csa_extra_layer * HEAD_DIM],
-            )
-            csa_idx_wq_b_layer_csa = pl.slice(
-                csa_idx_wq_b,
-                [Q_LORA, CSA_IDX_N_HEADS * CSA_IDX_HEAD_DIM],
-                [csa_extra_layer * Q_LORA, 0],
-            )
-            csa_idx_wq_b_scale_layer_csa = pl.slice(
-                csa_idx_wq_b_scale,
-                [CSA_IDX_N_HEADS * CSA_IDX_HEAD_DIM],
-                [csa_extra_layer * CSA_IDX_N_HEADS * CSA_IDX_HEAD_DIM],
-            )
-            csa_weights_proj_layer_csa = pl.slice(
-                csa_weights_proj,
-                [D, CSA_IDX_N_HEADS],
-                [csa_extra_layer * D, 0],
-            )
-            csa_hadamard_idx_layer_csa = pl.slice(
-                csa_hadamard_idx,
-                [CSA_IDX_HEAD_DIM, CSA_IDX_HEAD_DIM],
-                [csa_extra_layer * CSA_IDX_HEAD_DIM, 0],
-            )
-            csa_inner_wkv_layer_csa = pl.slice(
-                csa_inner_wkv,
-                [CSA_INNER_OUT_DIM, D],
-                [csa_extra_layer * CSA_INNER_OUT_DIM, 0],
-            )
-            csa_inner_wgate_layer_csa = pl.slice(
-                csa_inner_wgate,
-                [CSA_INNER_OUT_DIM, D],
-                [csa_extra_layer * CSA_INNER_OUT_DIM, 0],
-            )
-            csa_inner_ape_layer_csa = pl.slice(
-                csa_inner_ape,
-                [CSA_COMPRESS_RATIO, CSA_INNER_OUT_DIM],
-                [csa_extra_layer * CSA_COMPRESS_RATIO, 0],
-            )
-            csa_inner_norm_w_layer_csa = pl.slice(
-                csa_inner_norm_w,
-                [CSA_IDX_HEAD_DIM],
-                [csa_extra_layer * CSA_IDX_HEAD_DIM],
-            )
-            attn_sink_layer_csa = pl.slice(
-                attn_sink, [H], [csa_weight_layer * H]
-            )
-            wo_b_layer_csa = pl.slice(
-                wo_b, [D, LOCAL_O_WIDTH], [csa_weight_layer * D, 0]
-            )
-            wo_b_scale_layer_csa = pl.slice(
-                wo_b_scale, [D], [csa_weight_layer * D]
-            )
-            hc_ffn_scale_layer_csa = pl.slice(
-                hc_ffn_scale, [3], [csa_weight_layer * 3]
-            )
-            hc_ffn_base_layer_csa = pl.slice(
-                hc_ffn_base, [MIX_HC], [csa_weight_layer * MIX_HC]
-            )
+            hc_attn_fn_layer_csa = pl.slice(hc_attn_fn, [MIX_HC, HC_DIM], [csa_weight_layer * HC_FN_STORAGE_ROWS, 0])
+            hc_ffn_fn_layer_csa = pl.slice(hc_ffn_fn, [MIX_HC, HC_DIM], [csa_weight_layer * HC_FN_STORAGE_ROWS, 0])
+            wq_a_layer_csa: pl.Tensor[[D, Q_LORA], pl.BF16] = pl.slice(wq_a, [D, Q_LORA], [csa_weight_layer * D, 0])
+            wq_b_layer_csa: pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8] = pl.slice(wq_b, [Q_LORA, H * HEAD_DIM], [csa_weight_layer * Q_LORA, 0])
+            wq_b_scale_layer_csa: pl.Tensor[[H * HEAD_DIM], pl.FP32] = pl.slice(wq_b_scale, [H * HEAD_DIM], [csa_weight_layer * H * HEAD_DIM])
+            wkv_layer_csa: pl.Tensor[[D, HEAD_DIM], pl.BF16] = pl.slice(wkv, [D, HEAD_DIM], [csa_weight_layer * D, 0])
+            gamma_cq_layer_csa: pl.Tensor[[Q_LORA], pl.BF16] = pl.slice(gamma_cq, [Q_LORA], [csa_weight_layer * Q_LORA])
+            gamma_ckv_layer_csa: pl.Tensor[[HEAD_DIM], pl.BF16] = pl.slice(gamma_ckv, [HEAD_DIM], [csa_weight_layer * HEAD_DIM])
+            wo_a_layer_csa: pl.Tensor[[LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16] = pl.slice(wo_a, [LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], [csa_weight_layer * LOCAL_O_GROUPS, 0, 0])
+            routed_w1_layer_csa: pl.Tensor[[N_LOCAL, MOE_INTER, D], pl.INT8] = pl.slice(routed_w1, [N_LOCAL, MOE_INTER, D], [csa_weight_layer * N_LOCAL, 0, 0])
+            routed_w3_layer_csa: pl.Tensor[[N_LOCAL, MOE_INTER, D], pl.INT8] = pl.slice(routed_w3, [N_LOCAL, MOE_INTER, D], [csa_weight_layer * N_LOCAL, 0, 0])
+            routed_w2_layer_csa: pl.Tensor[[N_LOCAL, D, MOE_INTER], pl.INT8] = pl.slice(routed_w2, [N_LOCAL, D, MOE_INTER], [csa_weight_layer * N_LOCAL, 0, 0])
+            raw_kv_layer_csa = pl.slice(raw_kv_pool, [raw_blocks_per_layer, BLOCK_SIZE, 1, HEAD_DIM], [csa_model_layer * raw_blocks_per_layer, 0, 0, 0])
+            csa_state_layer_csa = pl.slice(csa_compress_state, [csa_state_blocks_per_layer, CSA_MAIN_STATE_BLOCK_SIZE, CSA_MAIN_STATE_DIM], [ordinal * csa_state_blocks_per_layer, 0, 0])
+            csa_cmp_kv_layer_csa = pl.slice(csa_cmp_kv, [csa_cmp_blocks_per_layer, BLOCK_SIZE, 1, HEAD_DIM], [ordinal * csa_cmp_blocks_per_layer, 0, 0, 0])
+            csa_inner_state_layer_csa = pl.slice(csa_inner_compress_state, [csa_inner_state_blocks_per_layer, CSA_INNER_STATE_BLOCK_SIZE, CSA_INNER_STATE_DIM], [ordinal * csa_inner_state_blocks_per_layer, 0, 0])
+            csa_idx_cache_layer_csa = pl.slice(csa_idx_kv_cache, [csa_idx_blocks_per_layer, BLOCK_SIZE, 1, CSA_IDX_HEAD_DIM], [ordinal * csa_idx_blocks_per_layer, 0, 0, 0])
+            csa_idx_scale_layer_csa = pl.slice(csa_idx_kv_scale, [csa_idx_blocks_per_layer, BLOCK_SIZE, 1, 1], [ordinal * csa_idx_blocks_per_layer, 0, 0, 0])
+            hc_attn_scale_layer_csa = pl.slice(hc_attn_scale, [3], [csa_weight_layer * 3])
+            hc_attn_base_layer_csa = pl.slice(hc_attn_base, [MIX_HC], [csa_weight_layer * MIX_HC])
+            attn_norm_w_layer_csa = pl.slice(attn_norm_w, [D], [csa_weight_layer * D])
+            csa_cmp_wkv_layer_csa = pl.slice(csa_cmp_wkv, [CSA_MAIN_OUT_DIM, D], [csa_extra_layer * CSA_MAIN_OUT_DIM, 0])
+            csa_cmp_wgate_layer_csa = pl.slice(csa_cmp_wgate, [CSA_MAIN_OUT_DIM, D], [csa_extra_layer * CSA_MAIN_OUT_DIM, 0])
+            csa_cmp_ape_layer_csa = pl.slice(csa_cmp_ape, [CSA_COMPRESS_RATIO, CSA_MAIN_OUT_DIM], [csa_extra_layer * CSA_COMPRESS_RATIO, 0])
+            csa_cmp_norm_w_layer_csa = pl.slice(csa_cmp_norm_w, [HEAD_DIM], [csa_extra_layer * HEAD_DIM])
+            csa_idx_wq_b_layer_csa = pl.slice(csa_idx_wq_b, [Q_LORA, CSA_IDX_N_HEADS * CSA_IDX_HEAD_DIM], [csa_extra_layer * Q_LORA, 0])
+            csa_idx_wq_b_scale_layer_csa = pl.slice(csa_idx_wq_b_scale, [CSA_IDX_N_HEADS * CSA_IDX_HEAD_DIM], [csa_extra_layer * CSA_IDX_N_HEADS * CSA_IDX_HEAD_DIM])
+            csa_weights_proj_layer_csa = pl.slice(csa_weights_proj, [D, CSA_IDX_N_HEADS], [csa_extra_layer * D, 0])
+            csa_hadamard_idx_layer_csa = pl.slice(csa_hadamard_idx, [CSA_IDX_HEAD_DIM, CSA_IDX_HEAD_DIM], [csa_extra_layer * CSA_IDX_HEAD_DIM, 0])
+            csa_inner_wkv_layer_csa = pl.slice(csa_inner_wkv, [CSA_INNER_OUT_DIM, D], [csa_extra_layer * CSA_INNER_OUT_DIM, 0])
+            csa_inner_wgate_layer_csa = pl.slice(csa_inner_wgate, [CSA_INNER_OUT_DIM, D], [csa_extra_layer * CSA_INNER_OUT_DIM, 0])
+            csa_inner_ape_layer_csa = pl.slice(csa_inner_ape, [CSA_COMPRESS_RATIO, CSA_INNER_OUT_DIM], [csa_extra_layer * CSA_COMPRESS_RATIO, 0])
+            csa_inner_norm_w_layer_csa = pl.slice(csa_inner_norm_w, [CSA_IDX_HEAD_DIM], [csa_extra_layer * CSA_IDX_HEAD_DIM])
+            attn_sink_layer_csa = pl.slice(attn_sink, [H], [csa_weight_layer * H])
+            wo_b_layer_csa = pl.slice(wo_b, [D, LOCAL_O_WIDTH], [csa_weight_layer * D, 0])
+            wo_b_scale_layer_csa = pl.slice(wo_b_scale, [D], [csa_weight_layer * D])
+            hc_ffn_scale_layer_csa = pl.slice(hc_ffn_scale, [3], [csa_weight_layer * 3])
+            hc_ffn_base_layer_csa = pl.slice(hc_ffn_base, [MIX_HC], [csa_weight_layer * MIX_HC])
             norm_w_layer_csa = pl.slice(norm_w, [D], [csa_weight_layer * D])
-            gate_w_layer_csa = pl.slice(
-                gate_w,
-                [N_EXPERTS_GLOBAL, D],
-                [csa_weight_layer * N_EXPERTS_GLOBAL, 0],
-            )
-            gate_bias_layer_csa = pl.slice(
-                gate_bias,
-                [N_EXPERTS_GLOBAL],
-                [csa_weight_layer * N_EXPERTS_GLOBAL],
-            )
-            tid2eid_layer_csa = pl.slice(
-                tid2eid, [VOCAB, TOPK], [csa_weight_layer * VOCAB, 0]
-            )
-            routed_w1_scale_layer_csa = pl.slice(
-                routed_w1_scale,
-                [N_LOCAL, MOE_INTER],
-                [csa_weight_layer * N_LOCAL, 0],
-            )
-            routed_w3_scale_layer_csa = pl.slice(
-                routed_w3_scale,
-                [N_LOCAL, MOE_INTER],
-                [csa_weight_layer * N_LOCAL, 0],
-            )
-            routed_w2_scale_layer_csa = pl.slice(
-                routed_w2_scale,
-                [N_LOCAL, D],
-                [csa_weight_layer * N_LOCAL, 0],
-            )
-            shared_w1_layer_csa = pl.slice(
-                shared_w1,
-                [MOE_INTER, D],
-                [csa_weight_layer * MOE_INTER, 0],
-            )
-            shared_w1_scale_layer_csa = pl.slice(
-                shared_w1_scale,
-                [MOE_INTER],
-                [csa_weight_layer * MOE_INTER],
-            )
-            shared_w3_layer_csa = pl.slice(
-                shared_w3,
-                [MOE_INTER, D],
-                [csa_weight_layer * MOE_INTER, 0],
-            )
-            shared_w3_scale_layer_csa = pl.slice(
-                shared_w3_scale,
-                [MOE_INTER],
-                [csa_weight_layer * MOE_INTER],
-            )
-            shared_w2_layer_csa = pl.slice(
-                shared_w2, [D, MOE_INTER], [csa_weight_layer * D, 0]
-            )
-            shared_w2_scale_layer_csa = pl.slice(
-                shared_w2_scale, [D], [csa_weight_layer * D]
-            )
-            decode_layer_csa(
-                x_ping,
-                hc_attn_fn_layer_csa, hc_attn_scale_layer_csa,
-                hc_attn_base_layer_csa, attn_norm_w_layer_csa,
-                wq_a_layer_csa, wq_b_layer_csa, wq_b_scale_layer_csa, wkv_layer_csa,
-                gamma_cq_layer_csa, gamma_ckv_layer_csa,
-                freqs_cos, freqs_sin,
-                csa_cmp_freqs_cos, csa_cmp_freqs_sin,
-                csa_cmp_wkv_layer_csa, csa_cmp_wgate_layer_csa,
-                csa_cmp_ape_layer_csa, csa_cmp_norm_w_layer_csa,
-                csa_state_layer_csa, csa_compress_state_block_table,
-                csa_idx_wq_b_layer_csa, csa_idx_wq_b_scale_layer_csa,
-                csa_weights_proj_layer_csa, csa_hadamard_idx_layer_csa,
-                csa_inner_wkv_layer_csa, csa_inner_wgate_layer_csa,
-                csa_inner_ape_layer_csa, csa_inner_norm_w_layer_csa,
-                csa_inner_state_layer_csa,
-                csa_inner_compress_state_block_table,
-                raw_kv_layer_csa, csa_cmp_kv_layer_csa, csa_cmp_block_table,
-                csa_idx_cache_layer_csa, csa_idx_scale_layer_csa,
-                csa_idx_block_table,
-                csa_ori_slot_mapping, csa_window_swa_indices,
-                csa_window_swa_lens, csa_cmp_slot_mapping,
-                csa_idx_slot_mapping, csa_state_slot_mapping,
-                csa_inner_state_slot_mapping, position_ids,
-                csa_kv_seq_lens, attn_sink_layer_csa,
-                wo_a_layer_csa, wo_b_layer_csa, wo_b_scale_layer_csa,
-                hc_ffn_fn_layer_csa, hc_ffn_scale_layer_csa,
-                hc_ffn_base_layer_csa, norm_w_layer_csa,
-                gate_w_layer_csa, gate_bias_layer_csa, tid2eid_layer_csa, moe_input_ids,
-                routed_w1_layer_csa, routed_w1_scale_layer_csa,
-                routed_w3_layer_csa, routed_w3_scale_layer_csa,
-                routed_w2_layer_csa, routed_w2_scale_layer_csa,
-                shared_w1_layer_csa, shared_w1_scale_layer_csa,
-                shared_w3_layer_csa, shared_w3_scale_layer_csa,
-                shared_w2_layer_csa, shared_w2_scale_layer_csa,
-                x_attn_active, x_moe_next, x_pong,
-                attention_window, attention_signal, o_window, o_signal,
-                recv_meta, recv_x, recv_aux, recv_route,
-                arrived, data_arrived, routed_y_buf, combine_arrived,
-                csa_model_layer, group_base, tp_rank, local_t, my_rank,
-                csa_model_layer + 1,
-            )
+            gate_w_layer_csa = pl.slice(gate_w, [N_EXPERTS_GLOBAL, D], [csa_weight_layer * N_EXPERTS_GLOBAL, 0])
+            gate_bias_layer_csa = pl.slice(gate_bias, [N_EXPERTS_GLOBAL], [csa_weight_layer * N_EXPERTS_GLOBAL])
+            tid2eid_layer_csa = pl.slice(tid2eid, [VOCAB, TOPK], [csa_weight_layer * VOCAB, 0])
+            routed_w1_scale_layer_csa = pl.slice(routed_w1_scale, [N_LOCAL, MOE_INTER], [csa_weight_layer * N_LOCAL, 0])
+            routed_w3_scale_layer_csa = pl.slice(routed_w3_scale, [N_LOCAL, MOE_INTER], [csa_weight_layer * N_LOCAL, 0])
+            routed_w2_scale_layer_csa = pl.slice(routed_w2_scale, [N_LOCAL, D], [csa_weight_layer * N_LOCAL, 0])
+            shared_w1_layer_csa = pl.slice(shared_w1, [MOE_INTER, D], [csa_weight_layer * MOE_INTER, 0])
+            shared_w1_scale_layer_csa = pl.slice(shared_w1_scale, [MOE_INTER], [csa_weight_layer * MOE_INTER])
+            shared_w3_layer_csa = pl.slice(shared_w3, [MOE_INTER, D], [csa_weight_layer * MOE_INTER, 0])
+            shared_w3_scale_layer_csa = pl.slice(shared_w3_scale, [MOE_INTER], [csa_weight_layer * MOE_INTER])
+            shared_w2_layer_csa = pl.slice(shared_w2, [D, MOE_INTER], [csa_weight_layer * D, 0])
+            shared_w2_scale_layer_csa = pl.slice(shared_w2_scale, [D], [csa_weight_layer * D])
+            with pl.scope():
+                if TP_SIZE == 1:
+                    decode_csa_tp1(
+                        x_ping,
+                        hc_attn_fn_layer_csa, hc_attn_scale_layer_csa, hc_attn_base_layer_csa,
+                        attn_norm_w_layer_csa, wq_a_layer_csa, wq_b_layer_csa, wq_b_scale_layer_csa,
+                        wkv_layer_csa, gamma_cq_layer_csa, gamma_ckv_layer_csa,
+                        freqs_cos, freqs_sin, csa_cmp_freqs_cos, csa_cmp_freqs_sin,
+                        csa_cmp_wkv_layer_csa, csa_cmp_wgate_layer_csa,
+                        csa_cmp_ape_layer_csa, csa_cmp_norm_w_layer_csa,
+                        csa_state_layer_csa, csa_compress_state_block_table,
+                        csa_idx_wq_b_layer_csa, csa_idx_wq_b_scale_layer_csa,
+                        csa_weights_proj_layer_csa, csa_hadamard_idx_layer_csa,
+                        csa_inner_wkv_layer_csa, csa_inner_wgate_layer_csa,
+                        csa_inner_ape_layer_csa, csa_inner_norm_w_layer_csa,
+                        csa_inner_state_layer_csa, csa_inner_compress_state_block_table,
+                        raw_kv_layer_csa, csa_cmp_kv_layer_csa, csa_cmp_block_table,
+                        csa_idx_cache_layer_csa, csa_idx_scale_layer_csa, csa_idx_block_table,
+                        csa_ori_slot_mapping, csa_window_swa_indices, csa_window_swa_lens,
+                        csa_cmp_slot_mapping, csa_idx_slot_mapping,
+                        csa_state_slot_mapping, csa_inner_state_slot_mapping,
+                        position_ids, csa_kv_seq_lens,
+                        attn_sink_layer_csa, wo_a_layer_csa, wo_b_layer_csa, wo_b_scale_layer_csa,
+                        x_attn_active,
+                    )
+                else:
+                    decode_csa(
+                        x_ping,
+                        hc_attn_fn_layer_csa, hc_attn_scale_layer_csa, hc_attn_base_layer_csa,
+                        attn_norm_w_layer_csa, wq_a_layer_csa, wq_b_layer_csa, wq_b_scale_layer_csa,
+                        wkv_layer_csa, gamma_cq_layer_csa, gamma_ckv_layer_csa,
+                        freqs_cos, freqs_sin, csa_cmp_freqs_cos, csa_cmp_freqs_sin,
+                        csa_cmp_wkv_layer_csa, csa_cmp_wgate_layer_csa,
+                        csa_cmp_ape_layer_csa, csa_cmp_norm_w_layer_csa,
+                        csa_state_layer_csa, csa_compress_state_block_table,
+                        csa_idx_wq_b_layer_csa, csa_idx_wq_b_scale_layer_csa,
+                        csa_weights_proj_layer_csa, csa_hadamard_idx_layer_csa,
+                        csa_inner_wkv_layer_csa, csa_inner_wgate_layer_csa,
+                        csa_inner_ape_layer_csa, csa_inner_norm_w_layer_csa,
+                        csa_inner_state_layer_csa, csa_inner_compress_state_block_table,
+                        raw_kv_layer_csa, csa_cmp_kv_layer_csa, csa_cmp_block_table,
+                        csa_idx_cache_layer_csa, csa_idx_scale_layer_csa, csa_idx_block_table,
+                        csa_ori_slot_mapping, csa_window_swa_indices, csa_window_swa_lens,
+                        csa_cmp_slot_mapping, csa_idx_slot_mapping,
+                        csa_state_slot_mapping, csa_inner_state_slot_mapping,
+                        position_ids, csa_kv_seq_lens,
+                        attn_sink_layer_csa, wo_a_layer_csa, wo_b_layer_csa, wo_b_scale_layer_csa,
+                        x_attn_active,
+                        attention_window, attention_signal, o_window, o_signal,
+                        group_base, tp_rank, local_t,
+                    )
+
+            with pl.scope():
+                x_attn_moe_csa = pl.create_tensor([MOE_TOKENS, HC_MULT, D], dtype=pl.FP32)
+                for token in pl.spmd(MOE_TOKENS, name_hint="decode_fwd_csa_attn_pack"):
+                    if token < local_t:
+                        x_attn_moe_csa[token : token + 1, 0 : HC_MULT, 0 : D] = x_attn_active[
+                            token : token + 1, 0 : HC_MULT, 0 : D
+                        ]
+                    else:
+                        zero_moe_row_csa = pl.full([1, HC_MULT, D], dtype=pl.FP32, value=0.0)
+                        x_attn_moe_csa[token : token + 1, 0 : HC_MULT, 0 : D] = zero_moe_row_csa
+                moe(
+                    x_attn_moe_csa,
+                    hc_ffn_fn_layer_csa, hc_ffn_scale_layer_csa, hc_ffn_base_layer_csa,
+                    norm_w_layer_csa, gate_w_layer_csa, gate_bias_layer_csa, tid2eid_layer_csa,
+                    moe_input_ids,
+                    routed_w1_layer_csa, routed_w1_scale_layer_csa,
+                    routed_w3_layer_csa, routed_w3_scale_layer_csa,
+                    routed_w2_layer_csa, routed_w2_scale_layer_csa,
+                    shared_w1_layer_csa, shared_w1_scale_layer_csa,
+                    shared_w3_layer_csa, shared_w3_scale_layer_csa,
+                    shared_w2_layer_csa, shared_w2_scale_layer_csa,
+                    x_moe_next,
+                    recv_meta, recv_x, recv_aux, recv_route, arrived, data_arrived,
+                    routed_y_buf, combine_arrived,
+                    csa_model_layer, local_t, my_rank, csa_model_layer + 1,
+                )
+                for token in pl.spmd(MOE_TOKENS, name_hint="decode_fwd_csa_active_trim"):
+                    if token < local_t:
+                        x_pong[token : token + 1, 0 : HC_MULT, 0 : D] = x_moe_next[
+                            token : token + 1, 0 : HC_MULT, 0 : D
+                        ]
 
         with pl.scope():
-            hc_attn_fn_layer_hca = pl.slice(
-                hc_attn_fn,
-                [MIX_HC, HC_DIM],
-                [hca_weight_layer * HC_FN_STORAGE_ROWS, 0],
-            )
-            hc_ffn_fn_layer_hca = pl.slice(
-                hc_ffn_fn,
-                [MIX_HC, HC_DIM],
-                [hca_weight_layer * HC_FN_STORAGE_ROWS, 0],
-            )
-            wq_a_layer_hca: pl.Tensor[[D, Q_LORA], pl.BF16] = pl.slice(
-                wq_a, [D, Q_LORA], [hca_weight_layer * D, 0]
-            )
-            wq_b_layer_hca: pl.Tensor[
-                [Q_LORA, H * HEAD_DIM], pl.INT8
-            ] = pl.slice(
-                wq_b,
-                [Q_LORA, H * HEAD_DIM],
-                [hca_weight_layer * Q_LORA, 0],
-            )
-            wq_b_scale_layer_hca: pl.Tensor[
-                [H * HEAD_DIM], pl.FP32
-            ] = pl.slice(
-                wq_b_scale,
-                [H * HEAD_DIM],
-                [hca_weight_layer * H * HEAD_DIM],
-            )
-            wkv_layer_hca: pl.Tensor[[D, HEAD_DIM], pl.BF16] = pl.slice(
-                wkv, [D, HEAD_DIM], [hca_weight_layer * D, 0]
-            )
-            gamma_cq_layer_hca: pl.Tensor[[Q_LORA], pl.BF16] = pl.slice(
-                gamma_cq, [Q_LORA], [hca_weight_layer * Q_LORA]
-            )
-            gamma_ckv_layer_hca: pl.Tensor[[HEAD_DIM], pl.BF16] = pl.slice(
-                gamma_ckv, [HEAD_DIM], [hca_weight_layer * HEAD_DIM]
-            )
-            wo_a_layer_hca: pl.Tensor[
-                [LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16
-            ] = pl.slice(
-                wo_a,
-                [LOCAL_O_GROUPS, O_LORA, O_GROUP_IN],
-                [hca_weight_layer * LOCAL_O_GROUPS, 0, 0],
-            )
-            routed_w1_layer_hca: pl.Tensor[
-                [N_LOCAL, MOE_INTER, D], pl.INT8
-            ] = pl.slice(
-                routed_w1,
-                [N_LOCAL, MOE_INTER, D],
-                [hca_weight_layer * N_LOCAL, 0, 0],
-            )
-            routed_w3_layer_hca: pl.Tensor[
-                [N_LOCAL, MOE_INTER, D], pl.INT8
-            ] = pl.slice(
-                routed_w3,
-                [N_LOCAL, MOE_INTER, D],
-                [hca_weight_layer * N_LOCAL, 0, 0],
-            )
-            routed_w2_layer_hca: pl.Tensor[
-                [N_LOCAL, D, MOE_INTER], pl.INT8
-            ] = pl.slice(
-                routed_w2,
-                [N_LOCAL, D, MOE_INTER],
-                [hca_weight_layer * N_LOCAL, 0, 0],
-            )
-            raw_kv_layer_hca = pl.slice(
-                raw_kv_pool,
-                [raw_blocks_per_layer, BLOCK_SIZE, 1, HEAD_DIM],
-                [hca_model_layer * raw_blocks_per_layer, 0, 0, 0],
-            )
-            hca_state_layer_hca = pl.slice(
-                hca_compress_state,
-                [
-                    hca_state_blocks_per_layer,
-                    HCA_COMPRESS_STATE_BLOCK_SIZE,
-                    HCA_COMPRESS_STATE_DIM,
-                ],
-                [ordinal * hca_state_blocks_per_layer, 0, 0],
-            )
-            hca_cmp_kv_layer_hca = pl.slice(
-                hca_cmp_kv,
-                [hca_cmp_blocks_per_layer, BLOCK_SIZE, 1, HEAD_DIM],
-                [ordinal * hca_cmp_blocks_per_layer, 0, 0, 0],
-            )
-            hc_attn_scale_layer_hca = pl.slice(
-                hc_attn_scale, [3], [hca_weight_layer * 3]
-            )
-            hc_attn_base_layer_hca = pl.slice(
-                hc_attn_base, [MIX_HC], [hca_weight_layer * MIX_HC]
-            )
-            attn_norm_w_layer_hca = pl.slice(
-                attn_norm_w, [D], [hca_weight_layer * D]
-            )
-            hca_cmp_wkv_layer_hca = pl.slice(
-                hca_cmp_wkv,
-                [HCA_MAIN_OUT_DIM, D],
-                [hca_extra_layer * HCA_MAIN_OUT_DIM, 0],
-            )
-            hca_cmp_wgate_layer_hca = pl.slice(
-                hca_cmp_wgate,
-                [HCA_MAIN_OUT_DIM, D],
-                [hca_extra_layer * HCA_MAIN_OUT_DIM, 0],
-            )
-            hca_cmp_ape_layer_hca = pl.slice(
-                hca_cmp_ape,
-                [HCA_COMPRESS_RATIO, HCA_MAIN_OUT_DIM],
-                [hca_extra_layer * HCA_COMPRESS_RATIO, 0],
-            )
-            hca_cmp_norm_w_layer_hca = pl.slice(
-                hca_cmp_norm_w,
-                [HEAD_DIM],
-                [hca_extra_layer * HEAD_DIM],
-            )
-            attn_sink_layer_hca = pl.slice(
-                attn_sink, [H], [hca_weight_layer * H]
-            )
-            wo_b_layer_hca = pl.slice(
-                wo_b, [D, LOCAL_O_WIDTH], [hca_weight_layer * D, 0]
-            )
-            wo_b_scale_layer_hca = pl.slice(
-                wo_b_scale, [D], [hca_weight_layer * D]
-            )
-            hc_ffn_scale_layer_hca = pl.slice(
-                hc_ffn_scale, [3], [hca_weight_layer * 3]
-            )
-            hc_ffn_base_layer_hca = pl.slice(
-                hc_ffn_base, [MIX_HC], [hca_weight_layer * MIX_HC]
-            )
+            hc_attn_fn_layer_hca = pl.slice(hc_attn_fn, [MIX_HC, HC_DIM], [hca_weight_layer * HC_FN_STORAGE_ROWS, 0])
+            hc_ffn_fn_layer_hca = pl.slice(hc_ffn_fn, [MIX_HC, HC_DIM], [hca_weight_layer * HC_FN_STORAGE_ROWS, 0])
+            wq_a_layer_hca: pl.Tensor[[D, Q_LORA], pl.BF16] = pl.slice(wq_a, [D, Q_LORA], [hca_weight_layer * D, 0])
+            wq_b_layer_hca: pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8] = pl.slice(wq_b, [Q_LORA, H * HEAD_DIM], [hca_weight_layer * Q_LORA, 0])
+            wq_b_scale_layer_hca: pl.Tensor[[H * HEAD_DIM], pl.FP32] = pl.slice(wq_b_scale, [H * HEAD_DIM], [hca_weight_layer * H * HEAD_DIM])
+            wkv_layer_hca: pl.Tensor[[D, HEAD_DIM], pl.BF16] = pl.slice(wkv, [D, HEAD_DIM], [hca_weight_layer * D, 0])
+            gamma_cq_layer_hca: pl.Tensor[[Q_LORA], pl.BF16] = pl.slice(gamma_cq, [Q_LORA], [hca_weight_layer * Q_LORA])
+            gamma_ckv_layer_hca: pl.Tensor[[HEAD_DIM], pl.BF16] = pl.slice(gamma_ckv, [HEAD_DIM], [hca_weight_layer * HEAD_DIM])
+            wo_a_layer_hca: pl.Tensor[[LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16] = pl.slice(wo_a, [LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], [hca_weight_layer * LOCAL_O_GROUPS, 0, 0])
+            routed_w1_layer_hca: pl.Tensor[[N_LOCAL, MOE_INTER, D], pl.INT8] = pl.slice(routed_w1, [N_LOCAL, MOE_INTER, D], [hca_weight_layer * N_LOCAL, 0, 0])
+            routed_w3_layer_hca: pl.Tensor[[N_LOCAL, MOE_INTER, D], pl.INT8] = pl.slice(routed_w3, [N_LOCAL, MOE_INTER, D], [hca_weight_layer * N_LOCAL, 0, 0])
+            routed_w2_layer_hca: pl.Tensor[[N_LOCAL, D, MOE_INTER], pl.INT8] = pl.slice(routed_w2, [N_LOCAL, D, MOE_INTER], [hca_weight_layer * N_LOCAL, 0, 0])
+            raw_kv_layer_hca = pl.slice(raw_kv_pool, [raw_blocks_per_layer, BLOCK_SIZE, 1, HEAD_DIM], [hca_model_layer * raw_blocks_per_layer, 0, 0, 0])
+            hca_state_layer_hca = pl.slice(hca_compress_state, [hca_state_blocks_per_layer, HCA_COMPRESS_STATE_BLOCK_SIZE, HCA_COMPRESS_STATE_DIM], [ordinal * hca_state_blocks_per_layer, 0, 0])
+            hca_cmp_kv_layer_hca = pl.slice(hca_cmp_kv, [hca_cmp_blocks_per_layer, BLOCK_SIZE, 1, HEAD_DIM], [ordinal * hca_cmp_blocks_per_layer, 0, 0, 0])
+            hc_attn_scale_layer_hca = pl.slice(hc_attn_scale, [3], [hca_weight_layer * 3])
+            hc_attn_base_layer_hca = pl.slice(hc_attn_base, [MIX_HC], [hca_weight_layer * MIX_HC])
+            attn_norm_w_layer_hca = pl.slice(attn_norm_w, [D], [hca_weight_layer * D])
+            hca_cmp_wkv_layer_hca = pl.slice(hca_cmp_wkv, [HCA_MAIN_OUT_DIM, D], [hca_extra_layer * HCA_MAIN_OUT_DIM, 0])
+            hca_cmp_wgate_layer_hca = pl.slice(hca_cmp_wgate, [HCA_MAIN_OUT_DIM, D], [hca_extra_layer * HCA_MAIN_OUT_DIM, 0])
+            hca_cmp_ape_layer_hca = pl.slice(hca_cmp_ape, [HCA_COMPRESS_RATIO, HCA_MAIN_OUT_DIM], [hca_extra_layer * HCA_COMPRESS_RATIO, 0])
+            hca_cmp_norm_w_layer_hca = pl.slice(hca_cmp_norm_w, [HEAD_DIM], [hca_extra_layer * HEAD_DIM])
+            attn_sink_layer_hca = pl.slice(attn_sink, [H], [hca_weight_layer * H])
+            wo_b_layer_hca = pl.slice(wo_b, [D, LOCAL_O_WIDTH], [hca_weight_layer * D, 0])
+            wo_b_scale_layer_hca = pl.slice(wo_b_scale, [D], [hca_weight_layer * D])
+            hc_ffn_scale_layer_hca = pl.slice(hc_ffn_scale, [3], [hca_weight_layer * 3])
+            hc_ffn_base_layer_hca = pl.slice(hc_ffn_base, [MIX_HC], [hca_weight_layer * MIX_HC])
             norm_w_layer_hca = pl.slice(norm_w, [D], [hca_weight_layer * D])
-            gate_w_layer_hca = pl.slice(
-                gate_w,
-                [N_EXPERTS_GLOBAL, D],
-                [hca_weight_layer * N_EXPERTS_GLOBAL, 0],
-            )
-            gate_bias_layer_hca = pl.slice(
-                gate_bias,
-                [N_EXPERTS_GLOBAL],
-                [hca_weight_layer * N_EXPERTS_GLOBAL],
-            )
-            tid2eid_layer_hca = pl.slice(
-                tid2eid, [VOCAB, TOPK], [hca_weight_layer * VOCAB, 0]
-            )
-            routed_w1_scale_layer_hca = pl.slice(
-                routed_w1_scale,
-                [N_LOCAL, MOE_INTER],
-                [hca_weight_layer * N_LOCAL, 0],
-            )
-            routed_w3_scale_layer_hca = pl.slice(
-                routed_w3_scale,
-                [N_LOCAL, MOE_INTER],
-                [hca_weight_layer * N_LOCAL, 0],
-            )
-            routed_w2_scale_layer_hca = pl.slice(
-                routed_w2_scale,
-                [N_LOCAL, D],
-                [hca_weight_layer * N_LOCAL, 0],
-            )
-            shared_w1_layer_hca = pl.slice(
-                shared_w1,
-                [MOE_INTER, D],
-                [hca_weight_layer * MOE_INTER, 0],
-            )
-            shared_w1_scale_layer_hca = pl.slice(
-                shared_w1_scale,
-                [MOE_INTER],
-                [hca_weight_layer * MOE_INTER],
-            )
-            shared_w3_layer_hca = pl.slice(
-                shared_w3,
-                [MOE_INTER, D],
-                [hca_weight_layer * MOE_INTER, 0],
-            )
-            shared_w3_scale_layer_hca = pl.slice(
-                shared_w3_scale,
-                [MOE_INTER],
-                [hca_weight_layer * MOE_INTER],
-            )
-            shared_w2_layer_hca = pl.slice(
-                shared_w2, [D, MOE_INTER], [hca_weight_layer * D, 0]
-            )
-            shared_w2_scale_layer_hca = pl.slice(
-                shared_w2_scale, [D], [hca_weight_layer * D]
-            )
-            decode_layer_hca(
-                x_pong,
-                hc_attn_fn_layer_hca, hc_attn_scale_layer_hca,
-                hc_attn_base_layer_hca, attn_norm_w_layer_hca,
-                wq_a_layer_hca, wq_b_layer_hca, wq_b_scale_layer_hca, wkv_layer_hca,
-                gamma_cq_layer_hca, gamma_ckv_layer_hca,
-                freqs_cos, freqs_sin,
-                hca_cmp_freqs_cos, hca_cmp_freqs_sin,
-                hca_cmp_wkv_layer_hca, hca_cmp_wgate_layer_hca,
-                hca_cmp_ape_layer_hca, hca_cmp_norm_w_layer_hca,
-                hca_state_layer_hca, hca_compress_state_block_table,
-                raw_kv_layer_hca, hca_cmp_kv_layer_hca, hca_cmp_block_table,
-                hca_ori_slot_mapping, hca_window_swa_indices,
-                hca_window_swa_lens, hca_cmp_slot_mapping,
-                hca_state_slot_mapping, position_ids, hca_kv_seq_lens,
-                attn_sink_layer_hca, wo_a_layer_hca, wo_b_layer_hca, wo_b_scale_layer_hca,
-                hc_ffn_fn_layer_hca, hc_ffn_scale_layer_hca,
-                hc_ffn_base_layer_hca, norm_w_layer_hca,
-                gate_w_layer_hca, gate_bias_layer_hca, tid2eid_layer_hca, moe_input_ids,
-                routed_w1_layer_hca, routed_w1_scale_layer_hca,
-                routed_w3_layer_hca, routed_w3_scale_layer_hca,
-                routed_w2_layer_hca, routed_w2_scale_layer_hca,
-                shared_w1_layer_hca, shared_w1_scale_layer_hca,
-                shared_w3_layer_hca, shared_w3_scale_layer_hca,
-                shared_w2_layer_hca, shared_w2_scale_layer_hca,
-                x_attn_active, x_moe_next, x_ping,
-                attention_window, attention_signal, o_window, o_signal,
-                recv_meta, recv_x, recv_aux, recv_route,
-                arrived, data_arrived, routed_y_buf, combine_arrived,
-                hca_model_layer, group_base, tp_rank, local_t, my_rank,
-                hca_model_layer + 1,
-            )
+            gate_w_layer_hca = pl.slice(gate_w, [N_EXPERTS_GLOBAL, D], [hca_weight_layer * N_EXPERTS_GLOBAL, 0])
+            gate_bias_layer_hca = pl.slice(gate_bias, [N_EXPERTS_GLOBAL], [hca_weight_layer * N_EXPERTS_GLOBAL])
+            tid2eid_layer_hca = pl.slice(tid2eid, [VOCAB, TOPK], [hca_weight_layer * VOCAB, 0])
+            routed_w1_scale_layer_hca = pl.slice(routed_w1_scale, [N_LOCAL, MOE_INTER], [hca_weight_layer * N_LOCAL, 0])
+            routed_w3_scale_layer_hca = pl.slice(routed_w3_scale, [N_LOCAL, MOE_INTER], [hca_weight_layer * N_LOCAL, 0])
+            routed_w2_scale_layer_hca = pl.slice(routed_w2_scale, [N_LOCAL, D], [hca_weight_layer * N_LOCAL, 0])
+            shared_w1_layer_hca = pl.slice(shared_w1, [MOE_INTER, D], [hca_weight_layer * MOE_INTER, 0])
+            shared_w1_scale_layer_hca = pl.slice(shared_w1_scale, [MOE_INTER], [hca_weight_layer * MOE_INTER])
+            shared_w3_layer_hca = pl.slice(shared_w3, [MOE_INTER, D], [hca_weight_layer * MOE_INTER, 0])
+            shared_w3_scale_layer_hca = pl.slice(shared_w3_scale, [MOE_INTER], [hca_weight_layer * MOE_INTER])
+            shared_w2_layer_hca = pl.slice(shared_w2, [D, MOE_INTER], [hca_weight_layer * D, 0])
+            shared_w2_scale_layer_hca = pl.slice(shared_w2_scale, [D], [hca_weight_layer * D])
+            with pl.scope():
+                if TP_SIZE == 1:
+                    decode_hca_tp1(
+                        x_pong,
+                        hc_attn_fn_layer_hca, hc_attn_scale_layer_hca, hc_attn_base_layer_hca,
+                        attn_norm_w_layer_hca, wq_a_layer_hca, wq_b_layer_hca, wq_b_scale_layer_hca,
+                        wkv_layer_hca, gamma_cq_layer_hca, gamma_ckv_layer_hca,
+                        freqs_cos, freqs_sin, hca_cmp_freqs_cos, hca_cmp_freqs_sin,
+                        hca_cmp_wkv_layer_hca, hca_cmp_wgate_layer_hca,
+                        hca_cmp_ape_layer_hca, hca_cmp_norm_w_layer_hca,
+                        hca_state_layer_hca, hca_compress_state_block_table,
+                        raw_kv_layer_hca, hca_cmp_kv_layer_hca, hca_cmp_block_table,
+                        hca_ori_slot_mapping, hca_window_swa_indices, hca_window_swa_lens,
+                        hca_cmp_slot_mapping, hca_state_slot_mapping,
+                        position_ids, hca_kv_seq_lens,
+                        attn_sink_layer_hca, wo_a_layer_hca, wo_b_layer_hca, wo_b_scale_layer_hca,
+                        x_attn_active,
+                    )
+                else:
+                    decode_hca(
+                        x_pong,
+                        hc_attn_fn_layer_hca, hc_attn_scale_layer_hca, hc_attn_base_layer_hca,
+                        attn_norm_w_layer_hca, wq_a_layer_hca, wq_b_layer_hca, wq_b_scale_layer_hca,
+                        wkv_layer_hca, gamma_cq_layer_hca, gamma_ckv_layer_hca,
+                        freqs_cos, freqs_sin, hca_cmp_freqs_cos, hca_cmp_freqs_sin,
+                        hca_cmp_wkv_layer_hca, hca_cmp_wgate_layer_hca,
+                        hca_cmp_ape_layer_hca, hca_cmp_norm_w_layer_hca,
+                        hca_state_layer_hca, hca_compress_state_block_table,
+                        raw_kv_layer_hca, hca_cmp_kv_layer_hca, hca_cmp_block_table,
+                        hca_ori_slot_mapping, hca_window_swa_indices, hca_window_swa_lens,
+                        hca_cmp_slot_mapping, hca_state_slot_mapping,
+                        position_ids, hca_kv_seq_lens,
+                        attn_sink_layer_hca, wo_a_layer_hca, wo_b_layer_hca, wo_b_scale_layer_hca,
+                        x_attn_active,
+                        attention_window, attention_signal, o_window, o_signal,
+                        group_base, tp_rank, local_t,
+                    )
+
+            with pl.scope():
+                x_attn_moe_hca = pl.create_tensor([MOE_TOKENS, HC_MULT, D], dtype=pl.FP32)
+                for token in pl.spmd(MOE_TOKENS, name_hint="decode_fwd_hca_attn_pack"):
+                    if token < local_t:
+                        x_attn_moe_hca[token : token + 1, 0 : HC_MULT, 0 : D] = x_attn_active[
+                            token : token + 1, 0 : HC_MULT, 0 : D
+                        ]
+                    else:
+                        zero_moe_row_hca = pl.full([1, HC_MULT, D], dtype=pl.FP32, value=0.0)
+                        x_attn_moe_hca[token : token + 1, 0 : HC_MULT, 0 : D] = zero_moe_row_hca
+                moe(
+                    x_attn_moe_hca,
+                    hc_ffn_fn_layer_hca, hc_ffn_scale_layer_hca, hc_ffn_base_layer_hca,
+                    norm_w_layer_hca, gate_w_layer_hca, gate_bias_layer_hca, tid2eid_layer_hca,
+                    moe_input_ids,
+                    routed_w1_layer_hca, routed_w1_scale_layer_hca,
+                    routed_w3_layer_hca, routed_w3_scale_layer_hca,
+                    routed_w2_layer_hca, routed_w2_scale_layer_hca,
+                    shared_w1_layer_hca, shared_w1_scale_layer_hca,
+                    shared_w3_layer_hca, shared_w3_scale_layer_hca,
+                    shared_w2_layer_hca, shared_w2_scale_layer_hca,
+                    x_moe_next,
+                    recv_meta, recv_x, recv_aux, recv_route, arrived, data_arrived,
+                    routed_y_buf, combine_arrived,
+                    hca_model_layer, local_t, my_rank, hca_model_layer + 1,
+                )
+                for token in pl.spmd(MOE_TOKENS, name_hint="decode_fwd_hca_active_trim"):
+                    if token < local_t:
+                        x_ping[token : token + 1, 0 : HC_MULT, 0 : D] = x_moe_next[
+                            token : token + 1, 0 : HC_MULT, 0 : D
+                        ]
 
     with pl.scope():
         csa_ordinal_last = pl.const(20, pl.INT32)
         model_layer_last = pl.const(42, pl.INT32)
         weight_layer_last = model_layer_last % FWD_WEIGHT_BANK_SIZE
         extra_layer_last = csa_ordinal_last % FWD_CSA_WEIGHT_BANK_SIZE
-        hc_attn_fn_layer_last = pl.slice(
-            hc_attn_fn,
-            [MIX_HC, HC_DIM],
-            [weight_layer_last * HC_FN_STORAGE_ROWS, 0],
-        )
-        hc_ffn_fn_layer_last = pl.slice(
-            hc_ffn_fn,
-            [MIX_HC, HC_DIM],
-            [weight_layer_last * HC_FN_STORAGE_ROWS, 0],
-        )
-        wq_a_layer_last: pl.Tensor[[D, Q_LORA], pl.BF16] = pl.slice(
-            wq_a, [D, Q_LORA], [weight_layer_last * D, 0]
-        )
-        wq_b_layer_last: pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8] = pl.slice(
-            wq_b, [Q_LORA, H * HEAD_DIM], [weight_layer_last * Q_LORA, 0]
-        )
-        wq_b_scale_layer_last: pl.Tensor[[H * HEAD_DIM], pl.FP32] = pl.slice(
-            wq_b_scale,
-            [H * HEAD_DIM],
-            [weight_layer_last * H * HEAD_DIM],
-        )
-        wkv_layer_last: pl.Tensor[[D, HEAD_DIM], pl.BF16] = pl.slice(
-            wkv, [D, HEAD_DIM], [weight_layer_last * D, 0]
-        )
-        gamma_cq_layer_last: pl.Tensor[[Q_LORA], pl.BF16] = pl.slice(
-            gamma_cq, [Q_LORA], [weight_layer_last * Q_LORA]
-        )
-        gamma_ckv_layer_last: pl.Tensor[[HEAD_DIM], pl.BF16] = pl.slice(
-            gamma_ckv, [HEAD_DIM], [weight_layer_last * HEAD_DIM]
-        )
-        wo_a_layer_last: pl.Tensor[
-            [LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16
-        ] = pl.slice(
-            wo_a,
-            [LOCAL_O_GROUPS, O_LORA, O_GROUP_IN],
-            [weight_layer_last * LOCAL_O_GROUPS, 0, 0],
-        )
-        routed_w1_layer_last: pl.Tensor[
-            [N_LOCAL, MOE_INTER, D], pl.INT8
-        ] = pl.slice(
-            routed_w1,
-            [N_LOCAL, MOE_INTER, D],
-            [weight_layer_last * N_LOCAL, 0, 0],
-        )
-        routed_w3_layer_last: pl.Tensor[
-            [N_LOCAL, MOE_INTER, D], pl.INT8
-        ] = pl.slice(
-            routed_w3,
-            [N_LOCAL, MOE_INTER, D],
-            [weight_layer_last * N_LOCAL, 0, 0],
-        )
-        routed_w2_layer_last: pl.Tensor[
-            [N_LOCAL, D, MOE_INTER], pl.INT8
-        ] = pl.slice(
-            routed_w2,
-            [N_LOCAL, D, MOE_INTER],
-            [weight_layer_last * N_LOCAL, 0, 0],
-        )
-        raw_kv_layer_last = pl.slice(
-            raw_kv_pool,
-            [raw_blocks_per_layer, BLOCK_SIZE, 1, HEAD_DIM],
-            [model_layer_last * raw_blocks_per_layer, 0, 0, 0],
-        )
-        csa_state_layer_last = pl.slice(
-            csa_compress_state,
-            [
-                csa_state_blocks_per_layer,
-                CSA_MAIN_STATE_BLOCK_SIZE,
-                CSA_MAIN_STATE_DIM,
-            ],
-            [csa_ordinal_last * csa_state_blocks_per_layer, 0, 0],
-        )
-        csa_cmp_kv_layer_last = pl.slice(
-            csa_cmp_kv,
-            [csa_cmp_blocks_per_layer, BLOCK_SIZE, 1, HEAD_DIM],
-            [csa_ordinal_last * csa_cmp_blocks_per_layer, 0, 0, 0],
-        )
-        csa_inner_state_layer_last = pl.slice(
-            csa_inner_compress_state,
-            [
-                csa_inner_state_blocks_per_layer,
-                CSA_INNER_STATE_BLOCK_SIZE,
-                CSA_INNER_STATE_DIM,
-            ],
-            [csa_ordinal_last * csa_inner_state_blocks_per_layer, 0, 0],
-        )
-        csa_idx_cache_layer_last = pl.slice(
-            csa_idx_kv_cache,
-            [
-                csa_idx_blocks_per_layer,
-                BLOCK_SIZE,
-                1,
-                CSA_IDX_HEAD_DIM,
-            ],
-            [csa_ordinal_last * csa_idx_blocks_per_layer, 0, 0, 0],
-        )
-        csa_idx_scale_layer_last = pl.slice(
-            csa_idx_kv_scale,
-            [csa_idx_blocks_per_layer, BLOCK_SIZE, 1, 1],
-            [csa_ordinal_last * csa_idx_blocks_per_layer, 0, 0, 0],
-        )
-        hc_attn_scale_layer_last = pl.slice(
-            hc_attn_scale, [3], [weight_layer_last * 3]
-        )
-        hc_attn_base_layer_last = pl.slice(
-            hc_attn_base, [MIX_HC], [weight_layer_last * MIX_HC]
-        )
-        attn_norm_w_layer_last = pl.slice(
-            attn_norm_w, [D], [weight_layer_last * D]
-        )
-        csa_cmp_wkv_layer_last = pl.slice(
-            csa_cmp_wkv,
-            [CSA_MAIN_OUT_DIM, D],
-            [extra_layer_last * CSA_MAIN_OUT_DIM, 0],
-        )
-        csa_cmp_wgate_layer_last = pl.slice(
-            csa_cmp_wgate,
-            [CSA_MAIN_OUT_DIM, D],
-            [extra_layer_last * CSA_MAIN_OUT_DIM, 0],
-        )
-        csa_cmp_ape_layer_last = pl.slice(
-            csa_cmp_ape,
-            [CSA_COMPRESS_RATIO, CSA_MAIN_OUT_DIM],
-            [extra_layer_last * CSA_COMPRESS_RATIO, 0],
-        )
-        csa_cmp_norm_w_layer_last = pl.slice(
-            csa_cmp_norm_w, [HEAD_DIM], [extra_layer_last * HEAD_DIM]
-        )
-        csa_idx_wq_b_layer_last = pl.slice(
-            csa_idx_wq_b,
-            [Q_LORA, CSA_IDX_N_HEADS * CSA_IDX_HEAD_DIM],
-            [extra_layer_last * Q_LORA, 0],
-        )
-        csa_idx_wq_b_scale_layer_last = pl.slice(
-            csa_idx_wq_b_scale,
-            [CSA_IDX_N_HEADS * CSA_IDX_HEAD_DIM],
-            [extra_layer_last * CSA_IDX_N_HEADS * CSA_IDX_HEAD_DIM],
-        )
-        csa_weights_proj_layer_last = pl.slice(
-            csa_weights_proj,
-            [D, CSA_IDX_N_HEADS],
-            [extra_layer_last * D, 0],
-        )
-        csa_hadamard_idx_layer_last = pl.slice(
-            csa_hadamard_idx,
-            [CSA_IDX_HEAD_DIM, CSA_IDX_HEAD_DIM],
-            [extra_layer_last * CSA_IDX_HEAD_DIM, 0],
-        )
-        csa_inner_wkv_layer_last = pl.slice(
-            csa_inner_wkv,
-            [CSA_INNER_OUT_DIM, D],
-            [extra_layer_last * CSA_INNER_OUT_DIM, 0],
-        )
-        csa_inner_wgate_layer_last = pl.slice(
-            csa_inner_wgate,
-            [CSA_INNER_OUT_DIM, D],
-            [extra_layer_last * CSA_INNER_OUT_DIM, 0],
-        )
-        csa_inner_ape_layer_last = pl.slice(
-            csa_inner_ape,
-            [CSA_COMPRESS_RATIO, CSA_INNER_OUT_DIM],
-            [extra_layer_last * CSA_COMPRESS_RATIO, 0],
-        )
-        csa_inner_norm_w_layer_last = pl.slice(
-            csa_inner_norm_w,
-            [CSA_IDX_HEAD_DIM],
-            [extra_layer_last * CSA_IDX_HEAD_DIM],
-        )
+        hc_attn_fn_layer_last = pl.slice(hc_attn_fn, [MIX_HC, HC_DIM], [weight_layer_last * HC_FN_STORAGE_ROWS, 0])
+        hc_ffn_fn_layer_last = pl.slice(hc_ffn_fn, [MIX_HC, HC_DIM], [weight_layer_last * HC_FN_STORAGE_ROWS, 0])
+        wq_a_layer_last: pl.Tensor[[D, Q_LORA], pl.BF16] = pl.slice(wq_a, [D, Q_LORA], [weight_layer_last * D, 0])
+        wq_b_layer_last: pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8] = pl.slice(wq_b, [Q_LORA, H * HEAD_DIM], [weight_layer_last * Q_LORA, 0])
+        wq_b_scale_layer_last: pl.Tensor[[H * HEAD_DIM], pl.FP32] = pl.slice(wq_b_scale, [H * HEAD_DIM], [weight_layer_last * H * HEAD_DIM])
+        wkv_layer_last: pl.Tensor[[D, HEAD_DIM], pl.BF16] = pl.slice(wkv, [D, HEAD_DIM], [weight_layer_last * D, 0])
+        gamma_cq_layer_last: pl.Tensor[[Q_LORA], pl.BF16] = pl.slice(gamma_cq, [Q_LORA], [weight_layer_last * Q_LORA])
+        gamma_ckv_layer_last: pl.Tensor[[HEAD_DIM], pl.BF16] = pl.slice(gamma_ckv, [HEAD_DIM], [weight_layer_last * HEAD_DIM])
+        wo_a_layer_last: pl.Tensor[[LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16] = pl.slice(wo_a, [LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], [weight_layer_last * LOCAL_O_GROUPS, 0, 0])
+        routed_w1_layer_last: pl.Tensor[[N_LOCAL, MOE_INTER, D], pl.INT8] = pl.slice(routed_w1, [N_LOCAL, MOE_INTER, D], [weight_layer_last * N_LOCAL, 0, 0])
+        routed_w3_layer_last: pl.Tensor[[N_LOCAL, MOE_INTER, D], pl.INT8] = pl.slice(routed_w3, [N_LOCAL, MOE_INTER, D], [weight_layer_last * N_LOCAL, 0, 0])
+        routed_w2_layer_last: pl.Tensor[[N_LOCAL, D, MOE_INTER], pl.INT8] = pl.slice(routed_w2, [N_LOCAL, D, MOE_INTER], [weight_layer_last * N_LOCAL, 0, 0])
+        raw_kv_layer_last = pl.slice(raw_kv_pool, [raw_blocks_per_layer, BLOCK_SIZE, 1, HEAD_DIM], [model_layer_last * raw_blocks_per_layer, 0, 0, 0])
+        csa_state_layer_last = pl.slice(csa_compress_state, [csa_state_blocks_per_layer, CSA_MAIN_STATE_BLOCK_SIZE, CSA_MAIN_STATE_DIM], [csa_ordinal_last * csa_state_blocks_per_layer, 0, 0])
+        csa_cmp_kv_layer_last = pl.slice(csa_cmp_kv, [csa_cmp_blocks_per_layer, BLOCK_SIZE, 1, HEAD_DIM], [csa_ordinal_last * csa_cmp_blocks_per_layer, 0, 0, 0])
+        csa_inner_state_layer_last = pl.slice(csa_inner_compress_state, [csa_inner_state_blocks_per_layer, CSA_INNER_STATE_BLOCK_SIZE, CSA_INNER_STATE_DIM], [csa_ordinal_last * csa_inner_state_blocks_per_layer, 0, 0])
+        csa_idx_cache_layer_last = pl.slice(csa_idx_kv_cache, [csa_idx_blocks_per_layer, BLOCK_SIZE, 1, CSA_IDX_HEAD_DIM], [csa_ordinal_last * csa_idx_blocks_per_layer, 0, 0, 0])
+        csa_idx_scale_layer_last = pl.slice(csa_idx_kv_scale, [csa_idx_blocks_per_layer, BLOCK_SIZE, 1, 1], [csa_ordinal_last * csa_idx_blocks_per_layer, 0, 0, 0])
+        hc_attn_scale_layer_last = pl.slice(hc_attn_scale, [3], [weight_layer_last * 3])
+        hc_attn_base_layer_last = pl.slice(hc_attn_base, [MIX_HC], [weight_layer_last * MIX_HC])
+        attn_norm_w_layer_last = pl.slice(attn_norm_w, [D], [weight_layer_last * D])
+        csa_cmp_wkv_layer_last = pl.slice(csa_cmp_wkv, [CSA_MAIN_OUT_DIM, D], [extra_layer_last * CSA_MAIN_OUT_DIM, 0])
+        csa_cmp_wgate_layer_last = pl.slice(csa_cmp_wgate, [CSA_MAIN_OUT_DIM, D], [extra_layer_last * CSA_MAIN_OUT_DIM, 0])
+        csa_cmp_ape_layer_last = pl.slice(csa_cmp_ape, [CSA_COMPRESS_RATIO, CSA_MAIN_OUT_DIM], [extra_layer_last * CSA_COMPRESS_RATIO, 0])
+        csa_cmp_norm_w_layer_last = pl.slice(csa_cmp_norm_w, [HEAD_DIM], [extra_layer_last * HEAD_DIM])
+        csa_idx_wq_b_layer_last = pl.slice(csa_idx_wq_b, [Q_LORA, CSA_IDX_N_HEADS * CSA_IDX_HEAD_DIM], [extra_layer_last * Q_LORA, 0])
+        csa_idx_wq_b_scale_layer_last = pl.slice(csa_idx_wq_b_scale, [CSA_IDX_N_HEADS * CSA_IDX_HEAD_DIM], [extra_layer_last * CSA_IDX_N_HEADS * CSA_IDX_HEAD_DIM])
+        csa_weights_proj_layer_last = pl.slice(csa_weights_proj, [D, CSA_IDX_N_HEADS], [extra_layer_last * D, 0])
+        csa_hadamard_idx_layer_last = pl.slice(csa_hadamard_idx, [CSA_IDX_HEAD_DIM, CSA_IDX_HEAD_DIM], [extra_layer_last * CSA_IDX_HEAD_DIM, 0])
+        csa_inner_wkv_layer_last = pl.slice(csa_inner_wkv, [CSA_INNER_OUT_DIM, D], [extra_layer_last * CSA_INNER_OUT_DIM, 0])
+        csa_inner_wgate_layer_last = pl.slice(csa_inner_wgate, [CSA_INNER_OUT_DIM, D], [extra_layer_last * CSA_INNER_OUT_DIM, 0])
+        csa_inner_ape_layer_last = pl.slice(csa_inner_ape, [CSA_COMPRESS_RATIO, CSA_INNER_OUT_DIM], [extra_layer_last * CSA_COMPRESS_RATIO, 0])
+        csa_inner_norm_w_layer_last = pl.slice(csa_inner_norm_w, [CSA_IDX_HEAD_DIM], [extra_layer_last * CSA_IDX_HEAD_DIM])
         attn_sink_layer_last = pl.slice(attn_sink, [H], [weight_layer_last * H])
-        wo_b_layer_last = pl.slice(
-            wo_b, [D, LOCAL_O_WIDTH], [weight_layer_last * D, 0]
-        )
-        wo_b_scale_layer_last = pl.slice(
-            wo_b_scale, [D], [weight_layer_last * D]
-        )
-        hc_ffn_scale_layer_last = pl.slice(
-            hc_ffn_scale, [3], [weight_layer_last * 3]
-        )
-        hc_ffn_base_layer_last = pl.slice(
-            hc_ffn_base, [MIX_HC], [weight_layer_last * MIX_HC]
-        )
+        wo_b_layer_last = pl.slice(wo_b, [D, LOCAL_O_WIDTH], [weight_layer_last * D, 0])
+        wo_b_scale_layer_last = pl.slice(wo_b_scale, [D], [weight_layer_last * D])
+        hc_ffn_scale_layer_last = pl.slice(hc_ffn_scale, [3], [weight_layer_last * 3])
+        hc_ffn_base_layer_last = pl.slice(hc_ffn_base, [MIX_HC], [weight_layer_last * MIX_HC])
         norm_w_layer_last = pl.slice(norm_w, [D], [weight_layer_last * D])
-        gate_w_layer_last = pl.slice(
-            gate_w,
-            [N_EXPERTS_GLOBAL, D],
-            [weight_layer_last * N_EXPERTS_GLOBAL, 0],
-        )
-        gate_bias_layer_last = pl.slice(
-            gate_bias,
-            [N_EXPERTS_GLOBAL],
-            [weight_layer_last * N_EXPERTS_GLOBAL],
-        )
-        tid2eid_layer_last = pl.slice(
-            tid2eid, [VOCAB, TOPK], [weight_layer_last * VOCAB, 0]
-        )
-        routed_w1_scale_layer_last = pl.slice(
-            routed_w1_scale,
-            [N_LOCAL, MOE_INTER],
-            [weight_layer_last * N_LOCAL, 0],
-        )
-        routed_w3_scale_layer_last = pl.slice(
-            routed_w3_scale,
-            [N_LOCAL, MOE_INTER],
-            [weight_layer_last * N_LOCAL, 0],
-        )
-        routed_w2_scale_layer_last = pl.slice(
-            routed_w2_scale, [N_LOCAL, D], [weight_layer_last * N_LOCAL, 0]
-        )
-        shared_w1_layer_last = pl.slice(
-            shared_w1, [MOE_INTER, D], [weight_layer_last * MOE_INTER, 0]
-        )
-        shared_w1_scale_layer_last = pl.slice(
-            shared_w1_scale, [MOE_INTER], [weight_layer_last * MOE_INTER]
-        )
-        shared_w3_layer_last = pl.slice(
-            shared_w3, [MOE_INTER, D], [weight_layer_last * MOE_INTER, 0]
-        )
-        shared_w3_scale_layer_last = pl.slice(
-            shared_w3_scale, [MOE_INTER], [weight_layer_last * MOE_INTER]
-        )
-        shared_w2_layer_last = pl.slice(
-            shared_w2, [D, MOE_INTER], [weight_layer_last * D, 0]
-        )
-        shared_w2_scale_layer_last = pl.slice(
-            shared_w2_scale, [D], [weight_layer_last * D]
-        )
-        decode_layer_csa(
-            x_ping,
-            hc_attn_fn_layer_last, hc_attn_scale_layer_last,
-            hc_attn_base_layer_last, attn_norm_w_layer_last,
-            wq_a_layer_last, wq_b_layer_last, wq_b_scale_layer_last, wkv_layer_last,
-            gamma_cq_layer_last, gamma_ckv_layer_last,
-            freqs_cos, freqs_sin,
-            csa_cmp_freqs_cos, csa_cmp_freqs_sin,
-            csa_cmp_wkv_layer_last, csa_cmp_wgate_layer_last,
-            csa_cmp_ape_layer_last, csa_cmp_norm_w_layer_last,
-            csa_state_layer_last, csa_compress_state_block_table,
-            csa_idx_wq_b_layer_last, csa_idx_wq_b_scale_layer_last,
-            csa_weights_proj_layer_last, csa_hadamard_idx_layer_last,
-            csa_inner_wkv_layer_last, csa_inner_wgate_layer_last,
-            csa_inner_ape_layer_last, csa_inner_norm_w_layer_last,
-            csa_inner_state_layer_last,
-            csa_inner_compress_state_block_table,
-            raw_kv_layer_last, csa_cmp_kv_layer_last, csa_cmp_block_table,
-            csa_idx_cache_layer_last, csa_idx_scale_layer_last,
-            csa_idx_block_table,
-            csa_ori_slot_mapping, csa_window_swa_indices,
-            csa_window_swa_lens, csa_cmp_slot_mapping,
-            csa_idx_slot_mapping, csa_state_slot_mapping,
-            csa_inner_state_slot_mapping, position_ids,
-            csa_kv_seq_lens, attn_sink_layer_last,
-            wo_a_layer_last, wo_b_layer_last, wo_b_scale_layer_last,
-            hc_ffn_fn_layer_last, hc_ffn_scale_layer_last,
-            hc_ffn_base_layer_last, norm_w_layer_last,
-            gate_w_layer_last, gate_bias_layer_last, tid2eid_layer_last, moe_input_ids,
-            routed_w1_layer_last, routed_w1_scale_layer_last,
-            routed_w3_layer_last, routed_w3_scale_layer_last,
-            routed_w2_layer_last, routed_w2_scale_layer_last,
-            shared_w1_layer_last, shared_w1_scale_layer_last,
-            shared_w3_layer_last, shared_w3_scale_layer_last,
-            shared_w2_layer_last, shared_w2_scale_layer_last,
-            x_attn_active, x_moe_next, pre_hc_hidden_out,
-            attention_window, attention_signal, o_window, o_signal,
-            recv_meta, recv_x, recv_aux, recv_route,
-            arrived, data_arrived, routed_y_buf, combine_arrived,
-            model_layer_last, group_base, tp_rank, local_t, my_rank,
-            pl.const(43, pl.INT32),
-        )
-    clear_moe_signals(
-        x_moe_next, arrived, data_arrived, combine_arrived
-    )
+        gate_w_layer_last = pl.slice(gate_w, [N_EXPERTS_GLOBAL, D], [weight_layer_last * N_EXPERTS_GLOBAL, 0])
+        gate_bias_layer_last = pl.slice(gate_bias, [N_EXPERTS_GLOBAL], [weight_layer_last * N_EXPERTS_GLOBAL])
+        tid2eid_layer_last = pl.slice(tid2eid, [VOCAB, TOPK], [weight_layer_last * VOCAB, 0])
+        routed_w1_scale_layer_last = pl.slice(routed_w1_scale, [N_LOCAL, MOE_INTER], [weight_layer_last * N_LOCAL, 0])
+        routed_w3_scale_layer_last = pl.slice(routed_w3_scale, [N_LOCAL, MOE_INTER], [weight_layer_last * N_LOCAL, 0])
+        routed_w2_scale_layer_last = pl.slice(routed_w2_scale, [N_LOCAL, D], [weight_layer_last * N_LOCAL, 0])
+        shared_w1_layer_last = pl.slice(shared_w1, [MOE_INTER, D], [weight_layer_last * MOE_INTER, 0])
+        shared_w1_scale_layer_last = pl.slice(shared_w1_scale, [MOE_INTER], [weight_layer_last * MOE_INTER])
+        shared_w3_layer_last = pl.slice(shared_w3, [MOE_INTER, D], [weight_layer_last * MOE_INTER, 0])
+        shared_w3_scale_layer_last = pl.slice(shared_w3_scale, [MOE_INTER], [weight_layer_last * MOE_INTER])
+        shared_w2_layer_last = pl.slice(shared_w2, [D, MOE_INTER], [weight_layer_last * D, 0])
+        shared_w2_scale_layer_last = pl.slice(shared_w2_scale, [D], [weight_layer_last * D])
+        with pl.scope():
+            if TP_SIZE == 1:
+                decode_csa_tp1(
+                    x_ping,
+                    hc_attn_fn_layer_last, hc_attn_scale_layer_last, hc_attn_base_layer_last,
+                    attn_norm_w_layer_last, wq_a_layer_last, wq_b_layer_last, wq_b_scale_layer_last,
+                    wkv_layer_last, gamma_cq_layer_last, gamma_ckv_layer_last,
+                    freqs_cos, freqs_sin, csa_cmp_freqs_cos, csa_cmp_freqs_sin,
+                    csa_cmp_wkv_layer_last, csa_cmp_wgate_layer_last,
+                    csa_cmp_ape_layer_last, csa_cmp_norm_w_layer_last,
+                    csa_state_layer_last, csa_compress_state_block_table,
+                    csa_idx_wq_b_layer_last, csa_idx_wq_b_scale_layer_last,
+                    csa_weights_proj_layer_last, csa_hadamard_idx_layer_last,
+                    csa_inner_wkv_layer_last, csa_inner_wgate_layer_last,
+                    csa_inner_ape_layer_last, csa_inner_norm_w_layer_last,
+                    csa_inner_state_layer_last, csa_inner_compress_state_block_table,
+                    raw_kv_layer_last, csa_cmp_kv_layer_last, csa_cmp_block_table,
+                    csa_idx_cache_layer_last, csa_idx_scale_layer_last, csa_idx_block_table,
+                    csa_ori_slot_mapping, csa_window_swa_indices, csa_window_swa_lens,
+                    csa_cmp_slot_mapping, csa_idx_slot_mapping,
+                    csa_state_slot_mapping, csa_inner_state_slot_mapping,
+                    position_ids, csa_kv_seq_lens,
+                    attn_sink_layer_last, wo_a_layer_last, wo_b_layer_last, wo_b_scale_layer_last,
+                    x_attn_active,
+                )
+            else:
+                decode_csa(
+                    x_ping,
+                    hc_attn_fn_layer_last, hc_attn_scale_layer_last, hc_attn_base_layer_last,
+                    attn_norm_w_layer_last, wq_a_layer_last, wq_b_layer_last, wq_b_scale_layer_last,
+                    wkv_layer_last, gamma_cq_layer_last, gamma_ckv_layer_last,
+                    freqs_cos, freqs_sin, csa_cmp_freqs_cos, csa_cmp_freqs_sin,
+                    csa_cmp_wkv_layer_last, csa_cmp_wgate_layer_last,
+                    csa_cmp_ape_layer_last, csa_cmp_norm_w_layer_last,
+                    csa_state_layer_last, csa_compress_state_block_table,
+                    csa_idx_wq_b_layer_last, csa_idx_wq_b_scale_layer_last,
+                    csa_weights_proj_layer_last, csa_hadamard_idx_layer_last,
+                    csa_inner_wkv_layer_last, csa_inner_wgate_layer_last,
+                    csa_inner_ape_layer_last, csa_inner_norm_w_layer_last,
+                    csa_inner_state_layer_last, csa_inner_compress_state_block_table,
+                    raw_kv_layer_last, csa_cmp_kv_layer_last, csa_cmp_block_table,
+                    csa_idx_cache_layer_last, csa_idx_scale_layer_last, csa_idx_block_table,
+                    csa_ori_slot_mapping, csa_window_swa_indices, csa_window_swa_lens,
+                    csa_cmp_slot_mapping, csa_idx_slot_mapping,
+                    csa_state_slot_mapping, csa_inner_state_slot_mapping,
+                    position_ids, csa_kv_seq_lens,
+                    attn_sink_layer_last, wo_a_layer_last, wo_b_layer_last, wo_b_scale_layer_last,
+                    x_attn_active,
+                    attention_window, attention_signal, o_window, o_signal,
+                    group_base, tp_rank, local_t,
+                )
+
+        with pl.scope():
+            x_attn_moe_last = pl.create_tensor([MOE_TOKENS, HC_MULT, D], dtype=pl.FP32)
+            for token in pl.spmd(MOE_TOKENS, name_hint="decode_fwd_last_attn_pack"):
+                if token < local_t:
+                    x_attn_moe_last[token : token + 1, 0 : HC_MULT, 0 : D] = x_attn_active[
+                        token : token + 1, 0 : HC_MULT, 0 : D
+                    ]
+                else:
+                    zero_moe_row_last = pl.full([1, HC_MULT, D], dtype=pl.FP32, value=0.0)
+                    x_attn_moe_last[token : token + 1, 0 : HC_MULT, 0 : D] = zero_moe_row_last
+            moe(
+                x_attn_moe_last,
+                hc_ffn_fn_layer_last, hc_ffn_scale_layer_last, hc_ffn_base_layer_last,
+                norm_w_layer_last, gate_w_layer_last, gate_bias_layer_last, tid2eid_layer_last,
+                moe_input_ids,
+                routed_w1_layer_last, routed_w1_scale_layer_last,
+                routed_w3_layer_last, routed_w3_scale_layer_last,
+                routed_w2_layer_last, routed_w2_scale_layer_last,
+                shared_w1_layer_last, shared_w1_scale_layer_last,
+                shared_w3_layer_last, shared_w3_scale_layer_last,
+                shared_w2_layer_last, shared_w2_scale_layer_last,
+                x_moe_next,
+                recv_meta, recv_x, recv_aux, recv_route, arrived, data_arrived,
+                routed_y_buf, combine_arrived,
+                model_layer_last, local_t, my_rank, pl.const(43, pl.INT32),
+            )
+            for token in pl.spmd(MOE_TOKENS, name_hint="decode_fwd_last_active_trim"):
+                if token < local_t:
+                    pre_hc_hidden_out[token : token + 1, 0 : HC_MULT, 0 : D] = x_moe_next[
+                        token : token + 1, 0 : HC_MULT, 0 : D
+                    ]
+    clear_moe_signals(x_moe_next, arrived, data_arrived, combine_arrived)
 
     with pl.scope():
-        hc_head(
-            pre_hc_hidden_out,
-            hc_head_fn,
-            hc_head_scale,
-            hc_head_base,
-            hidden_workspace,
-        )
+        hc_head(pre_hc_hidden_out, hc_head_fn, hc_head_scale, hc_head_base, hidden_workspace)
         final_norm_tid = rms_norm(hidden_workspace, final_norm_w, x_out)
-        logits, _lm_head_done_tid = lm_head(
+        lm_head(
             x_out,
             lm_head_weight,
             logit_row_indices,
@@ -2292,9 +1571,7 @@ def l3_decode_fwd(
     csa_cmp_freqs_sin.bind_dynamic(1, T_DYN)
     csa_compress_state.bind_dynamic(1, FWD_CSA_MAIN_STATE_BLOCKS_DYN)
     csa_compress_state_block_table.bind_dynamic(1, CSA_B_DYN)
-    csa_inner_compress_state.bind_dynamic(
-        1, FWD_CSA_INNER_STATE_BLOCKS_DYN
-    )
+    csa_inner_compress_state.bind_dynamic(1, FWD_CSA_INNER_STATE_BLOCKS_DYN)
     csa_inner_compress_state_block_table.bind_dynamic(1, CSA_B_DYN)
     csa_cmp_kv.bind_dynamic(1, FWD_CSA_CMP_BLOCKS_DYN)
     csa_cmp_block_table.bind_dynamic(1, CSA_B_DYN)
@@ -2325,114 +1602,40 @@ def l3_decode_fwd(
     pre_hc_hidden_out.bind_dynamic(1, T_DYN)
     x_out.bind_dynamic(1, T_DYN)
 
-    attention_window_buf = pld.alloc_window_buffer(
-        [ATTENTION_WINDOW_ROWS, O_GROUP_IN], dtype=pl.BF16
-    )
-    attention_signal_buf = pld.alloc_window_buffer(
-        [TP_SIZE, 1], dtype=pl.INT32
-    )
-    o_window_buf = pld.alloc_window_buffer(
-        [O_WINDOW_ROWS, D], dtype=pl.FP32
-    )
+    attention_window_buf = pld.alloc_window_buffer([ATTENTION_WINDOW_ROWS, O_GROUP_IN], dtype=pl.BF16)
+    attention_signal_buf = pld.alloc_window_buffer([TP_SIZE, 1], dtype=pl.INT32)
+    o_window_buf = pld.alloc_window_buffer([O_WINDOW_ROWS, D], dtype=pl.FP32)
     o_signal_buf = pld.alloc_window_buffer([TP_SIZE, 1], dtype=pl.INT32)
-    recv_meta_buf = pld.alloc_window_buffer(
-        [N_RANKS, N_LOCAL], dtype=pl.INT32
-    )
-    recv_x_buf = pld.alloc_window_buffer(
-        [N_LOCAL * RECV_MAX, D], dtype=pl.INT8
-    )
-    recv_aux_buf = pld.alloc_window_buffer(
-        [N_LOCAL * RECV_MAX, AUX_PAD], dtype=pl.FP32
-    )
-    recv_route_buf = pld.alloc_window_buffer(
-        [N_LOCAL * RECV_MAX, IDX_PAD], dtype=pl.INT32
-    )
+    recv_meta_buf = pld.alloc_window_buffer([N_RANKS, N_LOCAL], dtype=pl.INT32)
+    recv_x_buf = pld.alloc_window_buffer([N_LOCAL * RECV_MAX, D], dtype=pl.INT8)
+    recv_aux_buf = pld.alloc_window_buffer([N_LOCAL * RECV_MAX, AUX_PAD], dtype=pl.FP32)
+    recv_route_buf = pld.alloc_window_buffer([N_LOCAL * RECV_MAX, IDX_PAD], dtype=pl.INT32)
     arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
-    data_arrived_buf = pld.alloc_window_buffer(
-        [N_RANKS, 1], dtype=pl.INT32
-    )
-    routed_y_buf_buf = pld.alloc_window_buffer(
-        [N_ROUTES, D], dtype=pl.BF16
-    )
-    combine_arrived_buf = pld.alloc_window_buffer(
-        [N_RANKS, 1], dtype=pl.INT32
-    )
-    lm_head_hidden_window_buf = pld.alloc_window_buffer(
-        [GROUP_LOGIT_ROWS, D], dtype=pl.BF16
-    )
-    lm_head_hidden_done_buf = pld.alloc_window_buffer(
-        [LM_HEAD_TP_SIZE, 1], dtype=pl.INT32
-    )
-    lm_head_logits_window_buf = pld.alloc_window_buffer(
-        [MAX_LOGIT_ROWS * LM_HEAD_VOCAB], dtype=pl.FP32
-    )
-    lm_head_logits_done_buf = pld.alloc_window_buffer(
-        [LM_HEAD_TP_SIZE, 1], dtype=pl.INT32
-    )
+    data_arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
+    routed_y_buf_buf = pld.alloc_window_buffer([N_ROUTES, D], dtype=pl.BF16)
+    combine_arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
+    lm_head_hidden_window_buf = pld.alloc_window_buffer([GROUP_LOGIT_ROWS, D], dtype=pl.BF16)
+    lm_head_hidden_done_buf = pld.alloc_window_buffer([LM_HEAD_TP_SIZE, 1], dtype=pl.INT32)
+    lm_head_logits_window_buf = pld.alloc_window_buffer([MAX_LOGIT_ROWS * LM_HEAD_VOCAB], dtype=pl.FP32)
+    lm_head_logits_done_buf = pld.alloc_window_buffer([LM_HEAD_TP_SIZE, 1], dtype=pl.INT32)
 
     for rank in pl.range(pld.world_size()):
-        attention_window = pld.window(
-            attention_window_buf,
-            [ATTENTION_WINDOW_ROWS, O_GROUP_IN],
-            dtype=pl.BF16,
-        )
-        attention_signal = pld.window(
-            attention_signal_buf, [TP_SIZE, 1], dtype=pl.INT32
-        )
-        o_window = pld.window(
-            o_window_buf, [O_WINDOW_ROWS, D], dtype=pl.FP32
-        )
-        o_signal = pld.window(
-            o_signal_buf, [TP_SIZE, 1], dtype=pl.INT32
-        )
-        recv_meta = pld.window(
-            recv_meta_buf, [N_RANKS, N_LOCAL], dtype=pl.INT32
-        )
-        recv_x = pld.window(
-            recv_x_buf, [N_LOCAL * RECV_MAX, D], dtype=pl.INT8
-        )
-        recv_aux = pld.window(
-            recv_aux_buf,
-            [N_LOCAL * RECV_MAX, AUX_PAD],
-            dtype=pl.FP32,
-        )
-        recv_route = pld.window(
-            recv_route_buf,
-            [N_LOCAL * RECV_MAX, IDX_PAD],
-            dtype=pl.INT32,
-        )
-        arrived = pld.window(
-            arrived_buf, [N_RANKS, 1], dtype=pl.INT32
-        )
-        data_arrived = pld.window(
-            data_arrived_buf, [N_RANKS, 1], dtype=pl.INT32
-        )
-        routed_y_buf = pld.window(
-            routed_y_buf_buf, [N_ROUTES, D], dtype=pl.BF16
-        )
-        combine_arrived = pld.window(
-            combine_arrived_buf, [N_RANKS, 1], dtype=pl.INT32
-        )
-        lm_head_hidden_window = pld.window(
-            lm_head_hidden_window_buf,
-            [GROUP_LOGIT_ROWS, D],
-            dtype=pl.BF16,
-        )
-        lm_head_hidden_done = pld.window(
-            lm_head_hidden_done_buf,
-            [LM_HEAD_TP_SIZE, 1],
-            dtype=pl.INT32,
-        )
-        lm_head_logits_window = pld.window(
-            lm_head_logits_window_buf,
-            [MAX_LOGIT_ROWS * LM_HEAD_VOCAB],
-            dtype=pl.FP32,
-        )
-        lm_head_logits_done = pld.window(
-            lm_head_logits_done_buf,
-            [LM_HEAD_TP_SIZE, 1],
-            dtype=pl.INT32,
-        )
+        attention_window = pld.window(attention_window_buf, [ATTENTION_WINDOW_ROWS, O_GROUP_IN], dtype=pl.BF16)
+        attention_signal = pld.window(attention_signal_buf, [TP_SIZE, 1], dtype=pl.INT32)
+        o_window = pld.window(o_window_buf, [O_WINDOW_ROWS, D], dtype=pl.FP32)
+        o_signal = pld.window(o_signal_buf, [TP_SIZE, 1], dtype=pl.INT32)
+        recv_meta = pld.window(recv_meta_buf, [N_RANKS, N_LOCAL], dtype=pl.INT32)
+        recv_x = pld.window(recv_x_buf, [N_LOCAL * RECV_MAX, D], dtype=pl.INT8)
+        recv_aux = pld.window(recv_aux_buf, [N_LOCAL * RECV_MAX, AUX_PAD], dtype=pl.FP32)
+        recv_route = pld.window(recv_route_buf, [N_LOCAL * RECV_MAX, IDX_PAD], dtype=pl.INT32)
+        arrived = pld.window(arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
+        data_arrived = pld.window(data_arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
+        routed_y_buf = pld.window(routed_y_buf_buf, [N_ROUTES, D], dtype=pl.BF16)
+        combine_arrived = pld.window(combine_arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
+        lm_head_hidden_window = pld.window(lm_head_hidden_window_buf, [GROUP_LOGIT_ROWS, D], dtype=pl.BF16)
+        lm_head_hidden_done = pld.window(lm_head_hidden_done_buf, [LM_HEAD_TP_SIZE, 1], dtype=pl.INT32)
+        lm_head_logits_window = pld.window(lm_head_logits_window_buf, [MAX_LOGIT_ROWS * LM_HEAD_VOCAB], dtype=pl.FP32)
+        lm_head_logits_done = pld.window(lm_head_logits_done_buf, [LM_HEAD_TP_SIZE, 1], dtype=pl.INT32)
         tp_rank = rank % TP_SIZE
         group_base = rank - tp_rank
         decode_fwd(
@@ -2499,75 +1702,28 @@ def l3_decode_fwd(
 
 
 _COMMON_ATTN_WEIGHT_NAMES = (
-    "hc_attn_fn",
-    "hc_attn_scale",
-    "hc_attn_base",
-    "attn_norm_w",
-    "wq_a",
-    "wq_b",
-    "wq_b_scale",
-    "wkv",
-    "gamma_cq",
-    "gamma_ckv",
-    "attn_sink",
-    "wo_a",
-    "wo_b",
-    "wo_b_scale",
+    "hc_attn_fn", "hc_attn_scale", "hc_attn_base",
+    "attn_norm_w", "wq_a", "wq_b", "wq_b_scale", "wkv", "gamma_cq", "gamma_ckv",
+    "attn_sink", "wo_a", "wo_b", "wo_b_scale",
 )
 
-_HCA_EXTRA_WEIGHT_NAMES = (
-    "cmp_wkv",
-    "cmp_wgate",
-    "cmp_ape",
-    "cmp_norm_w",
-)
+_HCA_EXTRA_WEIGHT_NAMES = ("cmp_wkv", "cmp_wgate", "cmp_ape", "cmp_norm_w")
 
 _CSA_EXTRA_WEIGHT_NAMES = (
-    "cmp_wkv",
-    "cmp_wgate",
-    "cmp_ape",
-    "cmp_norm_w",
-    "idx_wq_b",
-    "idx_wq_b_scale",
-    "weights_proj",
-    "hadamard_idx",
-    "inner_wkv",
-    "inner_wgate",
-    "inner_ape",
-    "inner_norm_w",
+    "cmp_wkv", "cmp_wgate", "cmp_ape", "cmp_norm_w",
+    "idx_wq_b", "idx_wq_b_scale", "weights_proj", "hadamard_idx",
+    "inner_wkv", "inner_wgate", "inner_ape", "inner_norm_w",
 )
 
 _LAYER_WEIGHT_NAMES = (
     *_COMMON_ATTN_WEIGHT_NAMES,
-    "hc_ffn_fn",
-    "hc_ffn_scale",
-    "hc_ffn_base",
-    "norm_w",
-    "gate_w",
-    "gate_bias",
-    "tid2eid",
-    "routed_w1",
-    "routed_w1_scale",
-    "routed_w3",
-    "routed_w3_scale",
-    "routed_w2",
-    "routed_w2_scale",
-    "shared_w1",
-    "shared_w1_scale",
-    "shared_w3",
-    "shared_w3_scale",
-    "shared_w2",
-    "shared_w2_scale",
+    "hc_ffn_fn", "hc_ffn_scale", "hc_ffn_base",
+    "norm_w", "gate_w", "gate_bias", "tid2eid",
+    "routed_w1", "routed_w1_scale", "routed_w3", "routed_w3_scale", "routed_w2", "routed_w2_scale",
+    "shared_w1", "shared_w1_scale", "shared_w3", "shared_w3_scale", "shared_w2", "shared_w2_scale",
 )
 
-_SWA_METADATA_NAMES = (
-    "freqs_cos",
-    "freqs_sin",
-    "swa_slot_mapping",
-    "swa_indices",
-    "swa_lens",
-    "position_ids",
-)
+_SWA_METADATA_NAMES = ("freqs_cos", "freqs_sin", "swa_slot_mapping", "swa_indices", "swa_lens", "position_ids")
 
 _CSA_SOURCES = {
     "csa_cmp_freqs_cos": "cmp_freqs_cos",
@@ -2587,9 +1743,7 @@ _CSA_SOURCES = {
     "csa_inner_ape": "inner_ape",
     "csa_inner_norm_w": "inner_norm_w",
     "csa_inner_compress_state": "inner_compress_state",
-    "csa_inner_compress_state_block_table": (
-        "inner_compress_state_block_table"
-    ),
+    "csa_inner_compress_state_block_table": "inner_compress_state_block_table",
     "csa_cmp_kv": "cmp_kv",
     "csa_cmp_block_table": "cmp_block_table",
     "csa_idx_kv_cache": "idx_kv_cache",
@@ -2627,20 +1781,13 @@ _HCA_SOURCES = {
 def _copy_spec(name, source, *, is_output=None):
     from golden import TensorSpec
 
-    copied = TensorSpec(
-        name,
-        list(source.shape),
-        source.dtype,
-        init_value=source.init_value,
-        is_output=source.is_output if is_output is None else is_output,
-    )
+    output = source.is_output if is_output is None else is_output
+    copied = TensorSpec(name, list(source.shape), source.dtype, init_value=source.init_value, is_output=output)
     copied.resident = source.resident
     return copied
 
 
-def _make_weight_bank_spec(
-    name, source, bank_size, *, compile_only=False
-):
+def _make_weight_bank_spec(name, source, bank_size, *, compile_only=False):
     """Pack a static layer bank along the first rank-local data axis."""
     from golden import TensorSpec
 
@@ -2650,38 +1797,26 @@ def _make_weight_bank_spec(
         if storage_shape[0] != MIX_HC:
             raise ValueError(f"unexpected HC function shape for {name}")
         storage_shape[0] = HC_FN_STORAGE_ROWS
-    shape = [
-        N_RANKS,
-        int(bank_size) * int(storage_shape[0]),
-        *storage_shape[1:],
-    ]
+    shape = [N_RANKS, int(bank_size) * int(storage_shape[0]), *storage_shape[1:]]
 
     def init_value():
         import torch
 
         value = source.create_tensor()
         if pad_hc_fn:
-            padded = torch.zeros(
-                N_RANKS, HC_FN_STORAGE_ROWS, HC_DIM, dtype=value.dtype
-            )
+            padded = torch.zeros(N_RANKS, HC_FN_STORAGE_ROWS, HC_DIM, dtype=value.dtype)
             padded[:, :MIX_HC].copy_(value)
             value = padded
         repeats = [1, int(bank_size)] + [1] * (value.ndim - 2)
         return value.repeat(*repeats).contiguous()
 
-    spec = TensorSpec(
-        name,
-        shape,
-        source.dtype,
-        init_value=0 if compile_only else init_value,
-    )
+    initializer = 0 if compile_only else init_value
+    spec = TensorSpec(name, shape, source.dtype, init_value=initializer)
     spec.resident = "stacked"
     return spec
 
 
-def _make_packed_pool_spec(
-    name, source, layer_count, *, sentinel=False
-):
+def _make_packed_pool_spec(name, source, layer_count, *, sentinel=False):
     """Pack identical layer-local allocator pools along the block axis."""
     import torch
     from golden import TensorSpec
@@ -2697,24 +1832,15 @@ def _make_packed_pool_spec(
         packed = torch.empty(shape, dtype=source.dtype)
         extent = int(source.shape[1])
         for ordinal in range(layer_count):
-            packed[:, ordinal * extent : (ordinal + 1) * extent].fill_(
-                ordinal + 1
-            )
+            packed[:, ordinal * extent : (ordinal + 1) * extent].fill_(ordinal + 1)
         return packed
 
-    spec = TensorSpec(
-        name, shape, source.dtype, init_value=init_value, is_output=True
-    )
+    spec = TensorSpec(name, shape, source.dtype, init_value=init_value, is_output=True)
     spec.resident = "stacked"
     return spec
 
 
-def build_tensor_specs(
-    start_pos=None,
-    *,
-    weight_bank_size=RUNTIME_WEIGHT_BANK,
-    runtime_case="full_active",
-):
+def build_tensor_specs(start_pos=None, *, weight_bank_size=RUNTIME_WEIGHT_BANK, runtime_case="full_active"):
     """Build the production or bounded-runtime decode forward L3 fixture."""
     import inspect
 
@@ -2722,10 +1848,7 @@ def build_tensor_specs(
     from golden import TensorSpec
 
     if weight_bank_size != FWD_WEIGHT_BANK_SIZE:
-        raise ValueError(
-            "weight bank froze at module import as "
-            f"{FWD_WEIGHT_BANK_SIZE}, got {weight_bank_size}"
-        )
+        raise ValueError(f"weight bank froze at module import as {FWD_WEIGHT_BANK_SIZE}, got {weight_bank_size}")
     compile_only = runtime_case is None
     if not compile_only and weight_bank_size != RUNTIME_WEIGHT_BANK:
         raise ValueError("decode forward runtime witnesses use one reusable weight bank")
@@ -2740,260 +1863,160 @@ def build_tensor_specs(
     if runtime_case == "long_context_tail" and start_pos is None:
         start_pos = [0, 0, 0, 1048568]
 
-    def tensor_specs(builder, layer_id):
-        return {
-            spec.name: spec
-            for spec in builder(start_pos=start_pos, layer_id=layer_id)
-            if isinstance(spec, TensorSpec)
-        }
+    if start_pos is None:
+        active_batch = MOE_TOKENS // config.DECODE_SEQ
+    elif isinstance(start_pos, int):
+        active_batch = 1
+    elif isinstance(start_pos, (list, tuple)) and start_pos:
+        active_batch = len(start_pos)
+    else:
+        raise ValueError("start_pos must be None, an int, or a non-empty list/tuple")
+    local_t = active_batch * config.DECODE_SEQ
 
-    swa_specs = tensor_specs(layer.build_swa_layer_specs, 0)
-    csa_specs = tensor_specs(layer.build_csa_layer_specs, 2)
-    hca_specs = tensor_specs(layer.build_hca_layer_specs, 3)
-    local_t = int(swa_specs["freqs_cos"].shape[1])
+    def attention_specs(module):
+        specs = {}
+        for source in module.build_distributed_tensor_specs(local_t, start_pos=start_pos):
+            if not isinstance(source, TensorSpec):
+                continue
+
+            def init_value(source=source):
+                value = source.create_tensor()
+                repeats = [EP_SIZE // TP_SIZE] + [1] * (value.ndim - 1)
+                return value.repeat(*repeats)
+
+            spec = TensorSpec(
+                source.name, [N_RANKS, *source.shape[1:]], source.dtype,
+                init_value=init_value, is_output=source.is_output,
+            )
+            spec.resident = source.resident
+            specs[spec.name] = spec
+        return specs
+
+    swa_specs = attention_specs(swa)
+    csa_specs = attention_specs(csa)
+    hca_specs = attention_specs(hca)
+    for spec in moe_module.build_tensor_specs(layer_id=0, num_tokens=local_t):
+        if isinstance(spec, TensorSpec) and spec.name not in {"x_hc", "x_next"}:
+            swa_specs.setdefault(spec.name, spec)
+
     if int(csa_specs["freqs_cos"].shape[1]) != local_t:
         raise ValueError("CSA and SWA decode forward fixtures disagree on active rows")
     if int(hca_specs["freqs_cos"].shape[1]) != local_t:
         raise ValueError("HCA and SWA decode forward fixtures disagree on active rows")
 
     def zero_active():
-        return torch.zeros(
-            N_RANKS, local_t, HC_MULT, D, dtype=torch.float32
-        )
+        return torch.zeros(N_RANKS, local_t, HC_MULT, D, dtype=torch.float32)
 
     def init_input_ids():
         value = swa_specs["input_ids"].create_tensor()
-        return torch.remainder(
-            value[:, :local_t], RUNTIME_TEST_VOCAB
-        ).contiguous()
+        return torch.remainder(value[:, :local_t], RUNTIME_TEST_VOCAB).contiguous()
 
-    embedding_vocab = (
-        MODEL_CONFIG.vocab_size if compile_only else RUNTIME_TEST_VOCAB
-    )
+    embedding_vocab = MODEL_CONFIG.vocab_size if compile_only else RUNTIME_TEST_VOCAB
 
     def init_embed_weight():
-        return (
-            torch.randn(N_RANKS, embedding_vocab, D) * 0.05
-        ).to(torch.bfloat16)
+        return (torch.randn(N_RANKS, embedding_vocab, D) * 0.05).to(torch.bfloat16)
 
     sentinel = runtime_case == "packed_pool_sentinel"
     specs_by_name = {
         "embed_weight": TensorSpec(
-            "embed_weight",
-            [N_RANKS, embedding_vocab, D],
-            torch.bfloat16,
+            "embed_weight", [N_RANKS, embedding_vocab, D], torch.bfloat16,
             init_value=0 if compile_only else init_embed_weight,
         ),
         "raw_kv_pool": _make_packed_pool_spec(
-            "raw_kv_pool",
-            swa_specs["kv_cache"],
-            MAIN_LAYER_COUNT,
-            sentinel=sentinel,
+            "raw_kv_pool", swa_specs["kv_cache"], MAIN_LAYER_COUNT, sentinel=sentinel,
         ),
         "hca_compress_state": _make_packed_pool_spec(
-            "hca_compress_state",
-            hca_specs["compress_state"],
-            HCA_LAYER_COUNT,
-            sentinel=sentinel,
+            "hca_compress_state", hca_specs["compress_state"], HCA_LAYER_COUNT, sentinel=sentinel,
         ),
-        "hca_cmp_kv": _make_packed_pool_spec(
-            "hca_cmp_kv",
-            hca_specs["cmp_kv"],
-            HCA_LAYER_COUNT,
-            sentinel=sentinel,
-        ),
+        "hca_cmp_kv": _make_packed_pool_spec("hca_cmp_kv", hca_specs["cmp_kv"], HCA_LAYER_COUNT, sentinel=sentinel),
         "csa_compress_state": _make_packed_pool_spec(
-            "csa_compress_state",
-            csa_specs["compress_state"],
-            CSA_LAYER_COUNT,
-            sentinel=sentinel,
+            "csa_compress_state", csa_specs["compress_state"], CSA_LAYER_COUNT, sentinel=sentinel,
         ),
-        "csa_cmp_kv": _make_packed_pool_spec(
-            "csa_cmp_kv",
-            csa_specs["cmp_kv"],
-            CSA_LAYER_COUNT,
-            sentinel=sentinel,
-        ),
+        "csa_cmp_kv": _make_packed_pool_spec("csa_cmp_kv", csa_specs["cmp_kv"], CSA_LAYER_COUNT, sentinel=sentinel),
         "csa_inner_compress_state": _make_packed_pool_spec(
-            "csa_inner_compress_state",
-            csa_specs["inner_compress_state"],
-            CSA_LAYER_COUNT,
-            sentinel=sentinel,
+            "csa_inner_compress_state", csa_specs["inner_compress_state"], CSA_LAYER_COUNT, sentinel=sentinel,
         ),
         "csa_idx_kv_cache": _make_packed_pool_spec(
-            "csa_idx_kv_cache",
-            csa_specs["idx_kv_cache"],
-            CSA_LAYER_COUNT,
-            sentinel=sentinel,
+            "csa_idx_kv_cache", csa_specs["idx_kv_cache"], CSA_LAYER_COUNT, sentinel=sentinel,
         ),
         "csa_idx_kv_scale": _make_packed_pool_spec(
-            "csa_idx_kv_scale",
-            csa_specs["idx_kv_scale"],
-            CSA_LAYER_COUNT,
-            sentinel=sentinel,
+            "csa_idx_kv_scale", csa_specs["idx_kv_scale"], CSA_LAYER_COUNT, sentinel=sentinel,
         ),
-        "input_ids": TensorSpec(
-            "input_ids",
-            [N_RANKS, local_t],
-            torch.int64,
-            init_value=init_input_ids,
-        ),
-        "hc_head_fn": TensorSpec(
-            "hc_head_fn",
-            [N_RANKS, HC_MULT, HC_DIM],
-            torch.float32,
-            init_value=0,
-        ),
-        "hc_head_scale": TensorSpec(
-            "hc_head_scale", [N_RANKS, 1], torch.float32, init_value=1.0
-        ),
-        "hc_head_base": TensorSpec(
-            "hc_head_base",
-            [N_RANKS, HC_MULT],
-            torch.float32,
-            init_value=0,
-        ),
-        "final_norm_w": TensorSpec(
-            "final_norm_w",
-            [N_RANKS, D],
-            torch.bfloat16,
-            init_value=1.0,
-        ),
-        "lm_head_weight": TensorSpec(
-            "lm_head_weight",
-            [N_RANKS, VOCAB_PER_TP, D],
-            torch.bfloat16,
-            init_value=0,
-        ),
+        "input_ids": TensorSpec("input_ids", [N_RANKS, local_t], torch.int64, init_value=init_input_ids),
+        "hc_head_fn": TensorSpec("hc_head_fn", [N_RANKS, HC_MULT, HC_DIM], torch.float32, init_value=0),
+        "hc_head_scale": TensorSpec("hc_head_scale", [N_RANKS, 1], torch.float32, init_value=1.0),
+        "hc_head_base": TensorSpec("hc_head_base", [N_RANKS, HC_MULT], torch.float32, init_value=0),
+        "final_norm_w": TensorSpec("final_norm_w", [N_RANKS, D], torch.bfloat16, init_value=1.0),
+        "lm_head_weight": TensorSpec("lm_head_weight", [N_RANKS, VOCAB_PER_TP, D], torch.bfloat16, init_value=0),
         "logit_row_indices": TensorSpec(
-            "logit_row_indices",
-            [N_RANKS, MAX_LOGIT_ROWS],
-            torch.int32,
+            "logit_row_indices", [N_RANKS, MAX_LOGIT_ROWS], torch.int32,
             init_value=lambda: build_active_logit_row_indices_host(local_t),
         ),
-        "hidden_workspace": TensorSpec(
-            "hidden_workspace",
-            [N_RANKS, local_t, D],
-            torch.bfloat16,
-            is_output=True,
-        ),
+        "hidden_workspace": TensorSpec("hidden_workspace", [N_RANKS, local_t, D], torch.bfloat16, is_output=True),
         "x_ping": TensorSpec(
-            "x_ping",
-            [N_RANKS, local_t, HC_MULT, D],
-            torch.float32,
-            init_value=zero_active,
-            is_output=True,
+            "x_ping", [N_RANKS, local_t, HC_MULT, D], torch.float32,
+            init_value=zero_active, is_output=True,
         ),
         "x_pong": TensorSpec(
-            "x_pong",
-            [N_RANKS, local_t, HC_MULT, D],
-            torch.float32,
-            init_value=zero_active,
-            is_output=True,
+            "x_pong", [N_RANKS, local_t, HC_MULT, D], torch.float32,
+            init_value=zero_active, is_output=True,
         ),
         "x_attn_active": TensorSpec(
-            "x_attn_active",
-            [N_RANKS, local_t, HC_MULT, D],
-            torch.float32,
-            init_value=zero_active,
-            is_output=True,
+            "x_attn_active", [N_RANKS, local_t, HC_MULT, D], torch.float32,
+            init_value=zero_active, is_output=True,
         ),
         "x_moe_next": TensorSpec(
-            "x_moe_next",
-            [N_RANKS, MOE_TOKENS, HC_MULT, D],
-            torch.float32,
-            init_value=lambda: torch.zeros(
-                N_RANKS, MOE_TOKENS, HC_MULT, D, dtype=torch.float32
-            ),
-            is_output=True,
+            "x_moe_next", [N_RANKS, MOE_TOKENS, HC_MULT, D], torch.float32,
+            init_value=lambda: torch.zeros(N_RANKS, MOE_TOKENS, HC_MULT, D, dtype=torch.float32), is_output=True,
         ),
         "pre_hc_hidden_out": TensorSpec(
-            "pre_hc_hidden_out",
-            [N_RANKS, local_t, HC_MULT, D],
-            torch.float32,
-            is_output=True,
+            "pre_hc_hidden_out", [N_RANKS, local_t, HC_MULT, D], torch.float32, is_output=True,
         ),
-        "x_out": TensorSpec(
-            "x_out",
-            [N_RANKS, local_t, D],
-            torch.bfloat16,
-            is_output=True,
-        ),
-        "logits": TensorSpec(
-            "logits",
-            [N_RANKS, MAX_LOGIT_ROWS, LM_HEAD_VOCAB],
-            torch.float32,
-            is_output=True,
-        ),
+        "x_out": TensorSpec("x_out", [N_RANKS, local_t, D], torch.bfloat16, is_output=True),
+        "logits": TensorSpec("logits", [N_RANKS, MAX_LOGIT_ROWS, LM_HEAD_VOCAB], torch.float32, is_output=True),
         "sampled_ids": TensorSpec(
-            "sampled_ids",
-            [N_RANKS, MAX_LOGIT_ROWS, SAMPLED_IDS_PAD],
-            torch.int32,
-            is_output=True,
+            "sampled_ids", [N_RANKS, MAX_LOGIT_ROWS, SAMPLED_IDS_PAD], torch.int32, is_output=True,
         ),
     }
 
     for name in _LAYER_WEIGHT_NAMES:
-        specs_by_name[name] = _make_weight_bank_spec(
-            name,
-            swa_specs[name],
-            weight_bank_size,
-            compile_only=compile_only,
-        )
+        specs_by_name[name] = _make_weight_bank_spec(name, swa_specs[name], weight_bank_size, compile_only=compile_only)
     for name in _SWA_METADATA_NAMES:
         specs_by_name[name] = _copy_spec(name, swa_specs[name])
 
-    csa_weight_names = {
-        f"csa_{name}": name for name in _CSA_EXTRA_WEIGHT_NAMES
-    }
-    hca_weight_names = {
-        f"hca_{name}": name for name in _HCA_EXTRA_WEIGHT_NAMES
-    }
+    csa_weight_names = {f"csa_{name}": name for name in _CSA_EXTRA_WEIGHT_NAMES}
+    hca_weight_names = {f"hca_{name}": name for name in _HCA_EXTRA_WEIGHT_NAMES}
+    csa_bank_size = CSA_LAYER_COUNT if compile_only else RUNTIME_WEIGHT_BANK
     for public_name, source_name in csa_weight_names.items():
         specs_by_name[public_name] = _make_weight_bank_spec(
-            public_name,
-            csa_specs[source_name],
-            CSA_LAYER_COUNT if compile_only else RUNTIME_WEIGHT_BANK,
-            compile_only=compile_only,
+            public_name, csa_specs[source_name], csa_bank_size, compile_only=compile_only,
         )
+    hca_bank_size = HCA_LAYER_COUNT if compile_only else RUNTIME_WEIGHT_BANK
     for public_name, source_name in hca_weight_names.items():
         specs_by_name[public_name] = _make_weight_bank_spec(
-            public_name,
-            hca_specs[source_name],
-            HCA_LAYER_COUNT if compile_only else RUNTIME_WEIGHT_BANK,
-            compile_only=compile_only,
+            public_name, hca_specs[source_name], hca_bank_size, compile_only=compile_only,
         )
 
     packed_names = set(PACKED_POOL_LAYER_COUNTS)
     for public_name, source_name in _CSA_SOURCES.items():
         if public_name in packed_names or public_name in csa_weight_names:
             continue
-        specs_by_name[public_name] = _copy_spec(
-            public_name, csa_specs[source_name]
-        )
+        specs_by_name[public_name] = _copy_spec(public_name, csa_specs[source_name])
     for public_name, source_name in _HCA_SOURCES.items():
         if public_name in packed_names or public_name in hca_weight_names:
             continue
-        specs_by_name[public_name] = _copy_spec(
-            public_name, hca_specs[source_name]
-        )
+        specs_by_name[public_name] = _copy_spec(public_name, hca_specs[source_name])
 
-    parameter_names = list(
-        inspect.signature(l3_decode_fwd._func).parameters
-    )
+    parameter_names = list(inspect.signature(l3_decode_fwd._func).parameters)
     missing = [name for name in parameter_names if name not in specs_by_name]
     extra = [name for name in specs_by_name if name not in parameter_names]
     if missing or extra:
-        raise ValueError(
-            f"decode forward spec/signature mismatch: missing={missing}, extra={extra}"
-        )
+        raise ValueError(f"decode forward spec/signature mismatch: missing={missing}, extra={extra}")
     specs = [specs_by_name[name] for name in parameter_names]
     for spec in specs:
         if len(spec.shape) > MAX_PUBLIC_TENSOR_DIMS:
-            raise ValueError(
-                f"decode forward tensor {spec.name!r} exceeds "
-                f"{MAX_PUBLIC_TENSOR_DIMS} dimensions: {spec.shape}"
-            )
+            message = f"decode forward tensor {spec.name!r} exceeds {MAX_PUBLIC_TENSOR_DIMS} dimensions: {spec.shape}"
+            raise ValueError(message)
     return specs
 
 
@@ -3020,31 +2043,24 @@ def sampled_ids_compare(actual, _expected, **kwargs):
     if row_indices is None:
         return False, "    missing logit_row_indices input"
     active = row_indices >= 0
-    inactive_values = actual.masked_select(
-        (~active).unsqueeze(-1).expand_as(actual)
-    )
-    if inactive_values.numel() and not bool(
-        torch.all(inactive_values == -1)
-    ):
+    inactive_values = actual.masked_select((~active).unsqueeze(-1).expand_as(actual))
+    if inactive_values.numel() and not bool(torch.all(inactive_values == -1)):
         return False, "    inactive sampled-id rows are not -1"
     active_ids = actual[..., 0].masked_select(active)
-    if active_ids.numel() and bool(
-        ((active_ids < 0) | (active_ids >= LM_HEAD_VOCAB)).any()
-    ):
+    if active_ids.numel() and bool(((active_ids < 0) | (active_ids >= LM_HEAD_VOCAB)).any()):
         return False, "    active sampled token id is outside the vocabulary"
     return True, ""
 
 
 def _packed_pool_compare(layer_mappings, layer_count, block_size, pool_name):
     """Check every packed layer slice and reject writes outside local slots."""
+
     def compare(actual, expected, **kwargs):
         import torch
 
         if actual.shape != expected.shape:
-            return False, (
-                f"    {pool_name} shape mismatch: "
-                f"actual={tuple(actual.shape)} expected={tuple(expected.shape)}"
-            )
+            message = f"    {pool_name} shape mismatch: actual={tuple(actual.shape)} expected={tuple(expected.shape)}"
+            return False, message
         if actual.shape[1] % layer_count:
             return False, f"    {pool_name} packed extent is not divisible"
         if len(layer_mappings) != layer_count:
@@ -3067,37 +2083,21 @@ def _packed_pool_compare(layer_mappings, layer_count, block_size, pool_name):
                 invalid = (slots < -1) | (slots >= actual_rows.shape[0])
                 if bool(invalid.any()):
                     first = int(slots[invalid][0])
-                    return False, (
-                        f"    {pool_name} layer={ordinal} rank={rank} "
-                        f"contains out-of-range slot {first}"
-                    )
+                    return False, f"    {pool_name} layer={ordinal} rank={rank} contains out-of-range slot {first}"
                 slots = slots[slots >= 0]
-                target = torch.zeros(
-                    actual_rows.shape[0], dtype=torch.bool, device=actual.device
-                )
+                target = torch.zeros(actual_rows.shape[0], dtype=torch.bool, device=actual.device)
                 if slots.numel():
                     target[slots] = True
                 if not torch.equal(actual_rows[~target], expected_rows[~target]):
-                    return False, (
-                        f"    {pool_name} layer={ordinal} rank={rank} "
-                        "modified an unmapped row"
-                    )
+                    return False, f"    {pool_name} layer={ordinal} rank={rank} modified an unmapped row"
                 selected = actual_rows[target]
-                if selected.is_floating_point() and not bool(
-                    torch.isfinite(selected).all()
-                ):
-                    return False, (
-                        f"    {pool_name} layer={ordinal} rank={rank} "
-                        "wrote NaN or Inf"
-                    )
+                if selected.is_floating_point() and not bool(torch.isfinite(selected).all()):
+                    return False, f"    {pool_name} layer={ordinal} rank={rank} wrote NaN or Inf"
                 sentinel_value = ordinal + 1
-                if slots.numel() and bool(
-                    torch.all(expected_rows == sentinel_value)
-                ) and torch.equal(selected, expected_rows[target]):
-                    return False, (
-                        f"    {pool_name} layer={ordinal} rank={rank} "
-                        "did not update any mapped sentinel row"
-                    )
+                sentinel_initialized = bool(torch.all(expected_rows == sentinel_value))
+                selected_unchanged = torch.equal(selected, expected_rows[target])
+                if slots.numel() and sentinel_initialized and selected_unchanged:
+                    return False, f"    {pool_name} layer={ordinal} rank={rank} did not update any mapped sentinel row"
         return True, ""
 
     return compare
@@ -3105,100 +2105,47 @@ def _packed_pool_compare(layer_mappings, layer_count, block_size, pool_name):
 
 def compare_functions():
     """Return the decode forward runtime isolation and completion comparators."""
-    raw_mappings = tuple(
-        "swa_slot_mapping"
-        if entry["kind"] == "swa"
-        else f"{entry['kind']}_ori_slot_mapping"
-        for entry in LAYER_PLAN
-    )
+    raw_mappings = ("swa_slot_mapping",) * SWA_LAYER_COUNT
+    alternating_mappings = ("csa_ori_slot_mapping", "hca_ori_slot_mapping")
+    raw_mappings += tuple(mapping for _ in range(HCA_LAYER_COUNT) for mapping in alternating_mappings)
+    raw_mappings += ("csa_ori_slot_mapping",)
     csa_mappings = ("csa_state_slot_mapping",) * CSA_LAYER_COUNT
     csa_cmp_mappings = ("csa_cmp_slot_mapping",) * CSA_LAYER_COUNT
-    csa_inner_mappings = (
-        "csa_inner_state_slot_mapping",
-    ) * CSA_LAYER_COUNT
+    csa_inner_mappings = ("csa_inner_state_slot_mapping",) * CSA_LAYER_COUNT
     csa_idx_mappings = ("csa_idx_slot_mapping",) * CSA_LAYER_COUNT
     hca_state_mappings = ("hca_state_slot_mapping",) * HCA_LAYER_COUNT
     hca_cmp_mappings = ("hca_cmp_slot_mapping",) * HCA_LAYER_COUNT
     finite_names = {
-        "hidden_workspace",
-        "x_ping",
-        "x_pong",
-        "x_attn_active",
-        "x_moe_next",
-        "pre_hc_hidden_out",
-        "x_out",
-        "logits",
+        "hidden_workspace", "x_ping", "x_pong", "x_attn_active",
+        "x_moe_next", "pre_hc_hidden_out", "x_out", "logits",
     }
     compare = {name: finite_tensor_compare for name in finite_names}
     compare["sampled_ids"] = sampled_ids_compare
     compare.update({
-        "raw_kv_pool": _packed_pool_compare(
-            raw_mappings, MAIN_LAYER_COUNT, BLOCK_SIZE, "decode forward raw KV"
-        ),
+        "raw_kv_pool": _packed_pool_compare(raw_mappings, MAIN_LAYER_COUNT, BLOCK_SIZE, "decode forward raw KV"),
         "hca_compress_state": _packed_pool_compare(
-            hca_state_mappings,
-            HCA_LAYER_COUNT,
-            HCA_COMPRESS_STATE_BLOCK_SIZE,
-            "decode forward HCA state",
+            hca_state_mappings, HCA_LAYER_COUNT, HCA_COMPRESS_STATE_BLOCK_SIZE, "decode forward HCA state",
         ),
         "hca_cmp_kv": _packed_pool_compare(
-            hca_cmp_mappings,
-            HCA_LAYER_COUNT,
-            BLOCK_SIZE,
-            "decode forward HCA compressed KV",
+            hca_cmp_mappings, HCA_LAYER_COUNT, BLOCK_SIZE, "decode forward HCA compressed KV",
         ),
         "csa_compress_state": _packed_pool_compare(
-            csa_mappings,
-            CSA_LAYER_COUNT,
-            CSA_MAIN_STATE_BLOCK_SIZE,
-            "decode forward CSA main state",
+            csa_mappings, CSA_LAYER_COUNT, CSA_MAIN_STATE_BLOCK_SIZE, "decode forward CSA main state",
         ),
         "csa_cmp_kv": _packed_pool_compare(
-            csa_cmp_mappings,
-            CSA_LAYER_COUNT,
-            BLOCK_SIZE,
-            "decode forward CSA compressed KV",
+            csa_cmp_mappings, CSA_LAYER_COUNT, BLOCK_SIZE, "decode forward CSA compressed KV",
         ),
         "csa_inner_compress_state": _packed_pool_compare(
-            csa_inner_mappings,
-            CSA_LAYER_COUNT,
-            CSA_INNER_STATE_BLOCK_SIZE,
-            "decode forward CSA inner state",
+            csa_inner_mappings, CSA_LAYER_COUNT, CSA_INNER_STATE_BLOCK_SIZE, "decode forward CSA inner state",
         ),
         "csa_idx_kv_cache": _packed_pool_compare(
-            csa_idx_mappings,
-            CSA_LAYER_COUNT,
-            BLOCK_SIZE,
-            "decode forward CSA index KV",
+            csa_idx_mappings, CSA_LAYER_COUNT, BLOCK_SIZE, "decode forward CSA index KV",
         ),
         "csa_idx_kv_scale": _packed_pool_compare(
-            csa_idx_mappings,
-            CSA_LAYER_COUNT,
-            BLOCK_SIZE,
-            "decode forward CSA index scale",
+            csa_idx_mappings, CSA_LAYER_COUNT, BLOCK_SIZE, "decode forward CSA index scale",
         ),
     })
     return compare
-
-
-def build_shape_report(
-    start_pos=None, *, weight_bank_size=FWD_WEIGHT_BANK_SIZE
-):
-    """Return concrete decode forward device ABI shapes without materializing values."""
-    runtime_case = "full_active" if weight_bank_size == 1 else None
-    specs = build_tensor_specs(
-        start_pos,
-        weight_bank_size=weight_bank_size,
-        runtime_case=runtime_case,
-    )
-    shapes = {spec.name: list(spec.shape) for spec in specs}
-    return {
-        "weight_bank_size": weight_bank_size,
-        "active_tokens": shapes["freqs_cos"][1],
-        "raw_blocks_per_layer": shapes["raw_kv_pool"][1] // MAIN_LAYER_COUNT,
-        "maximum_public_tensor_dims": max(len(shape) for shape in shapes.values()),
-        "shapes": shapes,
-    }
 
 
 def _parse_start_pos(raw):
@@ -3216,13 +2163,8 @@ def main():
     from golden import run_jit
     from pypto.ir.distributed_compiled_program import DistributedConfig
 
-    parser = argparse.ArgumentParser(
-        description="DeepSeek-V4 D-Spark decode-forward integration"
-    )
-    parser.add_argument(
-        "-p", "--platform", type=str, default="a2a3",
-        choices=("a2a3", "a2a3sim", "a5", "a5sim"),
-    )
+    parser = argparse.ArgumentParser(description="DeepSeek-V4 D-Spark decode-forward integration")
+    parser.add_argument("-p", "--platform", type=str, default="a2a3", choices=("a2a3", "a2a3sim", "a5", "a5sim"))
     parser.add_argument("--tp", type=int, default=TP_SIZE, choices=_TP_CHOICES)
     parser.add_argument("--ep", type=int, default=EP_SIZE, choices=_EP_CHOICES)
     parser.add_argument(
@@ -3230,33 +2172,19 @@ def main():
         help=f"comma-separated device ids; EP={EP_SIZE} needs {EP_SIZE}",
     )
     parser.add_argument(
-        "--start-pos",
-        type=str,
-        default=None,
+        "--start-pos", type=str, default=None,
         help="a scalar selects batch=1; a comma-separated list sets the batch",
     )
-    parser.add_argument("--shape-only", action="store_true", default=False)
     parser.add_argument("--compile-only", action="store_true", default=False)
     parser.add_argument(
-        "--weight-bank-size",
-        type=int,
-        default=FWD_WEIGHT_BANK_SIZE,
-        choices=(1, MAIN_LAYER_COUNT),
+        "--weight-bank-size", type=int, default=FWD_WEIGHT_BANK_SIZE, choices=(1, MAIN_LAYER_COUNT),
         help="1 reuses weights at runtime; 43 builds production layer banks",
     )
     parser.add_argument(
-        "--runtime-case",
-        type=str,
-        default="full_active",
-        choices=(
-            "full_active",
-            "packed_pool_sentinel",
-            "long_context_tail",
-        ),
+        "--runtime-case", type=str, default="full_active",
+        choices=("full_active", "packed_pool_sentinel", "long_context_tail"),
     )
-    parser.add_argument(
-        "--enable-scope-stats", action="store_true", default=False
-    )
+    parser.add_argument("--enable-scope-stats", action="store_true", default=False)
     parser.add_argument("--runtime-dir", type=str, default=None)
     parser.add_argument("--golden-data", type=str, default=None)
     parser.add_argument("--save-data", action="store_true", default=False)
@@ -3265,56 +2193,27 @@ def main():
     args = parser.parse_args()
 
     if args.tp != TP_SIZE or args.ep != EP_SIZE:
-        parser.error(
-            f"parallel sizes froze at import as TP={TP_SIZE}, EP={EP_SIZE}"
-        )
+        parser.error(f"parallel sizes froze at import as TP={TP_SIZE}, EP={EP_SIZE}")
     start_pos = _parse_start_pos(args.start_pos)
     weight_bank_size = args.weight_bank_size
     if weight_bank_size != FWD_WEIGHT_BANK_SIZE:
-        parser.error(
-            "weight bank froze at import as "
-            f"{FWD_WEIGHT_BANK_SIZE}, got {weight_bank_size}"
-        )
-    if not args.compile_only and not args.shape_only and weight_bank_size != 1:
+        parser.error(f"weight bank froze at import as {FWD_WEIGHT_BANK_SIZE}, got {weight_bank_size}")
+    if not args.compile_only and weight_bank_size != 1:
         parser.error("decode forward runtime requires --weight-bank-size 1")
-    if args.shape_only:
-        report = build_shape_report(
-            start_pos, weight_bank_size=weight_bank_size
-        )
-        print(
-            f"TP={TP_SIZE} EP={EP_SIZE} "
-            f"weight_bank={report['weight_bank_size']} "
-            f"active_t={report['active_tokens']} "
-            f"layers={len(LAYER_PLAN)} "
-            f"raw_blocks_per_layer={report['raw_blocks_per_layer']} "
-            f"max_dims={report['maximum_public_tensor_dims']}"
-        )
-        return
 
     if args.device is None:
         args.device = ",".join(str(rank) for rank in range(EP_SIZE))
     try:
         device_ids = [int(device) for device in args.device.split(",")]
     except ValueError:
-        parser.error(
-            f"--device must be a comma-separated integer list, got "
-            f"{args.device!r}"
-        )
+        parser.error(f"--device must be a comma-separated integer list, got {args.device!r}")
     if len(device_ids) != EP_SIZE:
-        parser.error(
-            f"EP={EP_SIZE} needs exactly {EP_SIZE} devices, got {device_ids}"
-        )
-    if len(set(device_ids)) != len(device_ids) or any(
-        device < 0 for device in device_ids
-    ):
+        parser.error(f"EP={EP_SIZE} needs exactly {EP_SIZE} devices, got {device_ids}")
+    if len(set(device_ids)) != len(device_ids) or any(device < 0 for device in device_ids):
         parser.error(f"device IDs must be distinct and non-negative: {device_ids}")
 
     runtime_case = None if weight_bank_size == MAIN_LAYER_COUNT else args.runtime_case
-    specs = build_tensor_specs(
-        start_pos=start_pos,
-        weight_bank_size=weight_bank_size,
-        runtime_case=runtime_case,
-    )
+    specs = build_tensor_specs(start_pos=start_pos, weight_bank_size=weight_bank_size, runtime_case=runtime_case)
     result = run_jit(
         fn=l3_decode_fwd,
         specs=specs,

--- a/models/deepseek_v4_flash_dspark/decode_fwd.py
+++ b/models/deepseek_v4_flash_dspark/decode_fwd.py
@@ -51,7 +51,7 @@ import decode_swa as swa
 import moe as moe_module
 import pypto.language as pl
 import pypto.language.distributed as pld
-from decode_layer import decode_layer_swa
+from decode_layer import decode_layer_csa, decode_layer_hca, decode_layer_swa
 from lookup_embedding import VOCAB_DYN as EMBED_VOCAB_DYN
 from lookup_embedding import lookup_embedding
 from moe import clear_moe_signals
@@ -78,6 +78,12 @@ VOCAB_PER_TP = MODEL_CONFIG.vocab_size // TP_SIZE
 
 T_DYN = layer.T_DYN
 FWD_PACKED_RAW_BLOCKS_DYN = pl.dynamic("FWD_PACKED_RAW_BLOCKS_DYN")
+FWD_HCA_STATE_BLOCKS_DYN = pl.dynamic("FWD_HCA_STATE_BLOCKS_DYN")
+FWD_HCA_CMP_BLOCKS_DYN = pl.dynamic("FWD_HCA_CMP_BLOCKS_DYN")
+FWD_CSA_MAIN_STATE_BLOCKS_DYN = pl.dynamic("FWD_CSA_MAIN_STATE_BLOCKS_DYN")
+FWD_CSA_CMP_BLOCKS_DYN = pl.dynamic("FWD_CSA_CMP_BLOCKS_DYN")
+FWD_CSA_INNER_STATE_BLOCKS_DYN = pl.dynamic("FWD_CSA_INNER_STATE_BLOCKS_DYN")
+FWD_CSA_IDX_BLOCKS_DYN = pl.dynamic("FWD_CSA_IDX_BLOCKS_DYN")
 
 MIX_HC = layer.MIX_HC
 Q_LORA = layer.Q_LORA
@@ -102,8 +108,34 @@ AUX_PAD = layer.AUX_PAD
 IDX_PAD = layer.IDX_PAD
 N_ROUTES = layer.N_ROUTES
 
-TWO_SWA_LAYER_COUNT = 2
-TWO_SWA_TEST_VOCAB = 256
+HCA_B_DYN = layer.HCA_B_DYN
+HCA_CMP_TABLE_BLOCKS_DYN = layer.HCA_CMP_TABLE_BLOCKS_DYN
+HCA_B = layer.HCA_B
+HCA_MAIN_OUT_DIM = layer.HCA_MAIN_OUT_DIM
+HCA_COMPRESS_RATIO = layer.HCA_COMPRESS_RATIO
+HCA_COMPRESS_STATE_BLOCK_SIZE = layer.HCA_COMPRESS_STATE_BLOCK_SIZE
+HCA_COMPRESS_STATE_MAX_BLOCKS = layer.HCA_COMPRESS_STATE_MAX_BLOCKS
+HCA_COMPRESS_STATE_DIM = layer.HCA_COMPRESS_STATE_DIM
+
+CSA_B_DYN = layer.CSA_B_DYN
+CSA_MAIN_OUT_DIM = layer.CSA_MAIN_OUT_DIM
+CSA_COMPRESS_RATIO = layer.CSA_COMPRESS_RATIO
+CSA_MAIN_STATE_BLOCK_SIZE = layer.CSA_MAIN_STATE_BLOCK_SIZE
+CSA_MAIN_STATE_MAX_BLOCKS = layer.CSA_MAIN_STATE_MAX_BLOCKS
+CSA_MAIN_STATE_DIM = layer.CSA_MAIN_STATE_DIM
+CSA_IDX_N_HEADS = layer.CSA_IDX_N_HEADS
+CSA_IDX_HEAD_DIM = layer.CSA_IDX_HEAD_DIM
+CSA_INNER_OUT_DIM = layer.CSA_INNER_OUT_DIM
+CSA_INNER_STATE_BLOCK_SIZE = layer.CSA_INNER_STATE_BLOCK_SIZE
+CSA_INNER_STATE_MAX_BLOCKS = layer.CSA_INNER_STATE_MAX_BLOCKS
+CSA_INNER_STATE_DIM = layer.CSA_INNER_STATE_DIM
+CSA_CMP_MAX_BLOCKS = layer.CSA_CMP_MAX_BLOCKS
+CSA_IDX_MAX_BLOCKS = layer.CSA_IDX_MAX_BLOCKS
+
+MIXED_PREFIX_LAYER_COUNT = 4
+MIXED_PREFIX_CSA_LAYER_COUNT = 1
+MIXED_PREFIX_HCA_LAYER_COUNT = 1
+MIXED_PREFIX_TEST_VOCAB = 256
 
 
 def _validate_import_contract():
@@ -375,20 +407,20 @@ def mask_inactive_sample_rows(
 
 @pl.jit(auto_scope=False)
 def decode_fwd(
-    hc_attn_fn: pl.Tensor[[TWO_SWA_LAYER_COUNT * MIX_HC, HC_DIM], pl.FP32],
-    hc_attn_scale: pl.Tensor[[TWO_SWA_LAYER_COUNT * 3], pl.FP32],
-    hc_attn_base: pl.Tensor[[TWO_SWA_LAYER_COUNT * MIX_HC], pl.FP32],
-    attn_norm_w: pl.Tensor[[TWO_SWA_LAYER_COUNT * D], pl.BF16],
-    wq_a: pl.Tensor[[TWO_SWA_LAYER_COUNT * D, Q_LORA], pl.BF16],
+    hc_attn_fn: pl.Tensor[[MIXED_PREFIX_LAYER_COUNT * MIX_HC, HC_DIM], pl.FP32],
+    hc_attn_scale: pl.Tensor[[MIXED_PREFIX_LAYER_COUNT * 3], pl.FP32],
+    hc_attn_base: pl.Tensor[[MIXED_PREFIX_LAYER_COUNT * MIX_HC], pl.FP32],
+    attn_norm_w: pl.Tensor[[MIXED_PREFIX_LAYER_COUNT * D], pl.BF16],
+    wq_a: pl.Tensor[[MIXED_PREFIX_LAYER_COUNT * D, Q_LORA], pl.BF16],
     wq_b: pl.Tensor[
-        [TWO_SWA_LAYER_COUNT * Q_LORA, H * HEAD_DIM], pl.INT8
+        [MIXED_PREFIX_LAYER_COUNT * Q_LORA, H * HEAD_DIM], pl.INT8
     ],
     wq_b_scale: pl.Tensor[
-        [TWO_SWA_LAYER_COUNT * H * HEAD_DIM], pl.FP32
+        [MIXED_PREFIX_LAYER_COUNT * H * HEAD_DIM], pl.FP32
     ],
-    wkv: pl.Tensor[[TWO_SWA_LAYER_COUNT * D, HEAD_DIM], pl.BF16],
-    gamma_cq: pl.Tensor[[TWO_SWA_LAYER_COUNT * Q_LORA], pl.BF16],
-    gamma_ckv: pl.Tensor[[TWO_SWA_LAYER_COUNT * HEAD_DIM], pl.BF16],
+    wkv: pl.Tensor[[MIXED_PREFIX_LAYER_COUNT * D, HEAD_DIM], pl.BF16],
+    gamma_cq: pl.Tensor[[MIXED_PREFIX_LAYER_COUNT * Q_LORA], pl.BF16],
+    gamma_ckv: pl.Tensor[[MIXED_PREFIX_LAYER_COUNT * HEAD_DIM], pl.BF16],
     raw_kv_pool: pl.InOut[
         pl.Tensor[
             [FWD_PACKED_RAW_BLOCKS_DYN, BLOCK_SIZE, 1, HEAD_DIM],
@@ -401,64 +433,179 @@ def decode_fwd(
     swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
     swa_lens: pl.Tensor[[T_DYN], pl.INT32],
     position_ids: pl.Tensor[[T_DYN], pl.INT32],
-    attn_sink: pl.Tensor[[TWO_SWA_LAYER_COUNT * H], pl.FP32],
+    csa_cmp_freqs_cos: pl.Tensor[[T_DYN, ROPE_HEAD_DIM], pl.BF16],
+    csa_cmp_freqs_sin: pl.Tensor[[T_DYN, ROPE_HEAD_DIM], pl.BF16],
+    csa_cmp_wkv: pl.Tensor[[CSA_MAIN_OUT_DIM, D], pl.BF16],
+    csa_cmp_wgate: pl.Tensor[[CSA_MAIN_OUT_DIM, D], pl.BF16],
+    csa_cmp_ape: pl.Tensor[
+        [CSA_COMPRESS_RATIO, CSA_MAIN_OUT_DIM], pl.FP32
+    ],
+    csa_cmp_norm_w: pl.Tensor[[HEAD_DIM], pl.BF16],
+    csa_compress_state: pl.InOut[
+        pl.Tensor[
+            [
+                FWD_CSA_MAIN_STATE_BLOCKS_DYN,
+                CSA_MAIN_STATE_BLOCK_SIZE,
+                CSA_MAIN_STATE_DIM,
+            ],
+            pl.FP32,
+        ]
+    ],
+    csa_compress_state_block_table: pl.Tensor[
+        [CSA_B_DYN, CSA_MAIN_STATE_MAX_BLOCKS], pl.INT32
+    ],
+    csa_idx_wq_b: pl.Tensor[
+        [Q_LORA, CSA_IDX_N_HEADS * CSA_IDX_HEAD_DIM], pl.INT8
+    ],
+    csa_idx_wq_b_scale: pl.Tensor[
+        [CSA_IDX_N_HEADS * CSA_IDX_HEAD_DIM], pl.FP32
+    ],
+    csa_weights_proj: pl.Tensor[[D, CSA_IDX_N_HEADS], pl.BF16],
+    csa_hadamard_idx: pl.Tensor[
+        [CSA_IDX_HEAD_DIM, CSA_IDX_HEAD_DIM], pl.BF16
+    ],
+    csa_inner_wkv: pl.Tensor[[CSA_INNER_OUT_DIM, D], pl.BF16],
+    csa_inner_wgate: pl.Tensor[[CSA_INNER_OUT_DIM, D], pl.BF16],
+    csa_inner_ape: pl.Tensor[
+        [CSA_COMPRESS_RATIO, CSA_INNER_OUT_DIM], pl.FP32
+    ],
+    csa_inner_norm_w: pl.Tensor[[CSA_IDX_HEAD_DIM], pl.BF16],
+    csa_inner_compress_state: pl.InOut[
+        pl.Tensor[
+            [
+                FWD_CSA_INNER_STATE_BLOCKS_DYN,
+                CSA_INNER_STATE_BLOCK_SIZE,
+                CSA_INNER_STATE_DIM,
+            ],
+            pl.FP32,
+        ]
+    ],
+    csa_inner_compress_state_block_table: pl.Tensor[
+        [CSA_B_DYN, CSA_INNER_STATE_MAX_BLOCKS], pl.INT32
+    ],
+    csa_cmp_kv: pl.InOut[
+        pl.Tensor[
+            [FWD_CSA_CMP_BLOCKS_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16
+        ]
+    ],
+    csa_cmp_block_table: pl.Tensor[
+        [CSA_B_DYN, CSA_CMP_MAX_BLOCKS], pl.INT32
+    ],
+    csa_idx_kv_cache: pl.InOut[
+        pl.Tensor[
+            [FWD_CSA_IDX_BLOCKS_DYN, BLOCK_SIZE, 1, CSA_IDX_HEAD_DIM],
+            pl.INT8,
+        ]
+    ],
+    csa_idx_kv_scale: pl.InOut[
+        pl.Tensor[
+            [FWD_CSA_IDX_BLOCKS_DYN, BLOCK_SIZE, 1, 1], pl.FP32
+        ]
+    ],
+    csa_idx_block_table: pl.Tensor[
+        [CSA_B_DYN, CSA_IDX_MAX_BLOCKS], pl.INT32
+    ],
+    csa_ori_slot_mapping: pl.Tensor[[T_DYN], pl.INT64],
+    csa_window_swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
+    csa_window_swa_lens: pl.Tensor[[T_DYN], pl.INT32],
+    csa_cmp_slot_mapping: pl.Tensor[[T_DYN], pl.INT64],
+    csa_idx_slot_mapping: pl.Tensor[[T_DYN], pl.INT64],
+    csa_state_slot_mapping: pl.Tensor[[T_DYN], pl.INT64],
+    csa_inner_state_slot_mapping: pl.Tensor[[T_DYN], pl.INT64],
+    csa_kv_seq_lens: pl.Tensor[[CSA_B_DYN], pl.INT32],
+    hca_cmp_freqs_cos: pl.Tensor[[HCA_B, ROPE_HEAD_DIM // 2], pl.FP32],
+    hca_cmp_freqs_sin: pl.Tensor[[HCA_B, ROPE_HEAD_DIM // 2], pl.FP32],
+    hca_cmp_wkv: pl.Tensor[[HCA_MAIN_OUT_DIM, D], pl.BF16],
+    hca_cmp_wgate: pl.Tensor[[HCA_MAIN_OUT_DIM, D], pl.BF16],
+    hca_cmp_ape: pl.Tensor[
+        [HCA_COMPRESS_RATIO, HCA_MAIN_OUT_DIM], pl.FP32
+    ],
+    hca_cmp_norm_w: pl.Tensor[[HEAD_DIM], pl.BF16],
+    hca_compress_state: pl.InOut[
+        pl.Tensor[
+            [
+                FWD_HCA_STATE_BLOCKS_DYN,
+                HCA_COMPRESS_STATE_BLOCK_SIZE,
+                HCA_COMPRESS_STATE_DIM,
+            ],
+            pl.FP32,
+        ]
+    ],
+    hca_compress_state_block_table: pl.Tensor[
+        [HCA_B_DYN, HCA_COMPRESS_STATE_MAX_BLOCKS], pl.INT32
+    ],
+    hca_cmp_kv: pl.InOut[
+        pl.Tensor[
+            [FWD_HCA_CMP_BLOCKS_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16
+        ]
+    ],
+    hca_cmp_block_table: pl.Tensor[
+        [HCA_B_DYN, HCA_CMP_TABLE_BLOCKS_DYN], pl.INT32
+    ],
+    hca_ori_slot_mapping: pl.Tensor[[T_DYN], pl.INT64],
+    hca_window_swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
+    hca_window_swa_lens: pl.Tensor[[T_DYN], pl.INT32],
+    hca_cmp_slot_mapping: pl.Tensor[[T_DYN], pl.INT64],
+    hca_state_slot_mapping: pl.Tensor[[T_DYN], pl.INT64],
+    hca_kv_seq_lens: pl.Tensor[[HCA_B_DYN], pl.INT32],
+    attn_sink: pl.Tensor[[MIXED_PREFIX_LAYER_COUNT * H], pl.FP32],
     wo_a: pl.Tensor[
-        [TWO_SWA_LAYER_COUNT * LOCAL_O_GROUPS, O_LORA, O_GROUP_IN],
+        [MIXED_PREFIX_LAYER_COUNT * LOCAL_O_GROUPS, O_LORA, O_GROUP_IN],
         pl.BF16,
     ],
     wo_b: pl.Tensor[
-        [TWO_SWA_LAYER_COUNT * D, LOCAL_O_WIDTH], pl.INT8
+        [MIXED_PREFIX_LAYER_COUNT * D, LOCAL_O_WIDTH], pl.INT8
     ],
-    wo_b_scale: pl.Tensor[[TWO_SWA_LAYER_COUNT * D], pl.FP32],
+    wo_b_scale: pl.Tensor[[MIXED_PREFIX_LAYER_COUNT * D], pl.FP32],
     hc_ffn_fn: pl.Tensor[
-        [TWO_SWA_LAYER_COUNT * MIX_HC, HC_DIM], pl.FP32
+        [MIXED_PREFIX_LAYER_COUNT * MIX_HC, HC_DIM], pl.FP32
     ],
-    hc_ffn_scale: pl.Tensor[[TWO_SWA_LAYER_COUNT * 3], pl.FP32],
-    hc_ffn_base: pl.Tensor[[TWO_SWA_LAYER_COUNT * MIX_HC], pl.FP32],
-    norm_w: pl.Tensor[[TWO_SWA_LAYER_COUNT * D], pl.BF16],
+    hc_ffn_scale: pl.Tensor[[MIXED_PREFIX_LAYER_COUNT * 3], pl.FP32],
+    hc_ffn_base: pl.Tensor[[MIXED_PREFIX_LAYER_COUNT * MIX_HC], pl.FP32],
+    norm_w: pl.Tensor[[MIXED_PREFIX_LAYER_COUNT * D], pl.BF16],
     gate_w: pl.Tensor[
-        [TWO_SWA_LAYER_COUNT * N_EXPERTS_GLOBAL, D], pl.FP32
+        [MIXED_PREFIX_LAYER_COUNT * N_EXPERTS_GLOBAL, D], pl.FP32
     ],
     gate_bias: pl.Tensor[
-        [TWO_SWA_LAYER_COUNT * N_EXPERTS_GLOBAL], pl.FP32
+        [MIXED_PREFIX_LAYER_COUNT * N_EXPERTS_GLOBAL], pl.FP32
     ],
-    tid2eid: pl.Tensor[[TWO_SWA_LAYER_COUNT * VOCAB, TOPK], pl.INT32],
+    tid2eid: pl.Tensor[[MIXED_PREFIX_LAYER_COUNT * VOCAB, TOPK], pl.INT32],
     input_ids: pl.Tensor[[MOE_TOKENS], pl.INT64],
     routed_w1: pl.Tensor[
-        [TWO_SWA_LAYER_COUNT * N_LOCAL, MOE_INTER, D], pl.INT8
+        [MIXED_PREFIX_LAYER_COUNT * N_LOCAL, MOE_INTER, D], pl.INT8
     ],
     routed_w1_scale: pl.Tensor[
-        [TWO_SWA_LAYER_COUNT * N_LOCAL, MOE_INTER], pl.FP32
+        [MIXED_PREFIX_LAYER_COUNT * N_LOCAL, MOE_INTER], pl.FP32
     ],
     routed_w3: pl.Tensor[
-        [TWO_SWA_LAYER_COUNT * N_LOCAL, MOE_INTER, D], pl.INT8
+        [MIXED_PREFIX_LAYER_COUNT * N_LOCAL, MOE_INTER, D], pl.INT8
     ],
     routed_w3_scale: pl.Tensor[
-        [TWO_SWA_LAYER_COUNT * N_LOCAL, MOE_INTER], pl.FP32
+        [MIXED_PREFIX_LAYER_COUNT * N_LOCAL, MOE_INTER], pl.FP32
     ],
     routed_w2: pl.Tensor[
-        [TWO_SWA_LAYER_COUNT * N_LOCAL, D, MOE_INTER], pl.INT8
+        [MIXED_PREFIX_LAYER_COUNT * N_LOCAL, D, MOE_INTER], pl.INT8
     ],
     routed_w2_scale: pl.Tensor[
-        [TWO_SWA_LAYER_COUNT * N_LOCAL, D], pl.FP32
+        [MIXED_PREFIX_LAYER_COUNT * N_LOCAL, D], pl.FP32
     ],
     shared_w1: pl.Tensor[
-        [TWO_SWA_LAYER_COUNT * MOE_INTER, D], pl.INT8
+        [MIXED_PREFIX_LAYER_COUNT * MOE_INTER, D], pl.INT8
     ],
     shared_w1_scale: pl.Tensor[
-        [TWO_SWA_LAYER_COUNT * MOE_INTER], pl.FP32
+        [MIXED_PREFIX_LAYER_COUNT * MOE_INTER], pl.FP32
     ],
     shared_w3: pl.Tensor[
-        [TWO_SWA_LAYER_COUNT * MOE_INTER, D], pl.INT8
+        [MIXED_PREFIX_LAYER_COUNT * MOE_INTER, D], pl.INT8
     ],
     shared_w3_scale: pl.Tensor[
-        [TWO_SWA_LAYER_COUNT * MOE_INTER], pl.FP32
+        [MIXED_PREFIX_LAYER_COUNT * MOE_INTER], pl.FP32
     ],
     shared_w2: pl.Tensor[
-        [TWO_SWA_LAYER_COUNT * D, MOE_INTER], pl.INT8
+        [MIXED_PREFIX_LAYER_COUNT * D, MOE_INTER], pl.INT8
     ],
-    shared_w2_scale: pl.Tensor[[TWO_SWA_LAYER_COUNT * D], pl.FP32],
-    x_ping: pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32],
+    shared_w2_scale: pl.Tensor[[MIXED_PREFIX_LAYER_COUNT * D], pl.FP32],
+    x_ping: pl.InOut[pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32]],
     x_pong: pl.InOut[pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32]],
     x_attn_active: pl.InOut[
         pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32]
@@ -489,7 +636,7 @@ def decode_fwd(
     tp_rank: pl.Scalar[pl.INT32],
     my_rank: pl.Scalar[pl.INT32],
 ):
-    """Run the first two model layers with shared windows and ping-pong."""
+    """Run SWA, SWA, CSA, and HCA with shared windows and ping-pong."""
     x_ping.bind_dynamic(0, T_DYN)
     raw_kv_pool.bind_dynamic(0, FWD_PACKED_RAW_BLOCKS_DYN)
     freqs_cos.bind_dynamic(0, T_DYN)
@@ -498,13 +645,45 @@ def decode_fwd(
     swa_indices.bind_dynamic(0, T_DYN)
     swa_lens.bind_dynamic(0, T_DYN)
     position_ids.bind_dynamic(0, T_DYN)
+    csa_cmp_freqs_cos.bind_dynamic(0, T_DYN)
+    csa_cmp_freqs_sin.bind_dynamic(0, T_DYN)
+    csa_compress_state.bind_dynamic(0, FWD_CSA_MAIN_STATE_BLOCKS_DYN)
+    csa_compress_state_block_table.bind_dynamic(0, CSA_B_DYN)
+    csa_inner_compress_state.bind_dynamic(
+        0, FWD_CSA_INNER_STATE_BLOCKS_DYN
+    )
+    csa_inner_compress_state_block_table.bind_dynamic(0, CSA_B_DYN)
+    csa_cmp_kv.bind_dynamic(0, FWD_CSA_CMP_BLOCKS_DYN)
+    csa_cmp_block_table.bind_dynamic(0, CSA_B_DYN)
+    csa_idx_kv_cache.bind_dynamic(0, FWD_CSA_IDX_BLOCKS_DYN)
+    csa_idx_kv_scale.bind_dynamic(0, FWD_CSA_IDX_BLOCKS_DYN)
+    csa_idx_block_table.bind_dynamic(0, CSA_B_DYN)
+    csa_ori_slot_mapping.bind_dynamic(0, T_DYN)
+    csa_window_swa_indices.bind_dynamic(0, T_DYN)
+    csa_window_swa_lens.bind_dynamic(0, T_DYN)
+    csa_cmp_slot_mapping.bind_dynamic(0, T_DYN)
+    csa_idx_slot_mapping.bind_dynamic(0, T_DYN)
+    csa_state_slot_mapping.bind_dynamic(0, T_DYN)
+    csa_inner_state_slot_mapping.bind_dynamic(0, T_DYN)
+    csa_kv_seq_lens.bind_dynamic(0, CSA_B_DYN)
+    hca_compress_state.bind_dynamic(0, FWD_HCA_STATE_BLOCKS_DYN)
+    hca_compress_state_block_table.bind_dynamic(0, HCA_B_DYN)
+    hca_cmp_kv.bind_dynamic(0, FWD_HCA_CMP_BLOCKS_DYN)
+    hca_cmp_block_table.bind_dynamic(0, HCA_B_DYN)
+    hca_cmp_block_table.bind_dynamic(1, HCA_CMP_TABLE_BLOCKS_DYN)
+    hca_ori_slot_mapping.bind_dynamic(0, T_DYN)
+    hca_window_swa_indices.bind_dynamic(0, T_DYN)
+    hca_window_swa_lens.bind_dynamic(0, T_DYN)
+    hca_cmp_slot_mapping.bind_dynamic(0, T_DYN)
+    hca_state_slot_mapping.bind_dynamic(0, T_DYN)
+    hca_kv_seq_lens.bind_dynamic(0, HCA_B_DYN)
     x_pong.bind_dynamic(0, T_DYN)
     x_attn_active.bind_dynamic(0, T_DYN)
     x_out.bind_dynamic(0, T_DYN)
 
     local_t = pl.cast(pl.tensor.dim(x_ping, 0), pl.INT32)
     raw_blocks_per_layer = (
-        pl.tensor.dim(raw_kv_pool, 0) // TWO_SWA_LAYER_COUNT
+        pl.tensor.dim(raw_kv_pool, 0) // MIXED_PREFIX_LAYER_COUNT
     )
     with pl.scope():
         raw_kv_l0 = pl.slice(
@@ -758,12 +937,385 @@ def decode_fwd(
             shared_w1_l1, shared_w1_scale_l1,
             shared_w3_l1, shared_w3_scale_l1,
             shared_w2_l1, shared_w2_scale_l1,
-            x_attn_active, x_moe_next, x_out,
+            x_attn_active, x_moe_next, x_ping,
             attention_window, attention_signal, o_window, o_signal,
             recv_meta, recv_x, recv_aux, recv_route,
             arrived, data_arrived, routed_y_buf, combine_arrived,
             pl.const(1, pl.INT32), group_base, tp_rank, local_t, my_rank,
             pl.const(2, pl.INT32),
+        )
+    csa_state_blocks_per_layer = (
+        pl.tensor.dim(csa_compress_state, 0) // MIXED_PREFIX_CSA_LAYER_COUNT
+    )
+    csa_cmp_blocks_per_layer = (
+        pl.tensor.dim(csa_cmp_kv, 0) // MIXED_PREFIX_CSA_LAYER_COUNT
+    )
+    csa_inner_state_blocks_per_layer = (
+        pl.tensor.dim(csa_inner_compress_state, 0)
+        // MIXED_PREFIX_CSA_LAYER_COUNT
+    )
+    csa_idx_blocks_per_layer = (
+        pl.tensor.dim(csa_idx_kv_cache, 0) // MIXED_PREFIX_CSA_LAYER_COUNT
+    )
+    with pl.scope():
+        raw_kv_l2 = pl.slice(
+            raw_kv_pool,
+            [raw_blocks_per_layer, BLOCK_SIZE, 1, HEAD_DIM],
+            [2 * raw_blocks_per_layer, 0, 0, 0],
+        )
+        csa_compress_state_l0 = pl.slice(
+            csa_compress_state,
+            [
+                csa_state_blocks_per_layer,
+                CSA_MAIN_STATE_BLOCK_SIZE,
+                CSA_MAIN_STATE_DIM,
+            ],
+            [0, 0, 0],
+        )
+        csa_cmp_kv_l0 = pl.slice(
+            csa_cmp_kv,
+            [csa_cmp_blocks_per_layer, BLOCK_SIZE, 1, HEAD_DIM],
+            [0, 0, 0, 0],
+        )
+        csa_inner_compress_state_l0 = pl.slice(
+            csa_inner_compress_state,
+            [
+                csa_inner_state_blocks_per_layer,
+                CSA_INNER_STATE_BLOCK_SIZE,
+                CSA_INNER_STATE_DIM,
+            ],
+            [0, 0, 0],
+        )
+        csa_idx_kv_cache_l0 = pl.slice(
+            csa_idx_kv_cache,
+            [csa_idx_blocks_per_layer, BLOCK_SIZE, 1, CSA_IDX_HEAD_DIM],
+            [0, 0, 0, 0],
+        )
+        csa_idx_kv_scale_l0 = pl.slice(
+            csa_idx_kv_scale,
+            [csa_idx_blocks_per_layer, BLOCK_SIZE, 1, 1],
+            [0, 0, 0, 0],
+        )
+        hc_attn_fn_l2: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32] = pl.slice(
+            hc_attn_fn, [MIX_HC, HC_DIM], [2 * MIX_HC, 0]
+        )
+        hc_attn_scale_l2: pl.Tensor[[3], pl.FP32] = pl.slice(
+            hc_attn_scale, [3], [6]
+        )
+        hc_attn_base_l2: pl.Tensor[[MIX_HC], pl.FP32] = pl.slice(
+            hc_attn_base, [MIX_HC], [2 * MIX_HC]
+        )
+        attn_norm_w_l2: pl.Tensor[[D], pl.BF16] = pl.slice(
+            attn_norm_w, [D], [2 * D]
+        )
+        wq_a_l2: pl.Tensor[[D, Q_LORA], pl.BF16] = pl.slice(
+            wq_a, [D, Q_LORA], [2 * D, 0]
+        )
+        wq_b_l2: pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8] = pl.slice(
+            wq_b, [Q_LORA, H * HEAD_DIM], [2 * Q_LORA, 0]
+        )
+        wq_b_scale_l2: pl.Tensor[[H * HEAD_DIM], pl.FP32] = pl.slice(
+            wq_b_scale, [H * HEAD_DIM], [2 * H * HEAD_DIM]
+        )
+        wkv_l2: pl.Tensor[[D, HEAD_DIM], pl.BF16] = pl.slice(
+            wkv, [D, HEAD_DIM], [2 * D, 0]
+        )
+        gamma_cq_l2: pl.Tensor[[Q_LORA], pl.BF16] = pl.slice(
+            gamma_cq, [Q_LORA], [2 * Q_LORA]
+        )
+        gamma_ckv_l2: pl.Tensor[[HEAD_DIM], pl.BF16] = pl.slice(
+            gamma_ckv, [HEAD_DIM], [2 * HEAD_DIM]
+        )
+        attn_sink_l2: pl.Tensor[[H], pl.FP32] = pl.slice(
+            attn_sink, [H], [2 * H]
+        )
+        wo_a_l2: pl.Tensor[
+            [LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16
+        ] = pl.slice(
+            wo_a,
+            [LOCAL_O_GROUPS, O_LORA, O_GROUP_IN],
+            [2 * LOCAL_O_GROUPS, 0, 0],
+        )
+        wo_b_l2: pl.Tensor[[D, LOCAL_O_WIDTH], pl.INT8] = pl.slice(
+            wo_b, [D, LOCAL_O_WIDTH], [2 * D, 0]
+        )
+        wo_b_scale_l2: pl.Tensor[[D], pl.FP32] = pl.slice(
+            wo_b_scale, [D], [2 * D]
+        )
+        hc_ffn_fn_l2: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32] = pl.slice(
+            hc_ffn_fn, [MIX_HC, HC_DIM], [2 * MIX_HC, 0]
+        )
+        hc_ffn_scale_l2: pl.Tensor[[3], pl.FP32] = pl.slice(
+            hc_ffn_scale, [3], [6]
+        )
+        hc_ffn_base_l2: pl.Tensor[[MIX_HC], pl.FP32] = pl.slice(
+            hc_ffn_base, [MIX_HC], [2 * MIX_HC]
+        )
+        norm_w_l2: pl.Tensor[[D], pl.BF16] = pl.slice(
+            norm_w, [D], [2 * D]
+        )
+        gate_w_l2: pl.Tensor[[N_EXPERTS_GLOBAL, D], pl.FP32] = pl.slice(
+            gate_w, [N_EXPERTS_GLOBAL, D], [2 * N_EXPERTS_GLOBAL, 0]
+        )
+        gate_bias_l2: pl.Tensor[[N_EXPERTS_GLOBAL], pl.FP32] = pl.slice(
+            gate_bias, [N_EXPERTS_GLOBAL], [2 * N_EXPERTS_GLOBAL]
+        )
+        tid2eid_l2: pl.Tensor[[VOCAB, TOPK], pl.INT32] = pl.slice(
+            tid2eid, [VOCAB, TOPK], [2 * VOCAB, 0]
+        )
+        routed_w1_l2: pl.Tensor[
+            [N_LOCAL, MOE_INTER, D], pl.INT8
+        ] = pl.slice(
+            routed_w1, [N_LOCAL, MOE_INTER, D], [2 * N_LOCAL, 0, 0]
+        )
+        routed_w1_scale_l2: pl.Tensor[
+            [N_LOCAL, MOE_INTER], pl.FP32
+        ] = pl.slice(
+            routed_w1_scale, [N_LOCAL, MOE_INTER], [2 * N_LOCAL, 0]
+        )
+        routed_w3_l2: pl.Tensor[
+            [N_LOCAL, MOE_INTER, D], pl.INT8
+        ] = pl.slice(
+            routed_w3, [N_LOCAL, MOE_INTER, D], [2 * N_LOCAL, 0, 0]
+        )
+        routed_w3_scale_l2: pl.Tensor[
+            [N_LOCAL, MOE_INTER], pl.FP32
+        ] = pl.slice(
+            routed_w3_scale, [N_LOCAL, MOE_INTER], [2 * N_LOCAL, 0]
+        )
+        routed_w2_l2: pl.Tensor[
+            [N_LOCAL, D, MOE_INTER], pl.INT8
+        ] = pl.slice(
+            routed_w2, [N_LOCAL, D, MOE_INTER], [2 * N_LOCAL, 0, 0]
+        )
+        routed_w2_scale_l2: pl.Tensor[[N_LOCAL, D], pl.FP32] = pl.slice(
+            routed_w2_scale, [N_LOCAL, D], [2 * N_LOCAL, 0]
+        )
+        shared_w1_l2: pl.Tensor[[MOE_INTER, D], pl.INT8] = pl.slice(
+            shared_w1, [MOE_INTER, D], [2 * MOE_INTER, 0]
+        )
+        shared_w1_scale_l2: pl.Tensor[[MOE_INTER], pl.FP32] = pl.slice(
+            shared_w1_scale, [MOE_INTER], [2 * MOE_INTER]
+        )
+        shared_w3_l2: pl.Tensor[[MOE_INTER, D], pl.INT8] = pl.slice(
+            shared_w3, [MOE_INTER, D], [2 * MOE_INTER, 0]
+        )
+        shared_w3_scale_l2: pl.Tensor[[MOE_INTER], pl.FP32] = pl.slice(
+            shared_w3_scale, [MOE_INTER], [2 * MOE_INTER]
+        )
+        shared_w2_l2: pl.Tensor[[D, MOE_INTER], pl.INT8] = pl.slice(
+            shared_w2, [D, MOE_INTER], [2 * D, 0]
+        )
+        shared_w2_scale_l2: pl.Tensor[[D], pl.FP32] = pl.slice(
+            shared_w2_scale, [D], [2 * D]
+        )
+        decode_layer_csa(
+            x_ping,
+            hc_attn_fn_l2, hc_attn_scale_l2, hc_attn_base_l2,
+            attn_norm_w_l2, wq_a_l2, wq_b_l2, wq_b_scale_l2,
+            wkv_l2, gamma_cq_l2, gamma_ckv_l2,
+            freqs_cos, freqs_sin,
+            csa_cmp_freqs_cos, csa_cmp_freqs_sin,
+            csa_cmp_wkv, csa_cmp_wgate, csa_cmp_ape, csa_cmp_norm_w,
+            csa_compress_state_l0, csa_compress_state_block_table,
+            csa_idx_wq_b, csa_idx_wq_b_scale,
+            csa_weights_proj, csa_hadamard_idx,
+            csa_inner_wkv, csa_inner_wgate,
+            csa_inner_ape, csa_inner_norm_w,
+            csa_inner_compress_state_l0,
+            csa_inner_compress_state_block_table,
+            raw_kv_l2, csa_cmp_kv_l0, csa_cmp_block_table,
+            csa_idx_kv_cache_l0, csa_idx_kv_scale_l0,
+            csa_idx_block_table,
+            csa_ori_slot_mapping, csa_window_swa_indices,
+            csa_window_swa_lens, csa_cmp_slot_mapping,
+            csa_idx_slot_mapping, csa_state_slot_mapping,
+            csa_inner_state_slot_mapping, position_ids,
+            csa_kv_seq_lens, attn_sink_l2,
+            wo_a_l2, wo_b_l2, wo_b_scale_l2,
+            hc_ffn_fn_l2, hc_ffn_scale_l2, hc_ffn_base_l2,
+            norm_w_l2, gate_w_l2, gate_bias_l2, tid2eid_l2, input_ids,
+            routed_w1_l2, routed_w1_scale_l2,
+            routed_w3_l2, routed_w3_scale_l2,
+            routed_w2_l2, routed_w2_scale_l2,
+            shared_w1_l2, shared_w1_scale_l2,
+            shared_w3_l2, shared_w3_scale_l2,
+            shared_w2_l2, shared_w2_scale_l2,
+            x_attn_active, x_moe_next, x_pong,
+            attention_window, attention_signal, o_window, o_signal,
+            recv_meta, recv_x, recv_aux, recv_route,
+            arrived, data_arrived, routed_y_buf, combine_arrived,
+            pl.const(2, pl.INT32), group_base, tp_rank, local_t, my_rank,
+            pl.const(3, pl.INT32),
+        )
+
+    hca_state_blocks_per_layer = (
+        pl.tensor.dim(hca_compress_state, 0) // MIXED_PREFIX_HCA_LAYER_COUNT
+    )
+    hca_cmp_blocks_per_layer = (
+        pl.tensor.dim(hca_cmp_kv, 0) // MIXED_PREFIX_HCA_LAYER_COUNT
+    )
+    with pl.scope():
+        raw_kv_l3 = pl.slice(
+            raw_kv_pool,
+            [raw_blocks_per_layer, BLOCK_SIZE, 1, HEAD_DIM],
+            [3 * raw_blocks_per_layer, 0, 0, 0],
+        )
+        hca_compress_state_l0 = pl.slice(
+            hca_compress_state,
+            [
+                hca_state_blocks_per_layer,
+                HCA_COMPRESS_STATE_BLOCK_SIZE,
+                HCA_COMPRESS_STATE_DIM,
+            ],
+            [0, 0, 0],
+        )
+        hca_cmp_kv_l0 = pl.slice(
+            hca_cmp_kv,
+            [hca_cmp_blocks_per_layer, BLOCK_SIZE, 1, HEAD_DIM],
+            [0, 0, 0, 0],
+        )
+        hc_attn_fn_l3: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32] = pl.slice(
+            hc_attn_fn, [MIX_HC, HC_DIM], [3 * MIX_HC, 0]
+        )
+        hc_attn_scale_l3: pl.Tensor[[3], pl.FP32] = pl.slice(
+            hc_attn_scale, [3], [9]
+        )
+        hc_attn_base_l3: pl.Tensor[[MIX_HC], pl.FP32] = pl.slice(
+            hc_attn_base, [MIX_HC], [3 * MIX_HC]
+        )
+        attn_norm_w_l3: pl.Tensor[[D], pl.BF16] = pl.slice(
+            attn_norm_w, [D], [3 * D]
+        )
+        wq_a_l3: pl.Tensor[[D, Q_LORA], pl.BF16] = pl.slice(
+            wq_a, [D, Q_LORA], [3 * D, 0]
+        )
+        wq_b_l3: pl.Tensor[[Q_LORA, H * HEAD_DIM], pl.INT8] = pl.slice(
+            wq_b, [Q_LORA, H * HEAD_DIM], [3 * Q_LORA, 0]
+        )
+        wq_b_scale_l3: pl.Tensor[[H * HEAD_DIM], pl.FP32] = pl.slice(
+            wq_b_scale, [H * HEAD_DIM], [3 * H * HEAD_DIM]
+        )
+        wkv_l3: pl.Tensor[[D, HEAD_DIM], pl.BF16] = pl.slice(
+            wkv, [D, HEAD_DIM], [3 * D, 0]
+        )
+        gamma_cq_l3: pl.Tensor[[Q_LORA], pl.BF16] = pl.slice(
+            gamma_cq, [Q_LORA], [3 * Q_LORA]
+        )
+        gamma_ckv_l3: pl.Tensor[[HEAD_DIM], pl.BF16] = pl.slice(
+            gamma_ckv, [HEAD_DIM], [3 * HEAD_DIM]
+        )
+        attn_sink_l3: pl.Tensor[[H], pl.FP32] = pl.slice(
+            attn_sink, [H], [3 * H]
+        )
+        wo_a_l3: pl.Tensor[
+            [LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16
+        ] = pl.slice(
+            wo_a,
+            [LOCAL_O_GROUPS, O_LORA, O_GROUP_IN],
+            [3 * LOCAL_O_GROUPS, 0, 0],
+        )
+        wo_b_l3: pl.Tensor[[D, LOCAL_O_WIDTH], pl.INT8] = pl.slice(
+            wo_b, [D, LOCAL_O_WIDTH], [3 * D, 0]
+        )
+        wo_b_scale_l3: pl.Tensor[[D], pl.FP32] = pl.slice(
+            wo_b_scale, [D], [3 * D]
+        )
+        hc_ffn_fn_l3: pl.Tensor[[MIX_HC, HC_DIM], pl.FP32] = pl.slice(
+            hc_ffn_fn, [MIX_HC, HC_DIM], [3 * MIX_HC, 0]
+        )
+        hc_ffn_scale_l3: pl.Tensor[[3], pl.FP32] = pl.slice(
+            hc_ffn_scale, [3], [9]
+        )
+        hc_ffn_base_l3: pl.Tensor[[MIX_HC], pl.FP32] = pl.slice(
+            hc_ffn_base, [MIX_HC], [3 * MIX_HC]
+        )
+        norm_w_l3: pl.Tensor[[D], pl.BF16] = pl.slice(
+            norm_w, [D], [3 * D]
+        )
+        gate_w_l3: pl.Tensor[[N_EXPERTS_GLOBAL, D], pl.FP32] = pl.slice(
+            gate_w, [N_EXPERTS_GLOBAL, D], [3 * N_EXPERTS_GLOBAL, 0]
+        )
+        gate_bias_l3: pl.Tensor[[N_EXPERTS_GLOBAL], pl.FP32] = pl.slice(
+            gate_bias, [N_EXPERTS_GLOBAL], [3 * N_EXPERTS_GLOBAL]
+        )
+        tid2eid_l3: pl.Tensor[[VOCAB, TOPK], pl.INT32] = pl.slice(
+            tid2eid, [VOCAB, TOPK], [3 * VOCAB, 0]
+        )
+        routed_w1_l3: pl.Tensor[
+            [N_LOCAL, MOE_INTER, D], pl.INT8
+        ] = pl.slice(
+            routed_w1, [N_LOCAL, MOE_INTER, D], [3 * N_LOCAL, 0, 0]
+        )
+        routed_w1_scale_l3: pl.Tensor[
+            [N_LOCAL, MOE_INTER], pl.FP32
+        ] = pl.slice(
+            routed_w1_scale, [N_LOCAL, MOE_INTER], [3 * N_LOCAL, 0]
+        )
+        routed_w3_l3: pl.Tensor[
+            [N_LOCAL, MOE_INTER, D], pl.INT8
+        ] = pl.slice(
+            routed_w3, [N_LOCAL, MOE_INTER, D], [3 * N_LOCAL, 0, 0]
+        )
+        routed_w3_scale_l3: pl.Tensor[
+            [N_LOCAL, MOE_INTER], pl.FP32
+        ] = pl.slice(
+            routed_w3_scale, [N_LOCAL, MOE_INTER], [3 * N_LOCAL, 0]
+        )
+        routed_w2_l3: pl.Tensor[
+            [N_LOCAL, D, MOE_INTER], pl.INT8
+        ] = pl.slice(
+            routed_w2, [N_LOCAL, D, MOE_INTER], [3 * N_LOCAL, 0, 0]
+        )
+        routed_w2_scale_l3: pl.Tensor[[N_LOCAL, D], pl.FP32] = pl.slice(
+            routed_w2_scale, [N_LOCAL, D], [3 * N_LOCAL, 0]
+        )
+        shared_w1_l3: pl.Tensor[[MOE_INTER, D], pl.INT8] = pl.slice(
+            shared_w1, [MOE_INTER, D], [3 * MOE_INTER, 0]
+        )
+        shared_w1_scale_l3: pl.Tensor[[MOE_INTER], pl.FP32] = pl.slice(
+            shared_w1_scale, [MOE_INTER], [3 * MOE_INTER]
+        )
+        shared_w3_l3: pl.Tensor[[MOE_INTER, D], pl.INT8] = pl.slice(
+            shared_w3, [MOE_INTER, D], [3 * MOE_INTER, 0]
+        )
+        shared_w3_scale_l3: pl.Tensor[[MOE_INTER], pl.FP32] = pl.slice(
+            shared_w3_scale, [MOE_INTER], [3 * MOE_INTER]
+        )
+        shared_w2_l3: pl.Tensor[[D, MOE_INTER], pl.INT8] = pl.slice(
+            shared_w2, [D, MOE_INTER], [3 * D, 0]
+        )
+        shared_w2_scale_l3: pl.Tensor[[D], pl.FP32] = pl.slice(
+            shared_w2_scale, [D], [3 * D]
+        )
+        decode_layer_hca(
+            x_pong,
+            hc_attn_fn_l3, hc_attn_scale_l3, hc_attn_base_l3,
+            attn_norm_w_l3, wq_a_l3, wq_b_l3, wq_b_scale_l3,
+            wkv_l3, gamma_cq_l3, gamma_ckv_l3,
+            freqs_cos, freqs_sin,
+            hca_cmp_freqs_cos, hca_cmp_freqs_sin,
+            hca_cmp_wkv, hca_cmp_wgate, hca_cmp_ape, hca_cmp_norm_w,
+            hca_compress_state_l0, hca_compress_state_block_table,
+            raw_kv_l3, hca_cmp_kv_l0, hca_cmp_block_table,
+            hca_ori_slot_mapping, hca_window_swa_indices,
+            hca_window_swa_lens, hca_cmp_slot_mapping,
+            hca_state_slot_mapping, position_ids, hca_kv_seq_lens,
+            attn_sink_l3, wo_a_l3, wo_b_l3, wo_b_scale_l3,
+            hc_ffn_fn_l3, hc_ffn_scale_l3, hc_ffn_base_l3,
+            norm_w_l3, gate_w_l3, gate_bias_l3, tid2eid_l3, input_ids,
+            routed_w1_l3, routed_w1_scale_l3,
+            routed_w3_l3, routed_w3_scale_l3,
+            routed_w2_l3, routed_w2_scale_l3,
+            shared_w1_l3, shared_w1_scale_l3,
+            shared_w3_l3, shared_w3_scale_l3,
+            shared_w2_l3, shared_w2_scale_l3,
+            x_attn_active, x_moe_next, x_out,
+            attention_window, attention_signal, o_window, o_signal,
+            recv_meta, recv_x, recv_aux, recv_route,
+            arrived, data_arrived, routed_y_buf, combine_arrived,
+            pl.const(3, pl.INT32), group_base, tp_rank, local_t, my_rank,
+            pl.const(4, pl.INT32),
         )
         clear_moe_signals(
             x_moe_next, arrived, data_arrived, combine_arrived
@@ -774,34 +1326,34 @@ def decode_fwd(
 @pl.jit.host
 def l3_decode_fwd(
     hc_attn_fn: pl.Tensor[
-        [N_RANKS, TWO_SWA_LAYER_COUNT * MIX_HC, HC_DIM], pl.FP32
+        [N_RANKS, MIXED_PREFIX_LAYER_COUNT * MIX_HC, HC_DIM], pl.FP32
     ],
     hc_attn_scale: pl.Tensor[
-        [N_RANKS, TWO_SWA_LAYER_COUNT * 3], pl.FP32
+        [N_RANKS, MIXED_PREFIX_LAYER_COUNT * 3], pl.FP32
     ],
     hc_attn_base: pl.Tensor[
-        [N_RANKS, TWO_SWA_LAYER_COUNT * MIX_HC], pl.FP32
+        [N_RANKS, MIXED_PREFIX_LAYER_COUNT * MIX_HC], pl.FP32
     ],
     attn_norm_w: pl.Tensor[
-        [N_RANKS, TWO_SWA_LAYER_COUNT * D], pl.BF16
+        [N_RANKS, MIXED_PREFIX_LAYER_COUNT * D], pl.BF16
     ],
     wq_a: pl.Tensor[
-        [N_RANKS, TWO_SWA_LAYER_COUNT * D, Q_LORA], pl.BF16
+        [N_RANKS, MIXED_PREFIX_LAYER_COUNT * D, Q_LORA], pl.BF16
     ],
     wq_b: pl.Tensor[
-        [N_RANKS, TWO_SWA_LAYER_COUNT * Q_LORA, H * HEAD_DIM], pl.INT8
+        [N_RANKS, MIXED_PREFIX_LAYER_COUNT * Q_LORA, H * HEAD_DIM], pl.INT8
     ],
     wq_b_scale: pl.Tensor[
-        [N_RANKS, TWO_SWA_LAYER_COUNT * H * HEAD_DIM], pl.FP32
+        [N_RANKS, MIXED_PREFIX_LAYER_COUNT * H * HEAD_DIM], pl.FP32
     ],
     wkv: pl.Tensor[
-        [N_RANKS, TWO_SWA_LAYER_COUNT * D, HEAD_DIM], pl.BF16
+        [N_RANKS, MIXED_PREFIX_LAYER_COUNT * D, HEAD_DIM], pl.BF16
     ],
     gamma_cq: pl.Tensor[
-        [N_RANKS, TWO_SWA_LAYER_COUNT * Q_LORA], pl.BF16
+        [N_RANKS, MIXED_PREFIX_LAYER_COUNT * Q_LORA], pl.BF16
     ],
     gamma_ckv: pl.Tensor[
-        [N_RANKS, TWO_SWA_LAYER_COUNT * HEAD_DIM], pl.BF16
+        [N_RANKS, MIXED_PREFIX_LAYER_COUNT * HEAD_DIM], pl.BF16
     ],
     raw_kv_pool: pl.InOut[
         pl.Tensor[
@@ -825,83 +1377,244 @@ def l3_decode_fwd(
     swa_indices: pl.Tensor[[N_RANKS, T_DYN, WIN], pl.INT32],
     swa_lens: pl.Tensor[[N_RANKS, T_DYN], pl.INT32],
     position_ids: pl.Tensor[[N_RANKS, T_DYN], pl.INT32],
+    csa_cmp_freqs_cos: pl.Tensor[
+        [N_RANKS, T_DYN, ROPE_HEAD_DIM], pl.BF16
+    ],
+    csa_cmp_freqs_sin: pl.Tensor[
+        [N_RANKS, T_DYN, ROPE_HEAD_DIM], pl.BF16
+    ],
+    csa_cmp_wkv: pl.Tensor[[N_RANKS, CSA_MAIN_OUT_DIM, D], pl.BF16],
+    csa_cmp_wgate: pl.Tensor[
+        [N_RANKS, CSA_MAIN_OUT_DIM, D], pl.BF16
+    ],
+    csa_cmp_ape: pl.Tensor[
+        [N_RANKS, CSA_COMPRESS_RATIO, CSA_MAIN_OUT_DIM], pl.FP32
+    ],
+    csa_cmp_norm_w: pl.Tensor[[N_RANKS, HEAD_DIM], pl.BF16],
+    csa_compress_state: pl.InOut[
+        pl.Tensor[
+            [
+                N_RANKS,
+                FWD_CSA_MAIN_STATE_BLOCKS_DYN,
+                CSA_MAIN_STATE_BLOCK_SIZE,
+                CSA_MAIN_STATE_DIM,
+            ],
+            pl.FP32,
+        ]
+    ],
+    csa_compress_state_block_table: pl.Tensor[
+        [N_RANKS, CSA_B_DYN, CSA_MAIN_STATE_MAX_BLOCKS], pl.INT32
+    ],
+    csa_idx_wq_b: pl.Tensor[
+        [N_RANKS, Q_LORA, CSA_IDX_N_HEADS * CSA_IDX_HEAD_DIM], pl.INT8
+    ],
+    csa_idx_wq_b_scale: pl.Tensor[
+        [N_RANKS, CSA_IDX_N_HEADS * CSA_IDX_HEAD_DIM], pl.FP32
+    ],
+    csa_weights_proj: pl.Tensor[
+        [N_RANKS, D, CSA_IDX_N_HEADS], pl.BF16
+    ],
+    csa_hadamard_idx: pl.Tensor[
+        [N_RANKS, CSA_IDX_HEAD_DIM, CSA_IDX_HEAD_DIM], pl.BF16
+    ],
+    csa_inner_wkv: pl.Tensor[
+        [N_RANKS, CSA_INNER_OUT_DIM, D], pl.BF16
+    ],
+    csa_inner_wgate: pl.Tensor[
+        [N_RANKS, CSA_INNER_OUT_DIM, D], pl.BF16
+    ],
+    csa_inner_ape: pl.Tensor[
+        [N_RANKS, CSA_COMPRESS_RATIO, CSA_INNER_OUT_DIM], pl.FP32
+    ],
+    csa_inner_norm_w: pl.Tensor[
+        [N_RANKS, CSA_IDX_HEAD_DIM], pl.BF16
+    ],
+    csa_inner_compress_state: pl.InOut[
+        pl.Tensor[
+            [
+                N_RANKS,
+                FWD_CSA_INNER_STATE_BLOCKS_DYN,
+                CSA_INNER_STATE_BLOCK_SIZE,
+                CSA_INNER_STATE_DIM,
+            ],
+            pl.FP32,
+        ]
+    ],
+    csa_inner_compress_state_block_table: pl.Tensor[
+        [N_RANKS, CSA_B_DYN, CSA_INNER_STATE_MAX_BLOCKS], pl.INT32
+    ],
+    csa_cmp_kv: pl.InOut[
+        pl.Tensor[
+            [
+                N_RANKS,
+                FWD_CSA_CMP_BLOCKS_DYN,
+                BLOCK_SIZE,
+                1,
+                HEAD_DIM,
+            ],
+            pl.BF16,
+        ]
+    ],
+    csa_cmp_block_table: pl.Tensor[
+        [N_RANKS, CSA_B_DYN, CSA_CMP_MAX_BLOCKS], pl.INT32
+    ],
+    csa_idx_kv_cache: pl.InOut[
+        pl.Tensor[
+            [
+                N_RANKS,
+                FWD_CSA_IDX_BLOCKS_DYN,
+                BLOCK_SIZE,
+                1,
+                CSA_IDX_HEAD_DIM,
+            ],
+            pl.INT8,
+        ]
+    ],
+    csa_idx_kv_scale: pl.InOut[
+        pl.Tensor[
+            [N_RANKS, FWD_CSA_IDX_BLOCKS_DYN, BLOCK_SIZE, 1, 1],
+            pl.FP32,
+        ]
+    ],
+    csa_idx_block_table: pl.Tensor[
+        [N_RANKS, CSA_B_DYN, CSA_IDX_MAX_BLOCKS], pl.INT32
+    ],
+    csa_ori_slot_mapping: pl.Tensor[[N_RANKS, T_DYN], pl.INT64],
+    csa_window_swa_indices: pl.Tensor[
+        [N_RANKS, T_DYN, WIN], pl.INT32
+    ],
+    csa_window_swa_lens: pl.Tensor[[N_RANKS, T_DYN], pl.INT32],
+    csa_cmp_slot_mapping: pl.Tensor[[N_RANKS, T_DYN], pl.INT64],
+    csa_idx_slot_mapping: pl.Tensor[[N_RANKS, T_DYN], pl.INT64],
+    csa_state_slot_mapping: pl.Tensor[[N_RANKS, T_DYN], pl.INT64],
+    csa_inner_state_slot_mapping: pl.Tensor[
+        [N_RANKS, T_DYN], pl.INT64
+    ],
+    csa_kv_seq_lens: pl.Tensor[[N_RANKS, CSA_B_DYN], pl.INT32],
+    hca_cmp_freqs_cos: pl.Tensor[
+        [N_RANKS, HCA_B, ROPE_HEAD_DIM // 2], pl.FP32
+    ],
+    hca_cmp_freqs_sin: pl.Tensor[
+        [N_RANKS, HCA_B, ROPE_HEAD_DIM // 2], pl.FP32
+    ],
+    hca_cmp_wkv: pl.Tensor[[N_RANKS, HCA_MAIN_OUT_DIM, D], pl.BF16],
+    hca_cmp_wgate: pl.Tensor[
+        [N_RANKS, HCA_MAIN_OUT_DIM, D], pl.BF16
+    ],
+    hca_cmp_ape: pl.Tensor[
+        [N_RANKS, HCA_COMPRESS_RATIO, HCA_MAIN_OUT_DIM], pl.FP32
+    ],
+    hca_cmp_norm_w: pl.Tensor[[N_RANKS, HEAD_DIM], pl.BF16],
+    hca_compress_state: pl.InOut[
+        pl.Tensor[
+            [
+                N_RANKS,
+                FWD_HCA_STATE_BLOCKS_DYN,
+                HCA_COMPRESS_STATE_BLOCK_SIZE,
+                HCA_COMPRESS_STATE_DIM,
+            ],
+            pl.FP32,
+        ]
+    ],
+    hca_compress_state_block_table: pl.Tensor[
+        [N_RANKS, HCA_B_DYN, HCA_COMPRESS_STATE_MAX_BLOCKS], pl.INT32
+    ],
+    hca_cmp_kv: pl.InOut[
+        pl.Tensor[
+            [N_RANKS, FWD_HCA_CMP_BLOCKS_DYN, BLOCK_SIZE, 1, HEAD_DIM],
+            pl.BF16,
+        ]
+    ],
+    hca_cmp_block_table: pl.Tensor[
+        [N_RANKS, HCA_B_DYN, HCA_CMP_TABLE_BLOCKS_DYN], pl.INT32
+    ],
+    hca_ori_slot_mapping: pl.Tensor[[N_RANKS, T_DYN], pl.INT64],
+    hca_window_swa_indices: pl.Tensor[
+        [N_RANKS, T_DYN, WIN], pl.INT32
+    ],
+    hca_window_swa_lens: pl.Tensor[[N_RANKS, T_DYN], pl.INT32],
+    hca_cmp_slot_mapping: pl.Tensor[[N_RANKS, T_DYN], pl.INT64],
+    hca_state_slot_mapping: pl.Tensor[[N_RANKS, T_DYN], pl.INT64],
+    hca_kv_seq_lens: pl.Tensor[[N_RANKS, HCA_B_DYN], pl.INT32],
     attn_sink: pl.Tensor[
-        [N_RANKS, TWO_SWA_LAYER_COUNT * H], pl.FP32
+        [N_RANKS, MIXED_PREFIX_LAYER_COUNT * H], pl.FP32
     ],
     wo_a: pl.Tensor[
         [
             N_RANKS,
-            TWO_SWA_LAYER_COUNT * LOCAL_O_GROUPS,
+            MIXED_PREFIX_LAYER_COUNT * LOCAL_O_GROUPS,
             O_LORA,
             O_GROUP_IN,
         ],
         pl.BF16,
     ],
     wo_b: pl.Tensor[
-        [N_RANKS, TWO_SWA_LAYER_COUNT * D, LOCAL_O_WIDTH], pl.INT8
+        [N_RANKS, MIXED_PREFIX_LAYER_COUNT * D, LOCAL_O_WIDTH], pl.INT8
     ],
     wo_b_scale: pl.Tensor[
-        [N_RANKS, TWO_SWA_LAYER_COUNT * D], pl.FP32
+        [N_RANKS, MIXED_PREFIX_LAYER_COUNT * D], pl.FP32
     ],
     hc_ffn_fn: pl.Tensor[
-        [N_RANKS, TWO_SWA_LAYER_COUNT * MIX_HC, HC_DIM], pl.FP32
+        [N_RANKS, MIXED_PREFIX_LAYER_COUNT * MIX_HC, HC_DIM], pl.FP32
     ],
     hc_ffn_scale: pl.Tensor[
-        [N_RANKS, TWO_SWA_LAYER_COUNT * 3], pl.FP32
+        [N_RANKS, MIXED_PREFIX_LAYER_COUNT * 3], pl.FP32
     ],
     hc_ffn_base: pl.Tensor[
-        [N_RANKS, TWO_SWA_LAYER_COUNT * MIX_HC], pl.FP32
+        [N_RANKS, MIXED_PREFIX_LAYER_COUNT * MIX_HC], pl.FP32
     ],
     norm_w: pl.Tensor[
-        [N_RANKS, TWO_SWA_LAYER_COUNT * D], pl.BF16
+        [N_RANKS, MIXED_PREFIX_LAYER_COUNT * D], pl.BF16
     ],
     gate_w: pl.Tensor[
-        [N_RANKS, TWO_SWA_LAYER_COUNT * N_EXPERTS_GLOBAL, D], pl.FP32
+        [N_RANKS, MIXED_PREFIX_LAYER_COUNT * N_EXPERTS_GLOBAL, D], pl.FP32
     ],
     gate_bias: pl.Tensor[
-        [N_RANKS, TWO_SWA_LAYER_COUNT * N_EXPERTS_GLOBAL], pl.FP32
+        [N_RANKS, MIXED_PREFIX_LAYER_COUNT * N_EXPERTS_GLOBAL], pl.FP32
     ],
     tid2eid: pl.Tensor[
-        [N_RANKS, TWO_SWA_LAYER_COUNT * VOCAB, TOPK], pl.INT32
+        [N_RANKS, MIXED_PREFIX_LAYER_COUNT * VOCAB, TOPK], pl.INT32
     ],
     input_ids: pl.Tensor[[N_RANKS, MOE_TOKENS], pl.INT64],
     routed_w1: pl.Tensor[
-        [N_RANKS, TWO_SWA_LAYER_COUNT * N_LOCAL, MOE_INTER, D], pl.INT8
+        [N_RANKS, MIXED_PREFIX_LAYER_COUNT * N_LOCAL, MOE_INTER, D], pl.INT8
     ],
     routed_w1_scale: pl.Tensor[
-        [N_RANKS, TWO_SWA_LAYER_COUNT * N_LOCAL, MOE_INTER], pl.FP32
+        [N_RANKS, MIXED_PREFIX_LAYER_COUNT * N_LOCAL, MOE_INTER], pl.FP32
     ],
     routed_w3: pl.Tensor[
-        [N_RANKS, TWO_SWA_LAYER_COUNT * N_LOCAL, MOE_INTER, D], pl.INT8
+        [N_RANKS, MIXED_PREFIX_LAYER_COUNT * N_LOCAL, MOE_INTER, D], pl.INT8
     ],
     routed_w3_scale: pl.Tensor[
-        [N_RANKS, TWO_SWA_LAYER_COUNT * N_LOCAL, MOE_INTER], pl.FP32
+        [N_RANKS, MIXED_PREFIX_LAYER_COUNT * N_LOCAL, MOE_INTER], pl.FP32
     ],
     routed_w2: pl.Tensor[
-        [N_RANKS, TWO_SWA_LAYER_COUNT * N_LOCAL, D, MOE_INTER], pl.INT8
+        [N_RANKS, MIXED_PREFIX_LAYER_COUNT * N_LOCAL, D, MOE_INTER], pl.INT8
     ],
     routed_w2_scale: pl.Tensor[
-        [N_RANKS, TWO_SWA_LAYER_COUNT * N_LOCAL, D], pl.FP32
+        [N_RANKS, MIXED_PREFIX_LAYER_COUNT * N_LOCAL, D], pl.FP32
     ],
     shared_w1: pl.Tensor[
-        [N_RANKS, TWO_SWA_LAYER_COUNT * MOE_INTER, D], pl.INT8
+        [N_RANKS, MIXED_PREFIX_LAYER_COUNT * MOE_INTER, D], pl.INT8
     ],
     shared_w1_scale: pl.Tensor[
-        [N_RANKS, TWO_SWA_LAYER_COUNT * MOE_INTER], pl.FP32
+        [N_RANKS, MIXED_PREFIX_LAYER_COUNT * MOE_INTER], pl.FP32
     ],
     shared_w3: pl.Tensor[
-        [N_RANKS, TWO_SWA_LAYER_COUNT * MOE_INTER, D], pl.INT8
+        [N_RANKS, MIXED_PREFIX_LAYER_COUNT * MOE_INTER, D], pl.INT8
     ],
     shared_w3_scale: pl.Tensor[
-        [N_RANKS, TWO_SWA_LAYER_COUNT * MOE_INTER], pl.FP32
+        [N_RANKS, MIXED_PREFIX_LAYER_COUNT * MOE_INTER], pl.FP32
     ],
     shared_w2: pl.Tensor[
-        [N_RANKS, TWO_SWA_LAYER_COUNT * D, MOE_INTER], pl.INT8
+        [N_RANKS, MIXED_PREFIX_LAYER_COUNT * D, MOE_INTER], pl.INT8
     ],
     shared_w2_scale: pl.Tensor[
-        [N_RANKS, TWO_SWA_LAYER_COUNT * D], pl.FP32
+        [N_RANKS, MIXED_PREFIX_LAYER_COUNT * D], pl.FP32
     ],
-    x_ping: pl.Tensor[[N_RANKS, T_DYN, HC_MULT, D], pl.FP32],
+    x_ping: pl.InOut[
+        pl.Tensor[[N_RANKS, T_DYN, HC_MULT, D], pl.FP32]
+    ],
     x_pong: pl.InOut[
         pl.Tensor[[N_RANKS, T_DYN, HC_MULT, D], pl.FP32]
     ],
@@ -915,7 +1628,7 @@ def l3_decode_fwd(
         pl.Tensor[[N_RANKS, T_DYN, HC_MULT, D], pl.FP32]
     ],
 ):
-    """Allocate shared windows once and launch one two-SWA child per rank."""
+    """Allocate shared windows once and launch one four-layer child per rank."""
     x_ping.bind_dynamic(1, T_DYN)
     raw_kv_pool.bind_dynamic(1, FWD_PACKED_RAW_BLOCKS_DYN)
     freqs_cos.bind_dynamic(1, T_DYN)
@@ -924,6 +1637,38 @@ def l3_decode_fwd(
     swa_indices.bind_dynamic(1, T_DYN)
     swa_lens.bind_dynamic(1, T_DYN)
     position_ids.bind_dynamic(1, T_DYN)
+    csa_cmp_freqs_cos.bind_dynamic(1, T_DYN)
+    csa_cmp_freqs_sin.bind_dynamic(1, T_DYN)
+    csa_compress_state.bind_dynamic(1, FWD_CSA_MAIN_STATE_BLOCKS_DYN)
+    csa_compress_state_block_table.bind_dynamic(1, CSA_B_DYN)
+    csa_inner_compress_state.bind_dynamic(
+        1, FWD_CSA_INNER_STATE_BLOCKS_DYN
+    )
+    csa_inner_compress_state_block_table.bind_dynamic(1, CSA_B_DYN)
+    csa_cmp_kv.bind_dynamic(1, FWD_CSA_CMP_BLOCKS_DYN)
+    csa_cmp_block_table.bind_dynamic(1, CSA_B_DYN)
+    csa_idx_kv_cache.bind_dynamic(1, FWD_CSA_IDX_BLOCKS_DYN)
+    csa_idx_kv_scale.bind_dynamic(1, FWD_CSA_IDX_BLOCKS_DYN)
+    csa_idx_block_table.bind_dynamic(1, CSA_B_DYN)
+    csa_ori_slot_mapping.bind_dynamic(1, T_DYN)
+    csa_window_swa_indices.bind_dynamic(1, T_DYN)
+    csa_window_swa_lens.bind_dynamic(1, T_DYN)
+    csa_cmp_slot_mapping.bind_dynamic(1, T_DYN)
+    csa_idx_slot_mapping.bind_dynamic(1, T_DYN)
+    csa_state_slot_mapping.bind_dynamic(1, T_DYN)
+    csa_inner_state_slot_mapping.bind_dynamic(1, T_DYN)
+    csa_kv_seq_lens.bind_dynamic(1, CSA_B_DYN)
+    hca_compress_state.bind_dynamic(1, FWD_HCA_STATE_BLOCKS_DYN)
+    hca_compress_state_block_table.bind_dynamic(1, HCA_B_DYN)
+    hca_cmp_kv.bind_dynamic(1, FWD_HCA_CMP_BLOCKS_DYN)
+    hca_cmp_block_table.bind_dynamic(1, HCA_B_DYN)
+    hca_cmp_block_table.bind_dynamic(2, HCA_CMP_TABLE_BLOCKS_DYN)
+    hca_ori_slot_mapping.bind_dynamic(1, T_DYN)
+    hca_window_swa_indices.bind_dynamic(1, T_DYN)
+    hca_window_swa_lens.bind_dynamic(1, T_DYN)
+    hca_cmp_slot_mapping.bind_dynamic(1, T_DYN)
+    hca_state_slot_mapping.bind_dynamic(1, T_DYN)
+    hca_kv_seq_lens.bind_dynamic(1, HCA_B_DYN)
     x_pong.bind_dynamic(1, T_DYN)
     x_attn_active.bind_dynamic(1, T_DYN)
     x_out.bind_dynamic(1, T_DYN)
@@ -1013,7 +1758,33 @@ def l3_decode_fwd(
             wq_b_scale[rank], wkv[rank], gamma_cq[rank], gamma_ckv[rank],
             raw_kv_pool[rank], freqs_cos[rank], freqs_sin[rank],
             swa_slot_mapping[rank], swa_indices[rank], swa_lens[rank],
-            position_ids[rank], attn_sink[rank], wo_a[rank], wo_b[rank],
+            position_ids[rank],
+            csa_cmp_freqs_cos[rank], csa_cmp_freqs_sin[rank],
+            csa_cmp_wkv[rank], csa_cmp_wgate[rank], csa_cmp_ape[rank],
+            csa_cmp_norm_w[rank], csa_compress_state[rank],
+            csa_compress_state_block_table[rank],
+            csa_idx_wq_b[rank], csa_idx_wq_b_scale[rank],
+            csa_weights_proj[rank], csa_hadamard_idx[rank],
+            csa_inner_wkv[rank], csa_inner_wgate[rank],
+            csa_inner_ape[rank], csa_inner_norm_w[rank],
+            csa_inner_compress_state[rank],
+            csa_inner_compress_state_block_table[rank],
+            csa_cmp_kv[rank], csa_cmp_block_table[rank],
+            csa_idx_kv_cache[rank], csa_idx_kv_scale[rank],
+            csa_idx_block_table[rank], csa_ori_slot_mapping[rank],
+            csa_window_swa_indices[rank], csa_window_swa_lens[rank],
+            csa_cmp_slot_mapping[rank], csa_idx_slot_mapping[rank],
+            csa_state_slot_mapping[rank],
+            csa_inner_state_slot_mapping[rank], csa_kv_seq_lens[rank],
+            hca_cmp_freqs_cos[rank], hca_cmp_freqs_sin[rank],
+            hca_cmp_wkv[rank], hca_cmp_wgate[rank], hca_cmp_ape[rank],
+            hca_cmp_norm_w[rank], hca_compress_state[rank],
+            hca_compress_state_block_table[rank],
+            hca_cmp_kv[rank], hca_cmp_block_table[rank],
+            hca_ori_slot_mapping[rank], hca_window_swa_indices[rank],
+            hca_window_swa_lens[rank], hca_cmp_slot_mapping[rank],
+            hca_state_slot_mapping[rank], hca_kv_seq_lens[rank],
+            attn_sink[rank], wo_a[rank], wo_b[rank],
             wo_b_scale[rank],
             hc_ffn_fn[rank], hc_ffn_scale[rank], hc_ffn_base[rank],
             norm_w[rank], gate_w[rank], gate_bias[rank], tid2eid[rank],
@@ -1076,7 +1847,7 @@ _CSA_EXTRA_WEIGHT_NAMES = (
 
 _MOE_NON_WEIGHT_NAMES = {"x_attn_moe", "x_moe_next", "input_ids"}
 
-_TWO_SWA_LAYERED_WEIGHT_NAMES = (
+_MIXED_LAYERED_WEIGHT_NAMES = (
     *_COMMON_ATTN_WEIGHT_NAMES,
     "hc_ffn_fn",
     "hc_ffn_scale",
@@ -1099,7 +1870,7 @@ _TWO_SWA_LAYERED_WEIGHT_NAMES = (
     "shared_w2_scale",
 )
 
-_TWO_SWA_METADATA_NAMES = (
+_SWA_METADATA_NAMES = (
     "freqs_cos",
     "freqs_sin",
     "swa_slot_mapping",
@@ -1108,30 +1879,60 @@ _TWO_SWA_METADATA_NAMES = (
     "position_ids",
 )
 
-_TWO_SWA_ATTN_INPUT_NAMES = (
-    "x_hc",
-    "hc_attn_fn",
-    "hc_attn_scale",
-    "hc_attn_base",
-    "attn_norm_w",
-    "wq_a",
-    "wq_b",
-    "wq_b_scale",
-    "wkv",
-    "gamma_cq",
-    "gamma_ckv",
-    "freqs_cos",
-    "freqs_sin",
-    "kv_cache",
-    "swa_slot_mapping",
-    "swa_indices",
-    "swa_lens",
-    "position_ids",
-    "attn_sink",
-    "wo_a",
-    "wo_b",
-    "wo_b_scale",
-)
+_CSA_PREFIX_SOURCES = {
+    "csa_cmp_freqs_cos": "cmp_freqs_cos",
+    "csa_cmp_freqs_sin": "cmp_freqs_sin",
+    "csa_cmp_wkv": "cmp_wkv",
+    "csa_cmp_wgate": "cmp_wgate",
+    "csa_cmp_ape": "cmp_ape",
+    "csa_cmp_norm_w": "cmp_norm_w",
+    "csa_compress_state": "compress_state",
+    "csa_compress_state_block_table": "compress_state_block_table",
+    "csa_idx_wq_b": "idx_wq_b",
+    "csa_idx_wq_b_scale": "idx_wq_b_scale",
+    "csa_weights_proj": "weights_proj",
+    "csa_hadamard_idx": "hadamard_idx",
+    "csa_inner_wkv": "inner_wkv",
+    "csa_inner_wgate": "inner_wgate",
+    "csa_inner_ape": "inner_ape",
+    "csa_inner_norm_w": "inner_norm_w",
+    "csa_inner_compress_state": "inner_compress_state",
+    "csa_inner_compress_state_block_table": (
+        "inner_compress_state_block_table"
+    ),
+    "csa_cmp_kv": "cmp_kv",
+    "csa_cmp_block_table": "cmp_block_table",
+    "csa_idx_kv_cache": "idx_kv_cache",
+    "csa_idx_kv_scale": "idx_kv_scale",
+    "csa_idx_block_table": "idx_block_table",
+    "csa_ori_slot_mapping": "ori_slot_mapping",
+    "csa_window_swa_indices": "window_swa_indices",
+    "csa_window_swa_lens": "window_swa_lens",
+    "csa_cmp_slot_mapping": "cmp_slot_mapping",
+    "csa_idx_slot_mapping": "idx_slot_mapping",
+    "csa_state_slot_mapping": "state_slot_mapping",
+    "csa_inner_state_slot_mapping": "inner_state_slot_mapping",
+    "csa_kv_seq_lens": "kv_seq_lens",
+}
+
+_HCA_PREFIX_SOURCES = {
+    "hca_cmp_freqs_cos": "cmp_freqs_cos",
+    "hca_cmp_freqs_sin": "cmp_freqs_sin",
+    "hca_cmp_wkv": "cmp_wkv",
+    "hca_cmp_wgate": "cmp_wgate",
+    "hca_cmp_ape": "cmp_ape",
+    "hca_cmp_norm_w": "cmp_norm_w",
+    "hca_compress_state": "compress_state",
+    "hca_compress_state_block_table": "compress_state_block_table",
+    "hca_cmp_kv": "cmp_kv",
+    "hca_cmp_block_table": "cmp_block_table",
+    "hca_ori_slot_mapping": "ori_slot_mapping",
+    "hca_window_swa_indices": "window_swa_indices",
+    "hca_window_swa_lens": "window_swa_lens",
+    "hca_cmp_slot_mapping": "cmp_slot_mapping",
+    "hca_state_slot_mapping": "state_slot_mapping",
+    "hca_kv_seq_lens": "kv_seq_lens",
+}
 
 _METADATA_EXCLUDES = {
     "x_hc",
@@ -1235,58 +2036,91 @@ def _validate_public_shapes(sections):
     return maximum_dims
 
 
-def _make_two_swa_layered_spec(name, spec):
-    """Pack two copies of one rank-stacked layer weight along axis one."""
+def _make_mixed_layered_spec(name, source_specs):
+    """Pack the four real layer fixtures along the rank-local data axis."""
     from golden import TensorSpec
 
-    shape = list(spec.shape)
-    shape[1] *= TWO_SWA_LAYER_COUNT
+    shape = list(source_specs[0].shape)
+    shape[1] = sum(int(spec.shape[1]) for spec in source_specs)
+    reference_tail = tuple(source_specs[0].shape[2:])
+    for spec in source_specs:
+        if spec.shape[0] != N_RANKS or tuple(spec.shape[2:]) != reference_tail:
+            raise ValueError(f"mixed layer weight shape diverged for {name}")
 
     def init_value():
-        value = spec.create_tensor()
-        return value.repeat(
-            1, TWO_SWA_LAYER_COUNT, *([1] * (value.ndim - 2))
-        )
+        import torch
 
-    packed = TensorSpec(
-        name,
-        shape,
-        spec.dtype,
-        init_value=init_value,
-    )
+        return torch.cat(
+            [spec.create_tensor() for spec in source_specs], dim=1
+        ).contiguous()
+
+    packed = TensorSpec(name, shape, source_specs[0].dtype, init_value=init_value)
     packed.resident = "stacked"
     return packed
 
 
-def build_two_swa_tensor_specs(start_pos=None):
-    """Build the rank-stacked two-SWA prefix fixture in L3 ABI order."""
+def _copy_prefix_spec(name, source, *, is_output=None):
+    from golden import TensorSpec
+
+    copied = TensorSpec(
+        name,
+        list(source.shape),
+        source.dtype,
+        init_value=source.init_value,
+        is_output=source.is_output if is_output is None else is_output,
+    )
+    copied.resident = source.resident
+    return copied
+
+
+def build_mixed_prefix_tensor_specs(start_pos=None):
+    """Build the rank-stacked SWA/SWA/CSA/HCA fixture in L3 ABI order."""
     import inspect
 
     import torch
     from golden import TensorSpec
 
-    base_specs = {
-        spec.name: spec
-        for spec in layer.build_swa_layer_specs(start_pos=start_pos, layer_id=0)
-        if isinstance(spec, TensorSpec)
-    }
-    local_t = int(base_specs["freqs_cos"].shape[1])
+    builders = (
+        (layer.build_swa_layer_specs, 0),
+        (layer.build_swa_layer_specs, 1),
+        (layer.build_csa_layer_specs, 2),
+        (layer.build_hca_layer_specs, 3),
+    )
+    layer_specs = []
+    for builder, layer_id in builders:
+        layer_specs.append({
+            spec.name: spec
+            for spec in builder(start_pos=start_pos, layer_id=layer_id)
+            if isinstance(spec, TensorSpec)
+        })
+    swa0_specs, _swa1_specs, csa_specs, hca_specs = layer_specs
+    local_t = int(swa0_specs["freqs_cos"].shape[1])
+    if any(int(specs["freqs_cos"].shape[1]) != local_t for specs in layer_specs):
+        raise ValueError("mixed attention fixtures disagree on active tokens")
 
     def init_raw_kv_pool():
-        first = base_specs["kv_cache"].create_tensor()
-        second = (first.float() + 0.125).to(torch.bfloat16)
-        return torch.cat((first, second), dim=1)
+        layers = []
+        for ordinal, specs in enumerate(layer_specs):
+            value = specs["kv_cache"].create_tensor()
+            value = (value.float() + ordinal * 0.125).to(torch.bfloat16)
+            layers.append(value)
+        return torch.cat(layers, dim=1).contiguous()
 
     def init_input_ids():
-        value = base_specs["input_ids"].create_tensor()
-        return torch.remainder(value, TWO_SWA_TEST_VOCAB).contiguous()
+        value = swa0_specs["input_ids"].create_tensor()
+        return torch.remainder(value, MIXED_PREFIX_TEST_VOCAB).contiguous()
+
+    def zero_active():
+        return torch.zeros(
+            N_RANKS, local_t, HC_MULT, D, dtype=torch.float32
+        )
 
     specs_by_name = {
         "raw_kv_pool": TensorSpec(
             "raw_kv_pool",
             [
                 N_RANKS,
-                TWO_SWA_LAYER_COUNT * base_specs["kv_cache"].shape[1],
+                MIXED_PREFIX_LAYER_COUNT * swa0_specs["kv_cache"].shape[1],
                 BLOCK_SIZE,
                 1,
                 HEAD_DIM,
@@ -1305,24 +2139,21 @@ def build_two_swa_tensor_specs(start_pos=None):
             "x_ping",
             [N_RANKS, local_t, HC_MULT, D],
             torch.float32,
-            init_value=base_specs["x_hc"].init_value,
+            init_value=swa0_specs["x_hc"].init_value,
+            is_output=True,
         ),
         "x_pong": TensorSpec(
             "x_pong",
             [N_RANKS, local_t, HC_MULT, D],
             torch.float32,
-            init_value=lambda: torch.zeros(
-                N_RANKS, local_t, HC_MULT, D, dtype=torch.float32
-            ),
+            init_value=zero_active,
             is_output=True,
         ),
         "x_attn_active": TensorSpec(
             "x_attn_active",
             [N_RANKS, local_t, HC_MULT, D],
             torch.float32,
-            init_value=lambda: torch.zeros(
-                N_RANKS, local_t, HC_MULT, D, dtype=torch.float32
-            ),
+            init_value=zero_active,
             is_output=True,
         ),
         "x_moe_next": TensorSpec(
@@ -1343,21 +2174,20 @@ def build_two_swa_tensor_specs(start_pos=None):
     }
     specs_by_name["raw_kv_pool"].resident = "stacked"
 
-    for name in _TWO_SWA_LAYERED_WEIGHT_NAMES:
-        specs_by_name[name] = _make_two_swa_layered_spec(
-            name, base_specs[name]
+    for name in _MIXED_LAYERED_WEIGHT_NAMES:
+        specs_by_name[name] = _make_mixed_layered_spec(
+            name, [specs[name] for specs in layer_specs]
         )
-
-    for name in _TWO_SWA_METADATA_NAMES:
-        source = base_specs[name]
-        copied = TensorSpec(
-            name,
-            list(source.shape),
-            source.dtype,
-            init_value=source.init_value,
+    for name in _SWA_METADATA_NAMES:
+        specs_by_name[name] = _copy_prefix_spec(name, swa0_specs[name])
+    for public_name, source_name in _CSA_PREFIX_SOURCES.items():
+        specs_by_name[public_name] = _copy_prefix_spec(
+            public_name, csa_specs[source_name]
         )
-        copied.resident = source.resident
-        specs_by_name[name] = copied
+    for public_name, source_name in _HCA_PREFIX_SOURCES.items():
+        specs_by_name[public_name] = _copy_prefix_spec(
+            public_name, hca_specs[source_name]
+        )
 
     parameter_names = [
         name
@@ -1370,93 +2200,92 @@ def build_two_swa_tensor_specs(start_pos=None):
     extra = [name for name in specs_by_name if name not in parameter_names]
     if missing or extra:
         raise ValueError(
-            f"two-SWA spec/signature mismatch: missing={missing}, extra={extra}"
+            f"mixed-prefix spec/signature mismatch: missing={missing}, extra={extra}"
         )
     specs = [specs_by_name[name] for name in parameter_names]
     for spec in specs:
         if isinstance(spec, TensorSpec) and len(spec.shape) > MAX_PUBLIC_TENSOR_DIMS:
             raise ValueError(
-                f"two-SWA tensor {spec.name!r} exceeds "
+                f"mixed-prefix tensor {spec.name!r} exceeds "
                 f"{MAX_PUBLIC_TENSOR_DIMS} dimensions: {spec.shape}"
             )
     return specs
 
 
-def _two_swa_layer_value(value, layer_ordinal):
-    extent = value.shape[1] // TWO_SWA_LAYER_COUNT
+def _mixed_layer_value(value, layer_ordinal):
+    extent = value.shape[1] // MIXED_PREFIX_LAYER_COUNT
     begin = layer_ordinal * extent
     return value[:, begin : begin + extent]
 
 
-def golden_two_swa_decode_fwd(tensors):
-    """Compose two unchanged SWA+MoE goldens after the embedding preamble."""
+def golden_mixed_prefix_decode_fwd(tensors):
+    """Compose the unchanged four production layer goldens in model order."""
     import torch
 
     local_t = int(tensors["freqs_cos"].shape[1])
     current = tensors["x_ping"].clone()
     raw_blocks_per_layer = (
-        tensors["raw_kv_pool"].shape[1] // TWO_SWA_LAYER_COUNT
+        tensors["raw_kv_pool"].shape[1] // MIXED_PREFIX_LAYER_COUNT
     )
+    layer_kinds = ("swa", "swa", "csa", "hca")
+    kind_sources = {"csa": _CSA_PREFIX_SOURCES, "hca": _HCA_PREFIX_SOURCES}
+    golden_fns = {
+        "swa": layer.golden_decode_layer_swa,
+        "csa": layer.golden_decode_layer_csa,
+        "hca": layer.golden_decode_layer_hca,
+    }
 
-    for layer_ordinal in range(TWO_SWA_LAYER_COUNT):
+    for layer_ordinal, kind in enumerate(layer_kinds):
         raw_begin = layer_ordinal * raw_blocks_per_layer
-        raw_layer = tensors["raw_kv_pool"][
-            :, raw_begin : raw_begin + raw_blocks_per_layer
-        ]
         x_attn_active = torch.zeros_like(current)
-        for group in range(layer.TP_GROUPS):
-            group_begin = group * TP_SIZE
-            group_end = group_begin + TP_SIZE
-            group_tensors = {}
-            for name in _TWO_SWA_ATTN_INPUT_NAMES:
-                if name == "x_hc":
-                    value = current
-                elif name == "kv_cache":
-                    value = raw_layer
-                elif name in _TWO_SWA_LAYERED_WEIGHT_NAMES:
-                    value = _two_swa_layer_value(
-                        tensors[name], layer_ordinal
-                    )
-                else:
-                    value = tensors[name]
-                group_tensors[name] = value[group_begin:group_end]
-            group_tensors["x_out"] = x_attn_active[group_begin:group_end]
-            group_tensors["local_t"] = local_t
-            swa.golden_decode_swa(group_tensors)
-
-        x_attn_moe = torch.zeros(
+        x_moe_next = torch.zeros(
             N_RANKS, MOE_TOKENS, HC_MULT, D, dtype=torch.float32
         )
-        x_attn_moe[:, :local_t].copy_(x_attn_active)
-        x_moe_next = torch.zeros_like(x_attn_moe)
-        moe_tensors = dict(tensors)
-        for name in _TWO_SWA_LAYERED_WEIGHT_NAMES:
-            if name not in _COMMON_ATTN_WEIGHT_NAMES:
-                moe_tensors[name] = _two_swa_layer_value(
-                    tensors[name], layer_ordinal
-                )
-        moe_tensors.update(
-            {
-                "x_hc": x_attn_moe,
-                "x_next": x_moe_next,
-                "layer_id": layer_ordinal,
-                "num_tokens": local_t,
-            }
-        )
-        moe_module.golden_moe(moe_tensors)
-        current = x_moe_next[:, :local_t].clone()
+        x_next = torch.zeros_like(current)
+        layer_tensors = {
+            name: _mixed_layer_value(tensors[name], layer_ordinal)
+            for name in _MIXED_LAYERED_WEIGHT_NAMES
+        }
+        layer_tensors.update({
+            "x_hc": current,
+            "freqs_cos": tensors["freqs_cos"],
+            "freqs_sin": tensors["freqs_sin"],
+            "position_ids": tensors["position_ids"],
+            "kv_cache": tensors["raw_kv_pool"][
+                :, raw_begin : raw_begin + raw_blocks_per_layer
+            ],
+            "input_ids": tensors["input_ids"],
+            "x_attn_active": x_attn_active,
+            "x_moe_next": x_moe_next,
+            "x_next": x_next,
+            "layer_id": layer_ordinal,
+            "local_t": local_t,
+        })
+        if kind == "swa":
+            layer_tensors.update({
+                name: tensors[name]
+                for name in ("swa_slot_mapping", "swa_indices", "swa_lens")
+            })
+        else:
+            layer_tensors.update({
+                source_name: tensors[public_name]
+                for public_name, source_name in kind_sources[kind].items()
+            })
+        golden_fns[kind](layer_tensors)
+        current = x_next.clone()
         tensors["x_attn_active"].copy_(x_attn_active)
         tensors["x_moe_next"].copy_(x_moe_next)
         if layer_ordinal == 0:
             tensors["x_pong"].copy_(current)
-
+        elif layer_ordinal == 1:
+            tensors["x_ping"].copy_(current)
+        elif layer_ordinal == 2:
+            tensors["x_pong"].copy_(current)
     tensors["x_out"].copy_(current)
 
 
-def two_swa_packed_raw_pool_compare(
-    actual, expected, **kwargs
-):
-    """Check both local layer mappings and require all other rows unchanged."""
+def mixed_packed_raw_pool_compare(actual, expected, **kwargs):
+    """Check all four local raw mappings and every untouched cache row."""
     from golden import mapped_pool_ratio_allclose
 
     if actual.shape != expected.shape:
@@ -1464,36 +2293,32 @@ def two_swa_packed_raw_pool_compare(
             f"    raw pool shape mismatch: actual={tuple(actual.shape)} "
             f"expected={tuple(expected.shape)}"
         )
-    if actual.shape[1] % TWO_SWA_LAYER_COUNT:
-        return False, "    packed raw pool is not divisible by two SWA layers"
+    if actual.shape[1] % MIXED_PREFIX_LAYER_COUNT:
+        return False, "    packed raw pool is not divisible by four layers"
 
-    per_layer_blocks = actual.shape[1] // TWO_SWA_LAYER_COUNT
-    mapping = kwargs.get("inputs", {}).get("swa_slot_mapping")
-    if mapping is None:
-        return False, "    compare_fn missing input 'swa_slot_mapping'"
-    compare_layer0 = mapped_pool_ratio_allclose(
+    per_layer_blocks = actual.shape[1] // MIXED_PREFIX_LAYER_COUNT
+    mapping_names = (
         "swa_slot_mapping",
-        mapping_shape=tuple(mapping.shape),
-        block_size=BLOCK_SIZE,
-        leading_rank_axis=True,
-        pool_name="two-SWA raw KV cache",
-        atol=1e-4,
-        rtol=1.0 / 128,
-        max_error_ratio=0.005,
-    )
-    compare_layer1 = mapped_pool_ratio_allclose(
         "swa_slot_mapping",
-        mapping_shape=tuple(mapping.shape),
-        block_size=BLOCK_SIZE,
-        leading_rank_axis=True,
-        pool_name="two-SWA raw KV cache",
-        atol=0.01,
-        rtol=0.05,
-        max_error_ratio=0.05,
+        "csa_ori_slot_mapping",
+        "hca_ori_slot_mapping",
     )
-    for layer_ordinal in range(TWO_SWA_LAYER_COUNT):
+    inputs = kwargs.get("inputs", {})
+    for layer_ordinal, mapping_name in enumerate(mapping_names):
+        mapping = inputs.get(mapping_name)
+        if mapping is None:
+            return False, f"    compare_fn missing input {mapping_name!r}"
+        compare_layer = mapped_pool_ratio_allclose(
+            mapping_name,
+            mapping_shape=tuple(mapping.shape),
+            block_size=BLOCK_SIZE,
+            leading_rank_axis=True,
+            pool_name=f"mixed layer {layer_ordinal} raw KV cache",
+            atol=1e-4 if layer_ordinal == 0 else 0.01,
+            rtol=1.0 / 128 if layer_ordinal == 0 else 0.08,
+            max_error_ratio=0.005 if layer_ordinal == 0 else 0.08,
+        )
         begin = layer_ordinal * per_layer_blocks
-        compare_layer = compare_layer0 if layer_ordinal == 0 else compare_layer1
         ok, detail = compare_layer(
             actual[:, begin : begin + per_layer_blocks],
             expected[:, begin : begin + per_layer_blocks],
@@ -1504,9 +2329,9 @@ def two_swa_packed_raw_pool_compare(
     return True, ""
 
 
-def build_two_swa_shape_report(start_pos=None):
-    """Return the concrete Phase B L3 shapes without materializing tensors."""
-    specs = build_two_swa_tensor_specs(start_pos=start_pos)
+def build_mixed_prefix_shape_report(start_pos=None):
+    """Return concrete mixed-prefix L3 shapes without materializing tensors."""
+    specs = build_mixed_prefix_tensor_specs(start_pos=start_pos)
     shapes = {
         spec.name: list(spec.shape)
         for spec in specs
@@ -1517,7 +2342,7 @@ def build_two_swa_shape_report(start_pos=None):
         "ep": EP_SIZE,
         "active_tokens": shapes["freqs_cos"][1],
         "raw_blocks_per_layer": (
-            shapes["raw_kv_pool"][1] // TWO_SWA_LAYER_COUNT
+            shapes["raw_kv_pool"][1] // MIXED_PREFIX_LAYER_COUNT
         ),
         "maximum_public_tensor_dims": max(len(shape) for shape in shapes.values()),
         "shapes": shapes,
@@ -1633,7 +2458,7 @@ def _parse_start_pos(raw):
 def main():
     import argparse
 
-    from golden import ratio_reldiff, run_jit
+    from golden import mapped_pool_ratio_allclose, ratio_reldiff, run_jit
     from pypto.ir.distributed_compiled_program import DistributedConfig
 
     parser = argparse.ArgumentParser(
@@ -1674,7 +2499,7 @@ def main():
     start_pos = _parse_start_pos(args.start_pos)
     if args.shape_only:
         report = build_decode_fwd_shape_report(start_pos)
-        prefix_report = build_two_swa_shape_report(start_pos)
+        prefix_report = build_mixed_prefix_shape_report(start_pos)
         packed_summary = ", ".join(
             f"{name}={entry['total_extent']}"
             for name, entry in report["packed_layout"].items()
@@ -1691,7 +2516,7 @@ def main():
             f"{report['packed_pool_bytes_per_rank'] / (1024 ** 3):.3f}"
         )
         print(
-            "two_swa: "
+            "mixed_prefix: "
             f"active_t={prefix_report['active_tokens']} "
             f"raw_blocks_per_layer={prefix_report['raw_blocks_per_layer']} "
             f"max_dims={prefix_report['maximum_public_tensor_dims']}"
@@ -1716,12 +2541,12 @@ def main():
     ):
         parser.error(f"device IDs must be distinct and non-negative: {device_ids}")
 
-    specs = build_two_swa_tensor_specs(start_pos=start_pos)
+    specs = build_mixed_prefix_tensor_specs(start_pos=start_pos)
     local_t = next(spec.shape[1] for spec in specs if spec.name == "x_out")
     result = run_jit(
         fn=l3_decode_fwd,
         specs=specs,
-        golden_fn=golden_two_swa_decode_fwd,
+        golden_fn=golden_mixed_prefix_decode_fwd,
         golden_data=args.golden_data,
         save_data=args.save_data,
         compile_only=args.compile_only,
@@ -1740,18 +2565,89 @@ def main():
         rtol=1e-2,
         atol=1e-2,
         compare_fn={
-            "raw_kv_pool": two_swa_packed_raw_pool_compare,
-            "x_pong": ratio_reldiff(diff_thd=0.01, pct_thd=0.05),
+            "raw_kv_pool": mixed_packed_raw_pool_compare,
+            "hca_compress_state": mapped_pool_ratio_allclose(
+                "hca_state_slot_mapping",
+                mapping_shape=(N_RANKS, local_t),
+                block_size=HCA_COMPRESS_STATE_BLOCK_SIZE,
+                leading_rank_axis=True,
+                pool_name="mixed HCA compressor state",
+                atol=0.01,
+                rtol=0.08,
+                max_error_ratio=0.08,
+            ),
+            "hca_cmp_kv": mapped_pool_ratio_allclose(
+                "hca_cmp_slot_mapping",
+                mapping_shape=(N_RANKS, local_t),
+                block_size=BLOCK_SIZE,
+                leading_rank_axis=True,
+                pool_name="mixed HCA compressed KV cache",
+                atol=0.01,
+                rtol=0.08,
+                max_error_ratio=0.08,
+            ),
+            "csa_compress_state": mapped_pool_ratio_allclose(
+                "csa_state_slot_mapping",
+                mapping_shape=(N_RANKS, local_t),
+                block_size=CSA_MAIN_STATE_BLOCK_SIZE,
+                leading_rank_axis=True,
+                pool_name="mixed CSA main compressor state",
+                atol=0.01,
+                rtol=0.08,
+                max_error_ratio=0.08,
+            ),
+            "csa_cmp_kv": mapped_pool_ratio_allclose(
+                "csa_cmp_slot_mapping",
+                mapping_shape=(N_RANKS, local_t),
+                block_size=BLOCK_SIZE,
+                leading_rank_axis=True,
+                pool_name="mixed CSA compressed KV cache",
+                atol=0.01,
+                rtol=0.08,
+                max_error_ratio=0.08,
+            ),
+            "csa_inner_compress_state": mapped_pool_ratio_allclose(
+                "csa_inner_state_slot_mapping",
+                mapping_shape=(N_RANKS, local_t),
+                block_size=CSA_INNER_STATE_BLOCK_SIZE,
+                leading_rank_axis=True,
+                pool_name="mixed CSA inner compressor state",
+                atol=0.01,
+                rtol=0.08,
+                max_error_ratio=0.08,
+            ),
+            "csa_idx_kv_cache": mapped_pool_ratio_allclose(
+                "csa_idx_slot_mapping",
+                mapping_shape=(N_RANKS, local_t),
+                block_size=BLOCK_SIZE,
+                leading_rank_axis=True,
+                pool_name="mixed CSA indexer KV cache",
+                atol=1,
+                rtol=0,
+                max_error_ratio=0.08,
+            ),
+            "csa_idx_kv_scale": mapped_pool_ratio_allclose(
+                "csa_idx_slot_mapping",
+                mapping_shape=(N_RANKS, local_t),
+                block_size=BLOCK_SIZE,
+                leading_rank_axis=True,
+                pool_name="mixed CSA indexer KV scale",
+                atol=0.01,
+                rtol=0.08,
+                max_error_ratio=0.08,
+            ),
+            "x_ping": ratio_reldiff(diff_thd=0.01, pct_thd=0.06),
+            "x_pong": ratio_reldiff(diff_thd=0.01, pct_thd=0.15),
             "x_attn_active": ratio_reldiff(
-                diff_thd=0.01, pct_thd=0.05
+                diff_thd=0.01, pct_thd=0.15
             ),
             "x_moe_next": ratio_reldiff(
                 diff_thd=0.01,
-                pct_thd=0.06,
+                pct_thd=0.22,
                 valid_rows=local_t,
                 valid_axis=1,
             ),
-            "x_out": ratio_reldiff(diff_thd=0.01, pct_thd=0.06),
+            "x_out": ratio_reldiff(diff_thd=0.01, pct_thd=0.22),
         },
     )
     if not result.passed:

--- a/models/deepseek_v4_flash_dspark/expert_shared.py
+++ b/models/deepseek_v4_flash_dspark/expert_shared.py
@@ -114,21 +114,6 @@ def expert_shared(
         # stay in one task so this stage can start alongside dispatch_push.
         h_tile_fp32 = pl.create_tensor([SH_M_TILE, MOE_INTER], dtype=pl.FP32)
         h_tile_i8 = pl.create_tensor([SH_M_TILE, MOE_INTER], dtype=pl.INT8)
-        if SH_VALID_M < SH_M_TILE:
-            with pl.spmd(
-                MOE_INTER // QUANT_TILE,
-                name_hint="sh_h_tile_i8_pad",
-            ):
-                pad_block = pl.tile.get_block_idx()
-                pad_k0 = pad_block * QUANT_TILE
-                h_tile_i8[
-                    SH_VALID_M:SH_M_TILE,
-                    pad_k0 : pad_k0 + QUANT_TILE,
-                ] = pl.full(
-                    [SH_M_TILE - SH_VALID_M, QUANT_TILE],
-                    dtype=pl.INT8,
-                    value=0,
-                )
         h_tile_scale_dq = pl.create_tensor(
             [SH_M_TILE, SH_ROW_PAD], dtype=pl.FP32, manual_dep=True
         )

--- a/models/deepseek_v4_flash_dspark/expert_shared.py
+++ b/models/deepseek_v4_flash_dspark/expert_shared.py
@@ -113,9 +113,22 @@ def expert_shared(
         # blocks for the decode shape). Activation, row-amax, scale, and requant
         # stay in one task so this stage can start alongside dispatch_push.
         h_tile_fp32 = pl.create_tensor([SH_M_TILE, MOE_INTER], dtype=pl.FP32)
-        h_tile_i8 = pl.create_tensor(
-            [SH_M_TILE, MOE_INTER], dtype=pl.INT8, init_value=0
-        )
+        h_tile_i8 = pl.create_tensor([SH_M_TILE, MOE_INTER], dtype=pl.INT8)
+        if SH_VALID_M < SH_M_TILE:
+            with pl.spmd(
+                MOE_INTER // QUANT_TILE,
+                name_hint="sh_h_tile_i8_pad",
+            ):
+                pad_block = pl.tile.get_block_idx()
+                pad_k0 = pad_block * QUANT_TILE
+                h_tile_i8[
+                    SH_VALID_M:SH_M_TILE,
+                    pad_k0 : pad_k0 + QUANT_TILE,
+                ] = pl.full(
+                    [SH_M_TILE - SH_VALID_M, QUANT_TILE],
+                    dtype=pl.INT8,
+                    value=0,
+                )
         h_tile_scale_dq = pl.create_tensor(
             [SH_M_TILE, SH_ROW_PAD], dtype=pl.FP32, manual_dep=True
         )

--- a/models/deepseek_v4_flash_dspark/hc_head.py
+++ b/models/deepseek_v4_flash_dspark/hc_head.py
@@ -91,13 +91,26 @@ def hc_head(
         sq_part = pl.assemble(sq_part, sq_sum, [ok, t0])
 
     # linear: split-K head projection, fanned over (row-block x K-slice); each task
-    # atomic-adds its [LINEAR_T_TILE, HC_PAD] FP32 partial into the AICPU-zeroed mixes_raw
-    mixes_raw = pl.create_tensor([t_linear, HC_PAD], dtype=pl.FP32, init_value=0)
+    # atomic-adds its [LINEAR_T_TILE, HC_PAD] FP32 partial into the seeded mixes_raw
+    mixes_raw = pl.create_tensor([t_linear, HC_PAD], dtype=pl.FP32)
+    with pl.spmd(
+        t_linear // LINEAR_T_TILE,
+        name_hint="hc_head_linear_seed",
+    ) as linear_seed_tid:
+        seed_block = pl.tile.get_block_idx()
+        seed_t0 = seed_block * LINEAR_T_TILE
+        mixes_raw[seed_t0 : seed_t0 + LINEAR_T_TILE, 0:HC_PAD] = pl.full(
+            [LINEAR_T_TILE, HC_PAD],
+            dtype=pl.FP32,
+            value=0.0,
+        )
     if linear_full_rows > 0:
-        for task in pl.spmd(
+        with pl.spmd(
             (linear_full_rows // LINEAR_T_TILE) * LINEAR_OK,
             name_hint="hc_head_linear",
-        ):
+            deps=[linear_seed_tid],
+        ) as _linear_tid:
+            task = pl.tile.get_block_idx()
             t0 = (task // LINEAR_OK) * LINEAR_T_TILE
             k_base = (task % LINEAR_OK) * (HC_DIM // LINEAR_OK)
             acc_full = pl.create_tensor([LINEAR_T_TILE, HC_PAD], dtype=pl.FP32)
@@ -119,7 +132,12 @@ def hc_head(
     # At most one incomplete M=16 block exists. Keep it in a separate conditional
     # task so every aligned block above retains the original static-M Cube path.
     if linear_full_rows < t_dim:
-        for tail_task in pl.spmd(LINEAR_OK, name_hint="hc_head_linear_tail"):
+        with pl.spmd(
+            LINEAR_OK,
+            name_hint="hc_head_linear_tail",
+            deps=[linear_seed_tid],
+        ) as _linear_tail_tid:
+            tail_task = pl.tile.get_block_idx()
             k_base = tail_task * (HC_DIM // LINEAR_OK)
             tail_rows = t_dim - linear_full_rows
             acc_tail = pl.create_tensor([LINEAR_T_TILE, HC_PAD], dtype=pl.FP32)

--- a/models/deepseek_v4_flash_dspark/lm_head.py
+++ b/models/deepseek_v4_flash_dspark/lm_head.py
@@ -28,7 +28,7 @@ VOCAB = M.vocab_size
 MAX_LOGIT_ROWS = DECODE_TOKENS
 
 # parallelism
-_TP_CHOICES = (2, 4, 8, 16)
+_TP_CHOICES = (1, 2, 4, 8, 16)
 _DP_CHOICES = (1, 2, 4, 8, 16)
 _TP_DEFAULT = 2
 

--- a/models/deepseek_v4_flash_dspark/lm_head.py
+++ b/models/deepseek_v4_flash_dspark/lm_head.py
@@ -10,7 +10,6 @@
 # ci: no-sim    # CI marker: multi-card fixture; the fused C->V shard overflows the *sim UB limit -- device-only
 """DeepSeek-V4 Flash DSpark LM head: fused matmul+push projection with DP-owned hidden and TP vocab shards."""
 
-import os
 import sys
 
 import pypto.language as pl
@@ -83,10 +82,7 @@ GREEDY_BLOCK_SPAN = GREEDY_BLOCK_ROWS * GREEDY_ROW_WIDTH
 # 2^30: above every vocab id, clear of int32 overflow once a block base is added.
 GREEDY_INDEX_SENTINEL = 1073741824
 DONE_VALUE = 1
-
-# Ring heap: the depth-1 scope holds selected_hidden and owner_hiddens plus the
-# in-flight put payloads; 1 GiB clears the runtime default at tp=4.
-os.environ.setdefault("PTO2_RING_HEAP", "1073741824")
+LM_HEAD_RING_HEAP = 1 << 30
 
 assert MAX_LOGIT_ROWS % MM_ROW_TILE == 0, "each row block must be one owner's rows"
 assert MAX_LOGIT_ROWS % PUSH_ROW_TILE == 0, "row block must cover whole rows"
@@ -565,6 +561,7 @@ if __name__ == "__main__":
             platform=args.platform,
             enable_chip_swimlane=args.enable_chip_swimlane,
             enable_scope_stats=args.enable_scope_stats,
+            ring_heap=LM_HEAD_RING_HEAP,
         ),
         rtol=1e-3,
         atol=1e-3,


### PR DESCRIPTION
- add models/deepseek_v4_flash_dspark/decode_fwd.py: the full D-Spark
  decode forward over all 43 layers in the fixed order SWA, SWA,
  (CSA, HCA) x 20, CSA, reusing the production SWA/CSA/HCA layer entries
  without duplicating attention, compressor, indexer, output-projection,
  or MoE math
- run one rank-local L2 per rank with packed per-layer cache and state
  pools, activation ping-pong, and MoE epochs 1 through 43; the layer
  ordinal is packed into the block extent so public tensor ABIs stay at
  five dimensions or fewer
- keep model-layer and attention-kind ordinals separate, so layer 42
  maps to CSA ordinal 20
- allocate the attention/O-projection, MoE, and LM-head windows once at
  L3 and reuse them with independent epoch domains; each rank publishes
  one full-forward child rather than one child per layer
- connect the terminal HC head, RMSNorm, TP LM head, greedy sampling,
  inactive-row masking, and the single final MoE signal clear
- select the topology with --tp, --ep, and --weight-bank-size (1 for the
  shared-bank fixture, 43 for the production per-layer banks), and mark
  the entry device-only at EP2/TP2 with ci: devices=2 and ci: no-sim
- lm_head: accept TP1 alongside the existing TP2/TP4 paths, and pass the
  1 GiB ring heap through the runner's ring_heap argument instead of
  defaulting PTO2_RING_HEAP in the module
- hc_head: seed the split-K accumulator with an explicit spmd zero-fill
  that the projection tasks depend on, replacing the create_tensor
  init_value
- expert_shared: drop the redundant init_value on the requantized hidden
  tile

Related to #962.
