### PR TITLE
Refactor: split D-Spark decode attention from its TP publish step

### DIFF
--- a/models/deepseek_v4_flash_dspark/decode_csa.py
+++ b/models/deepseek_v4_flash_dspark/decode_csa.py
@@ -63,15 +63,20 @@ from decode_o_proj import (
     LOCAL_T_PAD,
     O_WINDOW_ROWS,
     decode_o_proj_tp1,
-    decode_sharded_o_projection_reduce_scatter,
     o_group_a2a,
+    o_proj_reduce_scatter,
 )
 from decode_sparse_attn_csa import (
+    ATTENTION_PUBLISH_T_TILE,
     ATTENTION_PUBLISH_WORKERS,
+    H_TILE,
+    NOPE_DIM,
+    PUBLISH_GROUPS,
     ROPE_CS_T_TILE,
+    SPARSE_BLOCKS,
     T_PAD,
-    publish_csa_o_groups,
     sparse_attn_csa,
+    sparse_attn_csa_tp1,
 )
 
 # Dynamic shape variables.
@@ -207,10 +212,7 @@ def decode_csa(
     wb_blocks = t_dim // CSA_WB_TOKEN_TILE
     x_mixed = pl.create_tensor([t_dim, D], dtype=pl.BF16)
     with pl.scope():
-        hc_pre(
-            x_hc, hc_attn_fn, hc_attn_scale, hc_attn_base,
-            x_mixed, post_t, comb_t,
-        )
+        hc_pre(x_hc, hc_attn_fn, hc_attn_scale, hc_attn_base, x_mixed, post_t, comb_t)
 
     idx_cos_il = pl.create_tensor([t_dim, ROPE_HEAD_DIM], dtype=pl.FP32)
     idx_sin_signed = pl.create_tensor([t_dim, ROPE_HEAD_DIM], dtype=pl.FP32)
@@ -222,10 +224,7 @@ def decode_csa(
             il_ones,
             pl.cast(pl.arange(0, [1, ROPE_HEAD_DIM], dtype=pl.INT32), target_type=pl.FP32),
         )
-        il_dup_f = pl.cast(
-            pl.cast(pl.mul(il_col, 0.5), target_type=pl.INT32, mode="trunc"),
-            target_type=pl.FP32,
-        )
+        il_dup_f = pl.cast(pl.cast(pl.mul(il_col, 0.5), target_type=pl.INT32, mode="trunc"), target_type=pl.FP32)
         il_dup_idx = pl.cast(il_dup_f, target_type=pl.INT32)
         il_lane = pl.sub(il_col, pl.mul(il_dup_f, 2.0))
         il_sign = pl.sub(pl.mul(il_lane, 2.0), 1.0)
@@ -284,9 +283,7 @@ def decode_csa(
                 write_row_i64 = pl.read(ori_slot_mapping, [write_t])
                 if write_row_i64 >= 0:
                     write_row = pl.cast(write_row_i64, pl.INDEX)
-                    kv_cache_flat[write_row : write_row + 1, 0 : HEAD_DIM] = kv[
-                        write_t : write_t + 1, 0 : HEAD_DIM
-                    ]
+                    kv_cache_flat[write_row : write_row + 1, 0 : HEAD_DIM] = kv[write_t : write_t + 1, 0 : HEAD_DIM]
 
         cmp_out = pl.create_tensor([t_dim, HEAD_DIM], dtype=pl.FP32)
         cmp_out, cmp_cache_write_tid = compressor_ratio4(
@@ -312,19 +309,101 @@ def decode_csa(
             kv_seq_lens, late_dep,
         )
 
-        attention_grouped = pl.create_tensor(
-            [O_GROUPS * LOCAL_T_PAD, O_GROUP_IN],
-            dtype=pl.BF16,
-        )
-        attention_signal, publish_tid = publish_csa_o_groups(
+        (
+            sparse_blk_mi, sparse_blk_li, sparse_blk_oi,
+            rope_cos_il, rope_sin_signed, rope_swap_idx,
+            qk_tid, attn_rope_tid,
+        ) = sparse_attn_csa(
             q, kv_cache, window_swa_indices,
             cmp_kv, cmp_block_table, idx_topk,
-            position_ids_t1, attn_sink, freqs_cos, freqs_sin,
-            attention_grouped,
-            attention_window, attention_signal,
-            group_base, tp_rank, local_t,
+            position_ids_t1, freqs_cos, freqs_sin,
             cache_ready_dep,
         )
+
+        attention_grouped = pl.create_tensor([O_GROUPS * LOCAL_T_PAD, O_GROUP_IN], dtype=pl.BF16)
+        pack_work_count = (t_dim // ATTENTION_PUBLISH_T_TILE) * (H // H_TILE)
+        with pl.spmd(
+            ATTENTION_PUBLISH_WORKERS,
+            name_hint="csa_merge_pack_publish",
+            deps=[qk_tid, attn_rope_tid],
+        ) as publish_tid:
+            worker = pl.tile.get_block_idx()
+            for pack_work in pl.range(worker, pack_work_count, ATTENTION_PUBLISH_WORKERS):
+                token_block = pack_work // (H // H_TILE)
+                m_h_idx = pack_work - token_block * (H // H_TILE)
+                m_t0 = token_block * ATTENTION_PUBLISH_T_TILE
+                m_h0 = m_h_idx * H_TILE
+                global_group0 = m_h0 // HEADS_PER_GROUP
+                destination_rank = global_group0 // LOCAL_O_GROUPS
+                local_group0 = global_group0 - destination_rank * LOCAL_O_GROUPS
+
+                for m_dt in pl.range(ATTENTION_PUBLISH_T_TILE):
+                    m_t = m_t0 + m_dt
+                    m_idx = m_t * (H // H_TILE) + m_h_idx
+                    m_blk_base = m_idx * SPARSE_BLOCKS * H_TILE
+                    m_mi = sparse_blk_mi[m_blk_base : m_blk_base + H_TILE, 0:1]
+                    m_li = sparse_blk_li[m_blk_base : m_blk_base + H_TILE, 0:1]
+                    m_oi = sparse_blk_oi[m_blk_base : m_blk_base + H_TILE, 0:HEAD_DIM]
+
+                    for m_sb in pl.pipeline(1, SPARSE_BLOCKS, stage=2):
+                        m_row = m_blk_base + m_sb * H_TILE
+                        m_cur_mi = sparse_blk_mi[m_row : m_row + H_TILE, 0:1]
+                        m_cur_li = sparse_blk_li[m_row : m_row + H_TILE, 0:1]
+                        m_cur_oi = sparse_blk_oi[m_row : m_row + H_TILE, 0:HEAD_DIM]
+                        m_mi_new = pl.maximum(m_mi, m_cur_mi)
+                        m_alpha = pl.exp(pl.sub(m_mi, m_mi_new))
+                        m_beta = pl.exp(pl.sub(m_cur_mi, m_mi_new))
+                        m_li = pl.add(pl.mul(m_alpha, m_li), pl.mul(m_beta, m_cur_li))
+                        m_oi = pl.add(pl.row_expand_mul(m_oi, m_alpha), pl.row_expand_mul(m_cur_oi, m_beta))
+                        m_mi = m_mi_new
+
+                    n_sink_bias = pl.reshape(attn_sink[m_h0 : m_h0 + H_TILE], [H_TILE, 1])
+                    n_sink_tile = pl.add(pl.sub(m_mi, m_mi), n_sink_bias)
+                    n_denom = pl.add(m_li, pl.exp(pl.sub(n_sink_tile, m_mi)))
+                    n_full = pl.row_expand_div(m_oi, n_denom)[0:H_TILE, 0:HEAD_DIM]
+                    n_bf16 = pl.cast(n_full, target_type=pl.BF16, mode="rint")
+
+                    m_rope = n_full[0:H_TILE, NOPE_DIM:HEAD_DIM]
+                    m_cos_il = rope_cos_il[m_t : m_t + 1, 0:ROPE_HEAD_DIM]
+                    m_sin_signed = rope_sin_signed[m_t : m_t + 1, 0:ROPE_HEAD_DIM]
+                    m_swapped = pl.gather(m_rope, dim=-1, index=rope_swap_idx[0:H_TILE, 0:ROPE_HEAD_DIM])
+                    m_rot = pl.add(pl.col_expand_mul(m_rope, m_cos_il), pl.col_expand_mul(m_swapped, m_sin_signed))
+                    n_rope_bf16 = pl.cast(m_rot, target_type=pl.BF16, mode="rint")
+                    n_full_bf16 = pl.concat(n_bf16[:, 0:NOPE_DIM], n_rope_bf16)
+
+                    for n_hi in pl.unroll(H_TILE):
+                        n_head = m_h0 + n_hi
+                        source_row = (n_head // HEADS_PER_GROUP) * T_PAD + m_t
+                        source_col = (n_head % HEADS_PER_GROUP) * HEAD_DIM
+                        attention_grouped[
+                            source_row : source_row + 1,
+                            source_col : source_col + HEAD_DIM,
+                        ] = n_full_bf16[n_hi : n_hi + 1, 0:HEAD_DIM]
+
+                for group_slot in pl.unroll(PUBLISH_GROUPS):
+                    source_row = (global_group0 + group_slot) * T_PAD + m_t0
+                    target_row = ((local_group0 + group_slot) * GROUP_T_PAD + tp_rank * local_t + m_t0)
+                    pld.tensor.put(
+                        dst=attention_window,
+                        peer=group_base + destination_rank,
+                        src=attention_grouped,
+                        dst_offsets=[target_row, 0],
+                        src_offsets=[source_row, 0],
+                        shape=[ATTENTION_PUBLISH_T_TILE, O_GROUP_IN],
+                        chunk_rows=ATTENTION_PUBLISH_T_TILE,
+                        chunk_cols=O_GROUP_IN,
+                    )
+
+            for peer_tp in pl.range(TP_SIZE):
+                if peer_tp != tp_rank:
+                    pld.system.notify(
+                        target=attention_signal,
+                        peer=group_base + peer_tp,
+                        offsets=[tp_rank, 0],
+                        value=1,
+                        op=pld.NotifyOp.AtomicAdd,
+                    )
+
         attention_local_flat, attention_signal = o_group_a2a(
             attention_local_flat,
             attention_window, attention_signal,
@@ -332,12 +411,9 @@ def decode_csa(
             publish_tid, ATTENTION_PUBLISH_WORKERS,
         )
 
-        attention_local_groups = pl.reshape(
-            attention_local_flat,
-            [LOCAL_O_GROUPS, GROUP_T_PAD, O_GROUP_IN],
-        )
+        attention_local_groups = pl.reshape(attention_local_flat, [LOCAL_O_GROUPS, GROUP_T_PAD, O_GROUP_IN])
         o_local = pl.create_tensor([LOCAL_T_PAD, D], dtype=pl.BF16)
-        o_local, o_signal = decode_sharded_o_projection_reduce_scatter(
+        o_local, o_signal = o_proj_reduce_scatter(
             attention_local_groups,
             wo_a, wo_b, wo_b_scale,
             local_t, o_local,
@@ -348,7 +424,7 @@ def decode_csa(
         for block in pl.spmd(t_dim // CSA_WB_TOKEN_TILE, name_hint="csa_o_local_bridge"):
             token_start = block * CSA_WB_TOKEN_TILE
             attn_out[token_start : token_start + CSA_WB_TOKEN_TILE, 0:D] = o_local[
-                token_start : token_start + CSA_WB_TOKEN_TILE, 0:D
+                token_start : token_start + CSA_WB_TOKEN_TILE, 0:D,
             ]
 
     with pl.scope():
@@ -377,9 +453,7 @@ def decode_csa_test(
     cmp_wgate: pl.Tensor[[MAIN_OUT_DIM, D], pl.BF16],
     cmp_ape: pl.Tensor[[COMPRESS_RATIO, MAIN_OUT_DIM], pl.FP32],
     cmp_norm_w: pl.Tensor[[HEAD_DIM], pl.BF16],
-    compress_state: pl.InOut[
-        pl.Tensor[[MAIN_STATE_BLOCK_NUM_DYN, MAIN_STATE_BLOCK_SIZE, MAIN_STATE_DIM], pl.FP32]
-    ],
+    compress_state: pl.InOut[pl.Tensor[[MAIN_STATE_BLOCK_NUM_DYN, MAIN_STATE_BLOCK_SIZE, MAIN_STATE_DIM], pl.FP32]],
     compress_state_block_table: pl.Tensor[[B_DYN, MAIN_STATE_MAX_BLOCKS], pl.INT32],
     idx_wq_b: pl.Tensor[[Q_LORA, IDX_N_HEADS * IDX_HEAD_DIM], pl.INT8],
     idx_wq_b_scale: pl.Tensor[[IDX_N_HEADS * IDX_HEAD_DIM], pl.FP32],
@@ -389,19 +463,13 @@ def decode_csa_test(
     inner_wgate: pl.Tensor[[INNER_OUT_DIM, D], pl.BF16],
     inner_ape: pl.Tensor[[COMPRESS_RATIO, INNER_OUT_DIM], pl.FP32],
     inner_norm_w: pl.Tensor[[IDX_HEAD_DIM], pl.BF16],
-    inner_compress_state: pl.InOut[
-        pl.Tensor[[INNER_STATE_BLOCK_NUM_DYN, INNER_STATE_BLOCK_SIZE, INNER_STATE_DIM], pl.FP32]
-    ],
+    inner_compress_state: pl.InOut[pl.Tensor[[INNER_STATE_BLOCK_NUM_DYN, INNER_STATE_BLOCK_SIZE, INNER_STATE_DIM], pl.FP32]],
     inner_compress_state_block_table: pl.Tensor[[B_DYN, INNER_STATE_MAX_BLOCKS], pl.INT32],
     kv_cache: pl.InOut[pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
     cmp_kv: pl.InOut[pl.Tensor[[CMP_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
     cmp_block_table: pl.Tensor[[B_DYN, CMP_MAX_BLOCKS], pl.INT32],
-    idx_kv_cache: pl.InOut[
-        pl.Tensor[[IDX_CACHE_BLOCK_NUM_DYN, BLOCK_SIZE, 1, IDX_HEAD_DIM], pl.INT8]
-    ],
-    idx_kv_scale: pl.InOut[
-        pl.Tensor[[IDX_CACHE_BLOCK_NUM_DYN, BLOCK_SIZE, 1, 1], pl.FP32]
-    ],
+    idx_kv_cache: pl.InOut[pl.Tensor[[IDX_CACHE_BLOCK_NUM_DYN, BLOCK_SIZE, 1, IDX_HEAD_DIM], pl.INT8]],
+    idx_kv_scale: pl.InOut[pl.Tensor[[IDX_CACHE_BLOCK_NUM_DYN, BLOCK_SIZE, 1, 1], pl.FP32]],
     idx_block_table: pl.Tensor[[B_DYN, IDX_MAX_BLOCKS], pl.INT32],
     ori_slot_mapping: pl.Tensor[[T_DYN], pl.INT64],
     window_swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
@@ -496,9 +564,7 @@ def l3_decode_csa(
     cmp_wgate: pl.Tensor[[TP_SIZE, MAIN_OUT_DIM, D], pl.BF16],
     cmp_ape: pl.Tensor[[TP_SIZE, COMPRESS_RATIO, MAIN_OUT_DIM], pl.FP32],
     cmp_norm_w: pl.Tensor[[TP_SIZE, HEAD_DIM], pl.BF16],
-    compress_state: pl.InOut[pl.Tensor[
-        [TP_SIZE, MAIN_STATE_BLOCK_NUM_DYN, MAIN_STATE_BLOCK_SIZE, MAIN_STATE_DIM], pl.FP32
-    ]],
+    compress_state: pl.InOut[pl.Tensor[[TP_SIZE, MAIN_STATE_BLOCK_NUM_DYN, MAIN_STATE_BLOCK_SIZE, MAIN_STATE_DIM], pl.FP32]],
     compress_state_block_table: pl.Tensor[[TP_SIZE, B_DYN, MAIN_STATE_MAX_BLOCKS], pl.INT32],
     idx_wq_b: pl.Tensor[[TP_SIZE, Q_LORA, IDX_N_HEADS * IDX_HEAD_DIM], pl.INT8],
     idx_wq_b_scale: pl.Tensor[[TP_SIZE, IDX_N_HEADS * IDX_HEAD_DIM], pl.FP32],
@@ -508,23 +574,13 @@ def l3_decode_csa(
     inner_wgate: pl.Tensor[[TP_SIZE, INNER_OUT_DIM, D], pl.BF16],
     inner_ape: pl.Tensor[[TP_SIZE, COMPRESS_RATIO, INNER_OUT_DIM], pl.FP32],
     inner_norm_w: pl.Tensor[[TP_SIZE, IDX_HEAD_DIM], pl.BF16],
-    inner_compress_state: pl.InOut[pl.Tensor[
-        [TP_SIZE, INNER_STATE_BLOCK_NUM_DYN, INNER_STATE_BLOCK_SIZE, INNER_STATE_DIM], pl.FP32
-    ]],
+    inner_compress_state: pl.InOut[pl.Tensor[[TP_SIZE, INNER_STATE_BLOCK_NUM_DYN, INNER_STATE_BLOCK_SIZE, INNER_STATE_DIM], pl.FP32]],
     inner_compress_state_block_table: pl.Tensor[[TP_SIZE, B_DYN, INNER_STATE_MAX_BLOCKS], pl.INT32],
-    kv_cache: pl.InOut[
-        pl.Tensor[[TP_SIZE, ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]
-    ],
-    cmp_kv: pl.InOut[
-        pl.Tensor[[TP_SIZE, CMP_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]
-    ],
+    kv_cache: pl.InOut[pl.Tensor[[TP_SIZE, ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
+    cmp_kv: pl.InOut[pl.Tensor[[TP_SIZE, CMP_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
     cmp_block_table: pl.Tensor[[TP_SIZE, B_DYN, CMP_MAX_BLOCKS], pl.INT32],
-    idx_kv_cache: pl.InOut[
-        pl.Tensor[[TP_SIZE, IDX_CACHE_BLOCK_NUM_DYN, BLOCK_SIZE, 1, IDX_HEAD_DIM], pl.INT8]
-    ],
-    idx_kv_scale: pl.InOut[
-        pl.Tensor[[TP_SIZE, IDX_CACHE_BLOCK_NUM_DYN, BLOCK_SIZE, 1, 1], pl.FP32]
-    ],
+    idx_kv_cache: pl.InOut[pl.Tensor[[TP_SIZE, IDX_CACHE_BLOCK_NUM_DYN, BLOCK_SIZE, 1, IDX_HEAD_DIM], pl.INT8]],
+    idx_kv_scale: pl.InOut[pl.Tensor[[TP_SIZE, IDX_CACHE_BLOCK_NUM_DYN, BLOCK_SIZE, 1, 1], pl.FP32]],
     idx_block_table: pl.Tensor[[TP_SIZE, B_DYN, IDX_MAX_BLOCKS], pl.INT32],
     ori_slot_mapping: pl.Tensor[[TP_SIZE, T_DYN], pl.INT64],
     window_swa_indices: pl.Tensor[[TP_SIZE, T_DYN, WIN], pl.INT32],
@@ -627,9 +683,7 @@ def decode_csa_tp1(
     cmp_wgate: pl.Tensor[[MAIN_OUT_DIM, D], pl.BF16],
     cmp_ape: pl.Tensor[[COMPRESS_RATIO, MAIN_OUT_DIM], pl.FP32],
     cmp_norm_w: pl.Tensor[[HEAD_DIM], pl.BF16],
-    compress_state: pl.Tensor[
-        [MAIN_STATE_BLOCK_NUM_DYN, MAIN_STATE_BLOCK_SIZE, MAIN_STATE_DIM], pl.FP32
-    ],
+    compress_state: pl.Tensor[[MAIN_STATE_BLOCK_NUM_DYN, MAIN_STATE_BLOCK_SIZE, MAIN_STATE_DIM], pl.FP32],
     compress_state_block_table: pl.Tensor[[B_DYN, MAIN_STATE_MAX_BLOCKS], pl.INT32],
     idx_wq_b: pl.Tensor[[Q_LORA, IDX_N_HEADS * IDX_HEAD_DIM], pl.INT8],
     idx_wq_b_scale: pl.Tensor[[IDX_N_HEADS * IDX_HEAD_DIM], pl.FP32],
@@ -639,9 +693,7 @@ def decode_csa_tp1(
     inner_wgate: pl.Tensor[[INNER_OUT_DIM, D], pl.BF16],
     inner_ape: pl.Tensor[[COMPRESS_RATIO, INNER_OUT_DIM], pl.FP32],
     inner_norm_w: pl.Tensor[[IDX_HEAD_DIM], pl.BF16],
-    inner_compress_state: pl.Tensor[
-        [INNER_STATE_BLOCK_NUM_DYN, INNER_STATE_BLOCK_SIZE, INNER_STATE_DIM], pl.FP32
-    ],
+    inner_compress_state: pl.Tensor[[INNER_STATE_BLOCK_NUM_DYN, INNER_STATE_BLOCK_SIZE, INNER_STATE_DIM], pl.FP32],
     inner_compress_state_block_table: pl.Tensor[[B_DYN, INNER_STATE_MAX_BLOCKS], pl.INT32],
     kv_cache: pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     cmp_kv: pl.Tensor[[CMP_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
@@ -682,10 +734,7 @@ def decode_csa_tp1(
             il_ones,
             pl.cast(pl.arange(0, [1, ROPE_HEAD_DIM], dtype=pl.INT32), target_type=pl.FP32),
         )
-        il_dup_f = pl.cast(
-            pl.cast(pl.mul(il_col, 0.5), target_type=pl.INT32, mode="trunc"),
-            target_type=pl.FP32,
-        )
+        il_dup_f = pl.cast(pl.cast(pl.mul(il_col, 0.5), target_type=pl.INT32, mode="trunc"), target_type=pl.FP32)
         il_dup_idx = pl.cast(il_dup_f, target_type=pl.INT32)
         il_lane = pl.sub(il_col, pl.mul(il_dup_f, 2.0))
         il_sign = pl.sub(pl.mul(il_lane, 2.0), 1.0)
@@ -748,9 +797,7 @@ def decode_csa_tp1(
                 write_row_i64 = pl.read(ori_slot_mapping, [write_t])
                 if write_row_i64 >= 0:
                     write_row = pl.cast(write_row_i64, pl.INDEX)
-                    kv_cache_flat[write_row : write_row + 1, 0 : HEAD_DIM] = kv[
-                        write_t : write_t + 1, 0 : HEAD_DIM
-                    ]
+                    kv_cache_flat[write_row : write_row + 1, 0 : HEAD_DIM] = kv[write_t : write_t + 1, 0 : HEAD_DIM]
 
         cmp_out = pl.create_tensor([t_dim, HEAD_DIM], dtype=pl.FP32)
         cmp_out, cmp_cache_write_tid = compressor_ratio4(
@@ -779,17 +826,13 @@ def decode_csa_tp1(
         # sparse_attn_csa folds the compressed-slot masking + valid-block flags in from the
         # raw indexer topk + position.
         o_packed_heads = pl.create_tensor([O_GROUPS * T_PAD, O_GROUP_IN], dtype=pl.BF16)
-        o_packed_heads, heads_dep = sparse_attn_csa(
+        o_packed_heads, heads_dep = sparse_attn_csa_tp1(
             q, kv_cache, window_swa_indices,
             cmp_kv, cmp_block_table, idx_topk, position_ids_t1,
             attn_sink, freqs_cos, freqs_sin,
             o_packed_heads, cache_ready_dep,
         )
-        attn_out = decode_o_proj_tp1(
-            o_packed_heads,
-            wo_a, wo_b, wo_b_scale,
-            attn_out, heads_dep,
-        )
+        attn_out = decode_o_proj_tp1(o_packed_heads, wo_a, wo_b, wo_b_scale, attn_out, heads_dep)
         hc_post(attn_out, x_hc, post_t, comb_t, x_out)
     return x_out
 
@@ -815,9 +858,7 @@ def decode_csa_tp1_test(
     cmp_wgate: pl.Tensor[[MAIN_OUT_DIM, D], pl.BF16],
     cmp_ape: pl.Tensor[[COMPRESS_RATIO, MAIN_OUT_DIM], pl.FP32],
     cmp_norm_w: pl.Tensor[[HEAD_DIM], pl.BF16],
-    compress_state: pl.InOut[
-        pl.Tensor[[MAIN_STATE_BLOCK_NUM_DYN, MAIN_STATE_BLOCK_SIZE, MAIN_STATE_DIM], pl.FP32]
-    ],
+    compress_state: pl.InOut[pl.Tensor[[MAIN_STATE_BLOCK_NUM_DYN, MAIN_STATE_BLOCK_SIZE, MAIN_STATE_DIM], pl.FP32]],
     compress_state_block_table: pl.Tensor[[B_DYN, MAIN_STATE_MAX_BLOCKS], pl.INT32],
     idx_wq_b: pl.Tensor[[Q_LORA, IDX_N_HEADS * IDX_HEAD_DIM], pl.INT8],
     idx_wq_b_scale: pl.Tensor[[IDX_N_HEADS * IDX_HEAD_DIM], pl.FP32],
@@ -827,19 +868,13 @@ def decode_csa_tp1_test(
     inner_wgate: pl.Tensor[[INNER_OUT_DIM, D], pl.BF16],
     inner_ape: pl.Tensor[[COMPRESS_RATIO, INNER_OUT_DIM], pl.FP32],
     inner_norm_w: pl.Tensor[[IDX_HEAD_DIM], pl.BF16],
-    inner_compress_state: pl.InOut[
-        pl.Tensor[[INNER_STATE_BLOCK_NUM_DYN, INNER_STATE_BLOCK_SIZE, INNER_STATE_DIM], pl.FP32]
-    ],
+    inner_compress_state: pl.InOut[pl.Tensor[[INNER_STATE_BLOCK_NUM_DYN, INNER_STATE_BLOCK_SIZE, INNER_STATE_DIM], pl.FP32]],
     inner_compress_state_block_table: pl.Tensor[[B_DYN, INNER_STATE_MAX_BLOCKS], pl.INT32],
     kv_cache: pl.InOut[pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
     cmp_kv: pl.InOut[pl.Tensor[[CMP_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
     cmp_block_table: pl.Tensor[[B_DYN, CMP_MAX_BLOCKS], pl.INT32],
-    idx_kv_cache: pl.InOut[
-        pl.Tensor[[IDX_CACHE_BLOCK_NUM_DYN, BLOCK_SIZE, 1, IDX_HEAD_DIM], pl.INT8]
-    ],
-    idx_kv_scale: pl.InOut[
-        pl.Tensor[[IDX_CACHE_BLOCK_NUM_DYN, BLOCK_SIZE, 1, 1], pl.FP32]
-    ],
+    idx_kv_cache: pl.InOut[pl.Tensor[[IDX_CACHE_BLOCK_NUM_DYN, BLOCK_SIZE, 1, IDX_HEAD_DIM], pl.INT8]],
+    idx_kv_scale: pl.InOut[pl.Tensor[[IDX_CACHE_BLOCK_NUM_DYN, BLOCK_SIZE, 1, 1], pl.FP32]],
     idx_block_table: pl.Tensor[[B_DYN, IDX_MAX_BLOCKS], pl.INT32],
     ori_slot_mapping: pl.Tensor[[T_DYN], pl.INT64],
     window_swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
@@ -960,9 +995,7 @@ def golden_decode_csa_tp1(tensors):
         return cos_il.contiguous(), (sin_il * sign).contiguous()
 
     idx_cos, idx_sin = interleave_rope(rope_cos_t, rope_sin_t)
-    cmp_cos, cmp_sin = interleave_rope(
-        tensors["cmp_freqs_cos"], tensors["cmp_freqs_sin"]
-    )
+    cmp_cos, cmp_sin = interleave_rope(tensors["cmp_freqs_cos"], tensors["cmp_freqs_sin"])
 
     q = torch.zeros(tokens, H, HEAD_DIM, dtype=torch.bfloat16)
     kv = torch.zeros(tokens, HEAD_DIM, dtype=torch.bfloat16)
@@ -1063,22 +1096,10 @@ def golden_decode_csa_tp1(tensors):
         "freqs_sin": rope_sin_t,
         "o_packed_heads": o_packed_heads,
     })
-    attn_out = golden_decode_o_proj_tp1(
-        o_packed_heads,
-        tensors["wo_a"],
-        tensors["wo_b"],
-        tensors["wo_b_scale"],
-        tokens,
-    )
+    attn_out = golden_decode_o_proj_tp1(o_packed_heads, tensors["wo_a"], tensors["wo_b"], tensors["wo_b_scale"], tokens)
 
     y = torch.zeros(tokens, HC_MULT, D, dtype=torch.float32)
-    golden_hc_post({
-        "x": attn_out,
-        "residual": tensors["x_hc"],
-        "post": post_t,
-        "comb": comb_t,
-        "y": y,
-    })
+    golden_hc_post({ "x": attn_out, "residual": tensors["x_hc"], "post": post_t, "comb": comb_t, "y": y, })
     tensors["x_out"][:] = y
 
 
@@ -1150,37 +1171,19 @@ def build_tensor_specs(start_pos=None, batch=B):
 
     def ring_slots(table, state_len, state_block_size):
         ring_rows = positions.to(torch.int64) % state_len
-        pages = torch.gather(
-            table.to(torch.int64), 1, ring_rows // state_block_size
-        )
+        pages = torch.gather(table.to(torch.int64), 1, ring_rows // state_block_size)
         return pages * state_block_size + ring_rows % state_block_size
 
-    main_state_slots = ring_slots(
-        main_state_block_table, MAIN_STATE_LEN, MAIN_STATE_BLOCK_SIZE
-    )
-    inner_state_slots = ring_slots(
-        inner_state_block_table, INNER_STATE_LEN, INNER_STATE_BLOCK_SIZE
-    )
+    main_state_slots = ring_slots(main_state_block_table, MAIN_STATE_LEN, MAIN_STATE_BLOCK_SIZE)
+    inner_state_slots = ring_slots(inner_state_block_table, INNER_STATE_LEN, INNER_STATE_BLOCK_SIZE)
 
     max_visible_rows = int((kv_seq_lens.to(torch.int64) // COMPRESS_RATIO).max())
     max_active_pages = max(1, (max_visible_rows + BLOCK_SIZE - 1) // BLOCK_SIZE)
     cmp_block_num = batch * max_active_pages
     idx_cache_block_num = batch * max_active_pages
-    window_block_table = block_table(
-        batch=batch,
-        table_blocks=ORI_MAX_BLOCKS,
-        physical_blocks=ORI_BLOCK_NUM,
-    )
-    cmp_block_table = block_table(
-        batch=batch,
-        table_blocks=CMP_MAX_BLOCKS,
-        physical_blocks=cmp_block_num,
-    )
-    idx_block_table = block_table(
-        batch=batch,
-        table_blocks=IDX_MAX_BLOCKS,
-        physical_blocks=idx_cache_block_num,
-    )
+    window_block_table = block_table(batch=batch, table_blocks=ORI_MAX_BLOCKS, physical_blocks=ORI_BLOCK_NUM)
+    cmp_block_table = block_table(batch=batch, table_blocks=CMP_MAX_BLOCKS, physical_blocks=cmp_block_num)
+    idx_block_table = block_table(batch=batch, table_blocks=IDX_MAX_BLOCKS, physical_blocks=idx_cache_block_num)
     def round_half_away_from_zero(x):
         return torch.sign(x) * torch.floor(torch.abs(x) + 0.5)
 
@@ -1276,10 +1279,7 @@ def build_tensor_specs(start_pos=None, batch=B):
     def init_hadamard_idx():
         h = torch.ones((1, 1))
         while h.shape[0] < IDX_HEAD_DIM:
-            h = torch.cat([
-                torch.cat([h, h], dim=1),
-                torch.cat([h, -h], dim=1),
-            ], dim=0)
+            h = torch.cat([torch.cat([h, h], dim=1), torch.cat([h, -h], dim=1)], dim=0)
         return h / (IDX_HEAD_DIM ** 0.5)
 
     def init_inner_wkv():
@@ -1318,7 +1318,7 @@ def build_tensor_specs(start_pos=None, batch=B):
 
     def init_idx_kv_cache():
         return init_normalized_cache(
-            (idx_cache_block_num, BLOCK_SIZE, 1, IDX_HEAD_DIM)
+            (idx_cache_block_num, BLOCK_SIZE, 1, IDX_HEAD_DIM),
         )
 
     def init_idx_block_table():
@@ -1417,15 +1417,11 @@ def build_tensor_specs(start_pos=None, batch=B):
     from utils import int8_quant_per_row
     _idx_kv_i8, _idx_kv_sc = int8_quant_per_row(
         shared_idx_kv_cache.float().reshape(
-            idx_cache_block_num * BLOCK_SIZE, IDX_HEAD_DIM
-        )
+            idx_cache_block_num * BLOCK_SIZE, IDX_HEAD_DIM,
+        ),
     )
-    shared_idx_kv_cache_i8 = _idx_kv_i8.view(
-        idx_cache_block_num, BLOCK_SIZE, 1, IDX_HEAD_DIM
-    )
-    shared_idx_kv_scale = _idx_kv_sc.view(
-        idx_cache_block_num, BLOCK_SIZE, 1, 1
-    )
+    shared_idx_kv_cache_i8 = _idx_kv_i8.view(idx_cache_block_num, BLOCK_SIZE, 1, IDX_HEAD_DIM)
+    shared_idx_kv_scale = _idx_kv_sc.view(idx_cache_block_num, BLOCK_SIZE, 1, 1)
 
     wq_b_bf16 = init_wq_b().to(torch.bfloat16)
     wq_b_i8, wq_b_scale = quant_w_per_output_channel(wq_b_bf16)
@@ -1512,16 +1508,12 @@ def build_distributed_tensor_specs(local_t, start_pos=None):
             or local_t % ROPE_CS_T_TILE != 0 or local_t % S != 0):
         raise ValueError(
             f"local_t must be a multiple of {ROPE_CS_T_TILE} "
-            f"in [{ROPE_CS_T_TILE}, {LOCAL_T}], got {local_t}"
+            f"in [{ROPE_CS_T_TILE}, {LOCAL_T}], got {local_t}",
         )
 
     local_batch = local_t // S
     base_specs = build_tensor_specs(start_pos=start_pos, batch=local_batch)
-    base_values = {
-        spec.name: spec.create_tensor()
-        for spec in base_specs
-        if spec.name != "x_out"
-    }
+    base_values = { spec.name: spec.create_tensor() for spec in base_specs if spec.name != "x_out" }
 
     def replicate(value):
         repeats = (TP_SIZE,) + (1,) * value.ndim
@@ -1529,12 +1521,8 @@ def build_distributed_tensor_specs(local_t, start_pos=None):
 
     values = {name: replicate(value) for name, value in base_values.items()}
 
-    values["wo_a"] = base_values["wo_a"].reshape(
-        TP_SIZE, LOCAL_O_GROUPS, O_LORA, O_GROUP_IN,
-    ).contiguous()
-    values["wo_b"] = base_values["wo_b"].reshape(
-        D, TP_SIZE, LOCAL_O_WIDTH,
-    ).permute(1, 0, 2).contiguous()
+    values["wo_a"] = base_values["wo_a"].reshape(TP_SIZE, LOCAL_O_GROUPS, O_LORA, O_GROUP_IN).contiguous()
+    values["wo_b"] = base_values["wo_b"].reshape(D, TP_SIZE, LOCAL_O_WIDTH).permute(1, 0, 2).contiguous()
     values["wo_b_scale"] = replicate(base_values["wo_b_scale"])
 
     resident_names = frozenset({
@@ -1581,11 +1569,7 @@ def golden_decode_csa(tensors):
     full_wo_b_scale = tensors["wo_b_scale"][0]
 
     for rank in range(TP_SIZE):
-        rank_tensors = {
-            name: value[rank]
-            for name, value in tensors.items()
-            if name != "local_t"
-        }
+        rank_tensors = { name: value[rank] for name, value in tensors.items() if name != "local_t" }
         rank_tensors["wo_a"] = full_wo_a
         rank_tensors["wo_b"] = full_wo_b
         rank_tensors["wo_b_scale"] = full_wo_b_scale
@@ -1619,10 +1603,7 @@ def _csa_x_out_compare():
         ) + 1e-9
         rdiff = torch.where(diff_abs < diff_thd, diff_abs, diff_abs / denom)
         bad_mask = rdiff > diff_thd
-        sign_flip = (
-            ((actual_f > 0) & (expected_f < 0))
-            | ((actual_f < 0) & (expected_f > 0))
-        )
+        sign_flip = (((actual_f > 0) & (expected_f < 0)) | ((actual_f < 0) & (expected_f > 0)))
         near_zero_sign_flip = (
             sign_flip
             & (actual_f.abs() <= near_zero_magnitude)
@@ -1659,16 +1640,9 @@ def build_full_compare(mapping_shape, *, leading_rank_axis, diagnostic_x_out=Fal
     """Compare the six mutable pools only at allocator-mapped rows."""
     from golden import error_distribution, mapped_pool_ratio_allclose
 
-    common = {
-        "mapping_shape": mapping_shape,
-        "leading_rank_axis": leading_rank_axis,
-    }
+    common = { "mapping_shape": mapping_shape, "leading_rank_axis": leading_rank_axis, }
     # Simulator x_out is diagnostic until CSA sparse-attention numerics match hardware.
-    x_out_compare = (
-        error_distribution(always_pass=False)
-        if diagnostic_x_out
-        else _csa_x_out_compare()
-    )
+    x_out_compare = (error_distribution(always_pass=False) if diagnostic_x_out else _csa_x_out_compare())
     return {
         "compress_state": mapped_pool_ratio_allclose(
             "state_slot_mapping",
@@ -1768,11 +1742,7 @@ if __name__ == "__main__":
     batch = B
     if args.start_pos is not None:
         try:
-            start_values = [
-                int(value.strip())
-                for value in args.start_pos.split(",")
-                if value.strip() != ""
-            ]
+            start_values = [int(value.strip()) for value in args.start_pos.split(",") if value.strip() != ""]
         except ValueError:
             parser.error(f"--start-pos must contain integers, got {args.start_pos!r}")
         if not start_values:

--- a/models/deepseek_v4_flash_dspark/decode_fwd.py
+++ b/models/deepseek_v4_flash_dspark/decode_fwd.py
@@ -1597,126 +1597,6 @@ def build_tensor_specs(start_pos=None, *, weight_bank_size=RUNTIME_WEIGHT_BANK, 
     return specs
 
 
-def finite_tensor_compare(actual, _expected, **_kwargs):
-    """Require a completed finite device result without duplicating 43 goldens."""
-    import torch
-
-    if actual.numel() == 0:
-        return False, "    decode forward output is empty"
-    if actual.is_floating_point() and not bool(torch.isfinite(actual).all()):
-        return False, "    decode forward output contains NaN or Inf"
-    return True, ""
-
-
-def sampled_ids_compare(actual, _expected, **kwargs):
-    """Validate active greedy ids and the inactive-row -1 contract."""
-    import torch
-
-    row_indices = kwargs.get("inputs", {}).get("logit_row_indices")
-    if row_indices is None:
-        return False, "    missing logit_row_indices input"
-    active = row_indices >= 0
-    inactive_values = actual.masked_select((~active).unsqueeze(-1).expand_as(actual))
-    if inactive_values.numel() and not bool(torch.all(inactive_values == -1)):
-        return False, "    inactive sampled-id rows are not -1"
-    active_ids = actual[..., 0].masked_select(active)
-    if active_ids.numel() and bool(((active_ids < 0) | (active_ids >= LM_HEAD_VOCAB)).any()):
-        return False, "    active sampled token id is outside the vocabulary"
-    return True, ""
-
-
-def _packed_pool_compare(layer_mappings, layer_count, block_size, pool_name):
-    """Check every packed layer slice and reject writes outside local slots."""
-
-    def compare(actual, expected, **kwargs):
-        import torch
-
-        if actual.shape != expected.shape:
-            message = f"    {pool_name} shape mismatch: actual={tuple(actual.shape)} expected={tuple(expected.shape)}"
-            return False, message
-        if actual.shape[1] % layer_count:
-            return False, f"    {pool_name} packed extent is not divisible"
-        if len(layer_mappings) != layer_count:
-            return False, f"    {pool_name} mapping count diverged"
-        inputs = kwargs.get("inputs", {})
-        extent = actual.shape[1] // layer_count
-        for ordinal, mapping_name in enumerate(layer_mappings):
-            mapping = inputs.get(mapping_name)
-            if mapping is None:
-                return False, f"    missing input {mapping_name!r}"
-            for rank in range(actual.shape[0]):
-                begin = ordinal * extent
-                actual_rows = actual[rank, begin : begin + extent].reshape(extent * block_size, *actual.shape[3:])
-                expected_rows = expected[rank, begin : begin + extent].reshape(extent * block_size, *expected.shape[3:])
-                slots = mapping[rank].to(dtype=torch.int64).reshape(-1)
-                invalid = (slots < -1) | (slots >= actual_rows.shape[0])
-                if bool(invalid.any()):
-                    first = int(slots[invalid][0])
-                    return False, f"    {pool_name} layer={ordinal} rank={rank} contains out-of-range slot {first}"
-                slots = slots[slots >= 0]
-                target = torch.zeros(actual_rows.shape[0], dtype=torch.bool, device=actual.device)
-                if slots.numel():
-                    target[slots] = True
-                if not torch.equal(actual_rows[~target], expected_rows[~target]):
-                    return False, f"    {pool_name} layer={ordinal} rank={rank} modified an unmapped row"
-                selected = actual_rows[target]
-                if selected.is_floating_point() and not bool(torch.isfinite(selected).all()):
-                    return False, f"    {pool_name} layer={ordinal} rank={rank} wrote NaN or Inf"
-                sentinel_value = ordinal + 1
-                sentinel_initialized = bool(torch.all(expected_rows == sentinel_value))
-                selected_unchanged = torch.equal(selected, expected_rows[target])
-                if slots.numel() and sentinel_initialized and selected_unchanged:
-                    return False, f"    {pool_name} layer={ordinal} rank={rank} did not update any mapped sentinel row"
-        return True, ""
-
-    return compare
-
-
-def compare_functions():
-    """Return the decode forward runtime isolation and completion comparators."""
-    raw_mappings = ("swa_slot_mapping",) * SWA_LAYER_COUNT
-    alternating_mappings = ("csa_ori_slot_mapping", "hca_ori_slot_mapping")
-    raw_mappings += tuple(mapping for _ in range(HCA_LAYER_COUNT) for mapping in alternating_mappings)
-    raw_mappings += ("csa_ori_slot_mapping",)
-    csa_mappings = ("csa_state_slot_mapping",) * CSA_LAYER_COUNT
-    csa_cmp_mappings = ("csa_cmp_slot_mapping",) * CSA_LAYER_COUNT
-    csa_inner_mappings = ("csa_inner_state_slot_mapping",) * CSA_LAYER_COUNT
-    csa_idx_mappings = ("csa_idx_slot_mapping",) * CSA_LAYER_COUNT
-    hca_state_mappings = ("hca_state_slot_mapping",) * HCA_LAYER_COUNT
-    hca_cmp_mappings = ("hca_cmp_slot_mapping",) * HCA_LAYER_COUNT
-    finite_names = {
-        "hidden_workspace", "x_ping", "x_pong", "x_attn_active",
-        "x_moe_next", "pre_hc_hidden_out", "x_out", "logits",
-    }
-    compare = {name: finite_tensor_compare for name in finite_names}
-    compare["sampled_ids"] = sampled_ids_compare
-    compare.update({
-        "raw_kv_pool": _packed_pool_compare(raw_mappings, MAIN_LAYER_COUNT, BLOCK_SIZE, "decode forward raw KV"),
-        "hca_compress_state": _packed_pool_compare(
-            hca_state_mappings, HCA_LAYER_COUNT, HCA_COMPRESS_STATE_BLOCK_SIZE, "decode forward HCA state",
-        ),
-        "hca_cmp_kv": _packed_pool_compare(
-            hca_cmp_mappings, HCA_LAYER_COUNT, BLOCK_SIZE, "decode forward HCA compressed KV",
-        ),
-        "csa_compress_state": _packed_pool_compare(
-            csa_mappings, CSA_LAYER_COUNT, CSA_MAIN_STATE_BLOCK_SIZE, "decode forward CSA main state",
-        ),
-        "csa_cmp_kv": _packed_pool_compare(
-            csa_cmp_mappings, CSA_LAYER_COUNT, BLOCK_SIZE, "decode forward CSA compressed KV",
-        ),
-        "csa_inner_compress_state": _packed_pool_compare(
-            csa_inner_mappings, CSA_LAYER_COUNT, CSA_INNER_STATE_BLOCK_SIZE, "decode forward CSA inner state",
-        ),
-        "csa_idx_kv_cache": _packed_pool_compare(
-            csa_idx_mappings, CSA_LAYER_COUNT, BLOCK_SIZE, "decode forward CSA index KV",
-        ),
-        "csa_idx_kv_scale": _packed_pool_compare(
-            csa_idx_mappings, CSA_LAYER_COUNT, BLOCK_SIZE, "decode forward CSA index scale",
-        ),
-    })
-    return compare
-
-
 def _parse_start_pos(raw):
     if raw is None:
         return None
@@ -1755,7 +1635,6 @@ def main():
     )
     parser.add_argument("--enable-scope-stats", action="store_true", default=False)
     parser.add_argument("--runtime-dir", type=str, default=None)
-    parser.add_argument("--golden-data", type=str, default=None)
     parser.add_argument("--save-data", action="store_true", default=False)
     parser.add_argument("--dump-passes", action="store_true", default=False)
     parser.add_argument("--log-level", type=str, default=None)
@@ -1786,7 +1665,6 @@ def main():
     result = run_jit(
         fn=l3_decode_fwd,
         specs=specs,
-        golden_data=args.golden_data,
         save_data=args.save_data,
         compile_only=args.compile_only,
         runtime_dir=args.runtime_dir,
@@ -1804,7 +1682,6 @@ def main():
         ),
         rtol=1e-2,
         atol=1e-2,
-        compare_fn=compare_functions(),
     )
     if not result.passed:
         if result.error:

--- a/models/deepseek_v4_flash_dspark/decode_fwd.py
+++ b/models/deepseek_v4_flash_dspark/decode_fwd.py
@@ -240,28 +240,17 @@ def mask_inactive_sample_rows(
 @pl.jit(auto_scope=False)
 def decode_fwd(
     embed_weight: pl.Tensor[[EMBED_VOCAB_DYN, D], pl.BF16],
-    hc_attn_fn: pl.Tensor[
-        [FWD_WEIGHT_BANK_SIZE * HC_FN_STORAGE_ROWS, HC_DIM], pl.FP32
-    ],
+    hc_attn_fn: pl.Tensor[[FWD_WEIGHT_BANK_SIZE * HC_FN_STORAGE_ROWS, HC_DIM], pl.FP32],
     hc_attn_scale: pl.Tensor[[FWD_WEIGHT_BANK_SIZE * 3], pl.FP32],
     hc_attn_base: pl.Tensor[[FWD_WEIGHT_BANK_SIZE * MIX_HC], pl.FP32],
     attn_norm_w: pl.Tensor[[FWD_WEIGHT_BANK_SIZE * D], pl.BF16],
     wq_a: pl.Tensor[[FWD_WEIGHT_BANK_SIZE * D, Q_LORA], pl.BF16],
-    wq_b: pl.Tensor[
-        [FWD_WEIGHT_BANK_SIZE * Q_LORA, H * HEAD_DIM], pl.INT8
-    ],
-    wq_b_scale: pl.Tensor[
-        [FWD_WEIGHT_BANK_SIZE * H * HEAD_DIM], pl.FP32
-    ],
+    wq_b: pl.Tensor[[FWD_WEIGHT_BANK_SIZE * Q_LORA, H * HEAD_DIM], pl.INT8],
+    wq_b_scale: pl.Tensor[[FWD_WEIGHT_BANK_SIZE * H * HEAD_DIM], pl.FP32],
     wkv: pl.Tensor[[FWD_WEIGHT_BANK_SIZE * D, HEAD_DIM], pl.BF16],
     gamma_cq: pl.Tensor[[FWD_WEIGHT_BANK_SIZE * Q_LORA], pl.BF16],
     gamma_ckv: pl.Tensor[[FWD_WEIGHT_BANK_SIZE * HEAD_DIM], pl.BF16],
-    raw_kv_pool: pl.InOut[
-        pl.Tensor[
-            [FWD_PACKED_RAW_BLOCKS_DYN, BLOCK_SIZE, 1, HEAD_DIM],
-            pl.BF16,
-        ]
-    ],
+    raw_kv_pool: pl.InOut[pl.Tensor[[FWD_PACKED_RAW_BLOCKS_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
     freqs_cos: pl.Tensor[[T_DYN, ROPE_HEAD_DIM], pl.BF16],
     freqs_sin: pl.Tensor[[T_DYN, ROPE_HEAD_DIM], pl.BF16],
     swa_slot_mapping: pl.Tensor[[T_DYN], pl.INT64],
@@ -270,98 +259,27 @@ def decode_fwd(
     position_ids: pl.Tensor[[T_DYN], pl.INT32],
     csa_cmp_freqs_cos: pl.Tensor[[T_DYN, ROPE_HEAD_DIM], pl.BF16],
     csa_cmp_freqs_sin: pl.Tensor[[T_DYN, ROPE_HEAD_DIM], pl.BF16],
-    csa_cmp_wkv: pl.Tensor[
-        [FWD_CSA_WEIGHT_BANK_SIZE * CSA_MAIN_OUT_DIM, D], pl.BF16
-    ],
-    csa_cmp_wgate: pl.Tensor[
-        [FWD_CSA_WEIGHT_BANK_SIZE * CSA_MAIN_OUT_DIM, D], pl.BF16
-    ],
-    csa_cmp_ape: pl.Tensor[
-        [FWD_CSA_WEIGHT_BANK_SIZE * CSA_COMPRESS_RATIO, CSA_MAIN_OUT_DIM],
-        pl.FP32,
-    ],
-    csa_cmp_norm_w: pl.Tensor[
-        [FWD_CSA_WEIGHT_BANK_SIZE * HEAD_DIM], pl.BF16
-    ],
-    csa_compress_state: pl.InOut[
-        pl.Tensor[
-            [
-                FWD_CSA_MAIN_STATE_BLOCKS_DYN,
-                CSA_MAIN_STATE_BLOCK_SIZE,
-                CSA_MAIN_STATE_DIM,
-            ],
-            pl.FP32,
-        ]
-    ],
-    csa_compress_state_block_table: pl.Tensor[
-        [CSA_B_DYN, CSA_MAIN_STATE_MAX_BLOCKS], pl.INT32
-    ],
-    csa_idx_wq_b: pl.Tensor[
-        [
-            FWD_CSA_WEIGHT_BANK_SIZE * Q_LORA,
-            CSA_IDX_N_HEADS * CSA_IDX_HEAD_DIM,
-        ],
-        pl.INT8,
-    ],
-    csa_idx_wq_b_scale: pl.Tensor[
-        [FWD_CSA_WEIGHT_BANK_SIZE * CSA_IDX_N_HEADS * CSA_IDX_HEAD_DIM],
-        pl.FP32,
-    ],
-    csa_weights_proj: pl.Tensor[
-        [FWD_CSA_WEIGHT_BANK_SIZE * D, CSA_IDX_N_HEADS], pl.BF16
-    ],
-    csa_hadamard_idx: pl.Tensor[
-        [FWD_CSA_WEIGHT_BANK_SIZE * CSA_IDX_HEAD_DIM, CSA_IDX_HEAD_DIM],
-        pl.BF16,
-    ],
-    csa_inner_wkv: pl.Tensor[
-        [FWD_CSA_WEIGHT_BANK_SIZE * CSA_INNER_OUT_DIM, D], pl.BF16
-    ],
-    csa_inner_wgate: pl.Tensor[
-        [FWD_CSA_WEIGHT_BANK_SIZE * CSA_INNER_OUT_DIM, D], pl.BF16
-    ],
-    csa_inner_ape: pl.Tensor[
-        [FWD_CSA_WEIGHT_BANK_SIZE * CSA_COMPRESS_RATIO, CSA_INNER_OUT_DIM],
-        pl.FP32,
-    ],
-    csa_inner_norm_w: pl.Tensor[
-        [FWD_CSA_WEIGHT_BANK_SIZE * CSA_IDX_HEAD_DIM], pl.BF16
-    ],
-    csa_inner_compress_state: pl.InOut[
-        pl.Tensor[
-            [
-                FWD_CSA_INNER_STATE_BLOCKS_DYN,
-                CSA_INNER_STATE_BLOCK_SIZE,
-                CSA_INNER_STATE_DIM,
-            ],
-            pl.FP32,
-        ]
-    ],
-    csa_inner_compress_state_block_table: pl.Tensor[
-        [CSA_B_DYN, CSA_INNER_STATE_MAX_BLOCKS], pl.INT32
-    ],
-    csa_cmp_kv: pl.InOut[
-        pl.Tensor[
-            [FWD_CSA_CMP_BLOCKS_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16
-        ]
-    ],
-    csa_cmp_block_table: pl.Tensor[
-        [CSA_B_DYN, CSA_CMP_MAX_BLOCKS], pl.INT32
-    ],
-    csa_idx_kv_cache: pl.InOut[
-        pl.Tensor[
-            [FWD_CSA_IDX_BLOCKS_DYN, BLOCK_SIZE, 1, CSA_IDX_HEAD_DIM],
-            pl.INT8,
-        ]
-    ],
-    csa_idx_kv_scale: pl.InOut[
-        pl.Tensor[
-            [FWD_CSA_IDX_BLOCKS_DYN, BLOCK_SIZE, 1, 1], pl.FP32
-        ]
-    ],
-    csa_idx_block_table: pl.Tensor[
-        [CSA_B_DYN, CSA_IDX_MAX_BLOCKS], pl.INT32
-    ],
+    csa_cmp_wkv: pl.Tensor[[FWD_CSA_WEIGHT_BANK_SIZE * CSA_MAIN_OUT_DIM, D], pl.BF16],
+    csa_cmp_wgate: pl.Tensor[[FWD_CSA_WEIGHT_BANK_SIZE * CSA_MAIN_OUT_DIM, D], pl.BF16],
+    csa_cmp_ape: pl.Tensor[[FWD_CSA_WEIGHT_BANK_SIZE * CSA_COMPRESS_RATIO, CSA_MAIN_OUT_DIM], pl.FP32],
+    csa_cmp_norm_w: pl.Tensor[[FWD_CSA_WEIGHT_BANK_SIZE * HEAD_DIM], pl.BF16],
+    csa_compress_state: pl.InOut[pl.Tensor[[FWD_CSA_MAIN_STATE_BLOCKS_DYN, CSA_MAIN_STATE_BLOCK_SIZE, CSA_MAIN_STATE_DIM], pl.FP32]],
+    csa_compress_state_block_table: pl.Tensor[[CSA_B_DYN, CSA_MAIN_STATE_MAX_BLOCKS], pl.INT32],
+    csa_idx_wq_b: pl.Tensor[[FWD_CSA_WEIGHT_BANK_SIZE * Q_LORA, CSA_IDX_N_HEADS * CSA_IDX_HEAD_DIM], pl.INT8],
+    csa_idx_wq_b_scale: pl.Tensor[[FWD_CSA_WEIGHT_BANK_SIZE * CSA_IDX_N_HEADS * CSA_IDX_HEAD_DIM], pl.FP32],
+    csa_weights_proj: pl.Tensor[[FWD_CSA_WEIGHT_BANK_SIZE * D, CSA_IDX_N_HEADS], pl.BF16],
+    csa_hadamard_idx: pl.Tensor[[FWD_CSA_WEIGHT_BANK_SIZE * CSA_IDX_HEAD_DIM, CSA_IDX_HEAD_DIM], pl.BF16],
+    csa_inner_wkv: pl.Tensor[[FWD_CSA_WEIGHT_BANK_SIZE * CSA_INNER_OUT_DIM, D], pl.BF16],
+    csa_inner_wgate: pl.Tensor[[FWD_CSA_WEIGHT_BANK_SIZE * CSA_INNER_OUT_DIM, D], pl.BF16],
+    csa_inner_ape: pl.Tensor[[FWD_CSA_WEIGHT_BANK_SIZE * CSA_COMPRESS_RATIO, CSA_INNER_OUT_DIM], pl.FP32],
+    csa_inner_norm_w: pl.Tensor[[FWD_CSA_WEIGHT_BANK_SIZE * CSA_IDX_HEAD_DIM], pl.BF16],
+    csa_inner_compress_state: pl.InOut[pl.Tensor[[FWD_CSA_INNER_STATE_BLOCKS_DYN, CSA_INNER_STATE_BLOCK_SIZE, CSA_INNER_STATE_DIM], pl.FP32]],
+    csa_inner_compress_state_block_table: pl.Tensor[[CSA_B_DYN, CSA_INNER_STATE_MAX_BLOCKS], pl.INT32],
+    csa_cmp_kv: pl.InOut[pl.Tensor[[FWD_CSA_CMP_BLOCKS_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
+    csa_cmp_block_table: pl.Tensor[[CSA_B_DYN, CSA_CMP_MAX_BLOCKS], pl.INT32],
+    csa_idx_kv_cache: pl.InOut[pl.Tensor[[FWD_CSA_IDX_BLOCKS_DYN, BLOCK_SIZE, 1, CSA_IDX_HEAD_DIM], pl.INT8]],
+    csa_idx_kv_scale: pl.InOut[pl.Tensor[[FWD_CSA_IDX_BLOCKS_DYN, BLOCK_SIZE, 1, 1], pl.FP32]],
+    csa_idx_block_table: pl.Tensor[[CSA_B_DYN, CSA_IDX_MAX_BLOCKS], pl.INT32],
     csa_ori_slot_mapping: pl.Tensor[[T_DYN], pl.INT64],
     csa_window_swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
     csa_window_swa_lens: pl.Tensor[[T_DYN], pl.INT32],
@@ -372,40 +290,14 @@ def decode_fwd(
     csa_kv_seq_lens: pl.Tensor[[CSA_B_DYN], pl.INT32],
     hca_cmp_freqs_cos: pl.Tensor[[HCA_B, ROPE_HEAD_DIM // 2], pl.FP32],
     hca_cmp_freqs_sin: pl.Tensor[[HCA_B, ROPE_HEAD_DIM // 2], pl.FP32],
-    hca_cmp_wkv: pl.Tensor[
-        [FWD_HCA_WEIGHT_BANK_SIZE * HCA_MAIN_OUT_DIM, D], pl.BF16
-    ],
-    hca_cmp_wgate: pl.Tensor[
-        [FWD_HCA_WEIGHT_BANK_SIZE * HCA_MAIN_OUT_DIM, D], pl.BF16
-    ],
-    hca_cmp_ape: pl.Tensor[
-        [FWD_HCA_WEIGHT_BANK_SIZE * HCA_COMPRESS_RATIO, HCA_MAIN_OUT_DIM],
-        pl.FP32,
-    ],
-    hca_cmp_norm_w: pl.Tensor[
-        [FWD_HCA_WEIGHT_BANK_SIZE * HEAD_DIM], pl.BF16
-    ],
-    hca_compress_state: pl.InOut[
-        pl.Tensor[
-            [
-                FWD_HCA_STATE_BLOCKS_DYN,
-                HCA_COMPRESS_STATE_BLOCK_SIZE,
-                HCA_COMPRESS_STATE_DIM,
-            ],
-            pl.FP32,
-        ]
-    ],
-    hca_compress_state_block_table: pl.Tensor[
-        [HCA_B_DYN, HCA_COMPRESS_STATE_MAX_BLOCKS], pl.INT32
-    ],
-    hca_cmp_kv: pl.InOut[
-        pl.Tensor[
-            [FWD_HCA_CMP_BLOCKS_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16
-        ]
-    ],
-    hca_cmp_block_table: pl.Tensor[
-        [HCA_B_DYN, HCA_CMP_TABLE_BLOCKS_DYN], pl.INT32
-    ],
+    hca_cmp_wkv: pl.Tensor[[FWD_HCA_WEIGHT_BANK_SIZE * HCA_MAIN_OUT_DIM, D], pl.BF16],
+    hca_cmp_wgate: pl.Tensor[[FWD_HCA_WEIGHT_BANK_SIZE * HCA_MAIN_OUT_DIM, D], pl.BF16],
+    hca_cmp_ape: pl.Tensor[[FWD_HCA_WEIGHT_BANK_SIZE * HCA_COMPRESS_RATIO, HCA_MAIN_OUT_DIM], pl.FP32],
+    hca_cmp_norm_w: pl.Tensor[[FWD_HCA_WEIGHT_BANK_SIZE * HEAD_DIM], pl.BF16],
+    hca_compress_state: pl.InOut[pl.Tensor[[FWD_HCA_STATE_BLOCKS_DYN, HCA_COMPRESS_STATE_BLOCK_SIZE, HCA_COMPRESS_STATE_DIM], pl.FP32]],
+    hca_compress_state_block_table: pl.Tensor[[HCA_B_DYN, HCA_COMPRESS_STATE_MAX_BLOCKS], pl.INT32],
+    hca_cmp_kv: pl.InOut[pl.Tensor[[FWD_HCA_CMP_BLOCKS_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
+    hca_cmp_block_table: pl.Tensor[[HCA_B_DYN, HCA_CMP_TABLE_BLOCKS_DYN], pl.INT32],
     hca_ori_slot_mapping: pl.Tensor[[T_DYN], pl.INT64],
     hca_window_swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
     hca_window_swa_lens: pl.Tensor[[T_DYN], pl.INT32],
@@ -413,26 +305,15 @@ def decode_fwd(
     hca_state_slot_mapping: pl.Tensor[[T_DYN], pl.INT64],
     hca_kv_seq_lens: pl.Tensor[[HCA_B_DYN], pl.INT32],
     attn_sink: pl.Tensor[[FWD_WEIGHT_BANK_SIZE * H], pl.FP32],
-    wo_a: pl.Tensor[
-        [FWD_WEIGHT_BANK_SIZE * LOCAL_O_GROUPS, O_LORA, O_GROUP_IN],
-        pl.BF16,
-    ],
-    wo_b: pl.Tensor[
-        [FWD_WEIGHT_BANK_SIZE * D, LOCAL_O_WIDTH], pl.INT8
-    ],
+    wo_a: pl.Tensor[[FWD_WEIGHT_BANK_SIZE * LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
+    wo_b: pl.Tensor[[FWD_WEIGHT_BANK_SIZE * D, LOCAL_O_WIDTH], pl.INT8],
     wo_b_scale: pl.Tensor[[FWD_WEIGHT_BANK_SIZE * D], pl.FP32],
-    hc_ffn_fn: pl.Tensor[
-        [FWD_WEIGHT_BANK_SIZE * HC_FN_STORAGE_ROWS, HC_DIM], pl.FP32
-    ],
+    hc_ffn_fn: pl.Tensor[[FWD_WEIGHT_BANK_SIZE * HC_FN_STORAGE_ROWS, HC_DIM], pl.FP32],
     hc_ffn_scale: pl.Tensor[[FWD_WEIGHT_BANK_SIZE * 3], pl.FP32],
     hc_ffn_base: pl.Tensor[[FWD_WEIGHT_BANK_SIZE * MIX_HC], pl.FP32],
     norm_w: pl.Tensor[[FWD_WEIGHT_BANK_SIZE * D], pl.BF16],
-    gate_w: pl.Tensor[
-        [FWD_WEIGHT_BANK_SIZE * N_EXPERTS_GLOBAL, D], pl.FP32
-    ],
-    gate_bias: pl.Tensor[
-        [FWD_WEIGHT_BANK_SIZE * N_EXPERTS_GLOBAL], pl.FP32
-    ],
+    gate_w: pl.Tensor[[FWD_WEIGHT_BANK_SIZE * N_EXPERTS_GLOBAL, D], pl.FP32],
+    gate_bias: pl.Tensor[[FWD_WEIGHT_BANK_SIZE * N_EXPERTS_GLOBAL], pl.FP32],
     tid2eid: pl.Tensor[[FWD_WEIGHT_BANK_SIZE * VOCAB, TOPK], pl.INT32],
     input_ids: pl.Tensor[[T_DYN], pl.INT64],
     hc_head_fn: pl.Tensor[[HC_MULT, HC_DIM], pl.FP32],
@@ -441,89 +322,43 @@ def decode_fwd(
     final_norm_w: pl.Tensor[[D], pl.BF16],
     lm_head_weight: pl.Tensor[[VOCAB_PER_TP, D], pl.BF16],
     logit_row_indices: pl.Tensor[[MAX_LOGIT_ROWS], pl.INT32],
-    routed_w1: pl.Tensor[
-        [FWD_WEIGHT_BANK_SIZE * N_LOCAL, MOE_INTER, D], pl.INT8
-    ],
-    routed_w1_scale: pl.Tensor[
-        [FWD_WEIGHT_BANK_SIZE * N_LOCAL, MOE_INTER], pl.FP32
-    ],
-    routed_w3: pl.Tensor[
-        [FWD_WEIGHT_BANK_SIZE * N_LOCAL, MOE_INTER, D], pl.INT8
-    ],
-    routed_w3_scale: pl.Tensor[
-        [FWD_WEIGHT_BANK_SIZE * N_LOCAL, MOE_INTER], pl.FP32
-    ],
-    routed_w2: pl.Tensor[
-        [FWD_WEIGHT_BANK_SIZE * N_LOCAL, D, MOE_INTER], pl.INT8
-    ],
-    routed_w2_scale: pl.Tensor[
-        [FWD_WEIGHT_BANK_SIZE * N_LOCAL, D], pl.FP32
-    ],
-    shared_w1: pl.Tensor[
-        [FWD_WEIGHT_BANK_SIZE * MOE_INTER, D], pl.INT8
-    ],
-    shared_w1_scale: pl.Tensor[
-        [FWD_WEIGHT_BANK_SIZE * MOE_INTER], pl.FP32
-    ],
-    shared_w3: pl.Tensor[
-        [FWD_WEIGHT_BANK_SIZE * MOE_INTER, D], pl.INT8
-    ],
-    shared_w3_scale: pl.Tensor[
-        [FWD_WEIGHT_BANK_SIZE * MOE_INTER], pl.FP32
-    ],
-    shared_w2: pl.Tensor[
-        [FWD_WEIGHT_BANK_SIZE * D, MOE_INTER], pl.INT8
-    ],
+    routed_w1: pl.Tensor[[FWD_WEIGHT_BANK_SIZE * N_LOCAL, MOE_INTER, D], pl.INT8],
+    routed_w1_scale: pl.Tensor[[FWD_WEIGHT_BANK_SIZE * N_LOCAL, MOE_INTER], pl.FP32],
+    routed_w3: pl.Tensor[[FWD_WEIGHT_BANK_SIZE * N_LOCAL, MOE_INTER, D], pl.INT8],
+    routed_w3_scale: pl.Tensor[[FWD_WEIGHT_BANK_SIZE * N_LOCAL, MOE_INTER], pl.FP32],
+    routed_w2: pl.Tensor[[FWD_WEIGHT_BANK_SIZE * N_LOCAL, D, MOE_INTER], pl.INT8],
+    routed_w2_scale: pl.Tensor[[FWD_WEIGHT_BANK_SIZE * N_LOCAL, D], pl.FP32],
+    shared_w1: pl.Tensor[[FWD_WEIGHT_BANK_SIZE * MOE_INTER, D], pl.INT8],
+    shared_w1_scale: pl.Tensor[[FWD_WEIGHT_BANK_SIZE * MOE_INTER], pl.FP32],
+    shared_w3: pl.Tensor[[FWD_WEIGHT_BANK_SIZE * MOE_INTER, D], pl.INT8],
+    shared_w3_scale: pl.Tensor[[FWD_WEIGHT_BANK_SIZE * MOE_INTER], pl.FP32],
+    shared_w2: pl.Tensor[[FWD_WEIGHT_BANK_SIZE * D, MOE_INTER], pl.INT8],
     shared_w2_scale: pl.Tensor[[FWD_WEIGHT_BANK_SIZE * D], pl.FP32],
     hidden_workspace: pl.Out[pl.Tensor[[T_DYN, D], pl.BF16]],
     x_ping: pl.InOut[pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32]],
     x_pong: pl.InOut[pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32]],
-    x_attn_active: pl.InOut[
-        pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32]
-    ],
-    x_moe_next: pl.InOut[
-        pl.Tensor[[MOE_TOKENS, HC_MULT, D], pl.FP32]
-    ],
-    pre_hc_hidden_out: pl.Out[
-        pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32]
-    ],
+    x_attn_active: pl.InOut[pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32]],
+    x_moe_next: pl.InOut[pl.Tensor[[MOE_TOKENS, HC_MULT, D], pl.FP32]],
+    pre_hc_hidden_out: pl.Out[pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32]],
     x_out: pl.Out[pl.Tensor[[T_DYN, D], pl.BF16]],
-    logits: pl.Out[
-        pl.Tensor[[MAX_LOGIT_ROWS, LM_HEAD_VOCAB], pl.FP32]
-    ],
-    sampled_ids: pl.Out[
-        pl.Tensor[[MAX_LOGIT_ROWS, SAMPLED_IDS_PAD], pl.INT32]
-    ],
-    attention_window: pld.DistributedTensor[
-        [ATTENTION_WINDOW_ROWS, O_GROUP_IN], pl.BF16
-    ],
+    logits: pl.Out[pl.Tensor[[MAX_LOGIT_ROWS, LM_HEAD_VOCAB], pl.FP32]],
+    sampled_ids: pl.Out[pl.Tensor[[MAX_LOGIT_ROWS, SAMPLED_IDS_PAD], pl.INT32]],
+    attention_window: pld.DistributedTensor[[ATTENTION_WINDOW_ROWS, O_GROUP_IN], pl.BF16],
     attention_signal: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
     o_window: pld.DistributedTensor[[O_WINDOW_ROWS, D], pl.FP32],
     o_signal: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
     recv_meta: pld.DistributedTensor[[N_RANKS, N_LOCAL], pl.INT32],
     recv_x: pld.DistributedTensor[[N_LOCAL * RECV_MAX, D], pl.INT8],
-    recv_aux: pld.DistributedTensor[
-        [N_LOCAL * RECV_MAX, AUX_PAD], pl.FP32
-    ],
-    recv_route: pld.DistributedTensor[
-        [N_LOCAL * RECV_MAX, IDX_PAD], pl.INT32
-    ],
+    recv_aux: pld.DistributedTensor[[N_LOCAL * RECV_MAX, AUX_PAD], pl.FP32],
+    recv_route: pld.DistributedTensor[[N_LOCAL * RECV_MAX, IDX_PAD], pl.INT32],
     arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
     data_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
     routed_y_buf: pld.DistributedTensor[[N_ROUTES, D], pl.BF16],
     combine_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
-    lm_head_hidden_window: pld.DistributedTensor[
-        [GROUP_LOGIT_ROWS, D], pl.BF16
-    ],
-    lm_head_hidden_done: pld.DistributedTensor[
-        [LM_HEAD_TP_SIZE, 1], pl.INT32
-    ],
-    lm_head_logits_window: pld.DistributedTensor[
-        [MAX_LOGIT_ROWS * LM_HEAD_VOCAB], pl.FP32
-    ],
-    lm_head_logits_done: pld.DistributedTensor[
-        [LM_HEAD_TP_SIZE, 1], pl.INT32
-    ],
+    lm_head_hidden_window: pld.DistributedTensor[[GROUP_LOGIT_ROWS, D], pl.BF16],
+    lm_head_hidden_done: pld.DistributedTensor[[LM_HEAD_TP_SIZE, 1], pl.INT32],
+    lm_head_logits_window: pld.DistributedTensor[[MAX_LOGIT_ROWS * LM_HEAD_VOCAB], pl.FP32],
+    lm_head_logits_done: pld.DistributedTensor[[LM_HEAD_TP_SIZE, 1], pl.INT32],
     group_base: pl.Scalar[pl.INT32],
     tp_rank: pl.Scalar[pl.INT32],
     my_rank: pl.Scalar[pl.INT32],
@@ -655,7 +490,7 @@ def decode_fwd(
             for token in pl.spmd(MOE_TOKENS, name_hint="decode_fwd_swa0_attn_pack"):
                 if token < local_t:
                     x_attn_moe_swa0[token : token + 1, 0 : HC_MULT, 0 : D] = x_attn_active[
-                        token : token + 1, 0 : HC_MULT, 0 : D
+                        token : token + 1, 0 : HC_MULT, 0 : D,
                     ]
                 else:
                     zero_moe_row_swa0 = pl.full([1, HC_MULT, D], dtype=pl.FP32, value=0.0)
@@ -678,9 +513,7 @@ def decode_fwd(
             )
             for token in pl.spmd(MOE_TOKENS, name_hint="decode_fwd_swa0_active_trim"):
                 if token < local_t:
-                    x_pong[token : token + 1, 0 : HC_MULT, 0 : D] = x_moe_next[
-                        token : token + 1, 0 : HC_MULT, 0 : D
-                    ]
+                    x_pong[token : token + 1, 0 : HC_MULT, 0 : D] = x_moe_next[token : token + 1, 0 : HC_MULT, 0 : D]
 
     with pl.scope():
         weight_layer_swa1 = pl.const(1, pl.INT32) % FWD_WEIGHT_BANK_SIZE
@@ -749,7 +582,7 @@ def decode_fwd(
             for token in pl.spmd(MOE_TOKENS, name_hint="decode_fwd_swa1_attn_pack"):
                 if token < local_t:
                     x_attn_moe_swa1[token : token + 1, 0 : HC_MULT, 0 : D] = x_attn_active[
-                        token : token + 1, 0 : HC_MULT, 0 : D
+                        token : token + 1, 0 : HC_MULT, 0 : D,
                     ]
                 else:
                     zero_moe_row_swa1 = pl.full([1, HC_MULT, D], dtype=pl.FP32, value=0.0)
@@ -772,9 +605,7 @@ def decode_fwd(
             )
             for token in pl.spmd(MOE_TOKENS, name_hint="decode_fwd_swa1_active_trim"):
                 if token < local_t:
-                    x_ping[token : token + 1, 0 : HC_MULT, 0 : D] = x_moe_next[
-                        token : token + 1, 0 : HC_MULT, 0 : D
-                    ]
+                    x_ping[token : token + 1, 0 : HC_MULT, 0 : D] = x_moe_next[token : token + 1, 0 : HC_MULT, 0 : D]
 
     for ordinal in pl.range(HCA_LAYER_COUNT):
         csa_model_layer = pl.cast(ordinal * 2 + 2, pl.INT32)
@@ -893,7 +724,7 @@ def decode_fwd(
                 for token in pl.spmd(MOE_TOKENS, name_hint="decode_fwd_csa_attn_pack"):
                     if token < local_t:
                         x_attn_moe_csa[token : token + 1, 0 : HC_MULT, 0 : D] = x_attn_active[
-                            token : token + 1, 0 : HC_MULT, 0 : D
+                            token : token + 1, 0 : HC_MULT, 0 : D,
                         ]
                     else:
                         zero_moe_row_csa = pl.full([1, HC_MULT, D], dtype=pl.FP32, value=0.0)
@@ -917,7 +748,7 @@ def decode_fwd(
                 for token in pl.spmd(MOE_TOKENS, name_hint="decode_fwd_csa_active_trim"):
                     if token < local_t:
                         x_pong[token : token + 1, 0 : HC_MULT, 0 : D] = x_moe_next[
-                            token : token + 1, 0 : HC_MULT, 0 : D
+                            token : token + 1, 0 : HC_MULT, 0 : D,
                         ]
 
         with pl.scope():
@@ -1004,7 +835,7 @@ def decode_fwd(
                 for token in pl.spmd(MOE_TOKENS, name_hint="decode_fwd_hca_attn_pack"):
                     if token < local_t:
                         x_attn_moe_hca[token : token + 1, 0 : HC_MULT, 0 : D] = x_attn_active[
-                            token : token + 1, 0 : HC_MULT, 0 : D
+                            token : token + 1, 0 : HC_MULT, 0 : D,
                         ]
                     else:
                         zero_moe_row_hca = pl.full([1, HC_MULT, D], dtype=pl.FP32, value=0.0)
@@ -1028,7 +859,7 @@ def decode_fwd(
                 for token in pl.spmd(MOE_TOKENS, name_hint="decode_fwd_hca_active_trim"):
                     if token < local_t:
                         x_ping[token : token + 1, 0 : HC_MULT, 0 : D] = x_moe_next[
-                            token : token + 1, 0 : HC_MULT, 0 : D
+                            token : token + 1, 0 : HC_MULT, 0 : D,
                         ]
 
     with pl.scope():
@@ -1144,7 +975,7 @@ def decode_fwd(
             for token in pl.spmd(MOE_TOKENS, name_hint="decode_fwd_last_attn_pack"):
                 if token < local_t:
                     x_attn_moe_last[token : token + 1, 0 : HC_MULT, 0 : D] = x_attn_active[
-                        token : token + 1, 0 : HC_MULT, 0 : D
+                        token : token + 1, 0 : HC_MULT, 0 : D,
                     ]
                 else:
                     zero_moe_row_last = pl.full([1, HC_MULT, D], dtype=pl.FP32, value=0.0)
@@ -1168,7 +999,7 @@ def decode_fwd(
             for token in pl.spmd(MOE_TOKENS, name_hint="decode_fwd_last_active_trim"):
                 if token < local_t:
                     pre_hc_hidden_out[token : token + 1, 0 : HC_MULT, 0 : D] = x_moe_next[
-                        token : token + 1, 0 : HC_MULT, 0 : D
+                        token : token + 1, 0 : HC_MULT, 0 : D,
                     ]
     clear_moe_signals(x_moe_next, arrived, data_arrived, combine_arrived)
 
@@ -1196,366 +1027,110 @@ def decode_fwd(
 
 @pl.jit.host
 def l3_decode_fwd(
-    embed_weight: pl.Tensor[
-        [N_RANKS, EMBED_VOCAB_DYN, D], pl.BF16
-    ],
-    hc_attn_fn: pl.Tensor[
-        [N_RANKS, FWD_WEIGHT_BANK_SIZE * HC_FN_STORAGE_ROWS, HC_DIM],
-        pl.FP32,
-    ],
+    embed_weight: pl.Tensor[[N_RANKS, EMBED_VOCAB_DYN, D], pl.BF16],
+    hc_attn_fn: pl.Tensor[[N_RANKS, FWD_WEIGHT_BANK_SIZE * HC_FN_STORAGE_ROWS, HC_DIM], pl.FP32],
     hc_attn_scale: pl.Tensor[[N_RANKS, FWD_WEIGHT_BANK_SIZE * 3], pl.FP32],
-    hc_attn_base: pl.Tensor[
-        [N_RANKS, FWD_WEIGHT_BANK_SIZE * MIX_HC], pl.FP32
-    ],
+    hc_attn_base: pl.Tensor[[N_RANKS, FWD_WEIGHT_BANK_SIZE * MIX_HC], pl.FP32],
     attn_norm_w: pl.Tensor[[N_RANKS, FWD_WEIGHT_BANK_SIZE * D], pl.BF16],
-    wq_a: pl.Tensor[
-        [N_RANKS, FWD_WEIGHT_BANK_SIZE * D, Q_LORA], pl.BF16
-    ],
-    wq_b: pl.Tensor[
-        [N_RANKS, FWD_WEIGHT_BANK_SIZE * Q_LORA, H * HEAD_DIM], pl.INT8
-    ],
-    wq_b_scale: pl.Tensor[
-        [N_RANKS, FWD_WEIGHT_BANK_SIZE * H * HEAD_DIM], pl.FP32
-    ],
-    wkv: pl.Tensor[
-        [N_RANKS, FWD_WEIGHT_BANK_SIZE * D, HEAD_DIM], pl.BF16
-    ],
-    gamma_cq: pl.Tensor[
-        [N_RANKS, FWD_WEIGHT_BANK_SIZE * Q_LORA], pl.BF16
-    ],
-    gamma_ckv: pl.Tensor[
-        [N_RANKS, FWD_WEIGHT_BANK_SIZE * HEAD_DIM], pl.BF16
-    ],
-    raw_kv_pool: pl.InOut[
-        pl.Tensor[
-            [
-                N_RANKS,
-                FWD_PACKED_RAW_BLOCKS_DYN,
-                BLOCK_SIZE,
-                1,
-                HEAD_DIM,
-            ],
-            pl.BF16,
-        ]
-    ],
+    wq_a: pl.Tensor[[N_RANKS, FWD_WEIGHT_BANK_SIZE * D, Q_LORA], pl.BF16],
+    wq_b: pl.Tensor[[N_RANKS, FWD_WEIGHT_BANK_SIZE * Q_LORA, H * HEAD_DIM], pl.INT8],
+    wq_b_scale: pl.Tensor[[N_RANKS, FWD_WEIGHT_BANK_SIZE * H * HEAD_DIM], pl.FP32],
+    wkv: pl.Tensor[[N_RANKS, FWD_WEIGHT_BANK_SIZE * D, HEAD_DIM], pl.BF16],
+    gamma_cq: pl.Tensor[[N_RANKS, FWD_WEIGHT_BANK_SIZE * Q_LORA], pl.BF16],
+    gamma_ckv: pl.Tensor[[N_RANKS, FWD_WEIGHT_BANK_SIZE * HEAD_DIM], pl.BF16],
+    raw_kv_pool: pl.InOut[pl.Tensor[[N_RANKS, FWD_PACKED_RAW_BLOCKS_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
     freqs_cos: pl.Tensor[[N_RANKS, T_DYN, ROPE_HEAD_DIM], pl.BF16],
     freqs_sin: pl.Tensor[[N_RANKS, T_DYN, ROPE_HEAD_DIM], pl.BF16],
     swa_slot_mapping: pl.Tensor[[N_RANKS, T_DYN], pl.INT64],
     swa_indices: pl.Tensor[[N_RANKS, T_DYN, WIN], pl.INT32],
     swa_lens: pl.Tensor[[N_RANKS, T_DYN], pl.INT32],
     position_ids: pl.Tensor[[N_RANKS, T_DYN], pl.INT32],
-    csa_cmp_freqs_cos: pl.Tensor[
-        [N_RANKS, T_DYN, ROPE_HEAD_DIM], pl.BF16
-    ],
-    csa_cmp_freqs_sin: pl.Tensor[
-        [N_RANKS, T_DYN, ROPE_HEAD_DIM], pl.BF16
-    ],
-    csa_cmp_wkv: pl.Tensor[
-        [N_RANKS, FWD_CSA_WEIGHT_BANK_SIZE * CSA_MAIN_OUT_DIM, D], pl.BF16
-    ],
-    csa_cmp_wgate: pl.Tensor[
-        [N_RANKS, FWD_CSA_WEIGHT_BANK_SIZE * CSA_MAIN_OUT_DIM, D], pl.BF16
-    ],
-    csa_cmp_ape: pl.Tensor[
-        [
-            N_RANKS,
-            FWD_CSA_WEIGHT_BANK_SIZE * CSA_COMPRESS_RATIO,
-            CSA_MAIN_OUT_DIM,
-        ],
-        pl.FP32,
-    ],
-    csa_cmp_norm_w: pl.Tensor[
-        [N_RANKS, FWD_CSA_WEIGHT_BANK_SIZE * HEAD_DIM], pl.BF16
-    ],
-    csa_compress_state: pl.InOut[
-        pl.Tensor[
-            [
-                N_RANKS,
-                FWD_CSA_MAIN_STATE_BLOCKS_DYN,
-                CSA_MAIN_STATE_BLOCK_SIZE,
-                CSA_MAIN_STATE_DIM,
-            ],
-            pl.FP32,
-        ]
-    ],
-    csa_compress_state_block_table: pl.Tensor[
-        [N_RANKS, CSA_B_DYN, CSA_MAIN_STATE_MAX_BLOCKS], pl.INT32
-    ],
-    csa_idx_wq_b: pl.Tensor[
-        [
-            N_RANKS,
-            FWD_CSA_WEIGHT_BANK_SIZE * Q_LORA,
-            CSA_IDX_N_HEADS * CSA_IDX_HEAD_DIM,
-        ],
-        pl.INT8,
-    ],
-    csa_idx_wq_b_scale: pl.Tensor[
-        [
-            N_RANKS,
-            FWD_CSA_WEIGHT_BANK_SIZE * CSA_IDX_N_HEADS * CSA_IDX_HEAD_DIM,
-        ],
-        pl.FP32,
-    ],
-    csa_weights_proj: pl.Tensor[
-        [N_RANKS, FWD_CSA_WEIGHT_BANK_SIZE * D, CSA_IDX_N_HEADS], pl.BF16
-    ],
-    csa_hadamard_idx: pl.Tensor[
-        [
-            N_RANKS,
-            FWD_CSA_WEIGHT_BANK_SIZE * CSA_IDX_HEAD_DIM,
-            CSA_IDX_HEAD_DIM,
-        ],
-        pl.BF16,
-    ],
-    csa_inner_wkv: pl.Tensor[
-        [N_RANKS, FWD_CSA_WEIGHT_BANK_SIZE * CSA_INNER_OUT_DIM, D],
-        pl.BF16,
-    ],
-    csa_inner_wgate: pl.Tensor[
-        [N_RANKS, FWD_CSA_WEIGHT_BANK_SIZE * CSA_INNER_OUT_DIM, D],
-        pl.BF16,
-    ],
-    csa_inner_ape: pl.Tensor[
-        [
-            N_RANKS,
-            FWD_CSA_WEIGHT_BANK_SIZE * CSA_COMPRESS_RATIO,
-            CSA_INNER_OUT_DIM,
-        ],
-        pl.FP32,
-    ],
-    csa_inner_norm_w: pl.Tensor[
-        [N_RANKS, FWD_CSA_WEIGHT_BANK_SIZE * CSA_IDX_HEAD_DIM], pl.BF16
-    ],
-    csa_inner_compress_state: pl.InOut[
-        pl.Tensor[
-            [
-                N_RANKS,
-                FWD_CSA_INNER_STATE_BLOCKS_DYN,
-                CSA_INNER_STATE_BLOCK_SIZE,
-                CSA_INNER_STATE_DIM,
-            ],
-            pl.FP32,
-        ]
-    ],
-    csa_inner_compress_state_block_table: pl.Tensor[
-        [N_RANKS, CSA_B_DYN, CSA_INNER_STATE_MAX_BLOCKS], pl.INT32
-    ],
-    csa_cmp_kv: pl.InOut[
-        pl.Tensor[
-            [
-                N_RANKS,
-                FWD_CSA_CMP_BLOCKS_DYN,
-                BLOCK_SIZE,
-                1,
-                HEAD_DIM,
-            ],
-            pl.BF16,
-        ]
-    ],
-    csa_cmp_block_table: pl.Tensor[
-        [N_RANKS, CSA_B_DYN, CSA_CMP_MAX_BLOCKS], pl.INT32
-    ],
-    csa_idx_kv_cache: pl.InOut[
-        pl.Tensor[
-            [
-                N_RANKS,
-                FWD_CSA_IDX_BLOCKS_DYN,
-                BLOCK_SIZE,
-                1,
-                CSA_IDX_HEAD_DIM,
-            ],
-            pl.INT8,
-        ]
-    ],
-    csa_idx_kv_scale: pl.InOut[
-        pl.Tensor[
-            [N_RANKS, FWD_CSA_IDX_BLOCKS_DYN, BLOCK_SIZE, 1, 1],
-            pl.FP32,
-        ]
-    ],
-    csa_idx_block_table: pl.Tensor[
-        [N_RANKS, CSA_B_DYN, CSA_IDX_MAX_BLOCKS], pl.INT32
-    ],
+    csa_cmp_freqs_cos: pl.Tensor[[N_RANKS, T_DYN, ROPE_HEAD_DIM], pl.BF16],
+    csa_cmp_freqs_sin: pl.Tensor[[N_RANKS, T_DYN, ROPE_HEAD_DIM], pl.BF16],
+    csa_cmp_wkv: pl.Tensor[[N_RANKS, FWD_CSA_WEIGHT_BANK_SIZE * CSA_MAIN_OUT_DIM, D], pl.BF16],
+    csa_cmp_wgate: pl.Tensor[[N_RANKS, FWD_CSA_WEIGHT_BANK_SIZE * CSA_MAIN_OUT_DIM, D], pl.BF16],
+    csa_cmp_ape: pl.Tensor[[N_RANKS, FWD_CSA_WEIGHT_BANK_SIZE * CSA_COMPRESS_RATIO, CSA_MAIN_OUT_DIM], pl.FP32],
+    csa_cmp_norm_w: pl.Tensor[[N_RANKS, FWD_CSA_WEIGHT_BANK_SIZE * HEAD_DIM], pl.BF16],
+    csa_compress_state: pl.InOut[pl.Tensor[[N_RANKS, FWD_CSA_MAIN_STATE_BLOCKS_DYN, CSA_MAIN_STATE_BLOCK_SIZE, CSA_MAIN_STATE_DIM], pl.FP32]],
+    csa_compress_state_block_table: pl.Tensor[[N_RANKS, CSA_B_DYN, CSA_MAIN_STATE_MAX_BLOCKS], pl.INT32],
+    csa_idx_wq_b: pl.Tensor[[N_RANKS, FWD_CSA_WEIGHT_BANK_SIZE * Q_LORA, CSA_IDX_N_HEADS * CSA_IDX_HEAD_DIM], pl.INT8],
+    csa_idx_wq_b_scale: pl.Tensor[[N_RANKS, FWD_CSA_WEIGHT_BANK_SIZE * CSA_IDX_N_HEADS * CSA_IDX_HEAD_DIM], pl.FP32],
+    csa_weights_proj: pl.Tensor[[N_RANKS, FWD_CSA_WEIGHT_BANK_SIZE * D, CSA_IDX_N_HEADS], pl.BF16],
+    csa_hadamard_idx: pl.Tensor[[N_RANKS, FWD_CSA_WEIGHT_BANK_SIZE * CSA_IDX_HEAD_DIM, CSA_IDX_HEAD_DIM], pl.BF16],
+    csa_inner_wkv: pl.Tensor[[N_RANKS, FWD_CSA_WEIGHT_BANK_SIZE * CSA_INNER_OUT_DIM, D], pl.BF16],
+    csa_inner_wgate: pl.Tensor[[N_RANKS, FWD_CSA_WEIGHT_BANK_SIZE * CSA_INNER_OUT_DIM, D], pl.BF16],
+    csa_inner_ape: pl.Tensor[[N_RANKS, FWD_CSA_WEIGHT_BANK_SIZE * CSA_COMPRESS_RATIO, CSA_INNER_OUT_DIM], pl.FP32],
+    csa_inner_norm_w: pl.Tensor[[N_RANKS, FWD_CSA_WEIGHT_BANK_SIZE * CSA_IDX_HEAD_DIM], pl.BF16],
+    csa_inner_compress_state: pl.InOut[pl.Tensor[[N_RANKS, FWD_CSA_INNER_STATE_BLOCKS_DYN, CSA_INNER_STATE_BLOCK_SIZE, CSA_INNER_STATE_DIM], pl.FP32]],
+    csa_inner_compress_state_block_table: pl.Tensor[[N_RANKS, CSA_B_DYN, CSA_INNER_STATE_MAX_BLOCKS], pl.INT32],
+    csa_cmp_kv: pl.InOut[pl.Tensor[[N_RANKS, FWD_CSA_CMP_BLOCKS_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
+    csa_cmp_block_table: pl.Tensor[[N_RANKS, CSA_B_DYN, CSA_CMP_MAX_BLOCKS], pl.INT32],
+    csa_idx_kv_cache: pl.InOut[pl.Tensor[[N_RANKS, FWD_CSA_IDX_BLOCKS_DYN, BLOCK_SIZE, 1, CSA_IDX_HEAD_DIM], pl.INT8]],
+    csa_idx_kv_scale: pl.InOut[pl.Tensor[[N_RANKS, FWD_CSA_IDX_BLOCKS_DYN, BLOCK_SIZE, 1, 1], pl.FP32]],
+    csa_idx_block_table: pl.Tensor[[N_RANKS, CSA_B_DYN, CSA_IDX_MAX_BLOCKS], pl.INT32],
     csa_ori_slot_mapping: pl.Tensor[[N_RANKS, T_DYN], pl.INT64],
-    csa_window_swa_indices: pl.Tensor[
-        [N_RANKS, T_DYN, WIN], pl.INT32
-    ],
+    csa_window_swa_indices: pl.Tensor[[N_RANKS, T_DYN, WIN], pl.INT32],
     csa_window_swa_lens: pl.Tensor[[N_RANKS, T_DYN], pl.INT32],
     csa_cmp_slot_mapping: pl.Tensor[[N_RANKS, T_DYN], pl.INT64],
     csa_idx_slot_mapping: pl.Tensor[[N_RANKS, T_DYN], pl.INT64],
     csa_state_slot_mapping: pl.Tensor[[N_RANKS, T_DYN], pl.INT64],
-    csa_inner_state_slot_mapping: pl.Tensor[
-        [N_RANKS, T_DYN], pl.INT64
-    ],
+    csa_inner_state_slot_mapping: pl.Tensor[[N_RANKS, T_DYN], pl.INT64],
     csa_kv_seq_lens: pl.Tensor[[N_RANKS, CSA_B_DYN], pl.INT32],
-    hca_cmp_freqs_cos: pl.Tensor[
-        [N_RANKS, HCA_B, ROPE_HEAD_DIM // 2], pl.FP32
-    ],
-    hca_cmp_freqs_sin: pl.Tensor[
-        [N_RANKS, HCA_B, ROPE_HEAD_DIM // 2], pl.FP32
-    ],
-    hca_cmp_wkv: pl.Tensor[
-        [N_RANKS, FWD_HCA_WEIGHT_BANK_SIZE * HCA_MAIN_OUT_DIM, D], pl.BF16
-    ],
-    hca_cmp_wgate: pl.Tensor[
-        [N_RANKS, FWD_HCA_WEIGHT_BANK_SIZE * HCA_MAIN_OUT_DIM, D], pl.BF16
-    ],
-    hca_cmp_ape: pl.Tensor[
-        [
-            N_RANKS,
-            FWD_HCA_WEIGHT_BANK_SIZE * HCA_COMPRESS_RATIO,
-            HCA_MAIN_OUT_DIM,
-        ],
-        pl.FP32,
-    ],
-    hca_cmp_norm_w: pl.Tensor[
-        [N_RANKS, FWD_HCA_WEIGHT_BANK_SIZE * HEAD_DIM], pl.BF16
-    ],
-    hca_compress_state: pl.InOut[
-        pl.Tensor[
-            [
-                N_RANKS,
-                FWD_HCA_STATE_BLOCKS_DYN,
-                HCA_COMPRESS_STATE_BLOCK_SIZE,
-                HCA_COMPRESS_STATE_DIM,
-            ],
-            pl.FP32,
-        ]
-    ],
-    hca_compress_state_block_table: pl.Tensor[
-        [N_RANKS, HCA_B_DYN, HCA_COMPRESS_STATE_MAX_BLOCKS], pl.INT32
-    ],
-    hca_cmp_kv: pl.InOut[
-        pl.Tensor[
-            [N_RANKS, FWD_HCA_CMP_BLOCKS_DYN, BLOCK_SIZE, 1, HEAD_DIM],
-            pl.BF16,
-        ]
-    ],
-    hca_cmp_block_table: pl.Tensor[
-        [N_RANKS, HCA_B_DYN, HCA_CMP_TABLE_BLOCKS_DYN], pl.INT32
-    ],
+    hca_cmp_freqs_cos: pl.Tensor[[N_RANKS, HCA_B, ROPE_HEAD_DIM // 2], pl.FP32],
+    hca_cmp_freqs_sin: pl.Tensor[[N_RANKS, HCA_B, ROPE_HEAD_DIM // 2], pl.FP32],
+    hca_cmp_wkv: pl.Tensor[[N_RANKS, FWD_HCA_WEIGHT_BANK_SIZE * HCA_MAIN_OUT_DIM, D], pl.BF16],
+    hca_cmp_wgate: pl.Tensor[[N_RANKS, FWD_HCA_WEIGHT_BANK_SIZE * HCA_MAIN_OUT_DIM, D], pl.BF16],
+    hca_cmp_ape: pl.Tensor[[N_RANKS, FWD_HCA_WEIGHT_BANK_SIZE * HCA_COMPRESS_RATIO, HCA_MAIN_OUT_DIM], pl.FP32],
+    hca_cmp_norm_w: pl.Tensor[[N_RANKS, FWD_HCA_WEIGHT_BANK_SIZE * HEAD_DIM], pl.BF16],
+    hca_compress_state: pl.InOut[pl.Tensor[[N_RANKS, FWD_HCA_STATE_BLOCKS_DYN, HCA_COMPRESS_STATE_BLOCK_SIZE, HCA_COMPRESS_STATE_DIM], pl.FP32]],
+    hca_compress_state_block_table: pl.Tensor[[N_RANKS, HCA_B_DYN, HCA_COMPRESS_STATE_MAX_BLOCKS], pl.INT32],
+    hca_cmp_kv: pl.InOut[pl.Tensor[[N_RANKS, FWD_HCA_CMP_BLOCKS_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
+    hca_cmp_block_table: pl.Tensor[[N_RANKS, HCA_B_DYN, HCA_CMP_TABLE_BLOCKS_DYN], pl.INT32],
     hca_ori_slot_mapping: pl.Tensor[[N_RANKS, T_DYN], pl.INT64],
-    hca_window_swa_indices: pl.Tensor[
-        [N_RANKS, T_DYN, WIN], pl.INT32
-    ],
+    hca_window_swa_indices: pl.Tensor[[N_RANKS, T_DYN, WIN], pl.INT32],
     hca_window_swa_lens: pl.Tensor[[N_RANKS, T_DYN], pl.INT32],
     hca_cmp_slot_mapping: pl.Tensor[[N_RANKS, T_DYN], pl.INT64],
     hca_state_slot_mapping: pl.Tensor[[N_RANKS, T_DYN], pl.INT64],
     hca_kv_seq_lens: pl.Tensor[[N_RANKS, HCA_B_DYN], pl.INT32],
     attn_sink: pl.Tensor[[N_RANKS, FWD_WEIGHT_BANK_SIZE * H], pl.FP32],
-    wo_a: pl.Tensor[
-        [
-            N_RANKS,
-            FWD_WEIGHT_BANK_SIZE * LOCAL_O_GROUPS,
-            O_LORA,
-            O_GROUP_IN,
-        ],
-        pl.BF16,
-    ],
-    wo_b: pl.Tensor[
-        [N_RANKS, FWD_WEIGHT_BANK_SIZE * D, LOCAL_O_WIDTH], pl.INT8
-    ],
-    wo_b_scale: pl.Tensor[
-        [N_RANKS, FWD_WEIGHT_BANK_SIZE * D], pl.FP32
-    ],
-    hc_ffn_fn: pl.Tensor[
-        [N_RANKS, FWD_WEIGHT_BANK_SIZE * HC_FN_STORAGE_ROWS, HC_DIM],
-        pl.FP32,
-    ],
-    hc_ffn_scale: pl.Tensor[
-        [N_RANKS, FWD_WEIGHT_BANK_SIZE * 3], pl.FP32
-    ],
-    hc_ffn_base: pl.Tensor[
-        [N_RANKS, FWD_WEIGHT_BANK_SIZE * MIX_HC], pl.FP32
-    ],
+    wo_a: pl.Tensor[[N_RANKS, FWD_WEIGHT_BANK_SIZE * LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
+    wo_b: pl.Tensor[[N_RANKS, FWD_WEIGHT_BANK_SIZE * D, LOCAL_O_WIDTH], pl.INT8],
+    wo_b_scale: pl.Tensor[[N_RANKS, FWD_WEIGHT_BANK_SIZE * D], pl.FP32],
+    hc_ffn_fn: pl.Tensor[[N_RANKS, FWD_WEIGHT_BANK_SIZE * HC_FN_STORAGE_ROWS, HC_DIM], pl.FP32],
+    hc_ffn_scale: pl.Tensor[[N_RANKS, FWD_WEIGHT_BANK_SIZE * 3], pl.FP32],
+    hc_ffn_base: pl.Tensor[[N_RANKS, FWD_WEIGHT_BANK_SIZE * MIX_HC], pl.FP32],
     norm_w: pl.Tensor[[N_RANKS, FWD_WEIGHT_BANK_SIZE * D], pl.BF16],
-    gate_w: pl.Tensor[
-        [N_RANKS, FWD_WEIGHT_BANK_SIZE * N_EXPERTS_GLOBAL, D], pl.FP32
-    ],
-    gate_bias: pl.Tensor[
-        [N_RANKS, FWD_WEIGHT_BANK_SIZE * N_EXPERTS_GLOBAL], pl.FP32
-    ],
-    tid2eid: pl.Tensor[
-        [N_RANKS, FWD_WEIGHT_BANK_SIZE * VOCAB, TOPK], pl.INT32
-    ],
+    gate_w: pl.Tensor[[N_RANKS, FWD_WEIGHT_BANK_SIZE * N_EXPERTS_GLOBAL, D], pl.FP32],
+    gate_bias: pl.Tensor[[N_RANKS, FWD_WEIGHT_BANK_SIZE * N_EXPERTS_GLOBAL], pl.FP32],
+    tid2eid: pl.Tensor[[N_RANKS, FWD_WEIGHT_BANK_SIZE * VOCAB, TOPK], pl.INT32],
     input_ids: pl.Tensor[[N_RANKS, T_DYN], pl.INT64],
-    hc_head_fn: pl.Tensor[
-        [N_RANKS, HC_MULT, HC_DIM], pl.FP32
-    ],
+    hc_head_fn: pl.Tensor[[N_RANKS, HC_MULT, HC_DIM], pl.FP32],
     hc_head_scale: pl.Tensor[[N_RANKS, 1], pl.FP32],
     hc_head_base: pl.Tensor[[N_RANKS, HC_MULT], pl.FP32],
     final_norm_w: pl.Tensor[[N_RANKS, D], pl.BF16],
-    lm_head_weight: pl.Tensor[
-        [N_RANKS, VOCAB_PER_TP, D], pl.BF16
-    ],
-    logit_row_indices: pl.Tensor[
-        [N_RANKS, MAX_LOGIT_ROWS], pl.INT32
-    ],
-    routed_w1: pl.Tensor[
-        [N_RANKS, FWD_WEIGHT_BANK_SIZE * N_LOCAL, MOE_INTER, D], pl.INT8
-    ],
-    routed_w1_scale: pl.Tensor[
-        [N_RANKS, FWD_WEIGHT_BANK_SIZE * N_LOCAL, MOE_INTER], pl.FP32
-    ],
-    routed_w3: pl.Tensor[
-        [N_RANKS, FWD_WEIGHT_BANK_SIZE * N_LOCAL, MOE_INTER, D], pl.INT8
-    ],
-    routed_w3_scale: pl.Tensor[
-        [N_RANKS, FWD_WEIGHT_BANK_SIZE * N_LOCAL, MOE_INTER], pl.FP32
-    ],
-    routed_w2: pl.Tensor[
-        [N_RANKS, FWD_WEIGHT_BANK_SIZE * N_LOCAL, D, MOE_INTER], pl.INT8
-    ],
-    routed_w2_scale: pl.Tensor[
-        [N_RANKS, FWD_WEIGHT_BANK_SIZE * N_LOCAL, D], pl.FP32
-    ],
-    shared_w1: pl.Tensor[
-        [N_RANKS, FWD_WEIGHT_BANK_SIZE * MOE_INTER, D], pl.INT8
-    ],
-    shared_w1_scale: pl.Tensor[
-        [N_RANKS, FWD_WEIGHT_BANK_SIZE * MOE_INTER], pl.FP32
-    ],
-    shared_w3: pl.Tensor[
-        [N_RANKS, FWD_WEIGHT_BANK_SIZE * MOE_INTER, D], pl.INT8
-    ],
-    shared_w3_scale: pl.Tensor[
-        [N_RANKS, FWD_WEIGHT_BANK_SIZE * MOE_INTER], pl.FP32
-    ],
-    shared_w2: pl.Tensor[
-        [N_RANKS, FWD_WEIGHT_BANK_SIZE * D, MOE_INTER], pl.INT8
-    ],
-    shared_w2_scale: pl.Tensor[
-        [N_RANKS, FWD_WEIGHT_BANK_SIZE * D], pl.FP32
-    ],
-    hidden_workspace: pl.Out[
-        pl.Tensor[[N_RANKS, T_DYN, D], pl.BF16]
-    ],
-    x_ping: pl.InOut[
-        pl.Tensor[[N_RANKS, T_DYN, HC_MULT, D], pl.FP32]
-    ],
-    x_pong: pl.InOut[
-        pl.Tensor[[N_RANKS, T_DYN, HC_MULT, D], pl.FP32]
-    ],
-    x_attn_active: pl.InOut[
-        pl.Tensor[[N_RANKS, T_DYN, HC_MULT, D], pl.FP32]
-    ],
-    x_moe_next: pl.InOut[
-        pl.Tensor[[N_RANKS, MOE_TOKENS, HC_MULT, D], pl.FP32]
-    ],
-    pre_hc_hidden_out: pl.Out[
-        pl.Tensor[[N_RANKS, T_DYN, HC_MULT, D], pl.FP32]
-    ],
-    x_out: pl.Out[
-        pl.Tensor[[N_RANKS, T_DYN, D], pl.BF16]
-    ],
-    logits: pl.Out[
-        pl.Tensor[[N_RANKS, MAX_LOGIT_ROWS, LM_HEAD_VOCAB], pl.FP32]
-    ],
-    sampled_ids: pl.Out[
-        pl.Tensor[
-            [N_RANKS, MAX_LOGIT_ROWS, SAMPLED_IDS_PAD], pl.INT32
-        ]
-    ],
+    lm_head_weight: pl.Tensor[[N_RANKS, VOCAB_PER_TP, D], pl.BF16],
+    logit_row_indices: pl.Tensor[[N_RANKS, MAX_LOGIT_ROWS], pl.INT32],
+    routed_w1: pl.Tensor[[N_RANKS, FWD_WEIGHT_BANK_SIZE * N_LOCAL, MOE_INTER, D], pl.INT8],
+    routed_w1_scale: pl.Tensor[[N_RANKS, FWD_WEIGHT_BANK_SIZE * N_LOCAL, MOE_INTER], pl.FP32],
+    routed_w3: pl.Tensor[[N_RANKS, FWD_WEIGHT_BANK_SIZE * N_LOCAL, MOE_INTER, D], pl.INT8],
+    routed_w3_scale: pl.Tensor[[N_RANKS, FWD_WEIGHT_BANK_SIZE * N_LOCAL, MOE_INTER], pl.FP32],
+    routed_w2: pl.Tensor[[N_RANKS, FWD_WEIGHT_BANK_SIZE * N_LOCAL, D, MOE_INTER], pl.INT8],
+    routed_w2_scale: pl.Tensor[[N_RANKS, FWD_WEIGHT_BANK_SIZE * N_LOCAL, D], pl.FP32],
+    shared_w1: pl.Tensor[[N_RANKS, FWD_WEIGHT_BANK_SIZE * MOE_INTER, D], pl.INT8],
+    shared_w1_scale: pl.Tensor[[N_RANKS, FWD_WEIGHT_BANK_SIZE * MOE_INTER], pl.FP32],
+    shared_w3: pl.Tensor[[N_RANKS, FWD_WEIGHT_BANK_SIZE * MOE_INTER, D], pl.INT8],
+    shared_w3_scale: pl.Tensor[[N_RANKS, FWD_WEIGHT_BANK_SIZE * MOE_INTER], pl.FP32],
+    shared_w2: pl.Tensor[[N_RANKS, FWD_WEIGHT_BANK_SIZE * D, MOE_INTER], pl.INT8],
+    shared_w2_scale: pl.Tensor[[N_RANKS, FWD_WEIGHT_BANK_SIZE * D], pl.FP32],
+    hidden_workspace: pl.Out[pl.Tensor[[N_RANKS, T_DYN, D], pl.BF16]],
+    x_ping: pl.InOut[pl.Tensor[[N_RANKS, T_DYN, HC_MULT, D], pl.FP32]],
+    x_pong: pl.InOut[pl.Tensor[[N_RANKS, T_DYN, HC_MULT, D], pl.FP32]],
+    x_attn_active: pl.InOut[pl.Tensor[[N_RANKS, T_DYN, HC_MULT, D], pl.FP32]],
+    x_moe_next: pl.InOut[pl.Tensor[[N_RANKS, MOE_TOKENS, HC_MULT, D], pl.FP32]],
+    pre_hc_hidden_out: pl.Out[pl.Tensor[[N_RANKS, T_DYN, HC_MULT, D], pl.FP32]],
+    x_out: pl.Out[pl.Tensor[[N_RANKS, T_DYN, D], pl.BF16]],
+    logits: pl.Out[pl.Tensor[[N_RANKS, MAX_LOGIT_ROWS, LM_HEAD_VOCAB], pl.FP32]],
+    sampled_ids: pl.Out[pl.Tensor[[N_RANKS, MAX_LOGIT_ROWS, SAMPLED_IDS_PAD], pl.INT32]],
 ):
     """Allocate each communication window once and submit one decode forward child."""
     embed_weight.bind_dynamic(1, EMBED_VOCAB_DYN)
@@ -2022,10 +1597,6 @@ def build_tensor_specs(start_pos=None, *, weight_bank_size=RUNTIME_WEIGHT_BANK, 
     return specs
 
 
-def golden_decode_fwd(_tensors):
-    """decode forward is a topology/isolation witness; layer math is gated earlier."""
-
-
 def finite_tensor_compare(actual, _expected, **_kwargs):
     """Require a completed finite device result without duplicating 43 goldens."""
     import torch
@@ -2075,12 +1646,8 @@ def _packed_pool_compare(layer_mappings, layer_count, block_size, pool_name):
                 return False, f"    missing input {mapping_name!r}"
             for rank in range(actual.shape[0]):
                 begin = ordinal * extent
-                actual_rows = actual[rank, begin : begin + extent].reshape(
-                    extent * block_size, *actual.shape[3:]
-                )
-                expected_rows = expected[rank, begin : begin + extent].reshape(
-                    extent * block_size, *expected.shape[3:]
-                )
+                actual_rows = actual[rank, begin : begin + extent].reshape(extent * block_size, *actual.shape[3:])
+                expected_rows = expected[rank, begin : begin + extent].reshape(extent * block_size, *expected.shape[3:])
                 slots = mapping[rank].to(dtype=torch.int64).reshape(-1)
                 invalid = (slots < -1) | (slots >= actual_rows.shape[0])
                 if bool(invalid.any()):
@@ -2219,7 +1786,6 @@ def main():
     result = run_jit(
         fn=l3_decode_fwd,
         specs=specs,
-        golden_fn=golden_decode_fwd,
         golden_data=args.golden_data,
         save_data=args.save_data,
         compile_only=args.compile_only,
@@ -2227,7 +1793,7 @@ def main():
         compile_cfg=dict(
             dump_passes=args.dump_passes,
             distributed_config=DistributedConfig(
-                device_ids=device_ids, num_sub_workers=0
+                device_ids=device_ids, num_sub_workers=0,
             ),
         ),
         runtime_cfg=dict(

--- a/models/deepseek_v4_flash_dspark/decode_fwd.py
+++ b/models/deepseek_v4_flash_dspark/decode_fwd.py
@@ -1597,6 +1597,10 @@ def build_tensor_specs(start_pos=None, *, weight_bank_size=RUNTIME_WEIGHT_BANK, 
     return specs
 
 
+def golden_decode_fwd(_tensors):
+    """No-op oracle: without one run_jit skips _validate, and so compare_fn."""
+
+
 def finite_tensor_compare(actual, _expected, **_kwargs):
     """Require a completed finite device result without duplicating 43 goldens."""
     import torch
@@ -1786,6 +1790,7 @@ def main():
     result = run_jit(
         fn=l3_decode_fwd,
         specs=specs,
+        golden_fn=golden_decode_fwd,
         golden_data=args.golden_data,
         save_data=args.save_data,
         compile_only=args.compile_only,

--- a/models/deepseek_v4_flash_dspark/decode_fwd.py
+++ b/models/deepseek_v4_flash_dspark/decode_fwd.py
@@ -1597,10 +1597,6 @@ def build_tensor_specs(start_pos=None, *, weight_bank_size=RUNTIME_WEIGHT_BANK, 
     return specs
 
 
-def golden_decode_fwd(_tensors):
-    """No-op oracle: without one run_jit skips _validate, and so compare_fn."""
-
-
 def finite_tensor_compare(actual, _expected, **_kwargs):
     """Require a completed finite device result without duplicating 43 goldens."""
     import torch
@@ -1790,7 +1786,6 @@ def main():
     result = run_jit(
         fn=l3_decode_fwd,
         specs=specs,
-        golden_fn=golden_decode_fwd,
         golden_data=args.golden_data,
         save_data=args.save_data,
         compile_only=args.compile_only,

--- a/models/deepseek_v4_flash_dspark/decode_hca.py
+++ b/models/deepseek_v4_flash_dspark/decode_hca.py
@@ -1319,11 +1319,8 @@ if __name__ == "__main__":
     if args.start_pos is not None:
         batch = len(args.start_pos) if isinstance(args.start_pos, list) else 1
         token_counts = (batch * S,)
-    elif TP_SIZE == 1:
-        token_counts = (LOCAL_T,)
     else:
-        # Capacity, then one row block below it: the dynamic token axis must hold at both.
-        token_counts = (LOCAL_T, LOCAL_T - VALID_TOKEN_TILE)
+        token_counts = (LOCAL_T,)
 
     for local_t in token_counts:
         if TP_SIZE == 1:

--- a/models/deepseek_v4_flash_dspark/decode_hca.py
+++ b/models/deepseek_v4_flash_dspark/decode_hca.py
@@ -65,17 +65,20 @@ from decode_o_proj import (
     LOCAL_T,
     LOCAL_T_PAD,
     O_WINDOW_ROWS,
-    decode_sharded_o_projection_reduce_scatter,
     decode_o_proj_tp1,
     o_group_a2a,
+    o_proj_reduce_scatter,
 )
 from decode_sparse_attn_hca import (
+    ATTENTION_PUBLISH_T_TILE,
     ATTENTION_PUBLISH_WORKERS,
+    H_TILE,
     HCA_MAX_COMPRESSED_ROWS,
+    PUBLISH_GROUPS,
     T_PAD,
     VALID_TOKEN_TILE,
-    publish_hca_o_groups,
     sparse_attn_hca,
+    sparse_attn_hca_tp1,
 )
 
 # Dynamic shape variables.
@@ -235,20 +238,85 @@ def decode_hca(
     attention_local_flat = pl.create_tensor([ATTENTION_WINDOW_ROWS, O_GROUP_IN], dtype=pl.BF16)
     attn_out = pl.create_tensor([t_dim, D], dtype=pl.BF16)
     with pl.scope():
-        attention_grouped = pl.create_tensor(
-            [O_GROUPS * LOCAL_T_PAD, O_GROUP_IN],
-            dtype=pl.BF16,
-        )
-        attention_signal, publish_tid = publish_hca_o_groups(
+        (
+            stream_heads,
+            rope_cos_il, rope_sin_signed, rope_swap_idx,
+            stream_heads_tid, rope_swap_tid, rope_cs_tid,
+        ) = sparse_attn_hca(
             q, kv_cache, window_swa_indices,
             cmp_kv, cmp_block_table,
             position_ids, kv_seq_lens,
             attn_sink, freqs_cos, freqs_sin,
-            attention_grouped,
-            attention_window, attention_signal,
-            group_base, tp_rank, local_t,
             cache_ready_dep,
         )
+
+        attention_grouped = pl.create_tensor([O_GROUPS * LOCAL_T_PAD, O_GROUP_IN], dtype=pl.BF16)
+        pack_work_count = (t_dim // ATTENTION_PUBLISH_T_TILE) * (H // H_TILE)
+        with pl.spmd(
+            ATTENTION_PUBLISH_WORKERS,
+            name_hint="hca_stream_pack_publish",
+            deps=[stream_heads_tid, rope_swap_tid, rope_cs_tid],
+        ) as publish_tid:
+            worker = pl.tile.get_block_idx()
+            for pack_work in pl.range(worker, pack_work_count, ATTENTION_PUBLISH_WORKERS):
+                token_block = pack_work // (H // H_TILE)
+                stream_h_tile = pack_work - token_block * (H // H_TILE)
+                stream_t0 = token_block * ATTENTION_PUBLISH_T_TILE
+                stream_h0 = stream_h_tile * H_TILE
+                global_group0 = stream_h0 // HEADS_PER_GROUP
+                destination_rank = global_group0 // LOCAL_O_GROUPS
+                local_group0 = global_group0 - destination_rank * LOCAL_O_GROUPS
+
+                for stream_dt in pl.unroll(ATTENTION_PUBLISH_T_TILE):
+                    stream_t = stream_t0 + stream_dt
+                    stream_state_row = stream_t * H + stream_h0
+                    stream_output = stream_heads[stream_state_row : stream_state_row + H_TILE, 0:HEAD_DIM]
+                    stream_bf16 = pl.cast(stream_output, target_type=pl.BF16, mode="rint")
+                    stream_rope = stream_output[0:H_TILE, NOPE_HEAD_DIM:HEAD_DIM]
+                    stream_cos_il = rope_cos_il[stream_t : stream_t + 1, 0:ROPE_HEAD_DIM]
+                    stream_sin_signed = rope_sin_signed[stream_t : stream_t + 1, 0:ROPE_HEAD_DIM]
+                    stream_swap_zero = pl.full([H_TILE, ROPE_HEAD_DIM], dtype=pl.INT32, value=0)
+                    stream_swap_idx = pl.col_expand_add(stream_swap_zero, rope_swap_idx[0:1, 0:ROPE_HEAD_DIM])
+                    stream_swapped = pl.gather(stream_rope, dim=-1, index=stream_swap_idx)
+                    stream_rot = pl.add(
+                        pl.col_expand_mul(stream_rope, stream_cos_il),
+                        pl.col_expand_mul(stream_swapped, stream_sin_signed),
+                    )
+                    n_rope_bf16 = pl.cast(stream_rot, target_type=pl.BF16, mode="rint")
+                    n_full_bf16 = pl.concat(stream_bf16[0:H_TILE, 0:NOPE_HEAD_DIM], n_rope_bf16)
+                    for n_hi in pl.unroll(H_TILE):
+                        n_head = stream_h0 + n_hi
+                        source_row = (n_head // HEADS_PER_GROUP) * T_PAD + stream_t
+                        source_col = (n_head % HEADS_PER_GROUP) * HEAD_DIM
+                        attention_grouped[
+                            source_row : source_row + 1,
+                            source_col : source_col + HEAD_DIM,
+                        ] = n_full_bf16[n_hi : n_hi + 1, 0:HEAD_DIM]
+
+                for group_slot in pl.unroll(PUBLISH_GROUPS):
+                    source_row = (global_group0 + group_slot) * T_PAD + stream_t0
+                    target_row = ((local_group0 + group_slot) * GROUP_T_PAD + tp_rank * local_t + stream_t0)
+                    pld.tensor.put(
+                        dst=attention_window,
+                        peer=group_base + destination_rank,
+                        src=attention_grouped,
+                        dst_offsets=[target_row, 0],
+                        src_offsets=[source_row, 0],
+                        shape=[ATTENTION_PUBLISH_T_TILE, O_GROUP_IN],
+                        chunk_rows=ATTENTION_PUBLISH_T_TILE,
+                        chunk_cols=O_GROUP_IN,
+                    )
+
+            for peer_tp in pl.range(TP_SIZE):
+                if peer_tp != tp_rank:
+                    pld.system.notify(
+                        target=attention_signal,
+                        peer=group_base + peer_tp,
+                        offsets=[tp_rank, 0],
+                        value=1,
+                        op=pld.NotifyOp.AtomicAdd,
+                    )
+
         attention_local_flat, attention_signal = o_group_a2a(
             attention_local_flat,
             attention_window, attention_signal,
@@ -256,12 +324,9 @@ def decode_hca(
             publish_tid, ATTENTION_PUBLISH_WORKERS,
         )
 
-        attention_local_groups = pl.reshape(
-            attention_local_flat,
-            [LOCAL_O_GROUPS, GROUP_T_PAD, O_GROUP_IN],
-        )
+        attention_local_groups = pl.reshape(attention_local_flat, [LOCAL_O_GROUPS, GROUP_T_PAD, O_GROUP_IN])
         o_local = pl.create_tensor([LOCAL_T_PAD, D], dtype=pl.BF16)
-        o_local, o_signal = decode_sharded_o_projection_reduce_scatter(
+        o_local, o_signal = o_proj_reduce_scatter(
             attention_local_groups,
             wo_a, wo_b, wo_b_scale,
             local_t, o_local,
@@ -550,11 +615,8 @@ def decode_hca_tp1(
 
     attn_out = pl.create_tensor([t_dim, D], dtype=pl.BF16)
     with pl.scope():
-        o_packed_heads = pl.create_tensor(
-            [O_GROUPS * T_PAD, O_GROUP_IN],
-            dtype=pl.BF16,
-        )
-        o_packed_heads, heads_dep = sparse_attn_hca(
+        o_packed_heads = pl.create_tensor([O_GROUPS * T_PAD, O_GROUP_IN], dtype=pl.BF16)
+        o_packed_heads, heads_dep = sparse_attn_hca_tp1(
             q, kv_cache, window_swa_indices,
             cmp_kv, cmp_block_table,
             position_ids, kv_seq_lens,
@@ -562,11 +624,7 @@ def decode_hca_tp1(
             o_packed_heads, cache_ready_dep,
         )
         with pl.scope():
-            decode_o_proj_tp1(
-                o_packed_heads,
-                wo_a, wo_b, wo_b_scale,
-                attn_out, heads_dep,
-            )
+            decode_o_proj_tp1(o_packed_heads, wo_a, wo_b, wo_b_scale, attn_out, heads_dep)
 
     with pl.scope():
         hc_post(attn_out, x_hc, post_t, comb_t, x_out)
@@ -758,21 +816,11 @@ def golden_decode_hca_tp1(tensors):
         "freqs_sin": rope_sin_T,
         "o_packed_heads": o_packed_heads,
     })
-    attn_out = golden_decode_o_proj_tp1(
-        o_packed_heads,
-        tensors["wo_a"], tensors["wo_b"], tensors["wo_b_scale"],
-        tokens,
-    )
+    attn_out = golden_decode_o_proj_tp1(o_packed_heads, tensors["wo_a"], tensors["wo_b"], tensors["wo_b_scale"], tokens)
 
     # ===== Block.hc_post =====
     y = torch.zeros(tokens, HC_MULT, D, dtype=torch.float32)
-    golden_hc_post({
-        "x": attn_out,
-        "residual": tensors["x_hc"],
-        "post": post_t,
-        "comb": comb_t,
-        "y": y,
-    })
+    golden_hc_post({ "x": attn_out, "residual": tensors["x_hc"], "post": post_t, "comb": comb_t, "y": y, })
 
     tensors["x_out"][:] = y
 
@@ -783,11 +831,7 @@ def golden_decode_hca(tensors):
     full_wo_b = tensors["wo_b"].permute(1, 0, 2).reshape(D, O_GROUPS * O_LORA)
 
     for rank in range(TP_SIZE):
-        rank_tensors = {
-            name: tensor[rank]
-            for name, tensor in tensors.items()
-            if name != "local_t"
-        }
+        rank_tensors = { name: tensor[rank] for name, tensor in tensors.items() if name != "local_t" }
         rank_tensors["wo_a"] = full_wo_a
         rank_tensors["wo_b"] = full_wo_b
         golden_decode_hca_tp1(rank_tensors)
@@ -824,7 +868,7 @@ def _validate_hca_token_count(token_count):
             or token_count % VALID_TOKEN_TILE != 0 or token_count % S != 0):
         raise ValueError(
             f"HCA token count must be a multiple of {VALID_TOKEN_TILE} and S={S} "
-            f"in [{VALID_TOKEN_TILE}, {LOCAL_T}], got {token_count}"
+            f"in [{VALID_TOKEN_TILE}, {LOCAL_T}], got {token_count}",
         )
 
 
@@ -836,24 +880,14 @@ def _hca_token_rope_tables(positions):
     half_dim = dim // 2
     base = float(M.compress_rope_theta)
     original_seq_len = int(M.original_max_position_embeddings)
-    inv_freq = 1.0 / (
-        base ** (torch.arange(0, dim, 2, dtype=torch.float32) / dim)
-    )
-    low = math.floor(
-        dim * math.log(original_seq_len / (int(M.beta_fast) * 2 * math.pi))
-        / (2 * math.log(base))
-    )
-    high = math.ceil(
-        dim * math.log(original_seq_len / (int(M.beta_slow) * 2 * math.pi))
-        / (2 * math.log(base))
-    )
+    inv_freq = 1.0 / (base ** (torch.arange(0, dim, 2, dtype=torch.float32) / dim))
+    low = math.floor(dim * math.log(original_seq_len / (int(M.beta_fast) * 2 * math.pi)) / (2 * math.log(base)))
+    high = math.ceil(dim * math.log(original_seq_len / (int(M.beta_slow) * 2 * math.pi)) / (2 * math.log(base)))
     low = max(low, 0)
     high = min(high, dim - 1)
     if low == high:
         high += 0.001
-    ramp = torch.clamp(
-        (torch.arange(half_dim, dtype=torch.float32) - low) / (high - low), 0, 1
-)
+    ramp = torch.clamp((torch.arange(half_dim, dtype=torch.float32) - low) / (high - low), 0, 1)
     smooth = 1 - ramp
     inv_freq = inv_freq / float(M.rope_factor) * (1 - smooth) + inv_freq * smooth
     angles = torch.outer(positions.to(torch.float32).reshape(-1), inv_freq)
@@ -882,7 +916,7 @@ def _hca_cmp_block_table(starts):
         if cursor + page_count > CMP_BLOCK_NUM:
             raise ValueError(
                 f"HCA compressed pool needs {cursor + page_count} pages for batch={batch}, "
-                f"capacity is {CMP_BLOCK_NUM}"
+                f"capacity is {CMP_BLOCK_NUM}",
             )
         if page_count:
             table[request, :page_count] = torch.arange(cursor, cursor + page_count, dtype=torch.int32)
@@ -906,11 +940,9 @@ def _hca_raw_block_table(positions):
         if cursor + page_count > ORI_BLOCK_NUM:
             raise ValueError(
                 f"HCA raw pool needs {cursor + page_count} pages for batch={batch}, "
-                f"capacity is {ORI_BLOCK_NUM}"
+                f"capacity is {ORI_BLOCK_NUM}",
             )
-        table[request, first_page:last_page + 1] = torch.arange(
-            cursor, cursor + page_count, dtype=torch.int32
-        )
+        table[request, first_page:last_page + 1] = torch.arange(cursor, cursor + page_count, dtype=torch.int32)
         cursor += page_count
     return table
 
@@ -1007,11 +1039,7 @@ def build_tensor_specs(start_pos=None, batch=B):
             physical_blocks=COMPRESS_STATE_PHYSICAL_BLOCKS,
         )
         state_positions = positions.to(torch.int64)
-        mapping = state_slot_mapping(
-            state_positions,
-            table,
-            state_block_size=COMPRESS_STATE_BLOCK_SIZE,
-        )
+        mapping = state_slot_mapping(state_positions, table, state_block_size=COMPRESS_STATE_BLOCK_SIZE)
         valid_rows = mapping[mapping >= 0]
         if torch.unique(valid_rows).numel() == valid_rows.numel():
             return table
@@ -1033,23 +1061,16 @@ def build_tensor_specs(start_pos=None, batch=B):
                     None,
                 )
                 if physical_block is None:
-                    physical_block = next(
-                        (block for block, used_mask in enumerate(occupancy) if used_mask == 0),
-                        None,
-                    )
+                    physical_block = next((block for block, used_mask in enumerate(occupancy) if used_mask == 0), None)
                 if physical_block is None:
                     raise ValueError(
                         f"HCA fixture cannot place {batch * S} active state rows "
-                        f"in {COMPRESS_STATE_BLOCK_NUM * COMPRESS_STATE_BLOCK_SIZE} physical rows"
+                        f"in {COMPRESS_STATE_BLOCK_NUM * COMPRESS_STATE_BLOCK_SIZE} physical rows",
                     )
                 table[request, logical_block] = physical_block
                 occupancy[physical_block] |= row_mask
 
-        mapping = state_slot_mapping(
-            state_positions,
-            table,
-            state_block_size=COMPRESS_STATE_BLOCK_SIZE,
-        )
+        mapping = state_slot_mapping(state_positions, table, state_block_size=COMPRESS_STATE_BLOCK_SIZE)
         valid_rows = mapping[mapping >= 0]
         if torch.unique(valid_rows).numel() != valid_rows.numel():
             raise ValueError("HCA fixture active state rows remain aliased")

--- a/models/deepseek_v4_flash_dspark/decode_layer.py
+++ b/models/deepseek_v4_flash_dspark/decode_layer.py
@@ -7,6 +7,7 @@
 # See LICENSE in the root of the software repository for the full text of the License.
 # -----------------------------------------------------------------------------------------------------------
 # ci: devices=2  # CI: 2-card run; borrows 2 cards via task-submit --device-num
+# ci: no-sim    # CI marker: distributed communication oracle requires real devices
 """DeepSeek-V4 D-Spark decode-layer integration."""
 
 import sys
@@ -131,11 +132,7 @@ AUX_PAD = moe_module.AUX_PAD
 IDX_PAD = moe_module.IDX_PAD
 N_ROUTES = moe_module.N_ROUTES
 
-_ATTENTION_MODULES = {
-    "swa": swa,
-    "hca": hca,
-    "csa": csa,
-}
+_ATTENTION_MODULES = { "swa": swa, "hca": hca, "csa": csa, }
 
 _SWA_INPUT_NAMES = (
     "x_hc",
@@ -259,30 +256,30 @@ def _validate_import_contract():
     for module in attention_modules:
         if module.TP_SIZE != TP_SIZE:
             raise ValueError(
-                f"{module.__name__} froze TP={module.TP_SIZE}, expected TP={TP_SIZE}"
+                f"{module.__name__} froze TP={module.TP_SIZE}, expected TP={TP_SIZE}",
             )
         if module.S != DECODE_SEQ:
             raise ValueError(
-                f"{module.__name__} uses S={module.S}, expected S={DECODE_SEQ}"
+                f"{module.__name__} uses S={module.S}, expected S={DECODE_SEQ}",
             )
         if module.T < MOE_TOKENS:
             raise ValueError(
                 f"{module.__name__} local capacity {module.T} is smaller than "
-                f"MoE capacity {MOE_TOKENS}"
+                f"MoE capacity {MOE_TOKENS}",
             )
         if module.MAX_SEQ_LEN != 1_048_576:
             raise ValueError(
                 f"{module.__name__} context ceiling must be 1M, got "
-                f"{module.MAX_SEQ_LEN}"
+                f"{module.MAX_SEQ_LEN}",
             )
     if moe_module.EP != EP_SIZE or moe_module.N_RANKS != EP_SIZE:
         raise ValueError(
             f"MoE froze EP={moe_module.EP}, N_RANKS={moe_module.N_RANKS}; "
-            f"expected EP={EP_SIZE}"
+            f"expected EP={EP_SIZE}",
         )
     if MOE_TOKENS % DECODE_SEQ != 0:
         raise ValueError(
-            f"MoE capacity {MOE_TOKENS} must be divisible by S={DECODE_SEQ}"
+            f"MoE capacity {MOE_TOKENS} must be divisible by S={DECODE_SEQ}",
         )
     for rank in range(EP_SIZE):
         tp_rank = rank % TP_SIZE
@@ -290,7 +287,7 @@ def _validate_import_contract():
         if group_base % TP_SIZE != 0 or group_base + TP_SIZE > EP_SIZE:
             raise ValueError(
                 f"rank {rank} maps outside its TP group: "
-                f"group_base={group_base}, tp_rank={tp_rank}"
+                f"group_base={group_base}, tp_rank={tp_rank}",
             )
 
 
@@ -303,7 +300,7 @@ def attention_kind_for_layer(layer_id):
     if not 0 <= layer_id < MODEL_CONFIG.num_hidden_layers:
         raise ValueError(
             f"layer_id must be in [0, {MODEL_CONFIG.num_hidden_layers - 1}], "
-            f"got {layer_id}"
+            f"got {layer_id}",
         )
     ratio = MODEL_CONFIG.compress_ratios[layer_id]
     if ratio == 0:
@@ -337,11 +334,11 @@ def _active_batch(start_pos):
 def _validate_active_tokens(active_tokens):
     if active_tokens <= 0 or active_tokens > MOE_TOKENS:
         raise ValueError(
-            f"active token count must be in [1, {MOE_TOKENS}], got {active_tokens}"
+            f"active token count must be in [1, {MOE_TOKENS}], got {active_tokens}",
         )
     if active_tokens % DECODE_SEQ != 0:
         raise ValueError(
-            f"active token count {active_tokens} must be divisible by S={DECODE_SEQ}"
+            f"active token count {active_tokens} must be divisible by S={DECODE_SEQ}",
         )
 
 
@@ -397,7 +394,7 @@ def build_layer_shape_report(layer_id, start_pos=None):
     _validate_active_tokens(active_tokens)
     if batch > module.B:
         raise ValueError(
-            f"{kind} batch {batch} exceeds TP{TP_SIZE} local capacity {module.B}"
+            f"{kind} batch {batch} exceeds TP{TP_SIZE} local capacity {module.B}",
         )
 
     specs = module.build_tensor_specs(start_pos=start_pos, batch=batch)
@@ -409,7 +406,7 @@ def build_layer_shape_report(layer_id, start_pos=None):
         if len(shape) > MAX_PUBLIC_TENSOR_DIMS:
             raise ValueError(
                 f"{kind} tensor {spec.name!r} would have {len(shape)} dimensions: "
-                f"{shape}"
+                f"{shape}",
             )
         distributed_shapes[spec.name] = shape
 
@@ -417,14 +414,14 @@ def build_layer_shape_report(layer_id, start_pos=None):
         if distributed_shapes[name][1] != active_tokens:
             raise ValueError(
                 f"{kind} tensor {name!r} must use active token extent "
-                f"{active_tokens}, got {distributed_shapes[name]}"
+                f"{active_tokens}, got {distributed_shapes[name]}",
             )
     if kind == "csa":
         for name in ("cmp_freqs_cos", "cmp_freqs_sin"):
             if distributed_shapes[name][1] != active_tokens:
                 raise ValueError(
                     f"CSA tensor {name!r} must use active token extent "
-                    f"{active_tokens}, got {distributed_shapes[name]}"
+                    f"{active_tokens}, got {distributed_shapes[name]}",
                 )
 
     bridge_shapes = {
@@ -442,7 +439,7 @@ def build_layer_shape_report(layer_id, start_pos=None):
             if len(shape) > MAX_PUBLIC_TENSOR_DIMS:
                 raise ValueError(
                     f"{section} tensor {name!r} would have {len(shape)} "
-                    f"dimensions: {shape}"
+                    f"dimensions: {shape}",
                 )
 
     return {
@@ -475,9 +472,7 @@ def decode_layer_swa(
     gamma_ckv: pl.Tensor[[HEAD_DIM], pl.BF16],
     freqs_cos: pl.Tensor[[T_DYN, ROPE_HEAD_DIM], pl.BF16],
     freqs_sin: pl.Tensor[[T_DYN, ROPE_HEAD_DIM], pl.BF16],
-    kv_cache: pl.InOut[
-        pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]
-    ],
+    kv_cache: pl.InOut[pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
     swa_slot_mapping: pl.Tensor[[T_DYN], pl.INT64],
     swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
     swa_lens: pl.Tensor[[T_DYN], pl.INT32],
@@ -507,24 +502,16 @@ def decode_layer_swa(
     shared_w2: pl.Tensor[[D, MOE_INTER], pl.INT8],
     shared_w2_scale: pl.Tensor[[D], pl.FP32],
     x_attn_active: pl.Out[pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32]],
-    x_moe_next: pl.Out[
-        pl.Tensor[[MOE_TOKENS, HC_MULT, D], pl.FP32]
-    ],
+    x_moe_next: pl.Out[pl.Tensor[[MOE_TOKENS, HC_MULT, D], pl.FP32]],
     x_next: pl.Out[pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32]],
-    attention_window: pld.DistributedTensor[
-        [ATTENTION_WINDOW_ROWS, O_GROUP_IN], pl.BF16
-    ],
+    attention_window: pld.DistributedTensor[[ATTENTION_WINDOW_ROWS, O_GROUP_IN], pl.BF16],
     attention_signal: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
     o_window: pld.DistributedTensor[[O_WINDOW_ROWS, D], pl.FP32],
     o_signal: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
     recv_meta: pld.DistributedTensor[[N_RANKS, N_LOCAL], pl.INT32],
     recv_x: pld.DistributedTensor[[N_LOCAL * RECV_MAX, D], pl.INT8],
-    recv_aux: pld.DistributedTensor[
-        [N_LOCAL * RECV_MAX, AUX_PAD], pl.FP32
-    ],
-    recv_route: pld.DistributedTensor[
-        [N_LOCAL * RECV_MAX, IDX_PAD], pl.INT32
-    ],
+    recv_aux: pld.DistributedTensor[[N_LOCAL * RECV_MAX, AUX_PAD], pl.FP32],
+    recv_route: pld.DistributedTensor[[N_LOCAL * RECV_MAX, IDX_PAD], pl.INT32],
     arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
     data_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
     routed_y_buf: pld.DistributedTensor[[N_ROUTES, D], pl.BF16],
@@ -567,18 +554,14 @@ def decode_layer_swa(
             )
 
     with pl.scope():
-        x_attn_moe = pl.create_tensor(
-            [MOE_TOKENS, HC_MULT, D], dtype=pl.FP32
-        )
+        x_attn_moe = pl.create_tensor([MOE_TOKENS, HC_MULT, D], dtype=pl.FP32)
         for token in pl.spmd(MOE_TOKENS, name_hint="decode_layer_attn_pack"):
             if token < active_t:
                 x_attn_moe[token : token + 1, 0 : HC_MULT, 0 : D] = (
                     x_attn_active[token : token + 1, 0 : HC_MULT, 0 : D]
                 )
             else:
-                x_attn_moe[token : token + 1, 0 : HC_MULT, 0 : D] = pl.full(
-                    [1, HC_MULT, D], dtype=pl.FP32, value=0.0
-                )
+                x_attn_moe[token : token + 1, 0 : HC_MULT, 0 : D] = pl.full([1, HC_MULT, D], dtype=pl.FP32, value=0.0)
 
         moe(
             x_attn_moe,
@@ -596,9 +579,7 @@ def decode_layer_swa(
 
         for token in pl.spmd(MOE_TOKENS, name_hint="decode_layer_active_trim"):
             if token < active_t:
-                x_next[token : token + 1, 0 : HC_MULT, 0 : D] = (
-                    x_moe_next[token : token + 1, 0 : HC_MULT, 0 : D]
-                )
+                x_next[token : token + 1, 0 : HC_MULT, 0 : D] = (x_moe_next[token : token + 1, 0 : HC_MULT, 0 : D])
     return x_next
 
 
@@ -617,9 +598,7 @@ def decode_layer_swa_test(
     gamma_ckv: pl.Tensor[[HEAD_DIM], pl.BF16],
     freqs_cos: pl.Tensor[[T_DYN, ROPE_HEAD_DIM], pl.BF16],
     freqs_sin: pl.Tensor[[T_DYN, ROPE_HEAD_DIM], pl.BF16],
-    kv_cache: pl.InOut[
-        pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]
-    ],
+    kv_cache: pl.InOut[pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
     swa_slot_mapping: pl.Tensor[[T_DYN], pl.INT64],
     swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
     swa_lens: pl.Tensor[[T_DYN], pl.INT32],
@@ -649,24 +628,16 @@ def decode_layer_swa_test(
     shared_w2: pl.Tensor[[D, MOE_INTER], pl.INT8],
     shared_w2_scale: pl.Tensor[[D], pl.FP32],
     x_attn_active: pl.Out[pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32]],
-    x_moe_next: pl.Out[
-        pl.Tensor[[MOE_TOKENS, HC_MULT, D], pl.FP32]
-    ],
+    x_moe_next: pl.Out[pl.Tensor[[MOE_TOKENS, HC_MULT, D], pl.FP32]],
     x_next: pl.Out[pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32]],
-    attention_window: pld.DistributedTensor[
-        [ATTENTION_WINDOW_ROWS, O_GROUP_IN], pl.BF16
-    ],
+    attention_window: pld.DistributedTensor[[ATTENTION_WINDOW_ROWS, O_GROUP_IN], pl.BF16],
     attention_signal: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
     o_window: pld.DistributedTensor[[O_WINDOW_ROWS, D], pl.FP32],
     o_signal: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
     recv_meta: pld.DistributedTensor[[N_RANKS, N_LOCAL], pl.INT32],
     recv_x: pld.DistributedTensor[[N_LOCAL * RECV_MAX, D], pl.INT8],
-    recv_aux: pld.DistributedTensor[
-        [N_LOCAL * RECV_MAX, AUX_PAD], pl.FP32
-    ],
-    recv_route: pld.DistributedTensor[
-        [N_LOCAL * RECV_MAX, IDX_PAD], pl.INT32
-    ],
+    recv_aux: pld.DistributedTensor[[N_LOCAL * RECV_MAX, AUX_PAD], pl.FP32],
+    recv_route: pld.DistributedTensor[[N_LOCAL * RECV_MAX, IDX_PAD], pl.INT32],
     arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
     data_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
     routed_y_buf: pld.DistributedTensor[[N_ROUTES, D], pl.BF16],
@@ -711,9 +682,7 @@ def decode_layer_swa_test(
         arrived, data_arrived, routed_y_buf, combine_arrived,
         layer_id, group_base, tp_rank, local_t, my_rank, moe_epoch,
     )
-    clear_moe_signals(
-        x_moe_next, arrived, data_arrived, combine_arrived
-    )
+    clear_moe_signals(x_moe_next, arrived, data_arrived, combine_arrived)
     return x_next
 
 
@@ -732,20 +701,13 @@ def l3_decode_layer_swa(
     gamma_ckv: pl.Tensor[[N_RANKS, HEAD_DIM], pl.BF16],
     freqs_cos: pl.Tensor[[N_RANKS, T_DYN, ROPE_HEAD_DIM], pl.BF16],
     freqs_sin: pl.Tensor[[N_RANKS, T_DYN, ROPE_HEAD_DIM], pl.BF16],
-    kv_cache: pl.InOut[
-        pl.Tensor[
-            [N_RANKS, ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM],
-            pl.BF16,
-        ]
-    ],
+    kv_cache: pl.InOut[pl.Tensor[[N_RANKS, ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
     swa_slot_mapping: pl.Tensor[[N_RANKS, T_DYN], pl.INT64],
     swa_indices: pl.Tensor[[N_RANKS, T_DYN, WIN], pl.INT32],
     swa_lens: pl.Tensor[[N_RANKS, T_DYN], pl.INT32],
     position_ids: pl.Tensor[[N_RANKS, T_DYN], pl.INT32],
     attn_sink: pl.Tensor[[N_RANKS, H], pl.FP32],
-    wo_a: pl.Tensor[
-        [N_RANKS, LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16
-    ],
+    wo_a: pl.Tensor[[N_RANKS, LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
     wo_b: pl.Tensor[[N_RANKS, D, LOCAL_O_WIDTH], pl.INT8],
     wo_b_scale: pl.Tensor[[N_RANKS, D], pl.FP32],
     hc_ffn_fn: pl.Tensor[[N_RANKS, MIX_HC, HC_DIM], pl.FP32],
@@ -757,13 +719,9 @@ def l3_decode_layer_swa(
     tid2eid: pl.Tensor[[N_RANKS, VOCAB, TOPK], pl.INT32],
     input_ids: pl.Tensor[[N_RANKS, MOE_TOKENS], pl.INT64],
     routed_w1: pl.Tensor[[N_RANKS, N_LOCAL, MOE_INTER, D], pl.INT8],
-    routed_w1_scale: pl.Tensor[
-        [N_RANKS, N_LOCAL, MOE_INTER], pl.FP32
-    ],
+    routed_w1_scale: pl.Tensor[[N_RANKS, N_LOCAL, MOE_INTER], pl.FP32],
     routed_w3: pl.Tensor[[N_RANKS, N_LOCAL, MOE_INTER, D], pl.INT8],
-    routed_w3_scale: pl.Tensor[
-        [N_RANKS, N_LOCAL, MOE_INTER], pl.FP32
-    ],
+    routed_w3_scale: pl.Tensor[[N_RANKS, N_LOCAL, MOE_INTER], pl.FP32],
     routed_w2: pl.Tensor[[N_RANKS, N_LOCAL, D, MOE_INTER], pl.INT8],
     routed_w2_scale: pl.Tensor[[N_RANKS, N_LOCAL, D], pl.FP32],
     shared_w1: pl.Tensor[[N_RANKS, MOE_INTER, D], pl.INT8],
@@ -772,15 +730,9 @@ def l3_decode_layer_swa(
     shared_w3_scale: pl.Tensor[[N_RANKS, MOE_INTER], pl.FP32],
     shared_w2: pl.Tensor[[N_RANKS, D, MOE_INTER], pl.INT8],
     shared_w2_scale: pl.Tensor[[N_RANKS, D], pl.FP32],
-    x_attn_active: pl.Out[
-        pl.Tensor[[N_RANKS, T_DYN, HC_MULT, D], pl.FP32]
-    ],
-    x_moe_next: pl.Out[
-        pl.Tensor[[N_RANKS, MOE_TOKENS, HC_MULT, D], pl.FP32]
-    ],
-    x_next: pl.Out[
-        pl.Tensor[[N_RANKS, T_DYN, HC_MULT, D], pl.FP32]
-    ],
+    x_attn_active: pl.Out[pl.Tensor[[N_RANKS, T_DYN, HC_MULT, D], pl.FP32]],
+    x_moe_next: pl.Out[pl.Tensor[[N_RANKS, MOE_TOKENS, HC_MULT, D], pl.FP32]],
+    x_next: pl.Out[pl.Tensor[[N_RANKS, T_DYN, HC_MULT, D], pl.FP32]],
     layer_id: pl.Scalar[pl.INT32],
     local_t: pl.Scalar[pl.INT32],
 ):
@@ -796,81 +748,33 @@ def l3_decode_layer_swa(
     x_attn_active.bind_dynamic(1, T_DYN)
     x_next.bind_dynamic(1, T_DYN)
 
-    attention_window_buf = pld.alloc_window_buffer(
-        [ATTENTION_WINDOW_ROWS, O_GROUP_IN], dtype=pl.BF16
-    )
-    attention_signal_buf = pld.alloc_window_buffer(
-        [TP_SIZE, 1], dtype=pl.INT32
-    )
+    attention_window_buf = pld.alloc_window_buffer([ATTENTION_WINDOW_ROWS, O_GROUP_IN], dtype=pl.BF16)
+    attention_signal_buf = pld.alloc_window_buffer([TP_SIZE, 1], dtype=pl.INT32)
     o_window_buf = pld.alloc_window_buffer([O_WINDOW_ROWS, D], dtype=pl.FP32)
     o_signal_buf = pld.alloc_window_buffer([TP_SIZE, 1], dtype=pl.INT32)
 
-    recv_meta_buf = pld.alloc_window_buffer(
-        [N_RANKS, N_LOCAL], dtype=pl.INT32
-    )
-    recv_x_buf = pld.alloc_window_buffer(
-        [N_LOCAL * RECV_MAX, D], dtype=pl.INT8
-    )
-    recv_aux_buf = pld.alloc_window_buffer(
-        [N_LOCAL * RECV_MAX, AUX_PAD], dtype=pl.FP32
-    )
-    recv_route_buf = pld.alloc_window_buffer(
-        [N_LOCAL * RECV_MAX, IDX_PAD], dtype=pl.INT32
-    )
+    recv_meta_buf = pld.alloc_window_buffer([N_RANKS, N_LOCAL], dtype=pl.INT32)
+    recv_x_buf = pld.alloc_window_buffer([N_LOCAL * RECV_MAX, D], dtype=pl.INT8)
+    recv_aux_buf = pld.alloc_window_buffer([N_LOCAL * RECV_MAX, AUX_PAD], dtype=pl.FP32)
+    recv_route_buf = pld.alloc_window_buffer([N_LOCAL * RECV_MAX, IDX_PAD], dtype=pl.INT32)
     arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
-    data_arrived_buf = pld.alloc_window_buffer(
-        [N_RANKS, 1], dtype=pl.INT32
-    )
-    routed_y_buf_buf = pld.alloc_window_buffer(
-        [N_ROUTES, D], dtype=pl.BF16
-    )
-    combine_arrived_buf = pld.alloc_window_buffer(
-        [N_RANKS, 1], dtype=pl.INT32
-    )
+    data_arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
+    routed_y_buf_buf = pld.alloc_window_buffer([N_ROUTES, D], dtype=pl.BF16)
+    combine_arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
 
     for rank in pl.range(pld.world_size()):
-        attention_window = pld.window(
-            attention_window_buf,
-            [ATTENTION_WINDOW_ROWS, O_GROUP_IN],
-            dtype=pl.BF16,
-        )
-        attention_signal = pld.window(
-            attention_signal_buf, [TP_SIZE, 1], dtype=pl.INT32
-        )
-        o_window = pld.window(
-            o_window_buf, [O_WINDOW_ROWS, D], dtype=pl.FP32
-        )
-        o_signal = pld.window(
-            o_signal_buf, [TP_SIZE, 1], dtype=pl.INT32
-        )
-        recv_meta = pld.window(
-            recv_meta_buf, [N_RANKS, N_LOCAL], dtype=pl.INT32
-        )
-        recv_x = pld.window(
-            recv_x_buf, [N_LOCAL * RECV_MAX, D], dtype=pl.INT8
-        )
-        recv_aux = pld.window(
-            recv_aux_buf,
-            [N_LOCAL * RECV_MAX, AUX_PAD],
-            dtype=pl.FP32,
-        )
-        recv_route = pld.window(
-            recv_route_buf,
-            [N_LOCAL * RECV_MAX, IDX_PAD],
-            dtype=pl.INT32,
-        )
-        arrived = pld.window(
-            arrived_buf, [N_RANKS, 1], dtype=pl.INT32
-        )
-        data_arrived = pld.window(
-            data_arrived_buf, [N_RANKS, 1], dtype=pl.INT32
-        )
-        routed_y_buf = pld.window(
-            routed_y_buf_buf, [N_ROUTES, D], dtype=pl.BF16
-        )
-        combine_arrived = pld.window(
-            combine_arrived_buf, [N_RANKS, 1], dtype=pl.INT32
-        )
+        attention_window = pld.window(attention_window_buf, [ATTENTION_WINDOW_ROWS, O_GROUP_IN], dtype=pl.BF16)
+        attention_signal = pld.window(attention_signal_buf, [TP_SIZE, 1], dtype=pl.INT32)
+        o_window = pld.window(o_window_buf, [O_WINDOW_ROWS, D], dtype=pl.FP32)
+        o_signal = pld.window(o_signal_buf, [TP_SIZE, 1], dtype=pl.INT32)
+        recv_meta = pld.window(recv_meta_buf, [N_RANKS, N_LOCAL], dtype=pl.INT32)
+        recv_x = pld.window(recv_x_buf, [N_LOCAL * RECV_MAX, D], dtype=pl.INT8)
+        recv_aux = pld.window(recv_aux_buf, [N_LOCAL * RECV_MAX, AUX_PAD], dtype=pl.FP32)
+        recv_route = pld.window(recv_route_buf, [N_LOCAL * RECV_MAX, IDX_PAD], dtype=pl.INT32)
+        arrived = pld.window(arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
+        data_arrived = pld.window(data_arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
+        routed_y_buf = pld.window(routed_y_buf_buf, [N_ROUTES, D], dtype=pl.BF16)
+        combine_arrived = pld.window(combine_arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
         tp_rank = rank % TP_SIZE
         group_base = rank - tp_rank
         decode_layer_swa_test(
@@ -921,32 +825,13 @@ def decode_layer_hca(
     cmp_freqs_sin: pl.Tensor[[HCA_B, ROPE_HEAD_DIM // 2], pl.FP32],
     cmp_wkv: pl.Tensor[[HCA_MAIN_OUT_DIM, D], pl.BF16],
     cmp_wgate: pl.Tensor[[HCA_MAIN_OUT_DIM, D], pl.BF16],
-    cmp_ape: pl.Tensor[
-        [HCA_COMPRESS_RATIO, HCA_MAIN_OUT_DIM], pl.FP32
-    ],
+    cmp_ape: pl.Tensor[[HCA_COMPRESS_RATIO, HCA_MAIN_OUT_DIM], pl.FP32],
     cmp_norm_w: pl.Tensor[[HEAD_DIM], pl.BF16],
-    compress_state: pl.InOut[
-        pl.Tensor[
-            [
-                HCA_COMPRESS_STATE_BLOCK_NUM_DYN,
-                HCA_COMPRESS_STATE_BLOCK_SIZE,
-                HCA_COMPRESS_STATE_DIM,
-            ],
-            pl.FP32,
-        ]
-    ],
-    compress_state_block_table: pl.Tensor[
-        [HCA_B_DYN, HCA_COMPRESS_STATE_MAX_BLOCKS], pl.INT32
-    ],
-    kv_cache: pl.InOut[
-        pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]
-    ],
-    cmp_kv: pl.InOut[
-        pl.Tensor[[HCA_CMP_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]
-    ],
-    cmp_block_table: pl.Tensor[
-        [HCA_B_DYN, HCA_CMP_TABLE_BLOCKS_DYN], pl.INT32
-    ],
+    compress_state: pl.InOut[pl.Tensor[[HCA_COMPRESS_STATE_BLOCK_NUM_DYN, HCA_COMPRESS_STATE_BLOCK_SIZE, HCA_COMPRESS_STATE_DIM], pl.FP32]],
+    compress_state_block_table: pl.Tensor[[HCA_B_DYN, HCA_COMPRESS_STATE_MAX_BLOCKS], pl.INT32],
+    kv_cache: pl.InOut[pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
+    cmp_kv: pl.InOut[pl.Tensor[[HCA_CMP_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
+    cmp_block_table: pl.Tensor[[HCA_B_DYN, HCA_CMP_TABLE_BLOCKS_DYN], pl.INT32],
     ori_slot_mapping: pl.Tensor[[T_DYN], pl.INT64],
     window_swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
     window_swa_lens: pl.Tensor[[T_DYN], pl.INT32],
@@ -979,24 +864,16 @@ def decode_layer_hca(
     shared_w2: pl.Tensor[[D, MOE_INTER], pl.INT8],
     shared_w2_scale: pl.Tensor[[D], pl.FP32],
     x_attn_active: pl.Out[pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32]],
-    x_moe_next: pl.Out[
-        pl.Tensor[[MOE_TOKENS, HC_MULT, D], pl.FP32]
-    ],
+    x_moe_next: pl.Out[pl.Tensor[[MOE_TOKENS, HC_MULT, D], pl.FP32]],
     x_next: pl.Out[pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32]],
-    attention_window: pld.DistributedTensor[
-        [ATTENTION_WINDOW_ROWS, O_GROUP_IN], pl.BF16
-    ],
+    attention_window: pld.DistributedTensor[[ATTENTION_WINDOW_ROWS, O_GROUP_IN], pl.BF16],
     attention_signal: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
     o_window: pld.DistributedTensor[[O_WINDOW_ROWS, D], pl.FP32],
     o_signal: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
     recv_meta: pld.DistributedTensor[[N_RANKS, N_LOCAL], pl.INT32],
     recv_x: pld.DistributedTensor[[N_LOCAL * RECV_MAX, D], pl.INT8],
-    recv_aux: pld.DistributedTensor[
-        [N_LOCAL * RECV_MAX, AUX_PAD], pl.FP32
-    ],
-    recv_route: pld.DistributedTensor[
-        [N_LOCAL * RECV_MAX, IDX_PAD], pl.INT32
-    ],
+    recv_aux: pld.DistributedTensor[[N_LOCAL * RECV_MAX, AUX_PAD], pl.FP32],
+    recv_route: pld.DistributedTensor[[N_LOCAL * RECV_MAX, IDX_PAD], pl.INT32],
     arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
     data_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
     routed_y_buf: pld.DistributedTensor[[N_ROUTES, D], pl.BF16],
@@ -1047,18 +924,14 @@ def decode_layer_hca(
             )
 
     with pl.scope():
-        x_attn_moe = pl.create_tensor(
-            [MOE_TOKENS, HC_MULT, D], dtype=pl.FP32
-        )
+        x_attn_moe = pl.create_tensor([MOE_TOKENS, HC_MULT, D], dtype=pl.FP32)
         for token in pl.spmd(MOE_TOKENS, name_hint="decode_layer_attn_pack"):
             if token < active_t:
                 x_attn_moe[token : token + 1, 0 : HC_MULT, 0 : D] = (
                     x_attn_active[token : token + 1, 0 : HC_MULT, 0 : D]
                 )
             else:
-                x_attn_moe[token : token + 1, 0 : HC_MULT, 0 : D] = pl.full(
-                    [1, HC_MULT, D], dtype=pl.FP32, value=0.0
-                )
+                x_attn_moe[token : token + 1, 0 : HC_MULT, 0 : D] = pl.full([1, HC_MULT, D], dtype=pl.FP32, value=0.0)
 
         moe(
             x_attn_moe,
@@ -1076,9 +949,7 @@ def decode_layer_hca(
 
         for token in pl.spmd(MOE_TOKENS, name_hint="decode_layer_active_trim"):
             if token < active_t:
-                x_next[token : token + 1, 0 : HC_MULT, 0 : D] = (
-                    x_moe_next[token : token + 1, 0 : HC_MULT, 0 : D]
-                )
+                x_next[token : token + 1, 0 : HC_MULT, 0 : D] = (x_moe_next[token : token + 1, 0 : HC_MULT, 0 : D])
     return x_next
 
 
@@ -1101,32 +972,13 @@ def decode_layer_hca_test(
     cmp_freqs_sin: pl.Tensor[[HCA_B, ROPE_HEAD_DIM // 2], pl.FP32],
     cmp_wkv: pl.Tensor[[HCA_MAIN_OUT_DIM, D], pl.BF16],
     cmp_wgate: pl.Tensor[[HCA_MAIN_OUT_DIM, D], pl.BF16],
-    cmp_ape: pl.Tensor[
-        [HCA_COMPRESS_RATIO, HCA_MAIN_OUT_DIM], pl.FP32
-    ],
+    cmp_ape: pl.Tensor[[HCA_COMPRESS_RATIO, HCA_MAIN_OUT_DIM], pl.FP32],
     cmp_norm_w: pl.Tensor[[HEAD_DIM], pl.BF16],
-    compress_state: pl.InOut[
-        pl.Tensor[
-            [
-                HCA_COMPRESS_STATE_BLOCK_NUM_DYN,
-                HCA_COMPRESS_STATE_BLOCK_SIZE,
-                HCA_COMPRESS_STATE_DIM,
-            ],
-            pl.FP32,
-        ]
-    ],
-    compress_state_block_table: pl.Tensor[
-        [HCA_B_DYN, HCA_COMPRESS_STATE_MAX_BLOCKS], pl.INT32
-    ],
-    kv_cache: pl.InOut[
-        pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]
-    ],
-    cmp_kv: pl.InOut[
-        pl.Tensor[[HCA_CMP_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]
-    ],
-    cmp_block_table: pl.Tensor[
-        [HCA_B_DYN, HCA_CMP_TABLE_BLOCKS_DYN], pl.INT32
-    ],
+    compress_state: pl.InOut[pl.Tensor[[HCA_COMPRESS_STATE_BLOCK_NUM_DYN, HCA_COMPRESS_STATE_BLOCK_SIZE, HCA_COMPRESS_STATE_DIM], pl.FP32]],
+    compress_state_block_table: pl.Tensor[[HCA_B_DYN, HCA_COMPRESS_STATE_MAX_BLOCKS], pl.INT32],
+    kv_cache: pl.InOut[pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
+    cmp_kv: pl.InOut[pl.Tensor[[HCA_CMP_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
+    cmp_block_table: pl.Tensor[[HCA_B_DYN, HCA_CMP_TABLE_BLOCKS_DYN], pl.INT32],
     ori_slot_mapping: pl.Tensor[[T_DYN], pl.INT64],
     window_swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
     window_swa_lens: pl.Tensor[[T_DYN], pl.INT32],
@@ -1159,24 +1011,16 @@ def decode_layer_hca_test(
     shared_w2: pl.Tensor[[D, MOE_INTER], pl.INT8],
     shared_w2_scale: pl.Tensor[[D], pl.FP32],
     x_attn_active: pl.Out[pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32]],
-    x_moe_next: pl.Out[
-        pl.Tensor[[MOE_TOKENS, HC_MULT, D], pl.FP32]
-    ],
+    x_moe_next: pl.Out[pl.Tensor[[MOE_TOKENS, HC_MULT, D], pl.FP32]],
     x_next: pl.Out[pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32]],
-    attention_window: pld.DistributedTensor[
-        [ATTENTION_WINDOW_ROWS, O_GROUP_IN], pl.BF16
-    ],
+    attention_window: pld.DistributedTensor[[ATTENTION_WINDOW_ROWS, O_GROUP_IN], pl.BF16],
     attention_signal: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
     o_window: pld.DistributedTensor[[O_WINDOW_ROWS, D], pl.FP32],
     o_signal: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
     recv_meta: pld.DistributedTensor[[N_RANKS, N_LOCAL], pl.INT32],
     recv_x: pld.DistributedTensor[[N_LOCAL * RECV_MAX, D], pl.INT8],
-    recv_aux: pld.DistributedTensor[
-        [N_LOCAL * RECV_MAX, AUX_PAD], pl.FP32
-    ],
-    recv_route: pld.DistributedTensor[
-        [N_LOCAL * RECV_MAX, IDX_PAD], pl.INT32
-    ],
+    recv_aux: pld.DistributedTensor[[N_LOCAL * RECV_MAX, AUX_PAD], pl.FP32],
+    recv_route: pld.DistributedTensor[[N_LOCAL * RECV_MAX, IDX_PAD], pl.INT32],
     arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
     data_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
     routed_y_buf: pld.DistributedTensor[[N_ROUTES, D], pl.BF16],
@@ -1233,9 +1077,7 @@ def decode_layer_hca_test(
         arrived, data_arrived, routed_y_buf, combine_arrived,
         layer_id, group_base, tp_rank, local_t, my_rank, moe_epoch,
     )
-    clear_moe_signals(
-        x_moe_next, arrived, data_arrived, combine_arrived
-    )
+    clear_moe_signals(x_moe_next, arrived, data_arrived, combine_arrived)
     return x_next
 
 
@@ -1254,47 +1096,17 @@ def l3_decode_layer_hca(
     gamma_ckv: pl.Tensor[[N_RANKS, HEAD_DIM], pl.BF16],
     freqs_cos: pl.Tensor[[N_RANKS, T_DYN, ROPE_HEAD_DIM], pl.BF16],
     freqs_sin: pl.Tensor[[N_RANKS, T_DYN, ROPE_HEAD_DIM], pl.BF16],
-    cmp_freqs_cos: pl.Tensor[
-        [N_RANKS, HCA_B, ROPE_HEAD_DIM // 2], pl.FP32
-    ],
-    cmp_freqs_sin: pl.Tensor[
-        [N_RANKS, HCA_B, ROPE_HEAD_DIM // 2], pl.FP32
-    ],
+    cmp_freqs_cos: pl.Tensor[[N_RANKS, HCA_B, ROPE_HEAD_DIM // 2], pl.FP32],
+    cmp_freqs_sin: pl.Tensor[[N_RANKS, HCA_B, ROPE_HEAD_DIM // 2], pl.FP32],
     cmp_wkv: pl.Tensor[[N_RANKS, HCA_MAIN_OUT_DIM, D], pl.BF16],
     cmp_wgate: pl.Tensor[[N_RANKS, HCA_MAIN_OUT_DIM, D], pl.BF16],
-    cmp_ape: pl.Tensor[
-        [N_RANKS, HCA_COMPRESS_RATIO, HCA_MAIN_OUT_DIM], pl.FP32
-    ],
+    cmp_ape: pl.Tensor[[N_RANKS, HCA_COMPRESS_RATIO, HCA_MAIN_OUT_DIM], pl.FP32],
     cmp_norm_w: pl.Tensor[[N_RANKS, HEAD_DIM], pl.BF16],
-    compress_state: pl.InOut[
-        pl.Tensor[
-            [
-                N_RANKS,
-                HCA_COMPRESS_STATE_BLOCK_NUM_DYN,
-                HCA_COMPRESS_STATE_BLOCK_SIZE,
-                HCA_COMPRESS_STATE_DIM,
-            ],
-            pl.FP32,
-        ]
-    ],
-    compress_state_block_table: pl.Tensor[
-        [N_RANKS, HCA_B_DYN, HCA_COMPRESS_STATE_MAX_BLOCKS], pl.INT32
-    ],
-    kv_cache: pl.InOut[
-        pl.Tensor[
-            [N_RANKS, ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM],
-            pl.BF16,
-        ]
-    ],
-    cmp_kv: pl.InOut[
-        pl.Tensor[
-            [N_RANKS, HCA_CMP_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM],
-            pl.BF16,
-        ]
-    ],
-    cmp_block_table: pl.Tensor[
-        [N_RANKS, HCA_B_DYN, HCA_CMP_TABLE_BLOCKS_DYN], pl.INT32
-    ],
+    compress_state: pl.InOut[pl.Tensor[[N_RANKS, HCA_COMPRESS_STATE_BLOCK_NUM_DYN, HCA_COMPRESS_STATE_BLOCK_SIZE, HCA_COMPRESS_STATE_DIM], pl.FP32]],
+    compress_state_block_table: pl.Tensor[[N_RANKS, HCA_B_DYN, HCA_COMPRESS_STATE_MAX_BLOCKS], pl.INT32],
+    kv_cache: pl.InOut[pl.Tensor[[N_RANKS, ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
+    cmp_kv: pl.InOut[pl.Tensor[[N_RANKS, HCA_CMP_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
+    cmp_block_table: pl.Tensor[[N_RANKS, HCA_B_DYN, HCA_CMP_TABLE_BLOCKS_DYN], pl.INT32],
     ori_slot_mapping: pl.Tensor[[N_RANKS, T_DYN], pl.INT64],
     window_swa_indices: pl.Tensor[[N_RANKS, T_DYN, WIN], pl.INT32],
     window_swa_lens: pl.Tensor[[N_RANKS, T_DYN], pl.INT32],
@@ -1303,9 +1115,7 @@ def l3_decode_layer_hca(
     position_ids: pl.Tensor[[N_RANKS, T_DYN], pl.INT32],
     kv_seq_lens: pl.Tensor[[N_RANKS, HCA_B_DYN], pl.INT32],
     attn_sink: pl.Tensor[[N_RANKS, H], pl.FP32],
-    wo_a: pl.Tensor[
-        [N_RANKS, LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16
-    ],
+    wo_a: pl.Tensor[[N_RANKS, LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
     wo_b: pl.Tensor[[N_RANKS, D, LOCAL_O_WIDTH], pl.INT8],
     wo_b_scale: pl.Tensor[[N_RANKS, D], pl.FP32],
     hc_ffn_fn: pl.Tensor[[N_RANKS, MIX_HC, HC_DIM], pl.FP32],
@@ -1317,13 +1127,9 @@ def l3_decode_layer_hca(
     tid2eid: pl.Tensor[[N_RANKS, VOCAB, TOPK], pl.INT32],
     input_ids: pl.Tensor[[N_RANKS, MOE_TOKENS], pl.INT64],
     routed_w1: pl.Tensor[[N_RANKS, N_LOCAL, MOE_INTER, D], pl.INT8],
-    routed_w1_scale: pl.Tensor[
-        [N_RANKS, N_LOCAL, MOE_INTER], pl.FP32
-    ],
+    routed_w1_scale: pl.Tensor[[N_RANKS, N_LOCAL, MOE_INTER], pl.FP32],
     routed_w3: pl.Tensor[[N_RANKS, N_LOCAL, MOE_INTER, D], pl.INT8],
-    routed_w3_scale: pl.Tensor[
-        [N_RANKS, N_LOCAL, MOE_INTER], pl.FP32
-    ],
+    routed_w3_scale: pl.Tensor[[N_RANKS, N_LOCAL, MOE_INTER], pl.FP32],
     routed_w2: pl.Tensor[[N_RANKS, N_LOCAL, D, MOE_INTER], pl.INT8],
     routed_w2_scale: pl.Tensor[[N_RANKS, N_LOCAL, D], pl.FP32],
     shared_w1: pl.Tensor[[N_RANKS, MOE_INTER, D], pl.INT8],
@@ -1332,15 +1138,9 @@ def l3_decode_layer_hca(
     shared_w3_scale: pl.Tensor[[N_RANKS, MOE_INTER], pl.FP32],
     shared_w2: pl.Tensor[[N_RANKS, D, MOE_INTER], pl.INT8],
     shared_w2_scale: pl.Tensor[[N_RANKS, D], pl.FP32],
-    x_attn_active: pl.Out[
-        pl.Tensor[[N_RANKS, T_DYN, HC_MULT, D], pl.FP32]
-    ],
-    x_moe_next: pl.Out[
-        pl.Tensor[[N_RANKS, MOE_TOKENS, HC_MULT, D], pl.FP32]
-    ],
-    x_next: pl.Out[
-        pl.Tensor[[N_RANKS, T_DYN, HC_MULT, D], pl.FP32]
-    ],
+    x_attn_active: pl.Out[pl.Tensor[[N_RANKS, T_DYN, HC_MULT, D], pl.FP32]],
+    x_moe_next: pl.Out[pl.Tensor[[N_RANKS, MOE_TOKENS, HC_MULT, D], pl.FP32]],
+    x_next: pl.Out[pl.Tensor[[N_RANKS, T_DYN, HC_MULT, D], pl.FP32]],
     layer_id: pl.Scalar[pl.INT32],
     local_t: pl.Scalar[pl.INT32],
 ):
@@ -1364,81 +1164,33 @@ def l3_decode_layer_hca(
     x_attn_active.bind_dynamic(1, T_DYN)
     x_next.bind_dynamic(1, T_DYN)
 
-    attention_window_buf = pld.alloc_window_buffer(
-        [ATTENTION_WINDOW_ROWS, O_GROUP_IN], dtype=pl.BF16
-    )
-    attention_signal_buf = pld.alloc_window_buffer(
-        [TP_SIZE, 1], dtype=pl.INT32
-    )
+    attention_window_buf = pld.alloc_window_buffer([ATTENTION_WINDOW_ROWS, O_GROUP_IN], dtype=pl.BF16)
+    attention_signal_buf = pld.alloc_window_buffer([TP_SIZE, 1], dtype=pl.INT32)
     o_window_buf = pld.alloc_window_buffer([O_WINDOW_ROWS, D], dtype=pl.FP32)
     o_signal_buf = pld.alloc_window_buffer([TP_SIZE, 1], dtype=pl.INT32)
 
-    recv_meta_buf = pld.alloc_window_buffer(
-        [N_RANKS, N_LOCAL], dtype=pl.INT32
-    )
-    recv_x_buf = pld.alloc_window_buffer(
-        [N_LOCAL * RECV_MAX, D], dtype=pl.INT8
-    )
-    recv_aux_buf = pld.alloc_window_buffer(
-        [N_LOCAL * RECV_MAX, AUX_PAD], dtype=pl.FP32
-    )
-    recv_route_buf = pld.alloc_window_buffer(
-        [N_LOCAL * RECV_MAX, IDX_PAD], dtype=pl.INT32
-    )
+    recv_meta_buf = pld.alloc_window_buffer([N_RANKS, N_LOCAL], dtype=pl.INT32)
+    recv_x_buf = pld.alloc_window_buffer([N_LOCAL * RECV_MAX, D], dtype=pl.INT8)
+    recv_aux_buf = pld.alloc_window_buffer([N_LOCAL * RECV_MAX, AUX_PAD], dtype=pl.FP32)
+    recv_route_buf = pld.alloc_window_buffer([N_LOCAL * RECV_MAX, IDX_PAD], dtype=pl.INT32)
     arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
-    data_arrived_buf = pld.alloc_window_buffer(
-        [N_RANKS, 1], dtype=pl.INT32
-    )
-    routed_y_buf_buf = pld.alloc_window_buffer(
-        [N_ROUTES, D], dtype=pl.BF16
-    )
-    combine_arrived_buf = pld.alloc_window_buffer(
-        [N_RANKS, 1], dtype=pl.INT32
-    )
+    data_arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
+    routed_y_buf_buf = pld.alloc_window_buffer([N_ROUTES, D], dtype=pl.BF16)
+    combine_arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
 
     for rank in pl.range(pld.world_size()):
-        attention_window = pld.window(
-            attention_window_buf,
-            [ATTENTION_WINDOW_ROWS, O_GROUP_IN],
-            dtype=pl.BF16,
-        )
-        attention_signal = pld.window(
-            attention_signal_buf, [TP_SIZE, 1], dtype=pl.INT32
-        )
-        o_window = pld.window(
-            o_window_buf, [O_WINDOW_ROWS, D], dtype=pl.FP32
-        )
-        o_signal = pld.window(
-            o_signal_buf, [TP_SIZE, 1], dtype=pl.INT32
-        )
-        recv_meta = pld.window(
-            recv_meta_buf, [N_RANKS, N_LOCAL], dtype=pl.INT32
-        )
-        recv_x = pld.window(
-            recv_x_buf, [N_LOCAL * RECV_MAX, D], dtype=pl.INT8
-        )
-        recv_aux = pld.window(
-            recv_aux_buf,
-            [N_LOCAL * RECV_MAX, AUX_PAD],
-            dtype=pl.FP32,
-        )
-        recv_route = pld.window(
-            recv_route_buf,
-            [N_LOCAL * RECV_MAX, IDX_PAD],
-            dtype=pl.INT32,
-        )
-        arrived = pld.window(
-            arrived_buf, [N_RANKS, 1], dtype=pl.INT32
-        )
-        data_arrived = pld.window(
-            data_arrived_buf, [N_RANKS, 1], dtype=pl.INT32
-        )
-        routed_y_buf = pld.window(
-            routed_y_buf_buf, [N_ROUTES, D], dtype=pl.BF16
-        )
-        combine_arrived = pld.window(
-            combine_arrived_buf, [N_RANKS, 1], dtype=pl.INT32
-        )
+        attention_window = pld.window(attention_window_buf, [ATTENTION_WINDOW_ROWS, O_GROUP_IN], dtype=pl.BF16)
+        attention_signal = pld.window(attention_signal_buf, [TP_SIZE, 1], dtype=pl.INT32)
+        o_window = pld.window(o_window_buf, [O_WINDOW_ROWS, D], dtype=pl.FP32)
+        o_signal = pld.window(o_signal_buf, [TP_SIZE, 1], dtype=pl.INT32)
+        recv_meta = pld.window(recv_meta_buf, [N_RANKS, N_LOCAL], dtype=pl.INT32)
+        recv_x = pld.window(recv_x_buf, [N_LOCAL * RECV_MAX, D], dtype=pl.INT8)
+        recv_aux = pld.window(recv_aux_buf, [N_LOCAL * RECV_MAX, AUX_PAD], dtype=pl.FP32)
+        recv_route = pld.window(recv_route_buf, [N_LOCAL * RECV_MAX, IDX_PAD], dtype=pl.INT32)
+        arrived = pld.window(arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
+        data_arrived = pld.window(data_arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
+        routed_y_buf = pld.window(routed_y_buf_buf, [N_ROUTES, D], dtype=pl.BF16)
+        combine_arrived = pld.window(combine_arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
         tp_rank = rank % TP_SIZE
         group_base = rank - tp_rank
         decode_layer_hca_test(
@@ -1494,82 +1246,26 @@ def decode_layer_csa(
     cmp_freqs_sin: pl.Tensor[[T_DYN, ROPE_HEAD_DIM], pl.BF16],
     cmp_wkv: pl.Tensor[[CSA_MAIN_OUT_DIM, D], pl.BF16],
     cmp_wgate: pl.Tensor[[CSA_MAIN_OUT_DIM, D], pl.BF16],
-    cmp_ape: pl.Tensor[
-        [CSA_COMPRESS_RATIO, CSA_MAIN_OUT_DIM], pl.FP32
-    ],
+    cmp_ape: pl.Tensor[[CSA_COMPRESS_RATIO, CSA_MAIN_OUT_DIM], pl.FP32],
     cmp_norm_w: pl.Tensor[[HEAD_DIM], pl.BF16],
-    compress_state: pl.InOut[
-        pl.Tensor[
-            [
-                CSA_MAIN_STATE_BLOCK_NUM_DYN,
-                CSA_MAIN_STATE_BLOCK_SIZE,
-                CSA_MAIN_STATE_DIM,
-            ],
-            pl.FP32,
-        ]
-    ],
-    compress_state_block_table: pl.Tensor[
-        [CSA_B_DYN, CSA_MAIN_STATE_MAX_BLOCKS], pl.INT32
-    ],
-    idx_wq_b: pl.Tensor[
-        [Q_LORA, CSA_IDX_N_HEADS * CSA_IDX_HEAD_DIM], pl.INT8
-    ],
-    idx_wq_b_scale: pl.Tensor[
-        [CSA_IDX_N_HEADS * CSA_IDX_HEAD_DIM], pl.FP32
-    ],
+    compress_state: pl.InOut[pl.Tensor[[CSA_MAIN_STATE_BLOCK_NUM_DYN, CSA_MAIN_STATE_BLOCK_SIZE, CSA_MAIN_STATE_DIM], pl.FP32]],
+    compress_state_block_table: pl.Tensor[[CSA_B_DYN, CSA_MAIN_STATE_MAX_BLOCKS], pl.INT32],
+    idx_wq_b: pl.Tensor[[Q_LORA, CSA_IDX_N_HEADS * CSA_IDX_HEAD_DIM], pl.INT8],
+    idx_wq_b_scale: pl.Tensor[[CSA_IDX_N_HEADS * CSA_IDX_HEAD_DIM], pl.FP32],
     weights_proj: pl.Tensor[[D, CSA_IDX_N_HEADS], pl.BF16],
-    hadamard_idx: pl.Tensor[
-        [CSA_IDX_HEAD_DIM, CSA_IDX_HEAD_DIM], pl.BF16
-    ],
+    hadamard_idx: pl.Tensor[[CSA_IDX_HEAD_DIM, CSA_IDX_HEAD_DIM], pl.BF16],
     inner_wkv: pl.Tensor[[CSA_INNER_OUT_DIM, D], pl.BF16],
     inner_wgate: pl.Tensor[[CSA_INNER_OUT_DIM, D], pl.BF16],
-    inner_ape: pl.Tensor[
-        [CSA_COMPRESS_RATIO, CSA_INNER_OUT_DIM], pl.FP32
-    ],
+    inner_ape: pl.Tensor[[CSA_COMPRESS_RATIO, CSA_INNER_OUT_DIM], pl.FP32],
     inner_norm_w: pl.Tensor[[CSA_IDX_HEAD_DIM], pl.BF16],
-    inner_compress_state: pl.InOut[
-        pl.Tensor[
-            [
-                CSA_INNER_STATE_BLOCK_NUM_DYN,
-                CSA_INNER_STATE_BLOCK_SIZE,
-                CSA_INNER_STATE_DIM,
-            ],
-            pl.FP32,
-        ]
-    ],
-    inner_compress_state_block_table: pl.Tensor[
-        [CSA_B_DYN, CSA_INNER_STATE_MAX_BLOCKS], pl.INT32
-    ],
-    kv_cache: pl.InOut[
-        pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]
-    ],
-    cmp_kv: pl.InOut[
-        pl.Tensor[
-            [CSA_CMP_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16
-        ]
-    ],
-    cmp_block_table: pl.Tensor[
-        [CSA_B_DYN, CSA_CMP_MAX_BLOCKS], pl.INT32
-    ],
-    idx_kv_cache: pl.InOut[
-        pl.Tensor[
-            [
-                CSA_IDX_CACHE_BLOCK_NUM_DYN,
-                BLOCK_SIZE,
-                1,
-                CSA_IDX_HEAD_DIM,
-            ],
-            pl.INT8,
-        ]
-    ],
-    idx_kv_scale: pl.InOut[
-        pl.Tensor[
-            [CSA_IDX_CACHE_BLOCK_NUM_DYN, BLOCK_SIZE, 1, 1], pl.FP32
-        ]
-    ],
-    idx_block_table: pl.Tensor[
-        [CSA_B_DYN, CSA_IDX_MAX_BLOCKS], pl.INT32
-    ],
+    inner_compress_state: pl.InOut[pl.Tensor[[CSA_INNER_STATE_BLOCK_NUM_DYN, CSA_INNER_STATE_BLOCK_SIZE, CSA_INNER_STATE_DIM], pl.FP32]],
+    inner_compress_state_block_table: pl.Tensor[[CSA_B_DYN, CSA_INNER_STATE_MAX_BLOCKS], pl.INT32],
+    kv_cache: pl.InOut[pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
+    cmp_kv: pl.InOut[pl.Tensor[[CSA_CMP_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
+    cmp_block_table: pl.Tensor[[CSA_B_DYN, CSA_CMP_MAX_BLOCKS], pl.INT32],
+    idx_kv_cache: pl.InOut[pl.Tensor[[CSA_IDX_CACHE_BLOCK_NUM_DYN, BLOCK_SIZE, 1, CSA_IDX_HEAD_DIM], pl.INT8]],
+    idx_kv_scale: pl.InOut[pl.Tensor[[CSA_IDX_CACHE_BLOCK_NUM_DYN, BLOCK_SIZE, 1, 1], pl.FP32]],
+    idx_block_table: pl.Tensor[[CSA_B_DYN, CSA_IDX_MAX_BLOCKS], pl.INT32],
     ori_slot_mapping: pl.Tensor[[T_DYN], pl.INT64],
     window_swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
     window_swa_lens: pl.Tensor[[T_DYN], pl.INT32],
@@ -1604,24 +1300,16 @@ def decode_layer_csa(
     shared_w2: pl.Tensor[[D, MOE_INTER], pl.INT8],
     shared_w2_scale: pl.Tensor[[D], pl.FP32],
     x_attn_active: pl.Out[pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32]],
-    x_moe_next: pl.Out[
-        pl.Tensor[[MOE_TOKENS, HC_MULT, D], pl.FP32]
-    ],
+    x_moe_next: pl.Out[pl.Tensor[[MOE_TOKENS, HC_MULT, D], pl.FP32]],
     x_next: pl.Out[pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32]],
-    attention_window: pld.DistributedTensor[
-        [ATTENTION_WINDOW_ROWS, O_GROUP_IN], pl.BF16
-    ],
+    attention_window: pld.DistributedTensor[[ATTENTION_WINDOW_ROWS, O_GROUP_IN], pl.BF16],
     attention_signal: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
     o_window: pld.DistributedTensor[[O_WINDOW_ROWS, D], pl.FP32],
     o_signal: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
     recv_meta: pld.DistributedTensor[[N_RANKS, N_LOCAL], pl.INT32],
     recv_x: pld.DistributedTensor[[N_LOCAL * RECV_MAX, D], pl.INT8],
-    recv_aux: pld.DistributedTensor[
-        [N_LOCAL * RECV_MAX, AUX_PAD], pl.FP32
-    ],
-    recv_route: pld.DistributedTensor[
-        [N_LOCAL * RECV_MAX, IDX_PAD], pl.INT32
-    ],
+    recv_aux: pld.DistributedTensor[[N_LOCAL * RECV_MAX, AUX_PAD], pl.FP32],
+    recv_route: pld.DistributedTensor[[N_LOCAL * RECV_MAX, IDX_PAD], pl.INT32],
     arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
     data_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
     routed_y_buf: pld.DistributedTensor[[N_ROUTES, D], pl.BF16],
@@ -1682,18 +1370,14 @@ def decode_layer_csa(
             )
 
     with pl.scope():
-        x_attn_moe = pl.create_tensor(
-            [MOE_TOKENS, HC_MULT, D], dtype=pl.FP32
-        )
+        x_attn_moe = pl.create_tensor([MOE_TOKENS, HC_MULT, D], dtype=pl.FP32)
         for token in pl.spmd(MOE_TOKENS, name_hint="decode_layer_attn_pack"):
             if token < active_t:
                 x_attn_moe[token : token + 1, 0 : HC_MULT, 0 : D] = (
                     x_attn_active[token : token + 1, 0 : HC_MULT, 0 : D]
                 )
             else:
-                x_attn_moe[token : token + 1, 0 : HC_MULT, 0 : D] = pl.full(
-                    [1, HC_MULT, D], dtype=pl.FP32, value=0.0
-                )
+                x_attn_moe[token : token + 1, 0 : HC_MULT, 0 : D] = pl.full([1, HC_MULT, D], dtype=pl.FP32, value=0.0)
 
         moe(
             x_attn_moe,
@@ -1711,9 +1395,7 @@ def decode_layer_csa(
 
         for token in pl.spmd(MOE_TOKENS, name_hint="decode_layer_active_trim"):
             if token < active_t:
-                x_next[token : token + 1, 0 : HC_MULT, 0 : D] = (
-                    x_moe_next[token : token + 1, 0 : HC_MULT, 0 : D]
-                )
+                x_next[token : token + 1, 0 : HC_MULT, 0 : D] = (x_moe_next[token : token + 1, 0 : HC_MULT, 0 : D])
     return x_next
 
 
@@ -1736,82 +1418,26 @@ def decode_layer_csa_test(
     cmp_freqs_sin: pl.Tensor[[T_DYN, ROPE_HEAD_DIM], pl.BF16],
     cmp_wkv: pl.Tensor[[CSA_MAIN_OUT_DIM, D], pl.BF16],
     cmp_wgate: pl.Tensor[[CSA_MAIN_OUT_DIM, D], pl.BF16],
-    cmp_ape: pl.Tensor[
-        [CSA_COMPRESS_RATIO, CSA_MAIN_OUT_DIM], pl.FP32
-    ],
+    cmp_ape: pl.Tensor[[CSA_COMPRESS_RATIO, CSA_MAIN_OUT_DIM], pl.FP32],
     cmp_norm_w: pl.Tensor[[HEAD_DIM], pl.BF16],
-    compress_state: pl.InOut[
-        pl.Tensor[
-            [
-                CSA_MAIN_STATE_BLOCK_NUM_DYN,
-                CSA_MAIN_STATE_BLOCK_SIZE,
-                CSA_MAIN_STATE_DIM,
-            ],
-            pl.FP32,
-        ]
-    ],
-    compress_state_block_table: pl.Tensor[
-        [CSA_B_DYN, CSA_MAIN_STATE_MAX_BLOCKS], pl.INT32
-    ],
-    idx_wq_b: pl.Tensor[
-        [Q_LORA, CSA_IDX_N_HEADS * CSA_IDX_HEAD_DIM], pl.INT8
-    ],
-    idx_wq_b_scale: pl.Tensor[
-        [CSA_IDX_N_HEADS * CSA_IDX_HEAD_DIM], pl.FP32
-    ],
+    compress_state: pl.InOut[pl.Tensor[[CSA_MAIN_STATE_BLOCK_NUM_DYN, CSA_MAIN_STATE_BLOCK_SIZE, CSA_MAIN_STATE_DIM], pl.FP32]],
+    compress_state_block_table: pl.Tensor[[CSA_B_DYN, CSA_MAIN_STATE_MAX_BLOCKS], pl.INT32],
+    idx_wq_b: pl.Tensor[[Q_LORA, CSA_IDX_N_HEADS * CSA_IDX_HEAD_DIM], pl.INT8],
+    idx_wq_b_scale: pl.Tensor[[CSA_IDX_N_HEADS * CSA_IDX_HEAD_DIM], pl.FP32],
     weights_proj: pl.Tensor[[D, CSA_IDX_N_HEADS], pl.BF16],
-    hadamard_idx: pl.Tensor[
-        [CSA_IDX_HEAD_DIM, CSA_IDX_HEAD_DIM], pl.BF16
-    ],
+    hadamard_idx: pl.Tensor[[CSA_IDX_HEAD_DIM, CSA_IDX_HEAD_DIM], pl.BF16],
     inner_wkv: pl.Tensor[[CSA_INNER_OUT_DIM, D], pl.BF16],
     inner_wgate: pl.Tensor[[CSA_INNER_OUT_DIM, D], pl.BF16],
-    inner_ape: pl.Tensor[
-        [CSA_COMPRESS_RATIO, CSA_INNER_OUT_DIM], pl.FP32
-    ],
+    inner_ape: pl.Tensor[[CSA_COMPRESS_RATIO, CSA_INNER_OUT_DIM], pl.FP32],
     inner_norm_w: pl.Tensor[[CSA_IDX_HEAD_DIM], pl.BF16],
-    inner_compress_state: pl.InOut[
-        pl.Tensor[
-            [
-                CSA_INNER_STATE_BLOCK_NUM_DYN,
-                CSA_INNER_STATE_BLOCK_SIZE,
-                CSA_INNER_STATE_DIM,
-            ],
-            pl.FP32,
-        ]
-    ],
-    inner_compress_state_block_table: pl.Tensor[
-        [CSA_B_DYN, CSA_INNER_STATE_MAX_BLOCKS], pl.INT32
-    ],
-    kv_cache: pl.InOut[
-        pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]
-    ],
-    cmp_kv: pl.InOut[
-        pl.Tensor[
-            [CSA_CMP_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16
-        ]
-    ],
-    cmp_block_table: pl.Tensor[
-        [CSA_B_DYN, CSA_CMP_MAX_BLOCKS], pl.INT32
-    ],
-    idx_kv_cache: pl.InOut[
-        pl.Tensor[
-            [
-                CSA_IDX_CACHE_BLOCK_NUM_DYN,
-                BLOCK_SIZE,
-                1,
-                CSA_IDX_HEAD_DIM,
-            ],
-            pl.INT8,
-        ]
-    ],
-    idx_kv_scale: pl.InOut[
-        pl.Tensor[
-            [CSA_IDX_CACHE_BLOCK_NUM_DYN, BLOCK_SIZE, 1, 1], pl.FP32
-        ]
-    ],
-    idx_block_table: pl.Tensor[
-        [CSA_B_DYN, CSA_IDX_MAX_BLOCKS], pl.INT32
-    ],
+    inner_compress_state: pl.InOut[pl.Tensor[[CSA_INNER_STATE_BLOCK_NUM_DYN, CSA_INNER_STATE_BLOCK_SIZE, CSA_INNER_STATE_DIM], pl.FP32]],
+    inner_compress_state_block_table: pl.Tensor[[CSA_B_DYN, CSA_INNER_STATE_MAX_BLOCKS], pl.INT32],
+    kv_cache: pl.InOut[pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
+    cmp_kv: pl.InOut[pl.Tensor[[CSA_CMP_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
+    cmp_block_table: pl.Tensor[[CSA_B_DYN, CSA_CMP_MAX_BLOCKS], pl.INT32],
+    idx_kv_cache: pl.InOut[pl.Tensor[[CSA_IDX_CACHE_BLOCK_NUM_DYN, BLOCK_SIZE, 1, CSA_IDX_HEAD_DIM], pl.INT8]],
+    idx_kv_scale: pl.InOut[pl.Tensor[[CSA_IDX_CACHE_BLOCK_NUM_DYN, BLOCK_SIZE, 1, 1], pl.FP32]],
+    idx_block_table: pl.Tensor[[CSA_B_DYN, CSA_IDX_MAX_BLOCKS], pl.INT32],
     ori_slot_mapping: pl.Tensor[[T_DYN], pl.INT64],
     window_swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
     window_swa_lens: pl.Tensor[[T_DYN], pl.INT32],
@@ -1846,24 +1472,16 @@ def decode_layer_csa_test(
     shared_w2: pl.Tensor[[D, MOE_INTER], pl.INT8],
     shared_w2_scale: pl.Tensor[[D], pl.FP32],
     x_attn_active: pl.Out[pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32]],
-    x_moe_next: pl.Out[
-        pl.Tensor[[MOE_TOKENS, HC_MULT, D], pl.FP32]
-    ],
+    x_moe_next: pl.Out[pl.Tensor[[MOE_TOKENS, HC_MULT, D], pl.FP32]],
     x_next: pl.Out[pl.Tensor[[T_DYN, HC_MULT, D], pl.FP32]],
-    attention_window: pld.DistributedTensor[
-        [ATTENTION_WINDOW_ROWS, O_GROUP_IN], pl.BF16
-    ],
+    attention_window: pld.DistributedTensor[[ATTENTION_WINDOW_ROWS, O_GROUP_IN], pl.BF16],
     attention_signal: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
     o_window: pld.DistributedTensor[[O_WINDOW_ROWS, D], pl.FP32],
     o_signal: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
     recv_meta: pld.DistributedTensor[[N_RANKS, N_LOCAL], pl.INT32],
     recv_x: pld.DistributedTensor[[N_LOCAL * RECV_MAX, D], pl.INT8],
-    recv_aux: pld.DistributedTensor[
-        [N_LOCAL * RECV_MAX, AUX_PAD], pl.FP32
-    ],
-    recv_route: pld.DistributedTensor[
-        [N_LOCAL * RECV_MAX, IDX_PAD], pl.INT32
-    ],
+    recv_aux: pld.DistributedTensor[[N_LOCAL * RECV_MAX, AUX_PAD], pl.FP32],
+    recv_route: pld.DistributedTensor[[N_LOCAL * RECV_MAX, IDX_PAD], pl.INT32],
     arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
     data_arrived: pld.DistributedTensor[[N_RANKS, 1], pl.INT32],
     routed_y_buf: pld.DistributedTensor[[N_ROUTES, D], pl.BF16],
@@ -1933,9 +1551,7 @@ def decode_layer_csa_test(
         arrived, data_arrived, routed_y_buf, combine_arrived,
         layer_id, group_base, tp_rank, local_t, my_rank, moe_epoch,
     )
-    clear_moe_signals(
-        x_moe_next, arrived, data_arrived, combine_arrived
-    )
+    clear_moe_signals(x_moe_next, arrived, data_arrived, combine_arrived)
     return x_next
 
 
@@ -1952,129 +1568,43 @@ def l3_decode_layer_csa(
     wkv: pl.Tensor[[N_RANKS, D, HEAD_DIM], pl.BF16],
     gamma_cq: pl.Tensor[[N_RANKS, Q_LORA], pl.BF16],
     gamma_ckv: pl.Tensor[[N_RANKS, HEAD_DIM], pl.BF16],
-    freqs_cos: pl.Tensor[
-        [N_RANKS, T_DYN, ROPE_HEAD_DIM], pl.BF16
-    ],
-    freqs_sin: pl.Tensor[
-        [N_RANKS, T_DYN, ROPE_HEAD_DIM], pl.BF16
-    ],
-    cmp_freqs_cos: pl.Tensor[
-        [N_RANKS, T_DYN, ROPE_HEAD_DIM], pl.BF16
-    ],
-    cmp_freqs_sin: pl.Tensor[
-        [N_RANKS, T_DYN, ROPE_HEAD_DIM], pl.BF16
-    ],
+    freqs_cos: pl.Tensor[[N_RANKS, T_DYN, ROPE_HEAD_DIM], pl.BF16],
+    freqs_sin: pl.Tensor[[N_RANKS, T_DYN, ROPE_HEAD_DIM], pl.BF16],
+    cmp_freqs_cos: pl.Tensor[[N_RANKS, T_DYN, ROPE_HEAD_DIM], pl.BF16],
+    cmp_freqs_sin: pl.Tensor[[N_RANKS, T_DYN, ROPE_HEAD_DIM], pl.BF16],
     cmp_wkv: pl.Tensor[[N_RANKS, CSA_MAIN_OUT_DIM, D], pl.BF16],
     cmp_wgate: pl.Tensor[[N_RANKS, CSA_MAIN_OUT_DIM, D], pl.BF16],
-    cmp_ape: pl.Tensor[
-        [N_RANKS, CSA_COMPRESS_RATIO, CSA_MAIN_OUT_DIM], pl.FP32
-    ],
+    cmp_ape: pl.Tensor[[N_RANKS, CSA_COMPRESS_RATIO, CSA_MAIN_OUT_DIM], pl.FP32],
     cmp_norm_w: pl.Tensor[[N_RANKS, HEAD_DIM], pl.BF16],
-    compress_state: pl.InOut[
-        pl.Tensor[
-            [
-                N_RANKS,
-                CSA_MAIN_STATE_BLOCK_NUM_DYN,
-                CSA_MAIN_STATE_BLOCK_SIZE,
-                CSA_MAIN_STATE_DIM,
-            ],
-            pl.FP32,
-        ]
-    ],
-    compress_state_block_table: pl.Tensor[
-        [N_RANKS, CSA_B_DYN, CSA_MAIN_STATE_MAX_BLOCKS], pl.INT32
-    ],
-    idx_wq_b: pl.Tensor[
-        [N_RANKS, Q_LORA, CSA_IDX_N_HEADS * CSA_IDX_HEAD_DIM], pl.INT8
-    ],
-    idx_wq_b_scale: pl.Tensor[
-        [N_RANKS, CSA_IDX_N_HEADS * CSA_IDX_HEAD_DIM], pl.FP32
-    ],
-    weights_proj: pl.Tensor[
-        [N_RANKS, D, CSA_IDX_N_HEADS], pl.BF16
-    ],
-    hadamard_idx: pl.Tensor[
-        [N_RANKS, CSA_IDX_HEAD_DIM, CSA_IDX_HEAD_DIM], pl.BF16
-    ],
+    compress_state: pl.InOut[pl.Tensor[[N_RANKS, CSA_MAIN_STATE_BLOCK_NUM_DYN, CSA_MAIN_STATE_BLOCK_SIZE, CSA_MAIN_STATE_DIM], pl.FP32]],
+    compress_state_block_table: pl.Tensor[[N_RANKS, CSA_B_DYN, CSA_MAIN_STATE_MAX_BLOCKS], pl.INT32],
+    idx_wq_b: pl.Tensor[[N_RANKS, Q_LORA, CSA_IDX_N_HEADS * CSA_IDX_HEAD_DIM], pl.INT8],
+    idx_wq_b_scale: pl.Tensor[[N_RANKS, CSA_IDX_N_HEADS * CSA_IDX_HEAD_DIM], pl.FP32],
+    weights_proj: pl.Tensor[[N_RANKS, D, CSA_IDX_N_HEADS], pl.BF16],
+    hadamard_idx: pl.Tensor[[N_RANKS, CSA_IDX_HEAD_DIM, CSA_IDX_HEAD_DIM], pl.BF16],
     inner_wkv: pl.Tensor[[N_RANKS, CSA_INNER_OUT_DIM, D], pl.BF16],
     inner_wgate: pl.Tensor[[N_RANKS, CSA_INNER_OUT_DIM, D], pl.BF16],
-    inner_ape: pl.Tensor[
-        [N_RANKS, CSA_COMPRESS_RATIO, CSA_INNER_OUT_DIM], pl.FP32
-    ],
+    inner_ape: pl.Tensor[[N_RANKS, CSA_COMPRESS_RATIO, CSA_INNER_OUT_DIM], pl.FP32],
     inner_norm_w: pl.Tensor[[N_RANKS, CSA_IDX_HEAD_DIM], pl.BF16],
-    inner_compress_state: pl.InOut[
-        pl.Tensor[
-            [
-                N_RANKS,
-                CSA_INNER_STATE_BLOCK_NUM_DYN,
-                CSA_INNER_STATE_BLOCK_SIZE,
-                CSA_INNER_STATE_DIM,
-            ],
-            pl.FP32,
-        ]
-    ],
-    inner_compress_state_block_table: pl.Tensor[
-        [N_RANKS, CSA_B_DYN, CSA_INNER_STATE_MAX_BLOCKS], pl.INT32
-    ],
-    kv_cache: pl.InOut[
-        pl.Tensor[
-            [N_RANKS, ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM],
-            pl.BF16,
-        ]
-    ],
-    cmp_kv: pl.InOut[
-        pl.Tensor[
-            [
-                N_RANKS,
-                CSA_CMP_BLOCK_NUM_DYN,
-                BLOCK_SIZE,
-                1,
-                HEAD_DIM,
-            ],
-            pl.BF16,
-        ]
-    ],
-    cmp_block_table: pl.Tensor[
-        [N_RANKS, CSA_B_DYN, CSA_CMP_MAX_BLOCKS], pl.INT32
-    ],
-    idx_kv_cache: pl.InOut[
-        pl.Tensor[
-            [
-                N_RANKS,
-                CSA_IDX_CACHE_BLOCK_NUM_DYN,
-                BLOCK_SIZE,
-                1,
-                CSA_IDX_HEAD_DIM,
-            ],
-            pl.INT8,
-        ]
-    ],
-    idx_kv_scale: pl.InOut[
-        pl.Tensor[
-            [N_RANKS, CSA_IDX_CACHE_BLOCK_NUM_DYN, BLOCK_SIZE, 1, 1],
-            pl.FP32,
-        ]
-    ],
-    idx_block_table: pl.Tensor[
-        [N_RANKS, CSA_B_DYN, CSA_IDX_MAX_BLOCKS], pl.INT32
-    ],
+    inner_compress_state: pl.InOut[pl.Tensor[[N_RANKS, CSA_INNER_STATE_BLOCK_NUM_DYN, CSA_INNER_STATE_BLOCK_SIZE, CSA_INNER_STATE_DIM], pl.FP32]],
+    inner_compress_state_block_table: pl.Tensor[[N_RANKS, CSA_B_DYN, CSA_INNER_STATE_MAX_BLOCKS], pl.INT32],
+    kv_cache: pl.InOut[pl.Tensor[[N_RANKS, ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
+    cmp_kv: pl.InOut[pl.Tensor[[N_RANKS, CSA_CMP_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16]],
+    cmp_block_table: pl.Tensor[[N_RANKS, CSA_B_DYN, CSA_CMP_MAX_BLOCKS], pl.INT32],
+    idx_kv_cache: pl.InOut[pl.Tensor[[N_RANKS, CSA_IDX_CACHE_BLOCK_NUM_DYN, BLOCK_SIZE, 1, CSA_IDX_HEAD_DIM], pl.INT8]],
+    idx_kv_scale: pl.InOut[pl.Tensor[[N_RANKS, CSA_IDX_CACHE_BLOCK_NUM_DYN, BLOCK_SIZE, 1, 1], pl.FP32]],
+    idx_block_table: pl.Tensor[[N_RANKS, CSA_B_DYN, CSA_IDX_MAX_BLOCKS], pl.INT32],
     ori_slot_mapping: pl.Tensor[[N_RANKS, T_DYN], pl.INT64],
-    window_swa_indices: pl.Tensor[
-        [N_RANKS, T_DYN, WIN], pl.INT32
-    ],
+    window_swa_indices: pl.Tensor[[N_RANKS, T_DYN, WIN], pl.INT32],
     window_swa_lens: pl.Tensor[[N_RANKS, T_DYN], pl.INT32],
     cmp_slot_mapping: pl.Tensor[[N_RANKS, T_DYN], pl.INT64],
     idx_slot_mapping: pl.Tensor[[N_RANKS, T_DYN], pl.INT64],
     state_slot_mapping: pl.Tensor[[N_RANKS, T_DYN], pl.INT64],
-    inner_state_slot_mapping: pl.Tensor[
-        [N_RANKS, T_DYN], pl.INT64
-    ],
+    inner_state_slot_mapping: pl.Tensor[[N_RANKS, T_DYN], pl.INT64],
     position_ids: pl.Tensor[[N_RANKS, T_DYN], pl.INT32],
     kv_seq_lens: pl.Tensor[[N_RANKS, CSA_B_DYN], pl.INT32],
     attn_sink: pl.Tensor[[N_RANKS, H], pl.FP32],
-    wo_a: pl.Tensor[
-        [N_RANKS, LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16
-    ],
+    wo_a: pl.Tensor[[N_RANKS, LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
     wo_b: pl.Tensor[[N_RANKS, D, LOCAL_O_WIDTH], pl.INT8],
     wo_b_scale: pl.Tensor[[N_RANKS, D], pl.FP32],
     hc_ffn_fn: pl.Tensor[[N_RANKS, MIX_HC, HC_DIM], pl.FP32],
@@ -2086,13 +1616,9 @@ def l3_decode_layer_csa(
     tid2eid: pl.Tensor[[N_RANKS, VOCAB, TOPK], pl.INT32],
     input_ids: pl.Tensor[[N_RANKS, MOE_TOKENS], pl.INT64],
     routed_w1: pl.Tensor[[N_RANKS, N_LOCAL, MOE_INTER, D], pl.INT8],
-    routed_w1_scale: pl.Tensor[
-        [N_RANKS, N_LOCAL, MOE_INTER], pl.FP32
-    ],
+    routed_w1_scale: pl.Tensor[[N_RANKS, N_LOCAL, MOE_INTER], pl.FP32],
     routed_w3: pl.Tensor[[N_RANKS, N_LOCAL, MOE_INTER, D], pl.INT8],
-    routed_w3_scale: pl.Tensor[
-        [N_RANKS, N_LOCAL, MOE_INTER], pl.FP32
-    ],
+    routed_w3_scale: pl.Tensor[[N_RANKS, N_LOCAL, MOE_INTER], pl.FP32],
     routed_w2: pl.Tensor[[N_RANKS, N_LOCAL, D, MOE_INTER], pl.INT8],
     routed_w2_scale: pl.Tensor[[N_RANKS, N_LOCAL, D], pl.FP32],
     shared_w1: pl.Tensor[[N_RANKS, MOE_INTER, D], pl.INT8],
@@ -2101,15 +1627,9 @@ def l3_decode_layer_csa(
     shared_w3_scale: pl.Tensor[[N_RANKS, MOE_INTER], pl.FP32],
     shared_w2: pl.Tensor[[N_RANKS, D, MOE_INTER], pl.INT8],
     shared_w2_scale: pl.Tensor[[N_RANKS, D], pl.FP32],
-    x_attn_active: pl.Out[
-        pl.Tensor[[N_RANKS, T_DYN, HC_MULT, D], pl.FP32]
-    ],
-    x_moe_next: pl.Out[
-        pl.Tensor[[N_RANKS, MOE_TOKENS, HC_MULT, D], pl.FP32]
-    ],
-    x_next: pl.Out[
-        pl.Tensor[[N_RANKS, T_DYN, HC_MULT, D], pl.FP32]
-    ],
+    x_attn_active: pl.Out[pl.Tensor[[N_RANKS, T_DYN, HC_MULT, D], pl.FP32]],
+    x_moe_next: pl.Out[pl.Tensor[[N_RANKS, MOE_TOKENS, HC_MULT, D], pl.FP32]],
+    x_next: pl.Out[pl.Tensor[[N_RANKS, T_DYN, HC_MULT, D], pl.FP32]],
     layer_id: pl.Scalar[pl.INT32],
     local_t: pl.Scalar[pl.INT32],
 ):
@@ -2141,78 +1661,32 @@ def l3_decode_layer_csa(
     x_attn_active.bind_dynamic(1, T_DYN)
     x_next.bind_dynamic(1, T_DYN)
 
-    attention_window_buf = pld.alloc_window_buffer(
-        [ATTENTION_WINDOW_ROWS, O_GROUP_IN], dtype=pl.BF16
-    )
-    attention_signal_buf = pld.alloc_window_buffer(
-        [TP_SIZE, 1], dtype=pl.INT32
-    )
-    o_window_buf = pld.alloc_window_buffer(
-        [O_WINDOW_ROWS, D], dtype=pl.FP32
-    )
-    o_signal_buf = pld.alloc_window_buffer(
-        [TP_SIZE, 1], dtype=pl.INT32
-    )
-    recv_meta_buf = pld.alloc_window_buffer(
-        [N_RANKS, N_LOCAL], dtype=pl.INT32
-    )
-    recv_x_buf = pld.alloc_window_buffer(
-        [N_LOCAL * RECV_MAX, D], dtype=pl.INT8
-    )
-    recv_aux_buf = pld.alloc_window_buffer(
-        [N_LOCAL * RECV_MAX, AUX_PAD], dtype=pl.FP32
-    )
-    recv_route_buf = pld.alloc_window_buffer(
-        [N_LOCAL * RECV_MAX, IDX_PAD], dtype=pl.INT32
-    )
-    arrived_buf = pld.alloc_window_buffer(
-        [N_RANKS, 1], dtype=pl.INT32
-    )
-    data_arrived_buf = pld.alloc_window_buffer(
-        [N_RANKS, 1], dtype=pl.INT32
-    )
-    routed_y_buf_buf = pld.alloc_window_buffer(
-        [N_ROUTES, D], dtype=pl.BF16
-    )
-    combine_arrived_buf = pld.alloc_window_buffer(
-        [N_RANKS, 1], dtype=pl.INT32
-    )
+    attention_window_buf = pld.alloc_window_buffer([ATTENTION_WINDOW_ROWS, O_GROUP_IN], dtype=pl.BF16)
+    attention_signal_buf = pld.alloc_window_buffer([TP_SIZE, 1], dtype=pl.INT32)
+    o_window_buf = pld.alloc_window_buffer([O_WINDOW_ROWS, D], dtype=pl.FP32)
+    o_signal_buf = pld.alloc_window_buffer([TP_SIZE, 1], dtype=pl.INT32)
+    recv_meta_buf = pld.alloc_window_buffer([N_RANKS, N_LOCAL], dtype=pl.INT32)
+    recv_x_buf = pld.alloc_window_buffer([N_LOCAL * RECV_MAX, D], dtype=pl.INT8)
+    recv_aux_buf = pld.alloc_window_buffer([N_LOCAL * RECV_MAX, AUX_PAD], dtype=pl.FP32)
+    recv_route_buf = pld.alloc_window_buffer([N_LOCAL * RECV_MAX, IDX_PAD], dtype=pl.INT32)
+    arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
+    data_arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
+    routed_y_buf_buf = pld.alloc_window_buffer([N_ROUTES, D], dtype=pl.BF16)
+    combine_arrived_buf = pld.alloc_window_buffer([N_RANKS, 1], dtype=pl.INT32)
 
     for rank in pl.range(pld.world_size()):
-        attention_window = pld.window(
-            attention_window_buf,
-            [ATTENTION_WINDOW_ROWS, O_GROUP_IN],
-            dtype=pl.BF16,
-        )
-        attention_signal = pld.window(
-            attention_signal_buf, [TP_SIZE, 1], dtype=pl.INT32
-        )
+        attention_window = pld.window(attention_window_buf, [ATTENTION_WINDOW_ROWS, O_GROUP_IN], dtype=pl.BF16)
+        attention_signal = pld.window(attention_signal_buf, [TP_SIZE, 1], dtype=pl.INT32)
         o_window = pld.window(o_window_buf, [O_WINDOW_ROWS, D], dtype=pl.FP32)
         o_signal = pld.window(o_signal_buf, [TP_SIZE, 1], dtype=pl.INT32)
-        recv_meta = pld.window(
-            recv_meta_buf, [N_RANKS, N_LOCAL], dtype=pl.INT32
-        )
-        recv_x = pld.window(
-            recv_x_buf, [N_LOCAL * RECV_MAX, D], dtype=pl.INT8
-        )
-        recv_aux = pld.window(
-            recv_aux_buf, [N_LOCAL * RECV_MAX, AUX_PAD], dtype=pl.FP32
-        )
-        recv_route = pld.window(
-            recv_route_buf, [N_LOCAL * RECV_MAX, IDX_PAD], dtype=pl.INT32
-        )
-        arrived = pld.window(
-            arrived_buf, [N_RANKS, 1], dtype=pl.INT32
-        )
-        data_arrived = pld.window(
-            data_arrived_buf, [N_RANKS, 1], dtype=pl.INT32
-        )
-        routed_y_buf = pld.window(
-            routed_y_buf_buf, [N_ROUTES, D], dtype=pl.BF16
-        )
-        combine_arrived = pld.window(
-            combine_arrived_buf, [N_RANKS, 1], dtype=pl.INT32
-        )
+        recv_meta = pld.window(recv_meta_buf, [N_RANKS, N_LOCAL], dtype=pl.INT32)
+        recv_x = pld.window(recv_x_buf, [N_LOCAL * RECV_MAX, D], dtype=pl.INT8)
+        recv_aux = pld.window(recv_aux_buf, [N_LOCAL * RECV_MAX, AUX_PAD], dtype=pl.FP32)
+        recv_route = pld.window(recv_route_buf, [N_LOCAL * RECV_MAX, IDX_PAD], dtype=pl.INT32)
+        arrived = pld.window(arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
+        data_arrived = pld.window(data_arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
+        routed_y_buf = pld.window(routed_y_buf_buf, [N_ROUTES, D], dtype=pl.BF16)
+        combine_arrived = pld.window(combine_arrived_buf, [N_RANKS, 1], dtype=pl.INT32)
         tp_rank = rank % TP_SIZE
         group_base = rank - tp_rank
         decode_layer_csa_test(
@@ -2292,20 +1766,18 @@ def build_swa_layer_specs(start_pos=None, layer_id=0):
     _validate_active_tokens(local_t)
     if batch > swa.B:
         raise ValueError(
-            f"SWA batch {batch} exceeds TP{TP_SIZE} local capacity {swa.B}"
+            f"SWA batch {batch} exceeds TP{TP_SIZE} local capacity {swa.B}",
         )
 
     specs = []
-    swa_specs = swa.build_distributed_tensor_specs(
-        local_t, start_pos=start_pos
-    )
+    swa_specs = swa.build_distributed_tensor_specs(local_t, start_pos=start_pos)
     for spec in swa_specs:
         if isinstance(spec, TensorSpec) and spec.name != "x_out":
             specs.append(_expand_swa_spec(spec))
 
     existing = {spec.name for spec in specs}
     for spec in moe_module.build_tensor_specs(
-        layer_id=layer_id, num_tokens=local_t
+        layer_id=layer_id, num_tokens=local_t,
     ):
         if not isinstance(spec, TensorSpec):
             continue
@@ -2336,14 +1808,14 @@ def build_swa_layer_specs(start_pos=None, layer_id=0):
             ),
             ScalarSpec("layer_id", torch.int32, layer_id),
             ScalarSpec("local_t", torch.int32, local_t),
-        ]
+        ],
     )
 
     specs_by_name = {spec.name: spec for spec in specs}
     parameter_names = [
         name
         for name, parameter in inspect.signature(
-            l3_decode_layer_swa._func
+            l3_decode_layer_swa._func,
         ).parameters.items()
         if parameter.default is inspect.Parameter.empty
     ]
@@ -2351,7 +1823,7 @@ def build_swa_layer_specs(start_pos=None, layer_id=0):
     extra = [name for name in specs_by_name if name not in parameter_names]
     if missing or extra:
         raise ValueError(
-            f"SWA layer spec/signature mismatch: missing={missing}, extra={extra}"
+            f"SWA layer spec/signature mismatch: missing={missing}, extra={extra}",
         )
     return [specs_by_name[name] for name in parameter_names]
 
@@ -2365,19 +1837,12 @@ def golden_decode_layer_swa(tensors):
     for group in range(TP_GROUPS):
         group_begin = group * TP_SIZE
         group_end = group_begin + TP_SIZE
-        group_tensors = {
-            name: tensors[name][group_begin:group_end]
-            for name in _SWA_INPUT_NAMES
-        }
-        group_tensors["x_out"] = tensors["x_attn_active"][
-            group_begin:group_end
-        ]
+        group_tensors = { name: tensors[name][group_begin:group_end] for name in _SWA_INPUT_NAMES }
+        group_tensors["x_out"] = tensors["x_attn_active"][group_begin:group_end]
         group_tensors["local_t"] = local_t
         swa.golden_decode_swa(group_tensors)
 
-    x_attn_moe = torch.zeros(
-        N_RANKS, MOE_TOKENS, HC_MULT, D, dtype=torch.float32
-    )
+    x_attn_moe = torch.zeros(N_RANKS, MOE_TOKENS, HC_MULT, D, dtype=torch.float32)
     x_attn_moe[:, :local_t].copy_(tensors["x_attn_active"])
     moe_tensors = dict(tensors)
     moe_tensors["x_hc"] = x_attn_moe
@@ -2421,20 +1886,18 @@ def build_hca_layer_specs(start_pos=None, layer_id=3):
     _validate_active_tokens(local_t)
     if batch > hca.B:
         raise ValueError(
-            f"HCA batch {batch} exceeds TP{TP_SIZE} local capacity {hca.B}"
+            f"HCA batch {batch} exceeds TP{TP_SIZE} local capacity {hca.B}",
         )
 
     specs = []
-    hca_specs = hca.build_distributed_tensor_specs(
-        local_t, start_pos=start_pos
-    )
+    hca_specs = hca.build_distributed_tensor_specs(local_t, start_pos=start_pos)
     for spec in hca_specs:
         if isinstance(spec, TensorSpec) and spec.name != "x_out":
             specs.append(_expand_hca_spec(spec))
 
     existing = {spec.name for spec in specs}
     for spec in moe_module.build_tensor_specs(
-        layer_id=layer_id, num_tokens=local_t
+        layer_id=layer_id, num_tokens=local_t,
     ):
         if not isinstance(spec, TensorSpec):
             continue
@@ -2465,14 +1928,14 @@ def build_hca_layer_specs(start_pos=None, layer_id=3):
             ),
             ScalarSpec("layer_id", torch.int32, layer_id),
             ScalarSpec("local_t", torch.int32, local_t),
-        ]
+        ],
     )
 
     specs_by_name = {spec.name: spec for spec in specs}
     parameter_names = [
         name
         for name, parameter in inspect.signature(
-            l3_decode_layer_hca._func
+            l3_decode_layer_hca._func,
         ).parameters.items()
         if parameter.default is inspect.Parameter.empty
     ]
@@ -2480,7 +1943,7 @@ def build_hca_layer_specs(start_pos=None, layer_id=3):
     extra = [name for name in specs_by_name if name not in parameter_names]
     if missing or extra:
         raise ValueError(
-            f"HCA layer spec/signature mismatch: missing={missing}, extra={extra}"
+            f"HCA layer spec/signature mismatch: missing={missing}, extra={extra}",
         )
     return [specs_by_name[name] for name in parameter_names]
 
@@ -2494,19 +1957,12 @@ def golden_decode_layer_hca(tensors):
     for group in range(TP_GROUPS):
         group_begin = group * TP_SIZE
         group_end = group_begin + TP_SIZE
-        group_tensors = {
-            name: tensors[name][group_begin:group_end]
-            for name in _HCA_INPUT_NAMES
-        }
-        group_tensors["x_out"] = tensors["x_attn_active"][
-            group_begin:group_end
-        ]
+        group_tensors = { name: tensors[name][group_begin:group_end] for name in _HCA_INPUT_NAMES }
+        group_tensors["x_out"] = tensors["x_attn_active"][group_begin:group_end]
         group_tensors["local_t"] = local_t
         hca.golden_decode_hca(group_tensors)
 
-    x_attn_moe = torch.zeros(
-        N_RANKS, MOE_TOKENS, HC_MULT, D, dtype=torch.float32
-    )
+    x_attn_moe = torch.zeros(N_RANKS, MOE_TOKENS, HC_MULT, D, dtype=torch.float32)
     x_attn_moe[:, :local_t].copy_(tensors["x_attn_active"])
     moe_tensors = dict(tensors)
     moe_tensors["x_hc"] = x_attn_moe
@@ -2550,20 +2006,18 @@ def build_csa_layer_specs(start_pos=None, layer_id=2):
     _validate_active_tokens(local_t)
     if batch > csa.B:
         raise ValueError(
-            f"CSA batch {batch} exceeds TP{TP_SIZE} local capacity {csa.B}"
+            f"CSA batch {batch} exceeds TP{TP_SIZE} local capacity {csa.B}",
         )
 
     specs = []
-    csa_specs = csa.build_distributed_tensor_specs(
-        local_t, start_pos=start_pos
-    )
+    csa_specs = csa.build_distributed_tensor_specs(local_t, start_pos=start_pos)
     for spec in csa_specs:
         if isinstance(spec, TensorSpec) and spec.name != "x_out":
             specs.append(_expand_csa_spec(spec))
 
     existing = {spec.name for spec in specs}
     for spec in moe_module.build_tensor_specs(
-        layer_id=layer_id, num_tokens=local_t
+        layer_id=layer_id, num_tokens=local_t,
     ):
         if not isinstance(spec, TensorSpec):
             continue
@@ -2594,14 +2048,14 @@ def build_csa_layer_specs(start_pos=None, layer_id=2):
             ),
             ScalarSpec("layer_id", torch.int32, layer_id),
             ScalarSpec("local_t", torch.int32, local_t),
-        ]
+        ],
     )
 
     specs_by_name = {spec.name: spec for spec in specs}
     parameter_names = [
         name
         for name, parameter in inspect.signature(
-            l3_decode_layer_csa._func
+            l3_decode_layer_csa._func,
         ).parameters.items()
         if parameter.default is inspect.Parameter.empty
     ]
@@ -2609,7 +2063,7 @@ def build_csa_layer_specs(start_pos=None, layer_id=2):
     extra = [name for name in specs_by_name if name not in parameter_names]
     if missing or extra:
         raise ValueError(
-            f"CSA layer spec/signature mismatch: missing={missing}, extra={extra}"
+            f"CSA layer spec/signature mismatch: missing={missing}, extra={extra}",
         )
     return [specs_by_name[name] for name in parameter_names]
 
@@ -2623,19 +2077,12 @@ def golden_decode_layer_csa(tensors):
     for group in range(TP_GROUPS):
         group_begin = group * TP_SIZE
         group_end = group_begin + TP_SIZE
-        group_tensors = {
-            name: tensors[name][group_begin:group_end]
-            for name in _CSA_INPUT_NAMES
-        }
-        group_tensors["x_out"] = tensors["x_attn_active"][
-            group_begin:group_end
-        ]
+        group_tensors = { name: tensors[name][group_begin:group_end] for name in _CSA_INPUT_NAMES }
+        group_tensors["x_out"] = tensors["x_attn_active"][group_begin:group_end]
         group_tensors["local_t"] = local_t
         csa.golden_decode_csa(group_tensors)
 
-    x_attn_moe = torch.zeros(
-        N_RANKS, MOE_TOKENS, HC_MULT, D, dtype=torch.float32
-    )
+    x_attn_moe = torch.zeros(N_RANKS, MOE_TOKENS, HC_MULT, D, dtype=torch.float32)
     x_attn_moe[:, :local_t].copy_(tensors["x_attn_active"])
     moe_tensors = dict(tensors)
     moe_tensors["x_hc"] = x_attn_moe
@@ -2684,10 +2131,10 @@ def main():
         help="a scalar selects batch=1; a comma-separated list sets batch to its length",
     )
     parser.add_argument(
-        "--enable-chip-swimlane", type=int, default=0, choices=range(5)
+        "--enable-chip-swimlane", type=int, default=0, choices=range(5),
     )
     parser.add_argument(
-        "--enable-scope-stats", action="store_true", default=False
+        "--enable-scope-stats", action="store_true", default=False,
     )
     parser.add_argument("--compile-only", action="store_true", default=False)
     parser.add_argument("--runtime-dir", type=str, default=None)
@@ -2699,9 +2146,7 @@ def main():
     args = parser.parse_args()
 
     if args.tp != TP_SIZE or args.ep != EP_SIZE:
-        parser.error(
-            f"parallel sizes froze at import as TP={TP_SIZE}, EP={EP_SIZE}"
-        )
+        parser.error(f"parallel sizes froze at import as TP={TP_SIZE}, EP={EP_SIZE}")
     start_pos = _parse_start_pos(args.start_pos)
     kind = attention_kind_for_layer(args.layer_id)
 
@@ -2713,7 +2158,7 @@ def main():
             f"groups={report['tp_groups']} "
             f"batch={report['active_batch']} "
             f"active_t={report['active_tokens']} "
-            f"moe_capacity={report['moe_capacity']}"
+            f"moe_capacity={report['moe_capacity']}",
         )
         return
 
@@ -2722,23 +2167,16 @@ def main():
     try:
         device_ids = [int(device) for device in args.device.split(",")]
     except ValueError:
-        parser.error(
-            f"--device must be a comma-separated integer list, got {args.device!r}"
-        )
+        parser.error(f"--device must be a comma-separated integer list, got {args.device!r}")
     if len(device_ids) != EP_SIZE or len(set(device_ids)) != EP_SIZE:
-        parser.error(
-            f"EP={EP_SIZE} needs exactly {EP_SIZE} distinct devices, "
-            f"got {device_ids}"
-        )
+        parser.error(f"EP={EP_SIZE} needs exactly {EP_SIZE} distinct devices, " f"got {device_ids}")
     if any(device < 0 for device in device_ids):
         parser.error(f"device IDs must be non-negative, got {device_ids}")
 
     local_t = report["active_tokens"]
     if kind == "swa":
         layer_fn = l3_decode_layer_swa
-        specs = build_swa_layer_specs(
-            start_pos=start_pos, layer_id=args.layer_id
-        )
+        specs = build_swa_layer_specs(start_pos=start_pos, layer_id=args.layer_id)
         golden_fn = golden_decode_layer_swa
         compare_fn = {
             "kv_cache": mapped_pool_ratio_allclose(
@@ -2752,7 +2190,7 @@ def main():
                 max_error_ratio=0.005,
             ),
             "x_attn_active": ratio_reldiff(
-                diff_thd=3e-3, pct_thd=0.008, max_diff_hd=1
+                diff_thd=3e-3, pct_thd=0.008, max_diff_hd=1,
             ),
             "x_moe_next": ratio_reldiff(
                 diff_thd=0.01,
@@ -2764,9 +2202,7 @@ def main():
         }
     elif kind == "hca":
         layer_fn = l3_decode_layer_hca
-        specs = build_hca_layer_specs(
-            start_pos=start_pos, layer_id=args.layer_id
-        )
+        specs = build_hca_layer_specs(start_pos=start_pos, layer_id=args.layer_id)
         golden_fn = golden_decode_layer_hca
         mapping_shape = (N_RANKS, local_t)
         compare_fn = {
@@ -2798,7 +2234,7 @@ def main():
                 rtol=1.0 / 128,
             ),
             "x_attn_active": ratio_reldiff(
-                diff_thd=3e-3, pct_thd=0.008, max_diff_hd=1
+                diff_thd=3e-3, pct_thd=0.008, max_diff_hd=1,
             ),
             "x_moe_next": ratio_reldiff(
                 diff_thd=0.01,
@@ -2810,9 +2246,7 @@ def main():
         }
     else:
         layer_fn = l3_decode_layer_csa
-        specs = build_csa_layer_specs(
-            start_pos=start_pos, layer_id=args.layer_id
-        )
+        specs = build_csa_layer_specs(start_pos=start_pos, layer_id=args.layer_id)
         golden_fn = golden_decode_layer_csa
         mapping_shape = (N_RANKS, local_t)
         compare_fn = {
@@ -2873,7 +2307,7 @@ def main():
                 max_error_ratio=0.01,
             ),
             "x_attn_active": ratio_reldiff(
-                diff_thd=4e-3, pct_thd=0.008, max_diff_hd=2
+                diff_thd=4e-3, pct_thd=0.008, max_diff_hd=2,
             ),
             "x_moe_next": ratio_reldiff(
                 diff_thd=0.01,
@@ -2895,7 +2329,7 @@ def main():
         compile_cfg=dict(
             dump_passes=args.dump_passes,
             distributed_config=DistributedConfig(
-                device_ids=device_ids, num_sub_workers=0
+                device_ids=device_ids, num_sub_workers=0,
             ),
         ),
         runtime_cfg=dict(

--- a/models/deepseek_v4_flash_dspark/decode_o_proj.py
+++ b/models/deepseek_v4_flash_dspark/decode_o_proj.py
@@ -54,7 +54,6 @@ O_GROUPS = M.o_groups
 HEADS_PER_GROUP = H // O_GROUPS
 O_GROUP_IN = HEADS_PER_GROUP * HEAD_DIM
 LOCAL_T = DECODE_TOKENS // TP_SIZE
-GROUP_T = TP_SIZE * LOCAL_T
 LOCAL_O_GROUPS = O_GROUPS // TP_SIZE
 LOCAL_O_WIDTH = LOCAL_O_GROUPS * O_LORA
 
@@ -147,11 +146,11 @@ def decode_o_proj_tp1(
     proj_a_rows = (t_dim + PROJ_A_ROW_TILE - 1) // PROJ_A_ROW_TILE
 
     # Back-to-back grouped output projection: proj_a[g] -> quant[g] -> proj_b[g]
-    # pipelines per group, because the PER-GROUP amax keeps the quant reduction
-    # inside one O_LORA group instead of barriering the whole row. manual_scope
-    # suppresses auto-dep, so every edge is explicit: proj_a waits on merge_norm,
-    # quant[g] on proj_a[g], proj_b[g] on quant[g]. proj_b_act combines the group
-    # partials with their row scales and is the consolidated attn_out writer.
+    # pipelines per group; the per-group amax keeps the quant reduction inside one
+    # O_LORA group. manual_scope suppresses auto-dep, so every edge is explicit:
+    # proj_a waits on heads_dep, quant[g] on proj_a[g], proj_b[g] on quant[g].
+    # proj_b_act combines the group partials with their row scales and is the
+    # consolidated attn_out writer.
     o_r_pad = pl.create_tensor([T_PAD, O_GROUPS * O_LORA], dtype=pl.FP32)
     o_r_i8_pad = pl.create_tensor([T_PAD, O_GROUPS * O_LORA], dtype=pl.INT8)
     act_scale_dq = pl.create_tensor([O_GROUPS, T_PAD], dtype=pl.FP32)
@@ -264,74 +263,6 @@ def decode_o_proj_tp1(
 
 
 @pl.jit.inline
-def tp_group_barrier(
-    signal: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
-    group_base: pl.Scalar[pl.INT32],
-    tp_rank: pl.Scalar[pl.INT32],
-    expected: pl.Scalar[pl.INT32],
-):
-    """Synchronize one contiguous physical TP group."""
-    for peer_tp in pl.range(TP_SIZE):
-        if peer_tp != tp_rank:
-            pld.system.notify(
-                target=signal, peer=group_base + peer_tp,
-                offsets=[tp_rank, 0], value=1, op=pld.NotifyOp.AtomicAdd,
-            )
-    for source_tp in pl.range(TP_SIZE):
-        if source_tp != tp_rank:
-            pld.system.wait(signal=signal, offsets=[source_tp, 0], expected=expected, cmp=pld.WaitCmp.Ge)
-    return signal
-
-
-@pl.jit.inline
-def reset_tp_group_signal(
-    signal: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
-    group_base: pl.Scalar[pl.INT32],
-    tp_rank: pl.Scalar[pl.INT32],
-):
-    """Clear this rank's peer-credit cells after a collective completes."""
-    reset_value = pl.cast(-2, pl.INT32)
-    self_rank = group_base + tp_rank
-    for source_tp in pl.range(TP_SIZE):
-        if source_tp != tp_rank:
-            pld.system.notify(
-                target=signal, peer=self_rank,
-                offsets=[source_tp, 0], value=reset_value, op=pld.NotifyOp.AtomicAdd,
-            )
-    return signal
-
-
-@pl.jit.incore
-def kv_token_allgather_step(
-    kv_local: pl.Tensor[[LOCAL_T, D], pl.BF16],
-    group_out: pl.InOut[pl.Tensor[[GROUP_T, D], pl.BF16]],
-    gather_window: pld.DistributedTensor[[GROUP_T, D], pl.BF16],
-    gather_signal: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
-    group_base: pl.Scalar[pl.INT32],
-    tp_rank: pl.Scalar[pl.INT32],
-    local_t: pl.Scalar[pl.INT32],
-):
-    """Gather valid rank-major token rows for the replicated KV projections."""
-    group_t = TP_SIZE * local_t
-    target_row = tp_rank * local_t
-    for peer_tp in pl.range(TP_SIZE):
-        pld.tensor.put(
-            dst=gather_window, peer=group_base + peer_tp, src=kv_local,
-            dst_offsets=[target_row, 0], src_offsets=[0, 0], shape=[local_t, D],
-            chunk_rows=COMM_ROW_TILE, chunk_cols=D,
-        )
-
-    expected_one = pl.cast(1, pl.INT32)
-    gather_signal = tp_group_barrier(gather_signal, group_base, tp_rank, expected_one)
-    for group_row in pl.range(group_t):
-        group_out[group_row : group_row + 1, 0:D] = gather_window[group_row : group_row + 1, 0:D]
-    expected_two = pl.cast(2, pl.INT32)
-    gather_signal = tp_group_barrier(gather_signal, group_base, tp_rank, expected_two)
-    gather_signal = reset_tp_group_signal(gather_signal, group_base, tp_rank)
-    return group_out, gather_signal
-
-
-@pl.jit.inline
 def o_group_a2a(
     local_groups_out: pl.Tensor[[ATTENTION_WINDOW_ROWS, O_GROUP_IN], pl.BF16],
     exchange_window: pld.DistributedTensor[[ATTENTION_WINDOW_ROWS, O_GROUP_IN], pl.BF16],
@@ -343,27 +274,14 @@ def o_group_a2a(
     publish_count: pl.Scalar[pl.INT32],
 ):
     """Finish a non-overlapping producer-fused exchange and release its window."""
-    with pl.at(
-        level=pl.Level.CORE_GROUP,
-        name_hint="o_group_a2a_wait",
-        deps=[publish_dep],
-    ) as wait_tid:
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="o_group_a2a_wait", deps=[publish_dep]) as wait_tid:
         expected = pl.cast(publish_count, pl.INT32)
         for source_tp in pl.range(TP_SIZE):
             if source_tp != tp_rank:
-                pld.system.wait(
-                    signal=exchange_signal,
-                    offsets=[source_tp, 0],
-                    expected=expected,
-                    cmp=pld.WaitCmp.Ge,
-                )
+                pld.system.wait(signal=exchange_signal, offsets=[source_tp, 0], expected=expected, cmp=pld.WaitCmp.Ge)
 
     group_t = TP_SIZE * local_t
-    with pl.spmd(
-        ATTENTION_PUBLISH_WORKERS,
-        name_hint="o_group_a2a_gather",
-        deps=[wait_tid],
-    ) as gather_tid:
+    with pl.spmd(ATTENTION_PUBLISH_WORKERS, name_hint="o_group_a2a_gather", deps=[wait_tid]) as gather_tid:
         worker = pl.tile.get_block_idx()
         for local_group in pl.range(LOCAL_O_GROUPS):
             group_base_row = local_group * GROUP_T_PAD
@@ -377,11 +295,7 @@ def o_group_a2a(
                     0:O_GROUP_IN,
                 ]
 
-    with pl.at(
-        level=pl.Level.CORE_GROUP,
-        name_hint="o_group_a2a_complete",
-        deps=[gather_tid],
-    ):
+    with pl.at(level=pl.Level.CORE_GROUP, name_hint="o_group_a2a_complete", deps=[gather_tid]):
         completion_anchor = pl.read(local_groups_out, [0, 0])
         for peer_tp in pl.range(TP_SIZE):
             if peer_tp != tp_rank:
@@ -419,28 +333,17 @@ def o_group_a2a(
 
 
 @pl.jit
-def decode_attention_collectives_fixture(
-    kv_local: pl.Tensor[[LOCAL_T, D], pl.BF16],
+def l2_o_group_a2a(
     attention_grouped: pl.Tensor[[O_GROUPS * LOCAL_T_PAD, O_GROUP_IN], pl.BF16],
-    kv_group: pl.InOut[pl.Tensor[[GROUP_T, D], pl.BF16]],
     attention_local_groups: pl.InOut[pl.Tensor[[LOCAL_O_GROUPS * GROUP_T_PAD, O_GROUP_IN], pl.BF16]],
-    kv_window: pld.DistributedTensor[[GROUP_T, D], pl.BF16],
-    kv_signal: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
     attention_window: pld.DistributedTensor[[ATTENTION_WINDOW_ROWS, O_GROUP_IN], pl.BF16],
     attention_signal: pld.DistributedTensor[[TP_SIZE, 1], pl.INT32],
     group_base: pl.Scalar[pl.INT32],
     tp_rank: pl.Scalar[pl.INT32],
     local_t: pl.Scalar[pl.INT32],
 ):
-    """Apply the decode attention communication transitions on one TP rank."""
-    kv_group, kv_signal = kv_token_allgather_step(
-        kv_local, kv_group, kv_window, kv_signal, group_base, tp_rank, local_t,
-    )
-
-    with pl.spmd(
-        ATTENTION_PUBLISH_WORKERS,
-        name_hint="o_group_a2a_fixture_publish",
-    ) as publish_tid:
+    """Publish one grouped token tile per O-group, then exchange it on one TP rank."""
+    with pl.spmd(ATTENTION_PUBLISH_WORKERS, name_hint="o_group_a2a_fixture_publish") as publish_tid:
         worker = pl.tile.get_block_idx()
         for global_group in pl.range(worker, O_GROUPS, ATTENTION_PUBLISH_WORKERS):
             destination_rank = global_group // LOCAL_O_GROUPS
@@ -478,37 +381,30 @@ def decode_attention_collectives_fixture(
         publish_tid,
         ATTENTION_PUBLISH_WORKERS,
     )
-    return kv_group, attention_local_groups, kv_signal, attention_signal
+    return attention_local_groups, attention_signal
 
 
 @pl.jit.host
-def l3_decode_attention_collectives_fixture(
-    kv_local: pl.Tensor[[TP_SIZE, LOCAL_T, D], pl.BF16],
+def l3_o_group_a2a(
     attention_grouped: pl.Tensor[[TP_SIZE, O_GROUPS * LOCAL_T_PAD, O_GROUP_IN], pl.BF16],
-    kv_group: pl.InOut[pl.Tensor[[TP_SIZE, GROUP_T, D], pl.BF16]],
     attention_local_groups: pl.InOut[pl.Tensor[[TP_SIZE, ATTENTION_WINDOW_ROWS, O_GROUP_IN], pl.BF16]],
     local_t: pl.Scalar[pl.INT32],
 ):
-    """Launch the decode attention communication fixture on one TP group."""
-    kv_window_buf = pld.alloc_window_buffer([GROUP_T, D], dtype=pl.BF16)
-    kv_signal_buf = pld.alloc_window_buffer([TP_SIZE, 1], dtype=pl.INT32)
+    """Launch the grouped attention exchange on one TP group."""
     attention_window_buf = pld.alloc_window_buffer([ATTENTION_WINDOW_ROWS, O_GROUP_IN], dtype=pl.BF16)
     attention_signal_buf = pld.alloc_window_buffer([TP_SIZE, 1], dtype=pl.INT32)
 
     for rank in pl.range(pld.world_size()):
-        kv_window = pld.window(kv_window_buf, [GROUP_T, D], dtype=pl.BF16)
-        kv_signal = pld.window(kv_signal_buf, [TP_SIZE, 1], dtype=pl.INT32)
         attention_window = pld.window(attention_window_buf, [ATTENTION_WINDOW_ROWS, O_GROUP_IN], dtype=pl.BF16)
         attention_signal = pld.window(attention_signal_buf, [TP_SIZE, 1], dtype=pl.INT32)
-        decode_attention_collectives_fixture(
-            kv_local[rank], attention_grouped[rank],
-            kv_group[rank], attention_local_groups[rank],
-            kv_window, kv_signal, attention_window, attention_signal,
+        l2_o_group_a2a(
+            attention_grouped[rank], attention_local_groups[rank],
+            attention_window, attention_signal,
             0, rank, local_t, device=rank,
         )
 
 
-def build_collective_tensor_specs(local_t=FIXTURE_LOCAL_T):
+def build_o_group_a2a_specs(local_t=FIXTURE_LOCAL_T):
     """Build deterministic four-rank inputs with poisoned capacity rows."""
     import torch
 
@@ -516,12 +412,6 @@ def build_collective_tensor_specs(local_t=FIXTURE_LOCAL_T):
 
     if local_t < 1 or local_t > LOCAL_T:
         raise ValueError(f"local_t must be in [1, {LOCAL_T}], got {local_t}")
-
-    def init_kv_local():
-        values = torch.arange(TP_SIZE * LOCAL_T * D, dtype=torch.int32)
-        values = values.remainder(251).reshape(TP_SIZE, LOCAL_T, D).to(torch.bfloat16)
-        values[:, local_t:] = -1000.0
-        return values
 
     def init_attention_grouped():
         shape = (TP_SIZE, O_GROUPS * LOCAL_T_PAD, O_GROUP_IN)
@@ -534,12 +424,7 @@ def build_collective_tensor_specs(local_t=FIXTURE_LOCAL_T):
     attention_grouped_shape = [TP_SIZE, O_GROUPS * LOCAL_T_PAD, O_GROUP_IN]
     attention_local_shape = [TP_SIZE, LOCAL_O_GROUPS * GROUP_T_PAD, O_GROUP_IN]
     return [
-        TensorSpec("kv_local", [TP_SIZE, LOCAL_T, D], torch.bfloat16, init_value=init_kv_local),
         TensorSpec("attention_grouped", attention_grouped_shape, torch.bfloat16, init_value=init_attention_grouped),
-        TensorSpec(
-            "kv_group", [TP_SIZE, GROUP_T, D], torch.bfloat16,
-            init_value=FIXTURE_OUTPUT_SENTINEL, is_output=True,
-        ),
         TensorSpec(
             "attention_local_groups", attention_local_shape, torch.bfloat16,
             init_value=FIXTURE_OUTPUT_SENTINEL, is_output=True,
@@ -548,16 +433,12 @@ def build_collective_tensor_specs(local_t=FIXTURE_LOCAL_T):
     ]
 
 
-def golden_decode_attention_collectives_fixture(tensors):
-    """Assemble the rank-major gather and grouped exchange."""
+def golden_o_group_a2a(tensors):
+    """Assemble the grouped exchange."""
     import torch
 
     local_t = int(tensors["local_t"])
     group_t = TP_SIZE * local_t
-    gathered_kv = tensors["kv_local"][:, :local_t].reshape(group_t, D)
-    tensors["kv_group"].fill_(FIXTURE_OUTPUT_SENTINEL)
-    tensors["kv_group"][:, :group_t] = gathered_kv.unsqueeze(0)
-
     grouped = tensors["attention_grouped"].reshape(TP_SIZE, O_GROUPS, LOCAL_T_PAD, O_GROUP_IN)
     exchanged = torch.full_like(tensors["attention_local_groups"], FIXTURE_OUTPUT_SENTINEL)
     for destination_rank in range(TP_SIZE):
@@ -570,7 +451,7 @@ def golden_decode_attention_collectives_fixture(tensors):
 
 
 @pl.jit.inline
-def decode_sharded_o_projection_reduce_scatter(
+def o_proj_reduce_scatter(
     attention_local_groups: pl.Tensor[[LOCAL_O_GROUPS, GROUP_T_PAD, O_GROUP_IN], pl.BF16],
     wo_a: pl.Tensor[[LOCAL_O_GROUPS, O_LORA, O_GROUP_IN], pl.BF16],
     wo_b: pl.Tensor[[D, LOCAL_O_WIDTH], pl.INT8],
@@ -609,25 +490,12 @@ def decode_sharded_o_projection_reduce_scatter(
             a_rows = pl.min(O_A_T_TILE, group_t - t0)
             src_row = attention_row + t0
             weight_row = o_a_col + n0
-            o_a_x0 = pl.slice(
-                attn_2d,
-                [O_A_T_TILE, O_A_K_TILE],
-                [src_row, 0],
-                valid_shape=[a_rows, O_A_K_TILE],
-            )
+            o_a_x0 = pl.slice(attn_2d, [O_A_T_TILE, O_A_K_TILE], [src_row, 0], valid_shape=[a_rows, O_A_K_TILE])
             o_a_w0 = wo_a_flat[weight_row : weight_row + O_A_N_TILE, 0:O_A_K_TILE]
             o_a_acc = pl.matmul(o_a_x0, o_a_w0, b_trans=True, out_dtype=pl.FP32)
             for k0 in pl.pipeline(O_A_K_TILE, O_GROUP_IN, O_A_K_TILE, stage=2):
-                o_a_xk = pl.slice(
-                    attn_2d,
-                    [O_A_T_TILE, O_A_K_TILE],
-                    [src_row, k0],
-                    valid_shape=[a_rows, O_A_K_TILE],
-                )
-                o_a_wk = wo_a_flat[
-                    weight_row : weight_row + O_A_N_TILE,
-                    k0 : k0 + O_A_K_TILE,
-                ]
+                o_a_xk = pl.slice(attn_2d, [O_A_T_TILE, O_A_K_TILE], [src_row, k0], valid_shape=[a_rows, O_A_K_TILE])
+                o_a_wk = wo_a_flat[weight_row : weight_row + O_A_N_TILE, k0 : k0 + O_A_K_TILE]
                 o_a_acc = pl.matmul_acc(o_a_acc, o_a_xk, o_a_wk, b_trans=True)
             o_a_valid = pl.set_validshape(o_a_acc, a_rows, O_A_N_TILE)
             o_a_fp32[t0 : t0 + O_A_T_TILE, weight_row : weight_row + O_A_N_TILE] = o_a_valid
@@ -635,12 +503,7 @@ def decode_sharded_o_projection_reduce_scatter(
         with pl.at(level=pl.Level.CORE_GROUP, name_hint="tp_o_a_quant", deps=[proj_a_tid]) as quant_tid:
             for qt in pl.pipeline(0, group_t, QUANT_T_TILE, stage=2):
                 quant_rows = pl.min(QUANT_T_TILE, group_t - qt)
-                o_a_tile = pl.slice(
-                    o_a_fp32,
-                    [QUANT_T_TILE, O_LORA],
-                    [qt, o_a_col],
-                    valid_shape=[quant_rows, O_LORA],
-                )
+                o_a_tile = pl.slice(o_a_fp32, [QUANT_T_TILE, O_LORA], [qt, o_a_col], valid_shape=[quant_rows, O_LORA])
                 o_a_abs = pl.abs(o_a_tile)
                 row_amax = pl.reshape(pl.row_max(o_a_abs), [1, QUANT_T_TILE])
                 amax_floor = pl.full([1, QUANT_T_TILE], dtype=pl.FP32, value=INT8_AMAX_EPS)
@@ -683,10 +546,7 @@ def decode_sharded_o_projection_reduce_scatter(
                 o_b_i32[t0 : t0 + O_B_T_TILE, partial_col : partial_col + O_B_N_TILE] = o_b_acc
         proj_b_tids[local_group] = proj_b_tid
 
-    publish_stage = pl.create_tensor(
-        [O_RS_PUBLISH_WORKERS * ACT_T_TILE, ACT_N_TILE],
-        dtype=pl.FP32,
-    )
+    publish_stage = pl.create_tensor([O_RS_PUBLISH_WORKERS * ACT_T_TILE, ACT_N_TILE], dtype=pl.FP32)
     with pl.spmd(
         O_RS_PUBLISH_WORKERS,
         name_hint="tp_o_b_dequant_publish",
@@ -713,12 +573,7 @@ def decode_sharded_o_projection_reduce_scatter(
                         valid_shape=[out_rows, ACT_N_TILE],
                     )
                     group_partial_fp32 = pl.cast(group_i32, target_type=pl.FP32, mode="none")
-                    scale_row = pl.slice(
-                        act_scale_dq,
-                        [1, ACT_T_TILE],
-                        [local_group, t0],
-                        valid_shape=[1, out_rows],
-                    )
+                    scale_row = pl.slice(act_scale_dq, [1, ACT_T_TILE], [local_group, t0], valid_shape=[1, out_rows])
                     scale_col = pl.reshape(scale_row, [ACT_T_TILE, 1])
                     group_dequant = pl.row_expand_mul(group_partial_fp32, scale_col)
                     dequant_acc = pl.add(dequant_acc, group_dequant)
@@ -726,10 +581,7 @@ def decode_sharded_o_projection_reduce_scatter(
                 o_b_fp32 = pl.col_expand_mul(dequant_acc, weight_scale)
                 publish_value = pl.set_validshape(o_b_fp32, out_rows, ACT_N_TILE)
                 stage_row = worker * ACT_T_TILE
-                publish_stage[
-                    stage_row : stage_row + ACT_T_TILE,
-                    0:ACT_N_TILE,
-                ] = publish_value
+                publish_stage[stage_row : stage_row + ACT_T_TILE, 0:ACT_N_TILE] = publish_value
                 target_row = tp_rank * LOCAL_T_PAD + owner_row
                 pld.tensor.put(
                     dst=reduce_window,
@@ -756,12 +608,7 @@ def decode_sharded_o_projection_reduce_scatter(
         expected = pl.cast(O_RS_PUBLISH_WORKERS, pl.INT32)
         for source_tp in pl.range(TP_SIZE):
             if source_tp != tp_rank:
-                pld.system.wait(
-                    signal=reduce_signal,
-                    offsets=[source_tp, 0],
-                    expected=expected,
-                    cmp=pld.WaitCmp.Ge,
-                )
+                pld.system.wait(signal=reduce_signal, offsets=[source_tp, 0], expected=expected, cmp=pld.WaitCmp.Ge)
 
     with pl.spmd(O_RS_REDUCE_WORKERS, name_hint="tp_o_rs_reduce", deps=[wait_tid]) as reduce_tid:
         worker = pl.tile.get_block_idx()
@@ -864,14 +711,14 @@ if __name__ == "__main__":
     if len(device_ids) != TP_SIZE:
         parser.error(f"need exactly {TP_SIZE} devices, got {device_ids}")
 
-    collective_local_t = FIXTURE_LOCAL_T if args.local_t is None else args.local_t
-    if not 1 <= collective_local_t <= LOCAL_T:
-        parser.error(f"--local-t must be in [1, {LOCAL_T}], got {collective_local_t}")
+    a2a_local_t = FIXTURE_LOCAL_T if args.local_t is None else args.local_t
+    if not 1 <= a2a_local_t <= LOCAL_T:
+        parser.error(f"--local-t must be in [1, {LOCAL_T}], got {a2a_local_t}")
 
     result = run_jit(
-        fn=l3_decode_attention_collectives_fixture,
-        specs=build_collective_tensor_specs(collective_local_t),
-        golden_fn=golden_decode_attention_collectives_fixture,
+        fn=l3_o_group_a2a,
+        specs=build_o_group_a2a_specs(a2a_local_t),
+        golden_fn=golden_o_group_a2a,
         compile_only=args.compile_only,
         runtime_dir=args.runtime_dir,
         compile_cfg=dict(

--- a/models/deepseek_v4_flash_dspark/decode_sparse_attn_csa.py
+++ b/models/deepseek_v4_flash_dspark/decode_sparse_attn_csa.py
@@ -14,7 +14,6 @@ masking folded in. The SWA and HCA variants live in sibling modules.
 
 
 import pypto.language as pl
-import pypto.language.distributed as pld
 
 from config import (
     FLASH as M,
@@ -103,7 +102,7 @@ if T % ATTENTION_PUBLISH_T_TILE != 0:
 
 
 @pl.jit.inline(auto_scope=False)
-def _compute_csa_attention_intermediates(
+def sparse_attn_csa(
     q: pl.Tensor[[T_DYN, H, HEAD_DIM], pl.BF16],
     ori_kv: pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     window_swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
@@ -115,7 +114,7 @@ def _compute_csa_attention_intermediates(
     freqs_sin: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
     cache_ready_dep: pl.Scalar[pl.TASK_ID],
 ):
-    """Compute CSA sparse-block states and inverse-RoPE metadata."""
+    """Plan and run CSA QK/PV over sparse blocks, and build inverse-RoPE metadata."""
     # Compressed index contract: -1 invalid, [0, ...) compressed KV slots.
     ori_block_num = pl.tensor.dim(ori_kv, 0)
     t_dim = pl.tensor.dim(q, 0)
@@ -170,10 +169,9 @@ def _compute_csa_attention_intermediates(
             # Additive softmax bias (0 valid / NEG_INF invalid) that qk_pv adds onto the
             # scaled scores, so invalid lanes exp to ~0 with no per-block mask multiply.
             v_win_f = pl.cast(window_swa_indices[bias_t0 : bias_t0 + BIAS_T_TILE, 0:WIN], target_type=pl.FP32)
-            # Index contract (line 138): raw == -1 invalid, raw >= 0 valid. min(idx, 0)
-            # is -1 for invalid / 0 for valid; * -NEG_INF gives NEG_INF / 0. Bit-exact,
-            # 2 vector ops instead of the add/max/min/sub clamp chain. c_out is the just-
-            # computed post-mask compressed slots (integer-valued), reused directly.
+            # Index contract: raw == -1 invalid, raw >= 0 valid. min(idx, 0) is -1 for
+            # invalid / 0 for valid; * -NEG_INF gives NEG_INF / 0. c_out is the
+            # post-mask compressed slots (integer-valued), reused directly.
             v_win_valid = pl.minimum(pl.maximum(pl.add(v_win_f, 1.0), 0.0), 1.0)
             sparse_bias[bias_t0 : bias_t0 + BIAS_T_TILE, 0:WIN] = pl.mul(pl.sub(v_win_valid, 1.0), -NEG_INF)
             sparse_bias[bias_t0 : bias_t0 + BIAS_T_TILE, WIN:TOPK] = pl.mul(pl.minimum(c_out, 0.0), -NEG_INF)
@@ -277,13 +275,9 @@ def _compute_csa_attention_intermediates(
                     else:
                         qk_kv = pl.gather_row(qk_kv, ori_kv_flat, [qk_r, 0], [0, 0], [1, HEAD_DIM])
 
-                # Cube-batch QK_M_TILE head rows per QK/PV matmul so the shared KV
-                # tile is extracted L1->L0 once per QK_M_TILE/H_TILE head-tiles
-                # (2x reuse at QK_M_TILE=32) instead of per head-tile. The
-                # [QK_M_TILE, ...] softmax result is sliced back into H_TILE-row
-                # stores at the SAME offsets as the per-head-tile path
-                # (qk_h_idx == qk_hb * (QK_M_TILE // H_TILE) + qk_sub), so the
-                # sparse_blk_* layout and merge_norm are bit-identical.
+                # Cube-batch QK_M_TILE head rows per QK/PV matmul. The [QK_M_TILE, ...]
+                # softmax result slices back into H_TILE-row stores at the same offsets
+                # as the per-head-tile path (qk_h_idx == qk_hb * (QK_M_TILE // H_TILE) + qk_sub).
                 for qk_hb in pl.pipeline(H // QK_M_TILE, stage=2):
                     qk_h0 = qk_hb * QK_M_TILE
                     qk_head_row = qk_t * H + qk_h0
@@ -363,152 +357,8 @@ def _compute_csa_attention_intermediates(
     )
 
 
-@pl.jit.inline(auto_scope=False)
-def publish_csa_o_groups(
-    q: pl.Tensor[[T_DYN, H, HEAD_DIM], pl.BF16],
-    ori_kv: pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
-    window_swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
-    cmp_kv: pl.Tensor[[CMP_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
-    cmp_block_table: pl.Tensor[[B_DYN, CMP_MAX_BLOCKS], pl.INT32],
-    idx_topk: pl.Tensor[[T_DYN, IDX_TOPK], pl.INT32],
-    position_ids: pl.Tensor[[T_DYN, 1], pl.INT32],
-    attn_sink: pl.Tensor[[H], pl.FP32],
-    freqs_cos: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
-    freqs_sin: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
-    attention_grouped: pl.Tensor[[O_GROUPS * T_PAD, O_GROUP_IN], pl.BF16],
-    exchange_window: pld.DistributedTensor[[ATTENTION_WINDOW_ROWS, O_GROUP_IN], pl.BF16],
-    exchange_signal: pld.DistributedTensor[[TP, 1], pl.INT32],
-    group_base: pl.Scalar[pl.INT32],
-    tp_rank: pl.Scalar[pl.INT32],
-    local_t: pl.Scalar[pl.INT32],
-    cache_ready_dep: pl.Scalar[pl.TASK_ID],
-):
-    """Merge CSA heads and publish completed O-group token tiles."""
-    (
-        sparse_blk_mi,
-        sparse_blk_li,
-        sparse_blk_oi,
-        rope_cos_il,
-        rope_sin_signed,
-        rope_swap_idx,
-        qk_tid,
-        rope_tid,
-    ) = _compute_csa_attention_intermediates(
-        q,
-        ori_kv,
-        window_swa_indices,
-        cmp_kv,
-        cmp_block_table,
-        idx_topk,
-        position_ids,
-        freqs_cos,
-        freqs_sin,
-        cache_ready_dep,
-    )
-    t_dim = pl.tensor.dim(q, 0)
-    pack_work_count = (t_dim // ATTENTION_PUBLISH_T_TILE) * (H // H_TILE)
-
-    with pl.spmd(
-        ATTENTION_PUBLISH_WORKERS,
-        name_hint="csa_merge_pack_publish",
-        deps=[qk_tid, rope_tid],
-    ) as publish_tid:
-        worker = pl.tile.get_block_idx()
-        for pack_work in pl.range(worker, pack_work_count, ATTENTION_PUBLISH_WORKERS):
-            token_block = pack_work // (H // H_TILE)
-            m_h_idx = pack_work - token_block * (H // H_TILE)
-            m_t0 = token_block * ATTENTION_PUBLISH_T_TILE
-            m_h0 = m_h_idx * H_TILE
-            global_group0 = m_h0 // HEADS_PER_GROUP
-            destination_rank = global_group0 // LOCAL_O_GROUPS
-            local_group0 = global_group0 - destination_rank * LOCAL_O_GROUPS
-
-            for m_dt in pl.range(ATTENTION_PUBLISH_T_TILE):
-                m_t = m_t0 + m_dt
-                m_idx = m_t * (H // H_TILE) + m_h_idx
-                m_blk_base = m_idx * SPARSE_BLOCKS * H_TILE
-                m_mi = sparse_blk_mi[m_blk_base : m_blk_base + H_TILE, 0:1]
-                m_li = sparse_blk_li[m_blk_base : m_blk_base + H_TILE, 0:1]
-                m_oi = sparse_blk_oi[m_blk_base : m_blk_base + H_TILE, 0:HEAD_DIM]
-
-                for m_sb in pl.pipeline(1, SPARSE_BLOCKS, stage=2):
-                    m_row = m_blk_base + m_sb * H_TILE
-                    m_cur_mi = sparse_blk_mi[m_row : m_row + H_TILE, 0:1]
-                    m_cur_li = sparse_blk_li[m_row : m_row + H_TILE, 0:1]
-                    m_cur_oi = sparse_blk_oi[m_row : m_row + H_TILE, 0:HEAD_DIM]
-                    m_mi_new = pl.maximum(m_mi, m_cur_mi)
-                    m_alpha = pl.exp(pl.sub(m_mi, m_mi_new))
-                    m_beta = pl.exp(pl.sub(m_cur_mi, m_mi_new))
-                    m_li = pl.add(pl.mul(m_alpha, m_li), pl.mul(m_beta, m_cur_li))
-                    m_oi = pl.add(
-                        pl.row_expand_mul(m_oi, m_alpha),
-                        pl.row_expand_mul(m_cur_oi, m_beta),
-                    )
-                    m_mi = m_mi_new
-
-                n_sink_bias = pl.reshape(attn_sink[m_h0 : m_h0 + H_TILE], [H_TILE, 1])
-                n_sink_tile = pl.add(pl.sub(m_mi, m_mi), n_sink_bias)
-                n_denom = pl.add(m_li, pl.exp(pl.sub(n_sink_tile, m_mi)))
-                n_full = pl.row_expand_div(m_oi, n_denom)[0:H_TILE, 0:HEAD_DIM]
-                n_bf16 = pl.cast(n_full, target_type=pl.BF16, mode="rint")
-
-                m_rope = n_full[0:H_TILE, NOPE_DIM:HEAD_DIM]
-                m_cos_il = rope_cos_il[m_t : m_t + 1, 0:ROPE_DIM]
-                m_sin_signed = rope_sin_signed[m_t : m_t + 1, 0:ROPE_DIM]
-                m_swapped = pl.gather(
-                    m_rope,
-                    dim=-1,
-                    index=rope_swap_idx[0:H_TILE, 0:ROPE_DIM],
-                )
-                m_rot = pl.add(
-                    pl.col_expand_mul(m_rope, m_cos_il),
-                    pl.col_expand_mul(m_swapped, m_sin_signed),
-                )
-                n_rope_bf16 = pl.cast(m_rot, target_type=pl.BF16, mode="rint")
-                n_full_bf16 = pl.concat(n_bf16[:, 0:NOPE_DIM], n_rope_bf16)
-
-                for n_hi in pl.unroll(H_TILE):
-                    n_head = m_h0 + n_hi
-                    source_row = (n_head // HEADS_PER_GROUP) * T_PAD + m_t
-                    source_col = (n_head % HEADS_PER_GROUP) * HEAD_DIM
-                    attention_grouped[
-                        source_row : source_row + 1,
-                        source_col : source_col + HEAD_DIM,
-                    ] = n_full_bf16[n_hi : n_hi + 1, 0:HEAD_DIM]
-
-            for group_slot in pl.unroll(PUBLISH_GROUPS):
-                source_row = (global_group0 + group_slot) * T_PAD + m_t0
-                target_row = (
-                    (local_group0 + group_slot) * GROUP_T_PAD
-                    + tp_rank * local_t
-                    + m_t0
-                )
-                pld.tensor.put(
-                    dst=exchange_window,
-                    peer=group_base + destination_rank,
-                    src=attention_grouped,
-                    dst_offsets=[target_row, 0],
-                    src_offsets=[source_row, 0],
-                    shape=[ATTENTION_PUBLISH_T_TILE, O_GROUP_IN],
-                    chunk_rows=ATTENTION_PUBLISH_T_TILE,
-                    chunk_cols=O_GROUP_IN,
-                )
-
-        for destination_rank in pl.range(TP):
-            if destination_rank != tp_rank:
-                pld.system.notify(
-                    target=exchange_signal,
-                    peer=group_base + destination_rank,
-                    offsets=[tp_rank, 0],
-                    value=1,
-                    op=pld.NotifyOp.AtomicAdd,
-                )
-
-    return exchange_signal, publish_tid
-
-
 @pl.jit.inline
-def sparse_attn_csa(
+def sparse_attn_csa_tp1(
     q: pl.Tensor[[T_DYN, H, HEAD_DIM], pl.BF16],
     ori_kv: pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     window_swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
@@ -528,15 +378,10 @@ def sparse_attn_csa(
     returned task ID covers every write to the packed output tensor.
     """
     (
-        sparse_blk_mi,
-        sparse_blk_li,
-        sparse_blk_oi,
-        rope_cos_il,
-        rope_sin_signed,
-        rope_swap_idx,
-        qk_tid,
-        rope_tid,
-    ) = _compute_csa_attention_intermediates(
+        sparse_blk_mi, sparse_blk_li, sparse_blk_oi,
+        rope_cos_il, rope_sin_signed, rope_swap_idx,
+        qk_tid, rope_tid,
+    ) = sparse_attn_csa(
         q,
         ori_kv,
         window_swa_indices,
@@ -550,11 +395,7 @@ def sparse_attn_csa(
     )
     t_dim = pl.tensor.dim(q, 0)
 
-    with pl.spmd(
-        t_dim * (H // H_TILE),
-        name_hint="merge_norm",
-        deps=[qk_tid, rope_tid],
-    ) as merge_tid:
+    with pl.spmd(t_dim * (H // H_TILE), name_hint="merge_norm", deps=[qk_tid, rope_tid]) as merge_tid:
         m_idx = pl.tile.get_block_idx()
         m_t = m_idx // (H // H_TILE)
         m_h_idx = m_idx - m_t * (H // H_TILE)
@@ -582,11 +423,8 @@ def sparse_attn_csa(
         n_full = pl.row_expand_div(m_oi, n_denom)[0 : H_TILE, 0 : HEAD_DIM]
         n_bf16 = pl.cast(n_full, target_type=pl.BF16, mode="rint")
 
-        # Inverse RoPE on this head-tile's fp32 rope segment. cos_il / sign*sin are
-        # head-invariant for token m_t, so col_expand them over the H_TILE head rows;
-        # rope_swap_idx (j^1, prebuilt above) pairs the interleaved real/imag lanes.
-        # Rounded to bf16 (golden also rounds inverse-RoPE to bf16) and packed into
-        # the group-major output.
+        # Inverse RoPE on this head-tile's fp32 rope segment: cos_il / sign*sin are
+        # head-invariant per token, rope_swap_idx (j^1) pairs the interleaved real/imag lanes.
         m_rope = n_full[0 : H_TILE, NOPE_DIM : HEAD_DIM]
         m_cos_il = rope_cos_il[m_t : m_t + 1, 0 : ROPE_DIM]
         m_sin_signed = rope_sin_signed[m_t : m_t + 1, 0 : ROPE_DIM]
@@ -598,8 +436,7 @@ def sparse_attn_csa(
         for n_hi in pl.unroll(H_TILE):
             n_pack_row = ((m_h0 + n_hi) // HEADS_PER_GROUP) * T_PAD + m_t
             n_col = ((m_h0 + n_hi) % HEADS_PER_GROUP) * HEAD_DIM
-            # one HEAD_DIM-wide store per head row instead of two: concat the nope and
-            # inverse-RoPE halves on chip so o_packed_heads takes a single contiguous write.
+            # One HEAD_DIM-wide store per head row: nope and inverse-RoPE halves concat on chip.
             o_packed_heads[n_pack_row : n_pack_row + 1, n_col : n_col + HEAD_DIM] = n_full_bf16[n_hi : n_hi + 1, :]
 
     return o_packed_heads, merge_tid
@@ -629,7 +466,7 @@ def sparse_attn_csa_test(
 
     cache_ready_dep = pl.system.task_dummy(deps=[])
     o_packed_flat = pl.reshape(o_packed_heads, [O_GROUPS * T_PAD, O_GROUP_IN])
-    o_packed_flat, _ = sparse_attn_csa(
+    o_packed_flat, _ = sparse_attn_csa_tp1(
         q,
         ori_kv, window_swa_indices,
         cmp_kv, cmp_block_table, idx_topk,
@@ -792,11 +629,7 @@ def build_tensor_specs(
         max_seq_len=MAX_SEQ_LEN,
         dtype=torch.bfloat16,
     )
-    shared_window_block_table = block_table(
-        batch=batch,
-        table_blocks=ORI_MAX_BLOCKS,
-        physical_blocks=ORI_BLOCK_NUM,
-    )
+    shared_window_block_table = block_table(batch=batch, table_blocks=ORI_MAX_BLOCKS, physical_blocks=ORI_BLOCK_NUM)
     shared_swa_indices = swa_indices_and_lens(
         positions,
         shared_window_block_table,
@@ -940,19 +773,13 @@ if __name__ == "__main__":
     start_pos = None
     if args.start_pos is not None:
         try:
-            start_values = [
-                int(value.strip())
-                for value in args.start_pos.split(",")
-                if value.strip() != ""
-            ]
+            start_values = [int(value.strip()) for value in args.start_pos.split(",") if value.strip() != ""]
         except ValueError:
             parser.error(f"--start-pos must contain integers, got {args.start_pos!r}")
         if not start_values:
             parser.error("--start-pos must contain at least one integer")
         if len(start_values) not in (1, args.batch):
-            parser.error(
-                f"--start-pos needs 1 or {args.batch} values, got {len(start_values)}"
-            )
+            parser.error(f"--start-pos needs 1 or {args.batch} values, got {len(start_values)}")
         start_pos = start_values[0] if len(start_values) == 1 else start_values
 
     print(f"compress_ratio={COMPRESS_RATIO} -> TOPK={TOPK} SPARSE_BLOCKS={SPARSE_BLOCKS} PADDED_TOPK={PADDED_TOPK}", flush=True)

--- a/models/deepseek_v4_flash_dspark/decode_sparse_attn_hca.py
+++ b/models/deepseek_v4_flash_dspark/decode_sparse_attn_hca.py
@@ -10,7 +10,6 @@
 
 
 import pypto.language as pl
-import pypto.language.distributed as pld
 
 from config import (
     FLASH as M,
@@ -106,7 +105,7 @@ if T % ATTENTION_PUBLISH_T_TILE != 0:
 
 
 @pl.jit.inline(auto_scope=False)
-def _compute_hca_attention_intermediates(
+def sparse_attn_hca(
     q: pl.Tensor[[T_DYN, H, HEAD_DIM], pl.BF16],
     ori_kv: pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     window_swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
@@ -119,7 +118,7 @@ def _compute_hca_attention_intermediates(
     freqs_sin: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
     cache_ready_dep: pl.Scalar[pl.TASK_ID],
 ):
-    """Compute normalized HCA stream heads and inverse-RoPE metadata."""
+    """Run the raw and compressed branches, merge them, and build inverse-RoPE metadata."""
     t_dim = pl.tensor.dim(q, 0)
     rope_cs_blocks = t_dim // ROPE_CS_T_TILE
     ori_block_num = pl.tensor.dim(ori_kv, 0)
@@ -154,16 +153,9 @@ def _compute_hca_attention_intermediates(
 
     with pl.scope():
         raw_kv = pl.create_tensor([t_dim * WIN, HEAD_DIM], dtype=pl.BF16)
-        raw_kv_t = pl.create_tensor(
-            [raw_tile_count * HEAD_DIM, RAW_K_TILE],
-            dtype=pl.BF16,
-        )
+        raw_kv_t = pl.create_tensor([raw_tile_count * HEAD_DIM, RAW_K_TILE], dtype=pl.BF16)
         raw_valid = pl.create_tensor([t_dim, WIN], dtype=pl.FP32)
-        with pl.spmd(
-            raw_gather_count,
-            name_hint="hca_gather_kv",
-            deps=[cache_ready_dep],
-        ) as raw_gather_tid:
+        with pl.spmd(raw_gather_count, name_hint="hca_gather_kv", deps=[cache_ready_dep]) as raw_gather_tid:
             g_task = pl.tile.get_block_idx()
             g_t = g_task // GATHER_SEGMENTS
             g_seg = g_task - g_t * GATHER_SEGMENTS
@@ -176,10 +168,7 @@ def _compute_hca_attention_intermediates(
                 g_run_matches = pl.cast(g_first >= 0, pl.INT32)
                 for g_dr in pl.unroll(GATHER_RUN_TILE):
                     g_slot_i32 = pl.read(window_swa_indices, [g_t, g_sk0 + g_dr])
-                    g_run_matches = g_run_matches * pl.cast(
-                        g_slot_i32 == g_first + g_dr,
-                        pl.INT32,
-                    )
+                    g_run_matches = g_run_matches * pl.cast(g_slot_i32 == g_first + g_dr, pl.INT32)
                 if g_run_matches == 1:
                     g_run_src = pl.cast(g_first, pl.INDEX)
                     raw_kv[
@@ -198,24 +187,13 @@ def _compute_hca_attention_intermediates(
                         g_slot_i32 = pl.read(window_swa_indices, [g_t, g_lane])
                         if g_slot_i32 >= 0:
                             g_slot = pl.cast(g_slot_i32, pl.INDEX)
-                            raw_kv[g_dst : g_dst + 1, 0:HEAD_DIM] = ori_kv_flat[
-                                g_slot : g_slot + 1,
-                                0:HEAD_DIM,
-                            ]
+                            raw_kv[g_dst : g_dst + 1, 0:HEAD_DIM] = ori_kv_flat[g_slot : g_slot + 1, 0:HEAD_DIM]
                             pl.write(raw_valid, [g_t, g_lane], 1.0)
                         else:
-                            raw_kv[g_dst : g_dst + 1, 0:HEAD_DIM] = pl.full(
-                                [1, HEAD_DIM],
-                                dtype=pl.BF16,
-                                value=0.0,
-                            )
+                            raw_kv[g_dst : g_dst + 1, 0:HEAD_DIM] = pl.full([1, HEAD_DIM], dtype=pl.BF16, value=0.0)
                             pl.write(raw_valid, [g_t, g_lane], 0.0)
 
-        with pl.spmd(
-            raw_tile_count,
-            name_hint="hca_raw_transpose",
-            deps=[raw_gather_tid],
-        ) as raw_transpose_tid:
+        with pl.spmd(raw_tile_count, name_hint="hca_raw_transpose", deps=[raw_gather_tid]) as raw_transpose_tid:
             raw_tile = pl.tile.get_block_idx()
             raw_row = raw_tile * RAW_K_TILE
             raw_t_row = raw_tile * HEAD_DIM
@@ -241,28 +219,14 @@ def _compute_hca_attention_intermediates(
             sw_next = pl.add(sw_col, 1.0)
             sw_lane_offset = pl.mul(sw_lane, 2.0)
             sw_swap = pl.sub(sw_next, sw_lane_offset)
-            rope_swap_idx[
-                sw_block : sw_block + 1,
-                0:ROPE_DIM,
-            ] = pl.cast(sw_swap, target_type=pl.INT32)
+            rope_swap_idx[sw_block : sw_block + 1, 0:ROPE_DIM] = pl.cast(sw_swap, target_type=pl.INT32)
 
-        with pl.spmd(
-            HALF_ROPE // ROPE_TILE,
-            name_hint="rope_cs",
-        ) as rope_cs_tid:
+        with pl.spmd(HALF_ROPE // ROPE_TILE, name_hint="rope_cs") as rope_cs_tid:
             cp = pl.tile.get_block_idx()
             cp_r0 = cp * ROPE_TILE
             cp_c0 = 2 * cp_r0
-            cs_one = pl.full(
-                [ROPE_CS_T_TILE, ROPE_INTERLEAVE_TILE],
-                dtype=pl.FP32,
-                value=1.0,
-            )
-            cs_index_i32 = pl.arange(
-                0,
-                [1, ROPE_INTERLEAVE_TILE],
-                dtype=pl.INT32,
-            )
+            cs_one = pl.full([ROPE_CS_T_TILE, ROPE_INTERLEAVE_TILE], dtype=pl.FP32, value=1.0)
+            cs_index_i32 = pl.arange(0, [1, ROPE_INTERLEAVE_TILE], dtype=pl.INT32)
             cs_index = pl.cast(cs_index_i32, target_type=pl.FP32)
             cs_col = pl.col_expand_mul(cs_one, cs_index)
             cs_dup = pl.mul(cs_col, 0.5)
@@ -272,54 +236,25 @@ def _compute_hca_attention_intermediates(
             cs_sign = pl.neg(pl.sub(pl.mul(cs_lane, 2.0), 1.0))
             for cs_rb in pl.range(rope_cs_blocks):
                 cs_t0 = cs_rb * ROPE_CS_T_TILE
-                cs_cos_bf16 = freqs_cos[
-                    cs_t0 : cs_t0 + ROPE_CS_T_TILE,
-                    cp_r0 : cp_r0 + ROPE_TILE,
-                ]
-                cs_sin_bf16 = freqs_sin[
-                    cs_t0 : cs_t0 + ROPE_CS_T_TILE,
-                    cp_r0 : cp_r0 + ROPE_TILE,
-                ]
+                cs_cos_bf16 = freqs_cos[cs_t0 : cs_t0 + ROPE_CS_T_TILE, cp_r0 : cp_r0 + ROPE_TILE]
+                cs_sin_bf16 = freqs_sin[cs_t0 : cs_t0 + ROPE_CS_T_TILE, cp_r0 : cp_r0 + ROPE_TILE]
                 cs_cos = pl.cast(cs_cos_bf16, target_type=pl.FP32)
                 cs_sin = pl.cast(cs_sin_bf16, target_type=pl.FP32)
                 cs_cos_dup = pl.gather(cs_cos, dim=-1, index=cs_dup_idx)
                 cs_sin_dup = pl.gather(cs_sin, dim=-1, index=cs_dup_idx)
                 cs_sin_signed = pl.mul(cs_sin_dup, cs_sign)
-                rope_cos_il[
-                    cs_t0 : cs_t0 + ROPE_CS_T_TILE,
-                    cp_c0 : cp_c0 + ROPE_INTERLEAVE_TILE,
-                ] = cs_cos_dup
-                rope_sin_signed[
-                    cs_t0 : cs_t0 + ROPE_CS_T_TILE,
-                    cp_c0 : cp_c0 + ROPE_INTERLEAVE_TILE,
-                ] = cs_sin_signed
+                rope_cos_il[cs_t0 : cs_t0 + ROPE_CS_T_TILE, cp_c0 : cp_c0 + ROPE_INTERLEAVE_TILE] = cs_cos_dup
+                rope_sin_signed[cs_t0 : cs_t0 + ROPE_CS_T_TILE, cp_c0 : cp_c0 + ROPE_INTERLEAVE_TILE] = cs_sin_signed
 
-        with pl.spmd(
-            stream_block_count,
-            name_hint="hca_raw_attn",
-            deps=[raw_transpose_tid],
-        ) as raw_heads_tid:
+        with pl.spmd(stream_block_count, name_hint="hca_raw_attn", deps=[raw_transpose_tid]) as raw_heads_tid:
             stream_idx = pl.tile.get_block_idx()
             stream_t = stream_idx // (H // H_TILE)
             stream_h_tile = stream_idx - stream_t * (H // H_TILE)
             stream_h0 = stream_h_tile * H_TILE
             stream_state_row = stream_t * H + stream_h0
-            stream_q = pl.load(
-                q_flat,
-                [stream_state_row, 0],
-                [H_TILE, HEAD_DIM],
-                target_memory=pl.MemorySpace.Vec,
-            )
-            stream_row_max_tmp = pl.create_tile(
-                [H_TILE, RAW_K_TILE],
-                dtype=pl.FP32,
-                target_memory=pl.MemorySpace.Vec,
-            )
-            stream_row_sum_tmp = pl.create_tile(
-                [H_TILE, RAW_K_TILE],
-                dtype=pl.FP32,
-                target_memory=pl.MemorySpace.Vec,
-            )
+            stream_q = pl.load(q_flat, [stream_state_row, 0], [H_TILE, HEAD_DIM], target_memory=pl.MemorySpace.Vec)
+            stream_row_max_tmp = pl.create_tile([H_TILE, RAW_K_TILE], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec)
+            stream_row_sum_tmp = pl.create_tile([H_TILE, RAW_K_TILE], dtype=pl.FP32, target_memory=pl.MemorySpace.Vec)
             for stream_raw_item in pl.unroll(WIN // RAW_K_TILE):
                 stream_raw_begin = stream_t * WIN + stream_raw_item * RAW_K_TILE
                 stream_valid_begin = stream_raw_item * RAW_K_TILE
@@ -329,9 +264,7 @@ def _compute_hca_attention_intermediates(
                     [RAW_K_TILE, HEAD_DIM],
                     target_memory=pl.MemorySpace.Vec,
                 )
-                stream_raw_t_begin = (
-                    stream_t * (WIN // RAW_K_TILE) + stream_raw_item
-                ) * HEAD_DIM
+                stream_raw_t_begin = (stream_t * (WIN // RAW_K_TILE) + stream_raw_item) * HEAD_DIM
                 stream_raw_kv_t_left = pl.load(
                     raw_kv_t,
                     [stream_raw_t_begin, 0],
@@ -350,80 +283,32 @@ def _compute_hca_attention_intermediates(
                     [1, RAW_K_TILE],
                     target_memory=pl.MemorySpace.Vec,
                 )
-                stream_raw_valid_zero = pl.tile.full(
-                    [H_TILE, RAW_K_TILE],
-                    dtype=pl.FP32,
-                    value=0.0,
-                )
-                stream_raw_valid = pl.col_expand_add(
-                    stream_raw_valid_zero,
-                    stream_raw_valid_row,
-                )
-                stream_raw_bias = pl.mul(
-                    pl.sub(stream_raw_valid, 1.0),
-                    -NEG_INF,
-                )
-                stream_raw_scores = pl.matmul(
-                    stream_q[:, 0:ATTN_D_TILE],
-                    stream_raw_kv_t_left,
-                    out_dtype=pl.FP32,
-                )
+                stream_raw_valid_zero = pl.tile.full([H_TILE, RAW_K_TILE], dtype=pl.FP32, value=0.0)
+                stream_raw_valid = pl.col_expand_add(stream_raw_valid_zero, stream_raw_valid_row)
+                stream_raw_bias = pl.mul(pl.sub(stream_raw_valid, 1.0), -NEG_INF)
+                stream_raw_scores = pl.matmul(stream_q[:, 0:ATTN_D_TILE], stream_raw_kv_t_left, out_dtype=pl.FP32)
                 stream_raw_scores = pl.matmul_acc(
                     stream_raw_scores,
                     stream_q[:, ATTN_D_TILE:HEAD_DIM],
                     stream_raw_kv_t_right,
                 )
-                stream_raw_scores = pl.add(
-                    pl.mul(stream_raw_scores, SOFTMAX_SCALE),
-                    stream_raw_bias,
-                )
-                stream_raw_mi_col = pl.row_max(
-                    stream_raw_scores,
-                    stream_row_max_tmp,
-                )
-                stream_raw_exp = pl.exp(
-                    pl.row_expand_sub(stream_raw_scores, stream_raw_mi_col)
-                )
+                stream_raw_scores = pl.add(pl.mul(stream_raw_scores, SOFTMAX_SCALE), stream_raw_bias)
+                stream_raw_mi_col = pl.row_max(stream_raw_scores, stream_row_max_tmp)
+                stream_raw_exp = pl.exp(pl.row_expand_sub(stream_raw_scores, stream_raw_mi_col))
                 stream_raw_exp = pl.mul(stream_raw_exp, stream_raw_valid)
-                stream_raw_li_col = pl.row_sum(
-                    stream_raw_exp,
-                    stream_row_sum_tmp,
-                )
-                stream_raw_exp_bf16 = pl.cast(
-                    stream_raw_exp,
-                    target_type=pl.BF16,
-                    mode="rint",
-                )
-                stream_raw_oi_left = pl.matmul(
-                    stream_raw_exp_bf16,
-                    stream_raw_kv[:, 0:ATTN_D_TILE],
-                    out_dtype=pl.FP32,
-                )
+                stream_raw_li_col = pl.row_sum(stream_raw_exp, stream_row_sum_tmp)
+                stream_raw_exp_bf16 = pl.cast(stream_raw_exp, target_type=pl.BF16, mode="rint")
+                stream_raw_oi_left = pl.matmul(stream_raw_exp_bf16, stream_raw_kv[:, 0:ATTN_D_TILE], out_dtype=pl.FP32)
                 stream_raw_oi_right = pl.matmul(
                     stream_raw_exp_bf16,
                     stream_raw_kv[:, ATTN_D_TILE : 2 * ATTN_D_TILE],
                     out_dtype=pl.FP32,
                 )
-                stream_raw_oi = pl.concat(
-                    stream_raw_oi_left,
-                    stream_raw_oi_right,
-                )
+                stream_raw_oi = pl.concat(stream_raw_oi_left, stream_raw_oi_right)
                 if stream_raw_item == 0:
-                    pl.store(
-                        stream_raw_mi_col,
-                        [stream_state_row, 0],
-                        stream_state_m,
-                    )
-                    pl.store(
-                        stream_raw_li_col,
-                        [stream_state_row, 0],
-                        stream_state_l,
-                    )
-                    pl.store(
-                        stream_raw_oi,
-                        [stream_state_row, 0],
-                        stream_heads,
-                    )
+                    pl.store(stream_raw_mi_col, [stream_state_row, 0], stream_state_m)
+                    pl.store(stream_raw_li_col, [stream_state_row, 0], stream_state_l)
+                    pl.store(stream_raw_oi, [stream_state_row, 0], stream_heads)
                 else:
                     stream_m = pl.load(
                         stream_state_m,
@@ -445,47 +330,23 @@ def _compute_hca_attention_intermediates(
                     )
                     stream_m_new = pl.maximum(stream_m, stream_raw_mi_col)
                     stream_alpha = pl.exp(pl.sub(stream_m, stream_m_new))
-                    stream_beta = pl.exp(
-                        pl.sub(stream_raw_mi_col, stream_m_new)
-                    )
-                    stream_l_new = pl.add(
-                        pl.mul(stream_alpha, stream_l),
-                        pl.mul(stream_beta, stream_raw_li_col),
-                    )
+                    stream_beta = pl.exp(pl.sub(stream_raw_mi_col, stream_m_new))
+                    stream_l_new = pl.add(pl.mul(stream_alpha, stream_l), pl.mul(stream_beta, stream_raw_li_col))
                     stream_o_new = pl.add(
                         pl.row_expand_mul(stream_o, stream_alpha),
                         pl.row_expand_mul(stream_raw_oi, stream_beta),
                     )
-                    pl.store(
-                        stream_m_new,
-                        [stream_state_row, 0],
-                        stream_state_m,
-                    )
-                    pl.store(
-                        stream_l_new,
-                        [stream_state_row, 0],
-                        stream_state_l,
-                    )
-                    pl.store(
-                        stream_o_new,
-                        [stream_state_row, 0],
-                        stream_heads,
-                    )
+                    pl.store(stream_m_new, [stream_state_row, 0], stream_state_m)
+                    pl.store(stream_l_new, [stream_state_row, 0], stream_state_l)
+                    pl.store(stream_o_new, [stream_state_row, 0], stream_heads)
 
         raw_branch_tids[0] = raw_heads_tid
         rope_swap_tids[0] = rope_swap_tid
         rope_cs_tids[0] = rope_cs_tid
 
     with pl.scope():
-        cmp_work_kv = pl.create_tensor(
-            [cmp_gather_count * ATTN_K_TILE, HEAD_DIM],
-            dtype=pl.BF16,
-        )
-        with pl.spmd(
-            cmp_gather_count,
-            name_hint="hca_cmp_work_gather",
-            deps=[cache_ready_dep],
-        ) as cmp_gather_tid:
+        cmp_work_kv = pl.create_tensor([cmp_gather_count * ATTN_K_TILE, HEAD_DIM], dtype=pl.BF16)
+        with pl.spmd(cmp_gather_count, name_hint="hca_cmp_work_gather", deps=[cache_ready_dep]) as cmp_gather_tid:
             gather_item = pl.tile.get_block_idx()
             gather_request = gather_item // cmp_work_count
             gather_work = gather_item - gather_request * cmp_work_count
@@ -503,10 +364,7 @@ def _compute_hca_attention_intermediates(
                     value=0.0,
                 )
                 if gather_page_col < cmp_table_blocks:
-                    gather_page_i32 = pl.read(
-                        cmp_block_table,
-                        [gather_request, gather_page_col],
-                    )
+                    gather_page_i32 = pl.read(cmp_block_table, [gather_request, gather_page_col])
                     if gather_page_i32 >= 0:
                         if gather_page_i32 < cmp_block_num:
                             gather_page_id = pl.cast(gather_page_i32, pl.INDEX)
@@ -519,38 +377,18 @@ def _compute_hca_attention_intermediates(
                                 0:HEAD_DIM,
                             ]
 
-        with pl.spmd(
-            cmp_qk_block_count,
-            name_hint="hca_cmp_qk_pv",
-            deps=[cmp_gather_tid],
-        ) as cmp_qk_tid:
+        with pl.spmd(cmp_qk_block_count, name_hint="hca_cmp_qk_pv", deps=[cmp_gather_tid]) as cmp_qk_tid:
             qk_item = pl.tile.get_block_idx()
             qk_t = qk_item // cmp_work_count
             qk_work = qk_item - qk_t * cmp_work_count
             qk_request = qk_t // S
             qk_work_row = qk_work * ATTN_K_TILE
             qk_token_base = qk_t * (H // H_TILE) * cmp_work_count * H_TILE
-            qk_neutral_m = pl.tile.full(
-                [H_TILE, 8],
-                dtype=pl.FP32,
-                value=NEG_INF,
-            )
-            qk_neutral_l = pl.tile.full(
-                [H_TILE, 8],
-                dtype=pl.FP32,
-                value=0.0,
-            )
-            qk_neutral_o = pl.tile.full(
-                [H_TILE, HEAD_DIM],
-                dtype=pl.FP32,
-                value=0.0,
-            )
+            qk_neutral_m = pl.tile.full([H_TILE, 8], dtype=pl.FP32, value=NEG_INF)
+            qk_neutral_l = pl.tile.full([H_TILE, 8], dtype=pl.FP32, value=0.0)
+            qk_neutral_o = pl.tile.full([H_TILE, HEAD_DIM], dtype=pl.FP32, value=0.0)
             for qk_h_idx in pl.unroll(H // H_TILE):
-                qk_row = (
-                    qk_token_base
-                    + qk_h_idx * cmp_work_count * H_TILE
-                    + qk_work * H_TILE
-                )
+                qk_row = (qk_token_base + qk_h_idx * cmp_work_count * H_TILE + qk_work * H_TILE)
                 pl.store(qk_neutral_m, [qk_row, 0], cmp_partial_m)
                 pl.store(qk_neutral_l, [qk_row, 0], cmp_partial_l)
                 pl.store(qk_neutral_o, [qk_row, 0], cmp_partial_o)
@@ -565,32 +403,21 @@ def _compute_hca_attention_intermediates(
                         qk_kv_len = pl.cast(qk_kv_len_i32, pl.INDEX)
                         qk_position_rows = (qk_position + 1) // COMPRESS_RATIO
                         qk_kv_rows = qk_kv_len // COMPRESS_RATIO
-                        qk_rows = pl.min(
-                            HCA_MAX_COMPRESSED_ROWS,
-                            pl.min(qk_position_rows, qk_kv_rows),
-                        )
+                        qk_rows = pl.min(HCA_MAX_COMPRESSED_ROWS, pl.min(qk_position_rows, qk_kv_rows))
 
             if qk_work_row < qk_rows:
                 qk_first_col = qk_work * CMP_PAGES_PER_WORK
-                qk_first_page_i32 = pl.read(
-                    cmp_block_table,
-                    [qk_request, qk_first_col],
-                )
+                qk_first_page_i32 = pl.read(cmp_block_table, [qk_request, qk_first_col])
                 if qk_first_page_i32 >= 0:
                     if qk_first_page_i32 < cmp_block_num:
-                        qk_work_src = (
-                            qk_request * cmp_work_count + qk_work
-                        ) * ATTN_K_TILE
+                        qk_work_src = (qk_request * cmp_work_count + qk_work) * ATTN_K_TILE
                         qk_kv = pl.load(
                             cmp_work_kv,
                             [qk_work_src, 0],
                             [ATTN_K_TILE, HEAD_DIM],
                             target_memory=pl.MemorySpace.Mat,
                         )
-                        qk_valid_rows = pl.min(
-                            ATTN_K_TILE,
-                            qk_rows - qk_work_row,
-                        )
+                        qk_valid_rows = pl.min(ATTN_K_TILE, qk_rows - qk_work_row)
                         qk_kv_t = pl.tile.transpose_view(qk_kv)
                         qk_row_max_tmp = pl.create_tile(
                             [QK_M_TILE, ATTN_K_TILE],
@@ -611,79 +438,26 @@ def _compute_hca_attention_intermediates(
                                 [QK_M_TILE, HEAD_DIM],
                                 target_memory=pl.MemorySpace.Mat,
                             )
-                            qk_scores = pl.matmul(
-                                qk_q,
-                                qk_kv_t,
-                                out_dtype=pl.FP32,
-                            )
+                            qk_scores = pl.matmul(qk_q, qk_kv_t, out_dtype=pl.FP32)
                             qk_scores = pl.mul(qk_scores, SOFTMAX_SCALE)
-                            qk_scores = pl.set_validshape(
-                                qk_scores,
-                                QK_M_TILE,
-                                qk_valid_rows,
-                            )
-                            qk_scores = pl.fillpad(
-                                qk_scores,
-                                pad_value=pl.PadValue.min,
-                            )
+                            qk_scores = pl.set_validshape(qk_scores, QK_M_TILE, qk_valid_rows)
+                            qk_scores = pl.fillpad(qk_scores, pad_value=pl.PadValue.min)
                             qk_mi = pl.row_max(qk_scores, qk_row_max_tmp)
-                            qk_exp = pl.exp(
-                                pl.row_expand_sub(qk_scores, qk_mi)
-                            )
+                            qk_exp = pl.exp(pl.row_expand_sub(qk_scores, qk_mi))
                             qk_li = pl.row_sum(qk_exp, qk_row_sum_tmp)
-                            qk_exp_bf16 = pl.cast(
-                                qk_exp,
-                                target_type=pl.BF16,
-                                mode="rint",
-                            )
-                            qk_oi_left = pl.matmul(
-                                qk_exp_bf16,
-                                qk_kv[:, 0:ATTN_D_TILE],
-                                out_dtype=pl.FP32,
-                            )
-                            qk_oi_right = pl.matmul(
-                                qk_exp_bf16,
-                                qk_kv[:, ATTN_D_TILE:HEAD_DIM],
-                                out_dtype=pl.FP32,
-                            )
+                            qk_exp_bf16 = pl.cast(qk_exp, target_type=pl.BF16, mode="rint")
+                            qk_oi_left = pl.matmul(qk_exp_bf16, qk_kv[:, 0:ATTN_D_TILE], out_dtype=pl.FP32)
+                            qk_oi_right = pl.matmul(qk_exp_bf16, qk_kv[:, ATTN_D_TILE:HEAD_DIM], out_dtype=pl.FP32)
                             qk_oi = pl.concat(qk_oi_left, qk_oi_right)
                             qk_h_idx0 = qk_hb * (QK_M_TILE // H_TILE)
-                            qk_row0 = (
-                                qk_token_base
-                                + qk_h_idx0 * cmp_work_count * H_TILE
-                                + qk_work * H_TILE
-                            )
+                            qk_row0 = (qk_token_base + qk_h_idx0 * cmp_work_count * H_TILE + qk_work * H_TILE)
                             qk_row1 = qk_row0 + cmp_work_count * H_TILE
-                            pl.store(
-                                qk_mi[0:H_TILE, 0:1],
-                                [qk_row0, 0],
-                                cmp_partial_m,
-                            )
-                            pl.store(
-                                qk_li[0:H_TILE, 0:1],
-                                [qk_row0, 0],
-                                cmp_partial_l,
-                            )
-                            pl.store(
-                                qk_oi[0:H_TILE, 0:HEAD_DIM],
-                                [qk_row0, 0],
-                                cmp_partial_o,
-                            )
-                            pl.store(
-                                qk_mi[H_TILE:QK_M_TILE, 0:1],
-                                [qk_row1, 0],
-                                cmp_partial_m,
-                            )
-                            pl.store(
-                                qk_li[H_TILE:QK_M_TILE, 0:1],
-                                [qk_row1, 0],
-                                cmp_partial_l,
-                            )
-                            pl.store(
-                                qk_oi[H_TILE:QK_M_TILE, 0:HEAD_DIM],
-                                [qk_row1, 0],
-                                cmp_partial_o,
-                            )
+                            pl.store(qk_mi[0:H_TILE, 0:1], [qk_row0, 0], cmp_partial_m)
+                            pl.store(qk_li[0:H_TILE, 0:1], [qk_row0, 0], cmp_partial_l)
+                            pl.store(qk_oi[0:H_TILE, 0:HEAD_DIM], [qk_row0, 0], cmp_partial_o)
+                            pl.store(qk_mi[H_TILE:QK_M_TILE, 0:1], [qk_row1, 0], cmp_partial_m)
+                            pl.store(qk_li[H_TILE:QK_M_TILE, 0:1], [qk_row1, 0], cmp_partial_l)
+                            pl.store(qk_oi[H_TILE:QK_M_TILE, 0:HEAD_DIM], [qk_row1, 0], cmp_partial_o)
 
         cmp_branch_tids[0] = cmp_qk_tid
 
@@ -697,31 +471,12 @@ def _compute_hca_attention_intermediates(
         stream_h_tile = stream_idx - stream_t * (H // H_TILE)
         stream_h0 = stream_h_tile * H_TILE
         stream_state_row = stream_t * H + stream_h0
-        stream_m = pl.load(
-            stream_state_m,
-            [stream_state_row, 0],
-            [H_TILE, 1],
-            target_memory=pl.MemorySpace.Vec,
-        )
-        stream_l = pl.load(
-            stream_state_l,
-            [stream_state_row, 0],
-            [H_TILE, 1],
-            target_memory=pl.MemorySpace.Vec,
-        )
-        stream_o = pl.load(
-            stream_heads,
-            [stream_state_row, 0],
-            [H_TILE, HEAD_DIM],
-            target_memory=pl.MemorySpace.Vec,
-        )
+        stream_m = pl.load(stream_state_m, [stream_state_row, 0], [H_TILE, 1], target_memory=pl.MemorySpace.Vec)
+        stream_l = pl.load(stream_state_l, [stream_state_row, 0], [H_TILE, 1], target_memory=pl.MemorySpace.Vec)
+        stream_o = pl.load(stream_heads, [stream_state_row, 0], [H_TILE, HEAD_DIM], target_memory=pl.MemorySpace.Vec)
         stream_token_base = stream_t * (H // H_TILE) * cmp_work_count * H_TILE
         for stream_work in pl.range(cmp_work_count):
-            stream_partial_row = (
-                stream_token_base
-                + stream_h_tile * cmp_work_count * H_TILE
-                + stream_work * H_TILE
-            )
+            stream_partial_row = (stream_token_base + stream_h_tile * cmp_work_count * H_TILE + stream_work * H_TILE)
             stream_cmp_m_aligned = pl.load(
                 cmp_partial_m,
                 [stream_partial_row, 0],
@@ -745,21 +500,10 @@ def _compute_hca_attention_intermediates(
             stream_m_new = pl.maximum(stream_m, stream_cmp_m)
             stream_alpha = pl.exp(pl.sub(stream_m, stream_m_new))
             stream_beta = pl.exp(pl.sub(stream_cmp_m, stream_m_new))
-            stream_l = pl.add(
-                pl.mul(stream_alpha, stream_l),
-                pl.mul(stream_beta, stream_cmp_l),
-            )
-            stream_o = pl.add(
-                pl.row_expand_mul(stream_o, stream_alpha),
-                pl.row_expand_mul(stream_cmp_o, stream_beta),
-            )
+            stream_l = pl.add(pl.mul(stream_alpha, stream_l), pl.mul(stream_beta, stream_cmp_l))
+            stream_o = pl.add(pl.row_expand_mul(stream_o, stream_alpha), pl.row_expand_mul(stream_cmp_o, stream_beta))
             stream_m = stream_m_new
-        stream_sink = pl.load(
-            attn_sink_col,
-            [stream_h0, 0],
-            [H_TILE, 1],
-            target_memory=pl.MemorySpace.Vec,
-        )
+        stream_sink = pl.load(attn_sink_col, [stream_h0, 0], [H_TILE, 1], target_memory=pl.MemorySpace.Vec)
         stream_sink_tile = pl.add(pl.sub(stream_m, stream_m), stream_sink)
         stream_denom = pl.add(stream_l, pl.exp(pl.sub(stream_sink_tile, stream_m)))
         stream_output = pl.row_expand_div(stream_o, stream_denom)
@@ -777,7 +521,7 @@ def _compute_hca_attention_intermediates(
 
 
 @pl.jit.inline(auto_scope=False)
-def sparse_attn_hca(
+def sparse_attn_hca_tp1(
     q: pl.Tensor[[T_DYN, H, HEAD_DIM], pl.BF16],
     ori_kv: pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     window_swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
@@ -794,13 +538,9 @@ def sparse_attn_hca(
     """Write HCA heads as grouped ``[T_PAD, O_GROUP_IN]`` slabs."""
     (
         stream_heads,
-        rope_cos_il,
-        rope_sin_signed,
-        rope_swap_idx,
-        stream_heads_tid,
-        rope_swap_tid,
-        rope_cs_tid,
-    ) = _compute_hca_attention_intermediates(
+        rope_cos_il, rope_sin_signed, rope_swap_idx,
+        stream_heads_tid, rope_swap_tid, rope_cs_tid,
+    ) = sparse_attn_hca(
         q,
         ori_kv,
         window_swa_indices,
@@ -826,9 +566,7 @@ def sparse_attn_hca(
         stream_h_tile = stream_idx - stream_t * (H // H_TILE)
         stream_h0 = stream_h_tile * H_TILE
         stream_state_row = stream_t * H + stream_h0
-        stream_output = stream_heads[
-            stream_state_row : stream_state_row + H_TILE, 0:HEAD_DIM
-        ]
+        stream_output = stream_heads[stream_state_row : stream_state_row + H_TILE, 0:HEAD_DIM]
         stream_bf16 = pl.cast(stream_output, target_type=pl.BF16, mode="rint")
         stream_rope = stream_output[0:H_TILE, NOPE_DIM:HEAD_DIM]
         stream_cos_il = rope_cos_il[stream_t : stream_t + 1, 0:ROPE_DIM]
@@ -852,131 +590,6 @@ def sparse_attn_hca(
             ] = n_full_bf16[n_hi : n_hi + 1, 0:HEAD_DIM]
 
     return o_packed_heads, heads_tid
-
-
-@pl.jit.inline(auto_scope=False)
-def publish_hca_o_groups(
-    q: pl.Tensor[[T_DYN, H, HEAD_DIM], pl.BF16],
-    ori_kv: pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
-    window_swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
-    cmp_kv: pl.Tensor[[CMP_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
-    cmp_block_table: pl.Tensor[[B_DYN, CMP_TABLE_BLOCKS_DYN], pl.INT32],
-    position_ids: pl.Tensor[[T_DYN], pl.INT32],
-    kv_seq_lens: pl.Tensor[[B_DYN], pl.INT32],
-    attn_sink: pl.Tensor[[H], pl.FP32],
-    freqs_cos: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
-    freqs_sin: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
-    attention_grouped: pl.Tensor[[O_GROUPS * T_PAD, O_GROUP_IN], pl.BF16],
-    exchange_window: pld.DistributedTensor[[ATTENTION_WINDOW_ROWS, O_GROUP_IN], pl.BF16],
-    exchange_signal: pld.DistributedTensor[[TP, 1], pl.INT32],
-    group_base: pl.Scalar[pl.INT32],
-    tp_rank: pl.Scalar[pl.INT32],
-    local_t: pl.Scalar[pl.INT32],
-    cache_ready_dep: pl.Scalar[pl.TASK_ID],
-):
-    """Pack HCA heads and publish completed O-group token tiles."""
-    (
-        stream_heads,
-        rope_cos_il,
-        rope_sin_signed,
-        rope_swap_idx,
-        stream_heads_tid,
-        rope_swap_tid,
-        rope_cs_tid,
-    ) = _compute_hca_attention_intermediates(
-        q,
-        ori_kv,
-        window_swa_indices,
-        cmp_kv,
-        cmp_block_table,
-        position_ids,
-        kv_seq_lens,
-        attn_sink,
-        freqs_cos,
-        freqs_sin,
-        cache_ready_dep,
-    )
-    t_dim = pl.tensor.dim(q, 0)
-    pack_work_count = (t_dim // ATTENTION_PUBLISH_T_TILE) * (H // H_TILE)
-
-    with pl.spmd(
-        ATTENTION_PUBLISH_WORKERS,
-        name_hint="hca_stream_pack_publish",
-        deps=[stream_heads_tid, rope_swap_tid, rope_cs_tid],
-    ) as publish_tid:
-        worker = pl.tile.get_block_idx()
-        for pack_work in pl.range(worker, pack_work_count, ATTENTION_PUBLISH_WORKERS):
-            token_block = pack_work // (H // H_TILE)
-            stream_h_tile = pack_work - token_block * (H // H_TILE)
-            stream_t0 = token_block * ATTENTION_PUBLISH_T_TILE
-            stream_h0 = stream_h_tile * H_TILE
-            global_group0 = stream_h0 // HEADS_PER_GROUP
-            destination_rank = global_group0 // LOCAL_O_GROUPS
-            local_group0 = global_group0 - destination_rank * LOCAL_O_GROUPS
-
-            for stream_dt in pl.unroll(ATTENTION_PUBLISH_T_TILE):
-                stream_t = stream_t0 + stream_dt
-                stream_state_row = stream_t * H + stream_h0
-                stream_output = stream_heads[
-                    stream_state_row : stream_state_row + H_TILE, 0:HEAD_DIM
-                ]
-                stream_bf16 = pl.cast(stream_output, target_type=pl.BF16, mode="rint")
-                stream_rope = stream_output[0:H_TILE, NOPE_DIM:HEAD_DIM]
-                stream_cos_il = rope_cos_il[stream_t : stream_t + 1, 0:ROPE_DIM]
-                stream_sin_signed = rope_sin_signed[stream_t : stream_t + 1, 0:ROPE_DIM]
-                stream_swap_zero = pl.full([H_TILE, ROPE_DIM], dtype=pl.INT32, value=0)
-                stream_swap_idx = pl.col_expand_add(
-                    stream_swap_zero,
-                    rope_swap_idx[0:1, 0:ROPE_DIM],
-                )
-                stream_swapped = pl.gather(stream_rope, dim=-1, index=stream_swap_idx)
-                stream_rot = pl.add(
-                    pl.col_expand_mul(stream_rope, stream_cos_il),
-                    pl.col_expand_mul(stream_swapped, stream_sin_signed),
-                )
-                n_rope_bf16 = pl.cast(stream_rot, target_type=pl.BF16, mode="rint")
-                n_full_bf16 = pl.concat(
-                    stream_bf16[0:H_TILE, 0:NOPE_DIM],
-                    n_rope_bf16,
-                )
-                for n_hi in pl.unroll(H_TILE):
-                    n_head = stream_h0 + n_hi
-                    source_row = (n_head // HEADS_PER_GROUP) * T_PAD + stream_t
-                    source_col = (n_head % HEADS_PER_GROUP) * HEAD_DIM
-                    attention_grouped[
-                        source_row : source_row + 1,
-                        source_col : source_col + HEAD_DIM,
-                    ] = n_full_bf16[n_hi : n_hi + 1, 0:HEAD_DIM]
-
-            for group_slot in pl.unroll(PUBLISH_GROUPS):
-                source_row = (global_group0 + group_slot) * T_PAD + stream_t0
-                target_row = (
-                    (local_group0 + group_slot) * GROUP_T_PAD
-                    + tp_rank * local_t
-                    + stream_t0
-                )
-                pld.tensor.put(
-                    dst=exchange_window,
-                    peer=group_base + destination_rank,
-                    src=attention_grouped,
-                    dst_offsets=[target_row, 0],
-                    src_offsets=[source_row, 0],
-                    shape=[ATTENTION_PUBLISH_T_TILE, O_GROUP_IN],
-                    chunk_rows=ATTENTION_PUBLISH_T_TILE,
-                    chunk_cols=O_GROUP_IN,
-                )
-
-        for destination_rank in pl.range(TP):
-            if destination_rank != tp_rank:
-                pld.system.notify(
-                    target=exchange_signal,
-                    peer=group_base + destination_rank,
-                    offsets=[tp_rank, 0],
-                    value=1,
-                    op=pld.NotifyOp.AtomicAdd,
-                )
-
-    return exchange_signal, publish_tid
 
 
 @pl.jit
@@ -1004,7 +617,7 @@ def sparse_attn_hca_test(
 
     cache_ready_dep = pl.system.task_dummy(deps=[])
     o_packed_flat = pl.reshape(o_packed_heads, [O_GROUPS * T_PAD, O_GROUP_IN])
-    o_packed_flat, _heads_tid = sparse_attn_hca(
+    o_packed_flat, _heads_tid = sparse_attn_hca_tp1(
         q, ori_kv, window_swa_indices,
         cmp_kv, cmp_block_table,
         position_ids, kv_seq_lens,
@@ -1146,36 +759,32 @@ def build_tensor_specs(
     if tokens % ROPE_CS_T_TILE != 0:
         raise ValueError(
             f"HCA sparse-attention token count {tokens} must be divisible by "
-            f"ROPE_CS_T_TILE={ROPE_CS_T_TILE}"
+            f"ROPE_CS_T_TILE={ROPE_CS_T_TILE}",
         )
 
     if mixed_topk_fixture:
         if batch != 4:
             raise ValueError("mixed HCA length fixture requires batch=4")
-        compressed_rows_by_request = torch.tensor(
-            [128, 128, 1024, 4096], dtype=torch.int32
-        )
+        compressed_rows_by_request = torch.tensor([128, 128, 1024, 4096], dtype=torch.int32)
     else:
         compressed_rows_by_request = torch.full(
-            (batch,), compressed_rows, dtype=torch.int32
+            (batch,), compressed_rows, dtype=torch.int32,
         )
 
     if bool((compressed_rows_by_request < 0).any()) or bool(
-        (compressed_rows_by_request > HCA_MAX_COMPRESSED_ROWS).any()
+        (compressed_rows_by_request > HCA_MAX_COMPRESSED_ROWS).any(),
     ):
         raise ValueError(
             f"compressed_rows must be in [0, {HCA_MAX_COMPRESSED_ROWS}], "
-            f"got {compressed_rows_by_request.tolist()}"
+            f"got {compressed_rows_by_request.tolist()}",
         )
-    pages_per_request = (
-        (compressed_rows_by_request.to(torch.int64) + BLOCK_SIZE - 1) // BLOCK_SIZE
-    )
+    pages_per_request = ((compressed_rows_by_request.to(torch.int64) + BLOCK_SIZE - 1) // BLOCK_SIZE)
     table_blocks = max(int(pages_per_request.max().item()), 1)
     required_pages = int(pages_per_request.sum().item())
     if required_pages > CMP_BLOCK_NUM:
         raise ValueError(
             f"HCA compressed pool needs {required_pages} pages, "
-            f"capacity is {CMP_BLOCK_NUM}"
+            f"capacity is {CMP_BLOCK_NUM}",
         )
 
     def init_q():

--- a/models/deepseek_v4_flash_dspark/decode_sparse_attn_swa.py
+++ b/models/deepseek_v4_flash_dspark/decode_sparse_attn_swa.py
@@ -14,7 +14,6 @@ variants live in sibling modules.
 
 
 import pypto.language as pl
-import pypto.language.distributed as pld
 
 from config import (
     FLASH as M,
@@ -93,7 +92,7 @@ if T % ATTENTION_PUBLISH_T_TILE != 0:
 
 
 @pl.jit.inline(auto_scope=False)
-def _compute_swa_attention_intermediates(
+def sparse_attn_swa(
     q: pl.Tensor[[T_DYN, H, HEAD_DIM], pl.BF16],
     ori_kv: pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
@@ -101,7 +100,7 @@ def _compute_swa_attention_intermediates(
     freqs_cos: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
     freqs_sin: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
 ):
-    """Prepare SWA attention partials and inverse-RoPE metadata."""
+    """Gather window KV, run QK/PV, and build inverse-RoPE metadata."""
     t_dim = pl.tensor.dim(q, 0)
     t_heads = t_dim * H
     t_win = t_dim * WIN
@@ -129,39 +128,32 @@ def _compute_swa_attention_intermediates(
                     g_sr0 = g_sub * GATHER_RUN
                     g_sdst = g_base + g_sr0
                     g_first = pl.read(swa_indices, [g_t, g_sr0])
-                    g_last = pl.read(
-                        swa_indices, [g_t, g_sr0 + GATHER_RUN - 1]
-                    )
+                    g_last = pl.read(swa_indices, [g_t, g_sr0 + GATHER_RUN - 1])
                     # A -1 slot anywhere in the run pins g_run_ok below the
                     # match value, so an invalid or block-straddling run takes
                     # the per-row path.
-                    g_run_ok = (
-                        (g_last - g_first)
-                        + pl.min(g_first, 0) * GATHER_RUN
-                    )
+                    g_run_ok = ((g_last - g_first) + pl.min(g_first, 0) * GATHER_RUN)
                     if g_run_ok == GATHER_RUN - 1:
                         g_run_src = pl.cast(g_first, pl.INDEX)
                         swa_kv_flat[
-                            g_sdst : g_sdst + GATHER_RUN, 0 : HEAD_DIM
+                            g_sdst : g_sdst + GATHER_RUN, 0 : HEAD_DIM,
                         ] = ori_kv_flat[
-                            g_run_src : g_run_src + GATHER_RUN, 0 : HEAD_DIM
+                            g_run_src : g_run_src + GATHER_RUN, 0 : HEAD_DIM,
                         ]
                     else:
                         for g_dr in pl.range(GATHER_RUN):
                             g_dst = g_sdst + g_dr
-                            g_slot_i32 = pl.read(
-                                swa_indices, [g_t, g_sr0 + g_dr]
-                            )
+                            g_slot_i32 = pl.read(swa_indices, [g_t, g_sr0 + g_dr])
                             if g_slot_i32 >= 0:
                                 g_slot = pl.cast(g_slot_i32, pl.INDEX)
                                 swa_kv_flat[
-                                    g_dst : g_dst + 1, 0 : HEAD_DIM
+                                    g_dst : g_dst + 1, 0 : HEAD_DIM,
                                 ] = ori_kv_flat[
-                                    g_slot : g_slot + 1, 0 : HEAD_DIM
+                                    g_slot : g_slot + 1, 0 : HEAD_DIM,
                                 ]
                             else:
                                 swa_kv_flat[
-                                    g_dst : g_dst + 1, 0 : HEAD_DIM
+                                    g_dst : g_dst + 1, 0 : HEAD_DIM,
                                 ] = pl.full(
                                     [1, HEAD_DIM],
                                     dtype=pl.BF16,
@@ -188,8 +180,7 @@ def _compute_swa_attention_intermediates(
                 qk_base = qk_t * WIN + qk_s0
                 qk_kv = swa_kv_flat[qk_base : qk_base + ATTN_K_TILE, 0 : HEAD_DIM]
 
-                # Keep both 32-head batches in one token task so they reuse the KV
-                # tile already resident in L1 instead of loading it once per block.
+                # Both head batches share one token task and one L1-resident KV tile.
                 for qk_hb in pl.pipeline(H // QK_M_TILE, stage=2):
                     qk_h0 = qk_hb * QK_M_TILE
                     qk_head_row = qk_t * H + qk_h0
@@ -213,10 +204,8 @@ def _compute_swa_attention_intermediates(
                         sparse_blk_li[qk_row : qk_row + H_TILE, 0 : 1] = qk_li[qk_r0 : qk_r0 + H_TILE, 0 : 1]
                         sparse_blk_oi[qk_row : qk_row + H_TILE, 0 : HEAD_DIM] = qk_oi[qk_r0 : qk_r0 + H_TILE, 0 : HEAD_DIM]
 
-    # Materialize the head-invariant interleaved cos and signed-sin rows once.
-    # This runs alongside qk_pv and keeps the exact indexed RoPE arithmetic used
-    # by the reference path while the group merge below changes only scheduling
-    # and store granularity.
+    # Head-invariant interleaved cos and signed-sin rows, materialized once
+    # alongside qk_pv.
     rope_cos_il = pl.create_tensor([T_PAD, ROPE_DIM], dtype=pl.FP32)
     rope_sin_signed = pl.create_tensor([T_PAD, ROPE_DIM], dtype=pl.FP32)
     rope_swap_idx = pl.create_tensor([H_TILE, ROPE_DIM], dtype=pl.INT32)
@@ -271,134 +260,7 @@ def _compute_swa_attention_intermediates(
 
 
 @pl.jit.inline(auto_scope=False)
-def publish_swa_o_groups(
-    q: pl.Tensor[[T_DYN, H, HEAD_DIM], pl.BF16],
-    ori_kv: pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
-    swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
-    sparse_bias: pl.Tensor[[T_DYN, PADDED_TOPK], pl.FP32],
-    attn_sink: pl.Tensor[[H], pl.FP32],
-    freqs_cos: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
-    freqs_sin: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
-    attention_grouped: pl.Tensor[[O_GROUPS * T_PAD, O_GROUP_IN], pl.BF16],
-    exchange_window: pld.DistributedTensor[[ATTENTION_WINDOW_ROWS, O_GROUP_IN], pl.BF16],
-    exchange_signal: pld.DistributedTensor[[TP, 1], pl.INT32],
-    group_base: pl.Scalar[pl.INT32],
-    tp_rank: pl.Scalar[pl.INT32],
-    local_t: pl.Scalar[pl.INT32],
-):
-    """Merge SWA heads and publish completed O-group token tiles."""
-    (
-        sparse_blk_mi,
-        sparse_blk_li,
-        sparse_blk_oi,
-        rope_cos_il,
-        rope_sin_signed,
-        rope_swap_idx,
-        qk_tid,
-        rope_tid,
-    ) = _compute_swa_attention_intermediates(
-        q,
-        ori_kv,
-        swa_indices,
-        sparse_bias,
-        freqs_cos,
-        freqs_sin,
-    )
-    t_dim = pl.tensor.dim(q, 0)
-    pack_work_count = (t_dim // ATTENTION_PUBLISH_T_TILE) * (H // H_TILE)
-    o_packed_heads = pl.reshape(
-        attention_grouped,
-        [O_GROUPS * T_PAD * HEADS_PER_GROUP, HEAD_DIM],
-    )
-
-    with pl.spmd(
-        ATTENTION_PUBLISH_WORKERS,
-        name_hint="swa_merge_pack_publish",
-        deps=[qk_tid, rope_tid],
-    ) as publish_tid:
-        worker = pl.tile.get_block_idx()
-        for pack_work in pl.range(worker, pack_work_count, ATTENTION_PUBLISH_WORKERS):
-            token_block = pack_work // (H // H_TILE)
-            head_tile = pack_work - token_block * (H // H_TILE)
-            token_start = token_block * ATTENTION_PUBLISH_T_TILE
-            head_start = head_tile * H_TILE
-            global_group_start = head_start // HEADS_PER_GROUP
-
-            for token_delta in pl.range(ATTENTION_PUBLISH_T_TILE):
-                token = token_start + token_delta
-                block_base = token * H + head_start
-                block_m = sparse_blk_mi[block_base : block_base + H_TILE, 0:1]
-                block_l = sparse_blk_li[block_base : block_base + H_TILE, 0:1]
-                block_o = sparse_blk_oi[block_base : block_base + H_TILE, 0:HEAD_DIM]
-
-                sink = pl.reshape(attn_sink[head_start : head_start + H_TILE], [H_TILE, 1])
-                sink_delta = pl.sub(sink, block_m)
-                sink_exp = pl.exp(sink_delta)
-                denom = pl.add(block_l, sink_exp)
-                normalized = pl.row_expand_div(block_o, denom)
-                full = normalized[0:H_TILE, 0:HEAD_DIM]
-                full_bf16 = pl.cast(full, target_type=pl.BF16, mode="rint")
-
-                rope = full[:, NOPE_DIM:HEAD_DIM]
-                swapped = pl.gather(rope, dim=-1, index=rope_swap_idx[:, :])
-                cos_il = rope_cos_il[token : token + 1, 0:ROPE_DIM]
-                sin_signed = rope_sin_signed[token : token + 1, 0:ROPE_DIM]
-                rope_cos = pl.col_expand_mul(rope, cos_il)
-                swap_sin = pl.col_expand_mul(swapped, sin_signed)
-                rotated = pl.add(rope_cos, swap_sin)
-                rope_bf16 = pl.cast(rotated, target_type=pl.BF16, mode="rint")
-
-                for group_slot in pl.unroll(PUBLISH_GROUPS):
-                    source_head = group_slot * HEADS_PER_GROUP
-                    pack_row = (global_group_start + group_slot) * T_PAD + token
-                    destination_head = pack_row * HEADS_PER_GROUP
-                    o_packed_heads[
-                        destination_head : destination_head + HEADS_PER_GROUP,
-                        0:NOPE_DIM,
-                    ] = full_bf16[
-                        source_head : source_head + HEADS_PER_GROUP,
-                        0:NOPE_DIM,
-                    ]
-                    o_packed_heads[
-                        destination_head : destination_head + HEADS_PER_GROUP,
-                        NOPE_DIM:HEAD_DIM,
-                    ] = rope_bf16[
-                        source_head : source_head + HEADS_PER_GROUP,
-                        0:ROPE_DIM,
-                    ]
-
-            for group_slot in pl.unroll(PUBLISH_GROUPS):
-                global_group = global_group_start + group_slot
-                destination_rank = global_group // LOCAL_O_GROUPS
-                local_group = global_group - destination_rank * LOCAL_O_GROUPS
-                source_row = global_group * T_PAD + token_start
-                target_row = local_group * GROUP_T_PAD + tp_rank * local_t + token_start
-                pld.tensor.put(
-                    dst=exchange_window,
-                    peer=group_base + destination_rank,
-                    src=attention_grouped,
-                    dst_offsets=[target_row, 0],
-                    src_offsets=[source_row, 0],
-                    shape=[ATTENTION_PUBLISH_T_TILE, O_GROUP_IN],
-                    chunk_rows=ATTENTION_PUBLISH_T_TILE,
-                    chunk_cols=O_GROUP_IN,
-                )
-
-        for peer_tp in pl.range(TP):
-            if peer_tp != tp_rank:
-                pld.system.notify(
-                    target=exchange_signal,
-                    peer=group_base + peer_tp,
-                    offsets=[tp_rank, 0],
-                    value=1,
-                    op=pld.NotifyOp.AtomicAdd,
-                )
-
-    return exchange_signal, publish_tid
-
-
-@pl.jit.inline(auto_scope=False)
-def sparse_attn_swa(
+def sparse_attn_swa_tp1(
     q: pl.Tensor[[T_DYN, H, HEAD_DIM], pl.BF16],
     ori_kv: pl.Tensor[[ORI_BLOCK_NUM_DYN, BLOCK_SIZE, 1, HEAD_DIM], pl.BF16],
     swa_indices: pl.Tensor[[T_DYN, WIN], pl.INT32],
@@ -408,29 +270,19 @@ def sparse_attn_swa(
     freqs_sin: pl.Tensor[[T_DYN, ROPE_DIM], pl.BF16],
     o_packed_heads: pl.Tensor[[O_GROUPS * T_PAD * HEADS_PER_GROUP, HEAD_DIM], pl.BF16],
 ) -> tuple[pl.Tensor, pl.Scalar[pl.TASK_ID]]:
-    """Write SWA heads as ``[group, T_PAD, head-in-group, dim]`` slabs."""
+    """Merge and normalize SWA heads into ``[group, T_PAD, head-in-group, dim]`` slabs."""
     (
-        sparse_blk_mi,
-        sparse_blk_li,
-        sparse_blk_oi,
-        rope_cos_il,
-        rope_sin_signed,
-        rope_swap_idx,
-        qk_tid,
-        rope_tid,
-    ) = _compute_swa_attention_intermediates(
+        sparse_blk_mi, sparse_blk_li, sparse_blk_oi,
+        rope_cos_il, rope_sin_signed, rope_swap_idx,
+        qk_tid, rope_tid,
+    ) = sparse_attn_swa(
         q, ori_kv, swa_indices, sparse_bias,
         freqs_cos, freqs_sin,
     )
     t_dim = pl.tensor.dim(q, 0)
     t_hblocks = t_dim * (H // H_TILE)
 
-    with pl.spmd(
-        MERGE_TASKS,
-        name_hint="merge_norm",
-        deps=[qk_tid, rope_tid],
-        allow_early_resolve=True,
-    ) as merge_tid:
+    with pl.spmd(MERGE_TASKS, name_hint="merge_norm", deps=[qk_tid, rope_tid], allow_early_resolve=True) as merge_tid:
         m_task = pl.tile.get_block_idx()
         for m_idx in pl.range(m_task, t_hblocks, MERGE_TASKS):
             m_t = m_idx // (H // H_TILE)
@@ -464,10 +316,10 @@ def sparse_attn_swa(
                 n_pack_row = (m_g0 + m_sg) * T_PAD + m_t
                 n_dst_head = n_pack_row * HEADS_PER_GROUP
                 o_packed_heads[n_dst_head : n_dst_head + HEADS_PER_GROUP, 0:NOPE_DIM] = n_bf16[
-                    m_src_h0 : m_src_h0 + HEADS_PER_GROUP, 0:NOPE_DIM
+                    m_src_h0 : m_src_h0 + HEADS_PER_GROUP, 0:NOPE_DIM,
                 ]
                 o_packed_heads[n_dst_head : n_dst_head + HEADS_PER_GROUP, NOPE_DIM:HEAD_DIM] = n_rope_bf16[
-                    m_src_h0 : m_src_h0 + HEADS_PER_GROUP, 0:ROPE_DIM
+                    m_src_h0 : m_src_h0 + HEADS_PER_GROUP, 0:ROPE_DIM,
                 ]
 
     return o_packed_heads, merge_tid
@@ -498,13 +350,10 @@ def sparse_attn_swa_test(
             v_t0 = vb * BIAS_T_TILE
             v_col_m = pl.col_expand(pl.full([BIAS_T_TILE, ATTN_K_TILE], dtype=pl.FP32, value=0.0), v_col)
             v_lens = pl.cast(pl.reshape(swa_lens[v_t0 : v_t0 + BIAS_T_TILE], [BIAS_T_TILE, 1]), target_type=pl.FP32)
-            v_valid = pl.minimum(
-                pl.maximum(pl.neg(pl.row_expand_sub(v_col_m, v_lens)), 0.0),
-                1.0,
-            )
+            v_valid = pl.minimum(pl.maximum(pl.neg(pl.row_expand_sub(v_col_m, v_lens)), 0.0), 1.0)
             sparse_bias[v_t0 : v_t0 + BIAS_T_TILE, 0:ATTN_K_TILE] = pl.mul(pl.sub(v_valid, 1.0), -NEG_INF)
     o_packed_flat = pl.reshape(o_packed_heads, [O_GROUPS * T_PAD * HEADS_PER_GROUP, HEAD_DIM])
-    o_packed_flat, _ = sparse_attn_swa(
+    o_packed_flat, _ = sparse_attn_swa_tp1(
         q, ori_kv, swa_indices, sparse_bias,
         attn_sink, freqs_cos, freqs_sin,
         o_packed_flat,
@@ -551,10 +400,7 @@ def golden_sparse_attn(tensors):
                 dtype=torch.bool,
             )
             if end - start < ATTN_K_TILE:
-                valid_tile = torch.cat([
-                    valid_tile,
-                    torch.zeros(ATTN_K_TILE - (end - start), dtype=torch.bool),
-                ])
+                valid_tile = torch.cat([valid_tile, torch.zeros(ATTN_K_TILE - (end - start), dtype=torch.bool)])
             valid_tile = valid_tile.to(device=ori_kv.device)
             kv_tile = torch.zeros(ATTN_K_TILE, HEAD_DIM, dtype=ori_kv.dtype, device=ori_kv.device)
             for r, slot in enumerate(slots):

--- a/models/deepseek_v4_flash_dspark/decode_swa.py
+++ b/models/deepseek_v4_flash_dspark/decode_swa.py
@@ -1006,12 +1006,8 @@ if __name__ == "__main__":
     if args.start_pos is not None:
         batch = len(args.start_pos) if isinstance(args.start_pos, list) else 1
         token_counts = (batch * S,)
-    elif TP_SIZE == 1:
-        # decode_swa_tp1 sizes its O projection from the static capacity.
-        token_counts = (LOCAL_T,)
     else:
-        # Capacity, then one row block below it: the dynamic token axis must hold at both.
-        token_counts = (LOCAL_T, LOCAL_T - BIAS_T_TILE)
+        token_counts = (LOCAL_T,)
 
     for local_t in token_counts:
         if TP_SIZE == 1:

--- a/models/deepseek_v4_flash_dspark/decode_swa.py
+++ b/models/deepseek_v4_flash_dspark/decode_swa.py
@@ -61,17 +61,20 @@ from decode_o_proj import (
     LOCAL_T,
     LOCAL_T_PAD,
     O_WINDOW_ROWS,
-    decode_sharded_o_projection_reduce_scatter,
     decode_o_proj_tp1,
     o_group_a2a,
+    o_proj_reduce_scatter,
 )
 from decode_sparse_attn_swa import (
+    ATTENTION_PUBLISH_T_TILE,
     ATTENTION_PUBLISH_WORKERS,
     ATTN_K_TILE,
+    H_TILE,
     PADDED_TOPK,
+    PUBLISH_GROUPS,
     T_PAD,
-    publish_swa_o_groups,
     sparse_attn_swa,
+    sparse_attn_swa_tp1,
 )
 
 # Dynamic shape variables.
@@ -212,14 +215,101 @@ def decode_swa(
     attention_local_flat = pl.create_tensor([ATTENTION_WINDOW_ROWS, O_GROUP_IN], dtype=pl.BF16)
     attn_out = pl.create_tensor([t_dim, D], dtype=pl.BF16)
     with pl.scope():
-        attention_grouped = pl.create_tensor([O_GROUPS * LOCAL_T_PAD, O_GROUP_IN], dtype=pl.BF16)
-        attention_signal, publish_tid = publish_swa_o_groups(
+        (
+            sparse_blk_mi, sparse_blk_li, sparse_blk_oi,
+            rope_cos_il, rope_sin_signed, rope_swap_idx,
+            qk_tid, rope_tid,
+        ) = sparse_attn_swa(
             q, kv_cache, swa_indices, sparse_bias,
-            attn_sink, freqs_cos, freqs_sin,
-            attention_grouped,
-            attention_window, attention_signal,
-            group_base, tp_rank, local_t,
+            freqs_cos, freqs_sin,
         )
+
+        attention_grouped = pl.create_tensor([O_GROUPS * LOCAL_T_PAD, O_GROUP_IN], dtype=pl.BF16)
+        pack_work_count = (t_dim // ATTENTION_PUBLISH_T_TILE) * (H // H_TILE)
+        o_packed_heads = pl.reshape(attention_grouped, [O_GROUPS * T_PAD * HEADS_PER_GROUP, HEAD_DIM])
+        with pl.spmd(
+            ATTENTION_PUBLISH_WORKERS,
+            name_hint="swa_merge_pack_publish",
+            deps=[qk_tid, rope_tid],
+        ) as publish_tid:
+            worker = pl.tile.get_block_idx()
+            for pack_work in pl.range(worker, pack_work_count, ATTENTION_PUBLISH_WORKERS):
+                token_block = pack_work // (H // H_TILE)
+                head_tile = pack_work - token_block * (H // H_TILE)
+                pack_t0 = token_block * ATTENTION_PUBLISH_T_TILE
+                head_start = head_tile * H_TILE
+                global_group_start = head_start // HEADS_PER_GROUP
+
+                for token_delta in pl.range(ATTENTION_PUBLISH_T_TILE):
+                    token = pack_t0 + token_delta
+                    block_base = token * H + head_start
+                    block_m = sparse_blk_mi[block_base : block_base + H_TILE, 0:1]
+                    block_l = sparse_blk_li[block_base : block_base + H_TILE, 0:1]
+                    block_o = sparse_blk_oi[block_base : block_base + H_TILE, 0:HEAD_DIM]
+
+                    sink = pl.reshape(attn_sink[head_start : head_start + H_TILE], [H_TILE, 1])
+                    sink_delta = pl.sub(sink, block_m)
+                    sink_exp = pl.exp(sink_delta)
+                    denom = pl.add(block_l, sink_exp)
+                    normalized = pl.row_expand_div(block_o, denom)
+                    full = normalized[0:H_TILE, 0:HEAD_DIM]
+                    full_bf16 = pl.cast(full, target_type=pl.BF16, mode="rint")
+
+                    rope = full[:, NOPE_HEAD_DIM:HEAD_DIM]
+                    swapped = pl.gather(rope, dim=-1, index=rope_swap_idx[:, :])
+                    cos_il = rope_cos_il[token : token + 1, 0:ROPE_HEAD_DIM]
+                    sin_signed = rope_sin_signed[token : token + 1, 0:ROPE_HEAD_DIM]
+                    rope_cos = pl.col_expand_mul(rope, cos_il)
+                    swap_sin = pl.col_expand_mul(swapped, sin_signed)
+                    rotated = pl.add(rope_cos, swap_sin)
+                    rope_bf16 = pl.cast(rotated, target_type=pl.BF16, mode="rint")
+
+                    for group_slot in pl.unroll(PUBLISH_GROUPS):
+                        source_head = group_slot * HEADS_PER_GROUP
+                        pack_row = (global_group_start + group_slot) * T_PAD + token
+                        destination_head = pack_row * HEADS_PER_GROUP
+                        o_packed_heads[
+                            destination_head : destination_head + HEADS_PER_GROUP,
+                            0:NOPE_HEAD_DIM,
+                        ] = full_bf16[
+                            source_head : source_head + HEADS_PER_GROUP,
+                            0:NOPE_HEAD_DIM,
+                        ]
+                        o_packed_heads[
+                            destination_head : destination_head + HEADS_PER_GROUP,
+                            NOPE_HEAD_DIM:HEAD_DIM,
+                        ] = rope_bf16[
+                            source_head : source_head + HEADS_PER_GROUP,
+                            0:ROPE_HEAD_DIM,
+                        ]
+
+                for group_slot in pl.unroll(PUBLISH_GROUPS):
+                    global_group = global_group_start + group_slot
+                    destination_rank = global_group // LOCAL_O_GROUPS
+                    local_group = global_group - destination_rank * LOCAL_O_GROUPS
+                    source_row = global_group * T_PAD + pack_t0
+                    target_row = local_group * GROUP_T_PAD + tp_rank * local_t + pack_t0
+                    pld.tensor.put(
+                        dst=attention_window,
+                        peer=group_base + destination_rank,
+                        src=attention_grouped,
+                        dst_offsets=[target_row, 0],
+                        src_offsets=[source_row, 0],
+                        shape=[ATTENTION_PUBLISH_T_TILE, O_GROUP_IN],
+                        chunk_rows=ATTENTION_PUBLISH_T_TILE,
+                        chunk_cols=O_GROUP_IN,
+                    )
+
+            for peer_tp in pl.range(TP_SIZE):
+                if peer_tp != tp_rank:
+                    pld.system.notify(
+                        target=attention_signal,
+                        peer=group_base + peer_tp,
+                        offsets=[tp_rank, 0],
+                        value=1,
+                        op=pld.NotifyOp.AtomicAdd,
+                    )
+
         attention_local_flat, attention_signal = o_group_a2a(
             attention_local_flat,
             attention_window, attention_signal,
@@ -227,12 +317,9 @@ def decode_swa(
             publish_tid, ATTENTION_PUBLISH_WORKERS,
         )
 
-        attention_local_groups = pl.reshape(
-            attention_local_flat,
-            [LOCAL_O_GROUPS, GROUP_T_PAD, O_GROUP_IN],
-        )
+        attention_local_groups = pl.reshape(attention_local_flat, [LOCAL_O_GROUPS, GROUP_T_PAD, O_GROUP_IN])
         o_local = pl.create_tensor([LOCAL_T_PAD, D], dtype=pl.BF16)
-        o_local, o_signal = decode_sharded_o_projection_reduce_scatter(
+        o_local, o_signal = o_proj_reduce_scatter(
             attention_local_groups,
             wo_a, wo_b, wo_b_scale,
             local_t, o_local,
@@ -447,24 +534,17 @@ def decode_swa_tp1(
             v_t0 = v_blk * BIAS_T_TILE
             v_col_m = pl.col_expand(pl.full([BIAS_T_TILE, WIN], dtype=pl.FP32, value=0.0), v_col)
             v_lens = pl.cast(pl.reshape(swa_lens[v_t0 : v_t0 + BIAS_T_TILE], [BIAS_T_TILE, 1]), target_type=pl.FP32)
-            v_valid = pl.minimum(
-                pl.maximum(pl.neg(pl.row_expand_sub(v_col_m, v_lens)), 0.0),
-                1.0,
-            )
+            v_valid = pl.minimum(pl.maximum(pl.neg(pl.row_expand_sub(v_col_m, v_lens)), 0.0), 1.0)
             sparse_bias[v_t0 : v_t0 + BIAS_T_TILE, 0:WIN] = pl.mul(pl.sub(v_valid, 1.0), -NEG_INF)
     attn_out = pl.create_tensor([t_dim, D], dtype=pl.BF16)
     o_packed_heads = pl.create_tensor([O_GROUPS * T_PAD * HEADS_PER_GROUP, HEAD_DIM], dtype=pl.BF16)
-    o_packed_heads, heads_dep = sparse_attn_swa(
+    o_packed_heads, heads_dep = sparse_attn_swa_tp1(
         q, kv_cache, swa_indices, sparse_bias,
         attn_sink, freqs_cos, freqs_sin,
         o_packed_heads,
     )
     o_packed = pl.reshape(o_packed_heads, [O_GROUPS * T_PAD, O_GROUP_IN])
-    attn_out = decode_o_proj_tp1(
-        o_packed,
-        wo_a, wo_b, wo_b_scale,
-        attn_out, heads_dep,
-    )
+    attn_out = decode_o_proj_tp1(o_packed, wo_a, wo_b, wo_b_scale, attn_out, heads_dep)
 
     hc_post(attn_out, x_hc, post_t, comb_t, x_out)
     return x_out
@@ -604,19 +684,11 @@ def golden_decode_swa_tp1(tensors):
         "freqs_sin": tensors["freqs_sin"],
         "o_packed_heads": o_packed_heads,
     })
-    attn_out = golden_decode_o_proj_tp1(
-        o_packed_heads, tensors["wo_a"], tensors["wo_b"], tensors["wo_b_scale"], tokens,
-    )
+    attn_out = golden_decode_o_proj_tp1(o_packed_heads, tensors["wo_a"], tensors["wo_b"], tensors["wo_b_scale"], tokens)
 
     # Block.hc_post
     y = torch.zeros(tokens, HC_MULT, D, dtype=torch.float32)
-    golden_hc_post({
-        "x": attn_out,
-        "residual": tensors["x_hc"],
-        "post": post_t,
-        "comb": comb_t,
-        "y": y,
-    })
+    golden_hc_post({ "x": attn_out, "residual": tensors["x_hc"], "post": post_t, "comb": comb_t, "y": y, })
 
     tensors["x_out"][:] = y
 
@@ -638,10 +710,7 @@ def build_tensor_specs(start_pos=None, batch=B):
 
     # Token-local RoPE: compute only the active-position rows the device needs,
     # never a full-context table. SWA uses the uncompressed RoPE profile.
-    _inv_freq = 1.0 / (
-        float(M.rope_theta)
-        ** (torch.arange(0, ROPE_HEAD_DIM, 2, dtype=torch.float32) / ROPE_HEAD_DIM)
-    )
+    _inv_freq = 1.0 / (float(M.rope_theta) ** (torch.arange(0, ROPE_HEAD_DIM, 2, dtype=torch.float32) / ROPE_HEAD_DIM))
 
     def init_rope_rows():
         positions = init_position_ids().to(torch.float32)
@@ -735,14 +804,14 @@ def build_tensor_specs(start_pos=None, batch=B):
             starts = torch.tensor(start_pos, dtype=torch.int32)
             if starts.shape != (batch,):
                 raise ValueError(
-                    f"mixed start_pos needs {batch} entries, got {starts.numel()}"
+                    f"mixed start_pos needs {batch} entries, got {starts.numel()}",
                 )
             if bool((starts < 0).any()):
                 raise ValueError("decode start positions must be non-negative")
             if bool((starts.to(torch.int64) + S > MAX_SEQ_LEN).any()):
                 raise ValueError(
                     "decode start positions plus seq length must fit "
-                    f"MAX_SEQ_LEN={MAX_SEQ_LEN}"
+                    f"MAX_SEQ_LEN={MAX_SEQ_LEN}",
                 )
             return starts
         return resolve_start_positions(
@@ -820,11 +889,7 @@ def build_distributed_tensor_specs(local_t, start_pos=None):
     rank_tensors = []
     for _ in range(TP_SIZE):
         local_specs = build_tensor_specs(start_pos=start_pos, batch=local_t // S)
-        rank_tensors.append({
-            spec.name: spec.create_tensor()
-            for spec in local_specs
-            if spec.name != "x_out"
-        })
+        rank_tensors.append({ spec.name: spec.create_tensor() for spec in local_specs if spec.name != "x_out" })
 
     replicated_names = (
         "hc_attn_fn", "hc_attn_scale", "hc_attn_base",
@@ -837,14 +902,8 @@ def build_distributed_tensor_specs(local_t, start_pos=None):
 
     full_wo_a = rank_tensors[0]["wo_a"]
     full_wo_b = rank_tensors[0]["wo_b"]
-    wo_a = torch.stack([
-        full_wo_a[rank * LOCAL_O_GROUPS : (rank + 1) * LOCAL_O_GROUPS]
-        for rank in range(TP_SIZE)
-    ])
-    wo_b = torch.stack([
-        full_wo_b[:, rank * LOCAL_O_WIDTH : (rank + 1) * LOCAL_O_WIDTH]
-        for rank in range(TP_SIZE)
-    ])
+    wo_a = torch.stack([full_wo_a[rank * LOCAL_O_GROUPS : (rank + 1) * LOCAL_O_GROUPS] for rank in range(TP_SIZE)])
+    wo_b = torch.stack([full_wo_b[:, rank * LOCAL_O_WIDTH : (rank + 1) * LOCAL_O_WIDTH] for rank in range(TP_SIZE)])
 
     def stacked(name):
         return torch.stack([rank_tensors[rank][name] for rank in range(TP_SIZE)])
@@ -890,11 +949,7 @@ def golden_decode_swa(tensors):
     full_wo_a = tensors["wo_a"].reshape(O_GROUPS, O_LORA, O_GROUP_IN)
     full_wo_b = tensors["wo_b"].permute(1, 0, 2).reshape(D, O_GROUPS * O_LORA)
     for rank in range(TP_SIZE):
-        rank_tensors = {
-            name: value[rank]
-            for name, value in tensors.items()
-            if name != "local_t"
-        }
+        rank_tensors = { name: value[rank] for name, value in tensors.items() if name != "local_t" }
         rank_tensors["wo_a"] = full_wo_a
         rank_tensors["wo_b"] = full_wo_b
         rank_tensors["wo_b_scale"] = tensors["wo_b_scale"][0]


### PR DESCRIPTION
- sparse_attn_{swa,csa,hca} now name the shared attention core (KV
  gather, QK/PV, inverse-RoPE metadata) that both the TP and TP1 paths
  consume; the merge-and-pack tails move to sparse_attn_*_tp1
- publish_*_o_groups are gone: each *_pack_publish task inlines into
  decode_{swa,csa,hca}, so the three attention modules no longer import
  pypto.language.distributed and all comm code lives on the decode side
- decode_o_proj: drop the KV-allgather fixture cluster
  (kv_token_allgather_step, tp_group_barrier, reset_tp_group_signal,
  GROUP_T), which no production path used, and rename the remaining
  exchange fixture to l2_o_group_a2a / l3_o_group_a2a
- decode_o_proj: rename decode_sharded_o_projection_reduce_scatter to
  o_proj_reduce_scatter, matching decode_o_proj_tp1 and the tp_o_rs_*
  scopes it drives
- decode_swa and decode_hca run one default token count instead of two,
  matching decode_csa
- decode_fwd: drop the golden oracle and the comparators it gated
  (finite_tensor_compare, sampled_ids_compare, _packed_pool_compare,
  compare_functions), the compare_fn and golden_data arguments, and the
  --golden-data option; decode forward is a topology and isolation
  witness, and the layer math it composes is validated by the per-layer
  entries
- decode_layer: add the ci: no-sim marker used by prefill_layer
- Apply the kernel style pass across the nine files: collapse wrapped
  statements, loop headers, and parameter annotations onto one line, and
  trim rationale prose from six comments

Task names, dependency edges, and tile shapes are unchanged; the only
renamed locals are the three that would otherwise collide after
inlining (pack_t0, attn_rope_tid, peer_tp).