### PR TITLE
Fix: align DeepSeek serving CI with paired PRs

### DIFF
--- a/.github/actions/pypto-serving-tests/action.yml
+++ b/.github/actions/pypto-serving-tests/action.yml
@@ -11,19 +11,23 @@ inputs:
   pypto-serving-checkout-path:
     description: Workspace-relative path where pypto-serving should be checked out.
     required: true
+  pypto-serving-ref:
+    description: pypto-serving git ref to test.
+    required: false
+    default: main
   model-name:
     description: Serving model guard to run (qwen3-14b or deepseek-v4).
     required: true
   pto2-ring-dep-pool:
-    description: PTO2_RING_DEP_POOL value for pypto-serving tests.
+    description: Scalar or four comma-separated PTO2_RING_DEP_POOL values for pypto-serving tests.
     required: false
     default: "16384"
   pto2-ring-task-window:
-    description: PTO2_RING_TASK_WINDOW value for pypto-serving tests.
+    description: Scalar or four comma-separated PTO2_RING_TASK_WINDOW values for pypto-serving tests.
     required: false
     default: "16384"
   pto2-ring-heap:
-    description: PTO2_RING_HEAP value for pypto-serving tests.
+    description: Scalar or four comma-separated PTO2_RING_HEAP values for pypto-serving tests.
     required: false
     default: "1073741824"
   deepseek-mtp-cases:
@@ -73,7 +77,7 @@ runs:
       uses: actions/checkout@v4
       with:
         repository: hw-native-sys/pypto-serving
-        ref: main
+        ref: ${{ inputs.pypto-serving-ref }}
         path: ${{ inputs.pypto-serving-checkout-path }}
         submodules: recursive
         persist-credentials: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -450,13 +450,17 @@ jobs:
         with:
           pypto-lib-checkout-path: checkout
           pypto-serving-checkout-path: serving-checkout
+          # PR #1023 and pypto-serving #187 form one cross-repository contract.
+          pypto-serving-ref: refs/pull/187/head
           model-name: deepseek-v4
           # Only the fused K=1 case runs on device: the k3-s4-b4 case starts a
           # second 8-card server for the same gate.
           deepseek-mtp-cases: k1
-          pto2-ring-dep-pool: "131072"
-          pto2-ring-task-window: "131072"
-          pto2-ring-heap: "2147483648"
+          pto2-ring-dep-pool: "16384,16384,16384,16384"
+          pto2-ring-task-window: "16384,16384,16384,16384"
+          # Keep each dispatch depth below the measured 1 GiB bound instead of
+          # broadcasting one 2 GiB scalar into all four static arenas.
+          pto2-ring-heap: "1073741824,1073741824,1073741824,1073741824"
 
       - name: Kill orphaned task-submit tasks
         if: always()


### PR DESCRIPTION
## 目的

本 PR 是 pypto-lib PR #1023 的门禁前置修复，不新增 DeepSeek 模型功能。

PR #1023 与 pypto-serving PR #187 是一组跨仓配套修改：#1023 提供 Serving contract，#187 消费该 contract 并实现 continuous chunked prefill。当前 pypto-lib 门禁默认检出 Serving `main`，无法验证这组尚未合入的配套代码；同时旧的标量 ring 配置会被 PyPTO `RunConfig` 广播到四层 ring，首次 prefill 前申请约 8 GiB static arena，导致 HBM OOM。

关联 PR：

- Lib contract：https://github.com/hw-native-sys/pypto-lib/pull/1023
- Serving 实现：https://github.com/hw-native-sys/pypto-serving/pull/187

## 修改内容

1. 为 `pypto-serving-tests` composite action 增加 `pypto-serving-ref` 输入，默认仍使用 Serving `main`，允许配套 PR 的门禁显式选择待验证的 Serving ref。
2. DeepSeek serving 门禁检出 `refs/pull/187/head`，并继续用当前 PR checkout 覆盖 Serving 的 `pypto-lib` 子模块，从而实际验证“#1023 Lib + #187 Serving”的组合。
3. DeepSeek 门禁使用四层显式 ring 配置：
   - task window：`16384,16384,16384,16384`
   - dependency pool：`16384,16384,16384,16384`
   - heap：`1073741824,1073741824,1073741824,1073741824`

该配置避免把单个 2 GiB heap 标量广播成约 8 GiB static arena。相同的四层配置已在拆分前的 #1023 组合门禁中完成一次 EP8、MTP K=1 实机验证，生成 128 token，测试通过。

## 依赖与验收方式

建议顺序：

1. 合入本 PR；
2. 将 #1023 rebase 到最新 `main`；
3. 由 #1023 的 `models/deepseek_v4_flash_mtp/` 变更触发 `serving-deepseek`；
4. 确认门禁实际检出 Serving #187，并通过 DeepSeek V4 MTP K=1 精度用例。

本 PR 只修改 CI infrastructure，因此它自身不会触发昂贵的 `serving-deepseek`。这是有意设计：#187 依赖仅存在于 #1023 的 `serving_contract.py`，让 #1061 自身运行 #187 会形成前置 PR 反向依赖后置 PR。最终验收应在 #1023 rebase 后完成。

## 范围说明

- 本 PR 不包含 #1023 的 chunk-prefill contract 或业务代码。
- 本 PR 不处理当前 PyPTO/PTO-ISA 工具链导致的 `a2a3sim`、`a5sim` Top-K 回归；该问题需要在对应仓库修复。
- Qwen serving 门禁仍使用默认 Serving `main`，行为不变。

## 本地检查

- `pre-commit run --files .github/workflows/ci.yml .github/actions/pypto-serving-tests/action.yml`
- `git diff --check`

以上检查均通过。
