### PR TITLE
Add: integrate sampling into DeepSeek V4 Flash decode

### DIFF
--- a/models/deepseek_v4_flash_mtp/decode_fwd.py
+++ b/models/deepseek_v4_flash_mtp/decode_fwd.py
@@ -288,6 +288,10 @@ def decode_fwd(
     final_norm_w: pl.Tensor[[D], pl.BF16],
     lm_head_weight: pl.Tensor[[VOCAB_PER_TP, D], pl.BF16],
     logit_row_indices: pl.Tensor[[MAX_LOGIT_ROWS], pl.INT32],
+    sampling_temperatures: pl.Tensor[[MAX_LOGIT_ROWS], pl.FP32],
+    sampling_top_ks: pl.Tensor[[MAX_LOGIT_ROWS], pl.INT32],
+    sampling_seeds: pl.Tensor[[MAX_LOGIT_ROWS], pl.INT32],
+    sampling_positions: pl.Tensor[[MAX_LOGIT_ROWS], pl.INT32],
     pre_hc_hidden_out: pl.Out[pl.Tensor[[T, HC_MULT, D], pl.FP32]],
     x_out: pl.Out[pl.Tensor[[T, D], pl.BF16]],
     logits: pl.Out[pl.Tensor[[MAX_LOGIT_ROWS, LM_HEAD_VOCAB], pl.FP32]],
@@ -725,8 +729,9 @@ def decode_fwd(
         hc_head(pre_hc_hidden_out, hc_head_fn, hc_head_scale, hc_head_base, x_head)
         rms_norm(x_head, final_norm_w, x_out)
         lm_head_with_sampling(
-            x_out, lm_head_weight, logit_row_indices, logits,
-            sampled_ids,
+            x_out, lm_head_weight, logit_row_indices,
+            sampling_temperatures, sampling_top_ks, sampling_seeds, sampling_positions,
+            logits, sampled_ids,
             lm_head_hidden_window, lm_head_hidden_done,
             lm_head_logits_window, lm_head_logits_done,
             my_rank // LM_HEAD_TP_SIZE * LM_HEAD_TP_SIZE,
@@ -814,6 +819,10 @@ def l2_decode_fwd(
     final_norm_w: pl.Tensor[[D], pl.BF16],
     lm_head_weight: pl.Tensor[[VOCAB_PER_TP, D], pl.BF16],
     logit_row_indices: pl.Tensor[[MAX_LOGIT_ROWS], pl.INT32],
+    sampling_temperatures: pl.Tensor[[MAX_LOGIT_ROWS], pl.FP32],
+    sampling_top_ks: pl.Tensor[[MAX_LOGIT_ROWS], pl.INT32],
+    sampling_seeds: pl.Tensor[[MAX_LOGIT_ROWS], pl.INT32],
+    sampling_positions: pl.Tensor[[MAX_LOGIT_ROWS], pl.INT32],
     pre_hc_hidden_out: pl.Out[pl.Tensor[[T, HC_MULT, D], pl.FP32]],
     x_out: pl.Out[pl.Tensor[[T, D], pl.BF16]],
     logits: pl.Out[pl.Tensor[[MAX_LOGIT_ROWS, LM_HEAD_VOCAB], pl.FP32]],
@@ -892,6 +901,7 @@ def l2_decode_fwd(
         input_ids,
         hc_head_fn, hc_head_scale, hc_head_base, final_norm_w,
         lm_head_weight, logit_row_indices,
+        sampling_temperatures, sampling_top_ks, sampling_seeds, sampling_positions,
         pre_hc_hidden_out, x_out, logits, sampled_ids,
         recv_meta, recv_x, recv_aux, recv_route,
         arrived, data_arrived, routed_y_buf, combine_arrived,
@@ -979,6 +989,10 @@ def l3_decode_fwd(
     final_norm_w: pl.Tensor[[N_RANKS, D], pl.BF16],
     pre_hc_hidden_out: pl.Out[pl.Tensor[[N_RANKS, T, HC_MULT, D], pl.FP32]],
     lm_head_weight: pl.Tensor[[N_RANKS, VOCAB_PER_TP, D], pl.BF16],
+    sampling_temperatures: pl.Tensor[[N_RANKS, MAX_LOGIT_ROWS], pl.FP32],
+    sampling_top_ks: pl.Tensor[[N_RANKS, MAX_LOGIT_ROWS], pl.INT32],
+    sampling_seeds: pl.Tensor[[N_RANKS, MAX_LOGIT_ROWS], pl.INT32],
+    sampling_positions: pl.Tensor[[N_RANKS, MAX_LOGIT_ROWS], pl.INT32],
     hidden_out: pl.Out[pl.Tensor[[N_RANKS, T, D], pl.BF16]],
     logits: pl.Out[pl.Tensor[[N_RANKS, MAX_LOGIT_ROWS, LM_HEAD_VOCAB], pl.FP32]],
     sampled_ids: pl.Out[
@@ -1038,6 +1052,8 @@ def l3_decode_fwd(
             hca_cmp_block_table[r], csa_cmp_block_table[r], idx_block_table[r],
             block_counts[r], input_ids[r], hc_head_fn[r], hc_head_scale[r], hc_head_base[r], final_norm_w[r],
             lm_head_weight[r], logit_row_indices[r],
+            sampling_temperatures[r], sampling_top_ks[r],
+            sampling_seeds[r], sampling_positions[r],
             pre_hc_hidden_out[r], hidden_out[r], logits[r], sampled_ids[r],
             recv_meta, recv_x, recv_aux, recv_route, arrived,
             data_arrived, routed_y_buf, combine_arrived,
@@ -1793,6 +1809,32 @@ def build_tensor_specs(
     specs.append(TensorSpec(
         "lm_head_weight", [N_RANKS, VOCAB_PER_TP, D], torch.bfloat16,
         init_value=init_lm_head_weight, resident="stacked",
+    ))
+    specs.append(TensorSpec(
+        "sampling_temperatures",
+        [N_RANKS, MAX_LOGIT_ROWS],
+        torch.float32,
+        init_value=lambda: torch.zeros(N_RANKS, MAX_LOGIT_ROWS),
+    ))
+    specs.append(TensorSpec(
+        "sampling_top_ks",
+        [N_RANKS, MAX_LOGIT_ROWS],
+        torch.int32,
+        init_value=lambda: torch.full(
+            (N_RANKS, MAX_LOGIT_ROWS), LM_HEAD_VOCAB, dtype=torch.int32
+        ),
+    ))
+    specs.append(TensorSpec(
+        "sampling_seeds",
+        [N_RANKS, MAX_LOGIT_ROWS],
+        torch.int32,
+        init_value=lambda: torch.zeros(N_RANKS, MAX_LOGIT_ROWS, dtype=torch.int32),
+    ))
+    specs.append(TensorSpec(
+        "sampling_positions",
+        [N_RANKS, MAX_LOGIT_ROWS],
+        torch.int32,
+        init_value=lambda: torch.zeros(N_RANKS, MAX_LOGIT_ROWS, dtype=torch.int32),
     ))
     specs.append(TensorSpec("hidden_out", [N_RANKS, T, D], torch.bfloat16, is_output=True))
     specs.append(TensorSpec("logits", [N_RANKS, MAX_LOGIT_ROWS, LM_HEAD_VOCAB], torch.float32, is_output=True))

--- a/models/deepseek_v4_flash_mtp/decode_fwd_mtp.py
+++ b/models/deepseek_v4_flash_mtp/decode_fwd_mtp.py
@@ -123,7 +123,11 @@ STATE_VALID = 0
 STATE_GENERATION = 1
 STATE_TAIL_POSITION = 2
 STATE_COMMITTED_COUNT = 3
-STATE_META_WIDTH = 4
+STATE_TEMPERATURE_MICROS = 4
+STATE_TOP_K = 5
+STATE_SEED = 6
+STATE_META_WIDTH = 7
+TEMPERATURE_SCALE = 1000000.0
 
 STATE_TAIL_TOKEN = 0
 STATE_DRAFT_TOKEN = 1
@@ -144,6 +148,10 @@ def prepare_decode_from_device_state(
     kv_seq_lens: pl.Tensor[[B], pl.INT32],
     tail_token_ids: pl.Tensor[[B], pl.INT64],
     tail_positions: pl.Tensor[[B], pl.INT32],
+    sampling_temperatures: pl.Tensor[[MAX_LOGIT_ROWS], pl.FP32],
+    sampling_top_ks: pl.Tensor[[MAX_LOGIT_ROWS], pl.INT32],
+    sampling_seeds: pl.Tensor[[MAX_LOGIT_ROWS], pl.INT32],
+    sampling_positions: pl.Tensor[[MAX_LOGIT_ROWS], pl.INT32],
 ):
     """Late-bind recurrent decode fields from stable device slots::
 
@@ -159,7 +167,21 @@ def prepare_decode_from_device_state(
     # One core owns these tightly packed scalar updates.  The metadata volume
     # is tiny, and single ownership avoids adjacent scalar DMA write races.
     for core in pl.spmd(1, name_hint="mtp_state_prepare"):
+        default_temperature = pl.cast(0.0, pl.FP32)
+        default_top_k = pl.cast(VOCAB, pl.INT32)
+        default_seed = pl.cast(0, pl.INT32)
+        default_position = pl.cast(0, pl.INT32)
         for request in pl.range(core, B):
+            row0 = request * S
+            row1 = row0 + 1
+            pl.write(sampling_temperatures, [row0], default_temperature)
+            pl.write(sampling_temperatures, [row1], default_temperature)
+            pl.write(sampling_top_ks, [row0], default_top_k)
+            pl.write(sampling_top_ks, [row1], default_top_k)
+            pl.write(sampling_seeds, [row0], default_seed)
+            pl.write(sampling_seeds, [row1], default_seed)
+            pl.write(sampling_positions, [row0], default_position)
+            pl.write(sampling_positions, [row1], default_position)
             slot_raw = pl.read(state_slot_ids, [request])
             if slot_raw >= 0:
                 slot = pl.cast(slot_raw, target_type=pl.INDEX)
@@ -167,11 +189,14 @@ def prepare_decode_from_device_state(
                 generation = pl.read(state_meta, [slot, STATE_GENERATION])
                 expected = pl.read(state_generations, [request])
                 if valid == 1 and generation == expected:
-                    row0 = request * S
-                    row1 = row0 + 1
                     tail_token = pl.read(state_tokens, [slot, STATE_TAIL_TOKEN])
                     draft_token = pl.read(state_tokens, [slot, STATE_DRAFT_TOKEN])
                     tail_position = pl.read(state_meta, [slot, STATE_TAIL_POSITION])
+                    temperature_micros = pl.read(state_meta, [slot, STATE_TEMPERATURE_MICROS])
+                    temperature_fp32 = pl.cast(temperature_micros, pl.FP32)
+                    temperature = pl.div(temperature_fp32, TEMPERATURE_SCALE)
+                    top_k = pl.read(state_meta, [slot, STATE_TOP_K])
+                    seed = pl.read(state_meta, [slot, STATE_SEED])
                     pl.write(input_ids, [row0], tail_token)
                     pl.write(input_ids, [row1], draft_token)
                     pl.write(
@@ -191,7 +216,62 @@ def prepare_decode_from_device_state(
                     )
                     pl.write(tail_token_ids, [request], tail_token)
                     pl.write(tail_positions, [request], tail_position)
+                    pl.write(sampling_temperatures, [row0], temperature)
+                    pl.write(sampling_temperatures, [row1], temperature)
+                    pl.write(sampling_top_ks, [row0], top_k)
+                    pl.write(sampling_top_ks, [row1], top_k)
+                    pl.write(sampling_seeds, [row0], seed)
+                    pl.write(sampling_seeds, [row1], seed)
+                    sampling_position0 = pl.cast(tail_position + 2, target_type=pl.INT32)
+                    sampling_position1 = pl.cast(tail_position + 3, target_type=pl.INT32)
+                    pl.write(sampling_positions, [row0], sampling_position0)
+                    pl.write(sampling_positions, [row1], sampling_position1)
     return input_ids, position_ids, kv_seq_lens, tail_token_ids, tail_positions
+
+
+@pl.jit.inline
+def prepare_mtp_sampling_from_device_state(
+    state_slot_ids: pl.Tensor[[B], pl.INT32],
+    state_generations: pl.Tensor[[B], pl.INT32],
+    state_meta: pl.Tensor[[B, STATE_META_WIDTH], pl.INT32],
+    position_ids: pl.Tensor[[T], pl.INT32],
+    sampling_temperatures: pl.Tensor[[MAX_LOGIT_ROWS], pl.FP32],
+    sampling_top_ks: pl.Tensor[[MAX_LOGIT_ROWS], pl.INT32],
+    sampling_seeds: pl.Tensor[[MAX_LOGIT_ROWS], pl.INT32],
+    sampling_positions: pl.Tensor[[MAX_LOGIT_ROWS], pl.INT32],
+):
+    """Build next-draft sampling controls from persistent request state."""
+    for core in pl.spmd(1, name_hint="mtp_state_sampling"):
+        default_temperature = pl.cast(0.0, pl.FP32)
+        default_top_k = pl.cast(VOCAB, pl.INT32)
+        default_seed = pl.cast(0, pl.INT32)
+        default_position = pl.cast(0, pl.INT32)
+        for row in pl.range(core, MAX_LOGIT_ROWS):
+            pl.write(sampling_temperatures, [row], default_temperature)
+            pl.write(sampling_top_ks, [row], default_top_k)
+            pl.write(sampling_seeds, [row], default_seed)
+            pl.write(sampling_positions, [row], default_position)
+        for request in pl.range(core, B):
+            slot_raw = pl.read(state_slot_ids, [request])
+            if slot_raw >= 0:
+                slot = pl.cast(slot_raw, target_type=pl.INDEX)
+                valid = pl.read(state_meta, [slot, STATE_VALID])
+                generation = pl.read(state_meta, [slot, STATE_GENERATION])
+                expected = pl.read(state_generations, [request])
+                if valid == 1 and generation == expected:
+                    temperature_micros = pl.read(state_meta, [slot, STATE_TEMPERATURE_MICROS])
+                    temperature_fp32 = pl.cast(temperature_micros, pl.FP32)
+                    temperature = pl.div(temperature_fp32, TEMPERATURE_SCALE)
+                    top_k = pl.read(state_meta, [slot, STATE_TOP_K])
+                    seed = pl.read(state_meta, [slot, STATE_SEED])
+                    row1 = request * S + 1
+                    row1_position = pl.read(position_ids, [row1])
+                    sampling_position = pl.cast(row1_position + 1, target_type=pl.INT32)
+                    pl.write(sampling_temperatures, [request], temperature)
+                    pl.write(sampling_top_ks, [request], top_k)
+                    pl.write(sampling_seeds, [request], seed)
+                    pl.write(sampling_positions, [request], sampling_position)
+    return sampling_temperatures, sampling_top_ks, sampling_seeds, sampling_positions
 
 
 @pl.jit.inline
@@ -392,6 +472,10 @@ def l2_decode_fwd_mtp(
     final_norm_w: pl.Tensor[[D], pl.BF16],
     lm_head_weight: pl.Tensor[[VOCAB_PER_TP, D], pl.BF16],
     logit_row_indices: pl.Tensor[[MAX_LOGIT_ROWS], pl.INT32],
+    sampling_temperatures: pl.InOut[pl.Tensor[[MAX_LOGIT_ROWS], pl.FP32]],
+    sampling_top_ks: pl.InOut[pl.Tensor[[MAX_LOGIT_ROWS], pl.INT32]],
+    sampling_seeds: pl.InOut[pl.Tensor[[MAX_LOGIT_ROWS], pl.INT32]],
+    sampling_positions: pl.InOut[pl.Tensor[[MAX_LOGIT_ROWS], pl.INT32]],
     pre_hc_hidden_out: pl.Out[pl.Tensor[[T, HC_MULT, D], pl.FP32]],
     hidden_out: pl.Out[pl.Tensor[[T, D], pl.BF16]],
     logits: pl.Out[pl.Tensor[[MAX_LOGIT_ROWS, LM_HEAD_VOCAB], pl.FP32]],
@@ -466,6 +550,10 @@ def l2_decode_fwd_mtp(
     mtp_mtp_hc_head_base: pl.Tensor[[HC_MULT], pl.FP32],
     mtp_mtp_norm_w: pl.Tensor[[D], pl.BF16],
     mtp_logit_row_indices: pl.Tensor[[MAX_LOGIT_ROWS], pl.INT32],
+    mtp_sampling_temperatures: pl.InOut[pl.Tensor[[MAX_LOGIT_ROWS], pl.FP32]],
+    mtp_sampling_top_ks: pl.InOut[pl.Tensor[[MAX_LOGIT_ROWS], pl.INT32]],
+    mtp_sampling_seeds: pl.InOut[pl.Tensor[[MAX_LOGIT_ROWS], pl.INT32]],
+    mtp_sampling_positions: pl.InOut[pl.Tensor[[MAX_LOGIT_ROWS], pl.INT32]],
     mtp_hidden_out: pl.Out[pl.Tensor[[T, D], pl.BF16]],
     mtp_next_pre_hc_hidden: pl.Out[pl.Tensor[[T, HC_MULT, D], pl.FP32]],
     mtp_logits: pl.Out[pl.Tensor[[MAX_LOGIT_ROWS, LM_HEAD_VOCAB], pl.FP32]],
@@ -495,6 +583,8 @@ def l2_decode_fwd_mtp(
         mtp_tail_slot_ids, mtp_state_generations, mtp_state_tokens, mtp_state_meta,
         input_ids, position_ids, kv_seq_lens,
         mtp_tail_token_ids, mtp_tail_positions,
+        sampling_temperatures, sampling_top_ks,
+        sampling_seeds, sampling_positions,
     )
     ori_slot_mapping = pl.create_tensor([T], dtype=pl.INT64)
     swa_slot_mapping = pl.create_tensor([T], dtype=pl.INT64)
@@ -554,6 +644,7 @@ def l2_decode_fwd_mtp(
         input_ids,
         hc_head_fn, hc_head_scale, hc_head_base, final_norm_w,
         lm_head_weight, logit_row_indices,
+        sampling_temperatures, sampling_top_ks, sampling_seeds, sampling_positions,
         pre_hc_hidden_out, hidden_out, logits, sampled_ids,
         recv_meta, recv_x, recv_aux, recv_route,
         arrived, data_arrived, routed_y_buf, combine_arrived,
@@ -564,6 +655,12 @@ def l2_decode_fwd_mtp(
         input_ids, position_ids, sampled_ids,
         mtp_tail_token_ids, mtp_tail_positions, mtp_tail_slot_ids,
         mtp_input_ids, mtp_position_ids, mtp_accepted_counts,
+    )
+    prepare_mtp_sampling_from_device_state(
+        mtp_tail_slot_ids, mtp_state_generations, mtp_state_meta,
+        mtp_position_ids,
+        mtp_sampling_temperatures, mtp_sampling_top_ks,
+        mtp_sampling_seeds, mtp_sampling_positions,
     )
     mtp_hidden_states = pl.create_tensor([T, D], dtype=pl.BF16)
     lookup_embedding(mtp_input_ids, embed_weight, mtp_hidden_states)
@@ -603,6 +700,8 @@ def l2_decode_fwd_mtp(
         mtp_shared_w1, mtp_shared_w1_scale, mtp_shared_w3, mtp_shared_w3_scale, mtp_shared_w2, mtp_shared_w2_scale,
         mtp_mtp_hc_head_fn, mtp_mtp_hc_head_scale, mtp_mtp_hc_head_base, mtp_mtp_norm_w,
         lm_head_weight, mtp_logit_row_indices,
+        mtp_sampling_temperatures, mtp_sampling_top_ks,
+        mtp_sampling_seeds, mtp_sampling_positions,
         mtp_hidden_out, mtp_next_pre_hc_hidden, mtp_logits, mtp_sampled_ids,
         mtp_recv_meta, mtp_recv_x, mtp_recv_aux, mtp_recv_route,
         mtp_arrived, mtp_data_arrived, mtp_routed_y_buf, mtp_combine_arrived,
@@ -715,6 +814,10 @@ def l3_decode_fwd_mtp(
     final_norm_w: pl.Tensor[[N_RANKS, D], pl.BF16],
     pre_hc_hidden_out: pl.Out[pl.Tensor[[N_RANKS, T, HC_MULT, D], pl.FP32]],
     lm_head_weight: pl.Tensor[[N_RANKS, VOCAB_PER_TP, D], pl.BF16],
+    sampling_temperatures: pl.InOut[pl.Tensor[[N_RANKS, MAX_LOGIT_ROWS], pl.FP32]],
+    sampling_top_ks: pl.InOut[pl.Tensor[[N_RANKS, MAX_LOGIT_ROWS], pl.INT32]],
+    sampling_seeds: pl.InOut[pl.Tensor[[N_RANKS, MAX_LOGIT_ROWS], pl.INT32]],
+    sampling_positions: pl.InOut[pl.Tensor[[N_RANKS, MAX_LOGIT_ROWS], pl.INT32]],
     hidden_out: pl.Out[pl.Tensor[[N_RANKS, T, D], pl.BF16]],
     logits: pl.Out[pl.Tensor[[N_RANKS, MAX_LOGIT_ROWS, LM_HEAD_VOCAB], pl.FP32]],
     sampled_ids: pl.Out[pl.Tensor[[N_RANKS, MAX_LOGIT_ROWS, SAMPLED_IDS_PAD], pl.INT32]],
@@ -780,6 +883,10 @@ def l3_decode_fwd_mtp(
     mtp_mtp_hc_head_scale: pl.Tensor[[N_RANKS, 1], pl.FP32],
     mtp_mtp_hc_head_base: pl.Tensor[[N_RANKS, HC_MULT], pl.FP32],
     mtp_mtp_norm_w: pl.Tensor[[N_RANKS, D], pl.BF16],
+    mtp_sampling_temperatures: pl.InOut[pl.Tensor[[N_RANKS, MAX_LOGIT_ROWS], pl.FP32]],
+    mtp_sampling_top_ks: pl.InOut[pl.Tensor[[N_RANKS, MAX_LOGIT_ROWS], pl.INT32]],
+    mtp_sampling_seeds: pl.InOut[pl.Tensor[[N_RANKS, MAX_LOGIT_ROWS], pl.INT32]],
+    mtp_sampling_positions: pl.InOut[pl.Tensor[[N_RANKS, MAX_LOGIT_ROWS], pl.INT32]],
     mtp_hidden_out: pl.Out[pl.Tensor[[N_RANKS, T, D], pl.BF16]],
     mtp_next_pre_hc_hidden: pl.Out[pl.Tensor[[N_RANKS, T, HC_MULT, D], pl.FP32]],
     mtp_logits: pl.Out[pl.Tensor[[N_RANKS, MAX_LOGIT_ROWS, LM_HEAD_VOCAB], pl.FP32]],
@@ -866,6 +973,8 @@ def l3_decode_fwd_mtp(
             input_ids[rank],
             hc_head_fn[rank], hc_head_scale[rank], hc_head_base[rank], final_norm_w[rank],
             lm_head_weight[rank], logit_row_indices[rank],
+            sampling_temperatures[rank], sampling_top_ks[rank],
+            sampling_seeds[rank], sampling_positions[rank],
             pre_hc_hidden_out[rank], hidden_out[rank], logits[rank], sampled_ids[rank],
             recv_meta, recv_x, recv_aux, recv_route,
             arrived, data_arrived, routed_y_buf, combine_arrived,
@@ -892,6 +1001,8 @@ def l3_decode_fwd_mtp(
             mtp_mtp_hc_head_fn[rank], mtp_mtp_hc_head_scale[rank], mtp_mtp_hc_head_base[rank],
             mtp_mtp_norm_w[rank],
             mtp_logit_row_indices[rank],
+            mtp_sampling_temperatures[rank], mtp_sampling_top_ks[rank],
+            mtp_sampling_seeds[rank], mtp_sampling_positions[rank],
             mtp_hidden_out[rank], mtp_next_pre_hc_hidden[rank], mtp_logits[rank], mtp_sampled_ids[rank],
             mtp_recv_meta, mtp_recv_x, mtp_recv_aux, mtp_recv_route,
             mtp_arrived, mtp_data_arrived, mtp_routed_y_buf, mtp_combine_arrived,
@@ -982,6 +1093,9 @@ def build_tensor_specs(
         meta[:, :, STATE_GENERATION] = 1
         meta[:, :, STATE_TAIL_POSITION] = start_pos - 1
         meta[:, :, STATE_COMMITTED_COUNT] = 0
+        meta[:, :, STATE_TEMPERATURE_MICROS] = 0
+        meta[:, :, STATE_TOP_K] = VOCAB
+        meta[:, :, STATE_SEED] = 0
         return meta
 
     specs.update(
@@ -1095,6 +1209,17 @@ def build_tensor_specs(
             continue
         specs[f"mtp_{name}"] = replace(spec, name=f"mtp_{name}")
 
+    sampling_names = {
+        "sampling_temperatures",
+        "sampling_top_ks",
+        "sampling_seeds",
+        "sampling_positions",
+    }
+    for name in sampling_names:
+        specs[name] = replace(specs[name], is_output=True)
+        mtp_name = f"mtp_{name}"
+        specs[mtp_name] = replace(specs[mtp_name], is_output=True)
+
     param_names = l3_decode_fwd_mtp._param_names()
     missing = set(param_names) - specs.keys()
     extra = specs.keys() - set(param_names)
@@ -1205,4 +1330,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-

--- a/models/deepseek_v4_flash_mtp/decode_mtp.py
+++ b/models/deepseek_v4_flash_mtp/decode_mtp.py
@@ -140,6 +140,10 @@ def decode_mtp(
     mtp_norm_w: pl.Tensor[[D], pl.BF16],
     lm_head_weight: pl.Tensor[[VOCAB_PER_TP, D], pl.BF16],
     logit_row_indices: pl.Tensor[[MAX_LOGIT_ROWS], pl.INT32],
+    sampling_temperatures: pl.Tensor[[MAX_LOGIT_ROWS], pl.FP32],
+    sampling_top_ks: pl.Tensor[[MAX_LOGIT_ROWS], pl.INT32],
+    sampling_seeds: pl.Tensor[[MAX_LOGIT_ROWS], pl.INT32],
+    sampling_positions: pl.Tensor[[MAX_LOGIT_ROWS], pl.INT32],
     hidden_out: pl.Out[pl.Tensor[[T, D], pl.BF16]],
     next_pre_hc_hidden: pl.Out[pl.Tensor[[T, HC_MULT, D], pl.FP32]],
     logits: pl.Out[pl.Tensor[[MAX_LOGIT_ROWS, LM_HEAD_VOCAB], pl.FP32]],
@@ -208,8 +212,9 @@ def decode_mtp(
         hc_head(next_pre_hc_hidden, mtp_hc_head_fn, mtp_hc_head_scale, mtp_hc_head_base, x_head)
         rms_norm(x_head, mtp_norm_w, hidden_out)
         lm_head_with_sampling(
-            hidden_out, lm_head_weight, logit_row_indices, logits,
-            sampled_ids,
+            hidden_out, lm_head_weight, logit_row_indices,
+            sampling_temperatures, sampling_top_ks, sampling_seeds, sampling_positions,
+            logits, sampled_ids,
             lm_head_hidden_window, lm_head_hidden_done,
             lm_head_logits_window, lm_head_logits_done,
             my_rank // LM_HEAD_TP_SIZE * LM_HEAD_TP_SIZE,
@@ -277,6 +282,10 @@ def l2_decode_mtp(
     mtp_norm_w: pl.Tensor[[D], pl.BF16],
     lm_head_weight: pl.Tensor[[VOCAB_PER_TP, D], pl.BF16],
     logit_row_indices: pl.Tensor[[MAX_LOGIT_ROWS], pl.INT32],
+    sampling_temperatures: pl.Tensor[[MAX_LOGIT_ROWS], pl.FP32],
+    sampling_top_ks: pl.Tensor[[MAX_LOGIT_ROWS], pl.INT32],
+    sampling_seeds: pl.Tensor[[MAX_LOGIT_ROWS], pl.INT32],
+    sampling_positions: pl.Tensor[[MAX_LOGIT_ROWS], pl.INT32],
     hidden_out: pl.Out[pl.Tensor[[T, D], pl.BF16]],
     next_pre_hc_hidden: pl.Out[pl.Tensor[[T, HC_MULT, D], pl.FP32]],
     logits: pl.Out[pl.Tensor[[MAX_LOGIT_ROWS, LM_HEAD_VOCAB], pl.FP32]],
@@ -325,6 +334,7 @@ def l2_decode_mtp(
         shared_w1, shared_w1_scale, shared_w3, shared_w3_scale, shared_w2, shared_w2_scale,
         mtp_hc_head_fn, mtp_hc_head_scale, mtp_hc_head_base, mtp_norm_w,
         lm_head_weight, logit_row_indices,
+        sampling_temperatures, sampling_top_ks, sampling_seeds, sampling_positions,
         hidden_out, next_pre_hc_hidden, logits, sampled_ids,
         recv_meta, recv_x, recv_aux, recv_route,
         arrived, data_arrived, routed_y_buf, combine_arrived,
@@ -391,6 +401,10 @@ def l3_decode_mtp(
     mtp_hc_head_base: pl.Tensor[[N_RANKS, HC_MULT], pl.FP32],
     mtp_norm_w: pl.Tensor[[N_RANKS, D], pl.BF16],
     lm_head_weight: pl.Tensor[[N_RANKS, VOCAB_PER_TP, D], pl.BF16],
+    sampling_temperatures: pl.Tensor[[N_RANKS, MAX_LOGIT_ROWS], pl.FP32],
+    sampling_top_ks: pl.Tensor[[N_RANKS, MAX_LOGIT_ROWS], pl.INT32],
+    sampling_seeds: pl.Tensor[[N_RANKS, MAX_LOGIT_ROWS], pl.INT32],
+    sampling_positions: pl.Tensor[[N_RANKS, MAX_LOGIT_ROWS], pl.INT32],
     hidden_out: pl.Out[pl.Tensor[[N_RANKS, T, D], pl.BF16]],
     next_pre_hc_hidden: pl.Out[pl.Tensor[[N_RANKS, T, HC_MULT, D], pl.FP32]],
     logits: pl.Out[pl.Tensor[[N_RANKS, MAX_LOGIT_ROWS, LM_HEAD_VOCAB], pl.FP32]],
@@ -447,6 +461,8 @@ def l3_decode_mtp(
             shared_w2[r], shared_w2_scale[r],
             mtp_hc_head_fn[r], mtp_hc_head_scale[r], mtp_hc_head_base[r], mtp_norm_w[r],
             lm_head_weight[r], logit_row_indices[r],
+            sampling_temperatures[r], sampling_top_ks[r],
+            sampling_seeds[r], sampling_positions[r],
             hidden_out[r], next_pre_hc_hidden[r], logits[r], sampled_ids[r],
             recv_meta, recv_x, recv_aux, recv_route,
             arrived, data_arrived, routed_y_buf, combine_arrived,
@@ -780,6 +796,40 @@ def build_tensor_specs(start_pos=DECODE_START_POS, num_tokens=T, ori_block_num=O
         resident="stacked",
     )
     specs.append(lm_head_spec)
+    specs.append(
+        TensorSpec(
+            "sampling_temperatures",
+            [N_RANKS, MAX_LOGIT_ROWS],
+            torch.float32,
+            init_value=lambda: torch.zeros(N_RANKS, MAX_LOGIT_ROWS),
+        )
+    )
+    specs.append(
+        TensorSpec(
+            "sampling_top_ks",
+            [N_RANKS, MAX_LOGIT_ROWS],
+            torch.int32,
+            init_value=lambda: torch.full(
+                (N_RANKS, MAX_LOGIT_ROWS), LM_HEAD_VOCAB, dtype=torch.int32
+            ),
+        )
+    )
+    specs.append(
+        TensorSpec(
+            "sampling_seeds",
+            [N_RANKS, MAX_LOGIT_ROWS],
+            torch.int32,
+            init_value=lambda: torch.zeros(N_RANKS, MAX_LOGIT_ROWS, dtype=torch.int32),
+        )
+    )
+    specs.append(
+        TensorSpec(
+            "sampling_positions",
+            [N_RANKS, MAX_LOGIT_ROWS],
+            torch.int32,
+            init_value=lambda: torch.zeros(N_RANKS, MAX_LOGIT_ROWS, dtype=torch.int32),
+        )
+    )
     hidden_out_spec = TensorSpec(
         "hidden_out", [N_RANKS, T, D], torch.bfloat16,
         is_output=True, resident="stacked",
@@ -884,6 +934,10 @@ def golden_decode_mtp(tensors):
         "hidden_states": tensors["hidden_out"],
         "lm_head_weight": tensors["lm_head_weight"],
         "logit_row_indices": tensors["logit_row_indices"],
+        "sampling_temperatures": tensors["sampling_temperatures"],
+        "sampling_top_ks": tensors["sampling_top_ks"],
+        "sampling_seeds": tensors["sampling_seeds"],
+        "sampling_positions": tensors["sampling_positions"],
         "logits": tensors["logits"],
         "sampled_ids": tensors["sampled_ids"],
     }

--- a/models/deepseek_v4_flash_mtp/lm_head.py
+++ b/models/deepseek_v4_flash_mtp/lm_head.py
@@ -20,7 +20,8 @@ import pypto.language as pl
 import pypto.language.distributed as pld
 from pypto.ir.distributed_compiled_program import DistributedConfig
 
-from config import DECODE_TOKENS, FLASH as M, FP32_NEG_INF
+from config import DECODE_TOKENS, FLASH as M
+from sample import golden_sample, sample
 
 
 T_DYN = pl.dynamic("LM_HEAD_T_DYN")
@@ -68,10 +69,6 @@ FUSED_K_TILE = 256
 FUSED_VOCAB_TILE = 256
 HIDDEN_GATHER_TILE = 512
 LOGITS_COMM_TILE = 2048
-# Greedy sampling scans each row as a [GREEDY_BLOCK_ROWS, GREEDY_ROW_WIDTH] grid.
-# 8 rows keeps a reduction result at 32 B; alloc_tile rejects the 4 B a [1, 1] gives.
-GREEDY_ROW_WIDTH = 808
-GREEDY_BLOCK_ROWS = 8
 
 # Derived layout. The vocab shard rarely divides the matmul tile, so the last tile
 # is ragged: a plain ceil tile count, the weight load carries a valid_shape, and
@@ -87,10 +84,6 @@ LOGITS_COMM_TAIL = VOCAB_PER_TP % LOGITS_COMM_TILE
 N_LOGITS_COMM_TILES = VOCAB_PER_TP // LOGITS_COMM_TILE
 LOGITS_COMM_BLOCKS = min(FUSED_LM_HEAD_CORES, N_LOGITS_COMM_TILES + (1 if LOGITS_COMM_TAIL != 0 else 0))
 LOGITS_TAIL_BLOCK = N_LOGITS_COMM_TILES % LOGITS_COMM_BLOCKS
-GREEDY_GRID_ROWS = VOCAB // GREEDY_ROW_WIDTH
-GREEDY_BLOCK_SPAN = GREEDY_BLOCK_ROWS * GREEDY_ROW_WIDTH
-# 2^30: above every vocab id, clear of int32 overflow once a block base is added.
-GREEDY_INDEX_SENTINEL = 1073741824
 
 # Keeps the GM staging race-free: each UP_DOWN lane writes exactly the row band it
 # later reads, and the two lanes' bands are disjoint.
@@ -98,9 +91,6 @@ assert SHARD_ROWS == OWNERS_PER_LANE * MAX_LOGIT_ROWS, (
     "each AIV lane's shard rows must be exactly the rows of the owners it pushes"
 )
 assert GROUP_LOGIT_ROWS % 16 == 0, "matmul M extent must be a multiple of 16"
-assert GREEDY_BLOCK_ROWS * 4 % 32 == 0, "reduction result must clear the 32 B column floor"
-assert GREEDY_ROW_WIDTH * 4 % 32 == 0, "block row must clear the 32 B row floor"
-assert VOCAB < GREEDY_INDEX_SENTINEL, "sentinel must lose every row_min against a real id"
 assert TP_SIZE in _TP_CHOICES, f"--tp must be one of {_TP_CHOICES} (got {TP_SIZE})"
 assert DP_SIZE in _DP_CHOICES, f"--dp must be one of {_DP_CHOICES} (got {DP_SIZE})"
 
@@ -336,72 +326,15 @@ def lm_head_test(
     return logits
 
 
-@pl.jit.inline
-def greedy_sample(
-    logits: pl.Tensor[[MAX_LOGIT_ROWS, VOCAB], pl.FP32],
-    sampled_ids: pl.Tensor[[MAX_LOGIT_ROWS, SAMPLED_IDS_PAD], pl.INT32],
-):
-    """Select the first maximum token id from each full-vocabulary logits row."""
-    # One pass per row into a [BLOCK_ROWS, ROW_WIDTH] accumulator carrying the
-    # running maximum and the block that set it; a lane's column is its position.
-    logits_grid = pl.reshape(logits, [MAX_LOGIT_ROWS * GREEDY_GRID_ROWS, GREEDY_ROW_WIDTH])
-    for row in pl.spmd(MAX_LOGIT_ROWS, name_hint="lm_head_greedy_sample"):
-        row_base = row * GREEDY_GRID_ROWS
-        running_max = pl.full([GREEDY_BLOCK_ROWS, GREEDY_ROW_WIDTH], dtype=pl.FP32, value=FP32_NEG_INF)
-        running_base = pl.full([GREEDY_BLOCK_ROWS, GREEDY_ROW_WIDTH], dtype=pl.INT32, value=0)
-        for block in pl.range(GREEDY_GRID_ROWS // GREEDY_BLOCK_ROWS):
-            block_row = row_base + block * GREEDY_BLOCK_ROWS
-            scores = logits_grid[block_row : block_row + GREEDY_BLOCK_ROWS, 0:GREEDY_ROW_WIDTH]
-            # Strict greater-than, so a lane keeps the earliest block it peaked at.
-            is_newer = pl.cmp(scores, running_max, cmp_type=4)
-            newer = pl.cast(is_newer, target_type=pl.INT32)
-            running_max = pl.maximum(running_max, scores)
-            block_base = pl.cast(block * GREEDY_BLOCK_SPAN, pl.INT32)
-            to_new = pl.neg(pl.sub(running_base, block_base))
-            running_base = pl.add(running_base, pl.mul(newer, to_new))
-
-        # Broadcast the lane maxima back and column-reduce: every entry is then the
-        # row maximum. A scalar pl.max over the lanes miscompiles on fp32
-        # (ptoas_bitcast has no float overload).
-        lane_maxima = pl.row_max(running_max)
-        lane_zeros = pl.full([GREEDY_BLOCK_ROWS, GREEDY_ROW_WIDTH], dtype=pl.FP32, value=0.0)
-        lane_broadcast = pl.row_expand_add(lane_zeros, lane_maxima)
-        best_value = pl.read(pl.col_max(lane_broadcast), [0, 0])
-
-        # Flat index of every lane still at the row maximum, sentinel for the rest.
-        # The lane * width term folds into the scalar combine below, keeping the
-        # ramp a broadcast row rather than an (illegal) 2D arange.
-        ramp_zeros = pl.full([GREEDY_BLOCK_ROWS, GREEDY_ROW_WIDTH], dtype=pl.INT32, value=0)
-        column_ramp = pl.col_expand(ramp_zeros, pl.arange(0, [1, GREEDY_ROW_WIDTH], dtype=pl.INT32))
-        flat_index = pl.add(running_base, column_ramp)
-        is_max = pl.cmp(running_max, best_value, cmp_type=0)
-        hit = pl.cast(is_max, target_type=pl.INT32)
-        offset_index = pl.sub(flat_index, GREEDY_INDEX_SENTINEL)
-        candidates = pl.add(pl.mul(hit, offset_index), GREEDY_INDEX_SENTINEL)
-        lane_indices = pl.row_min(candidates)
-        best_index = pl.read(lane_indices, [0, 0])
-        for lane in pl.range(1, GREEDY_BLOCK_ROWS):
-            lane_term = pl.cast(lane * GREEDY_ROW_WIDTH, pl.INT32)
-            lane_best = pl.read(lane_indices, [lane, 0]) + lane_term
-            best_index = pl.min(best_index, lane_best)
-
-        sampled_row = pl.create_tensor([1, SAMPLED_IDS_PAD], dtype=pl.INT32)
-        sampled_row[:, :] = pl.full(
-            [1, SAMPLED_IDS_PAD],
-            dtype=pl.INT32,
-            value=0,
-        )
-        pl.write(sampled_row, [0, 0], best_index)
-        sampled_ids[row : row + 1, :] = sampled_row
-
-    return sampled_ids
-
-
 @pl.jit.inline(auto_scope=False)
 def lm_head_with_sampling(
     hidden_states: pl.Tensor[[T_DYN, D], pl.BF16],
     lm_head_weight: pl.Tensor[[VOCAB_PER_TP, D], pl.BF16],
     logit_row_indices: pl.Tensor[[MAX_LOGIT_ROWS], pl.INT32],
+    sampling_temperatures: pl.Tensor[[MAX_LOGIT_ROWS], pl.FP32],
+    sampling_top_ks: pl.Tensor[[MAX_LOGIT_ROWS], pl.INT32],
+    sampling_seeds: pl.Tensor[[MAX_LOGIT_ROWS], pl.INT32],
+    sampling_positions: pl.Tensor[[MAX_LOGIT_ROWS], pl.INT32],
     logits: pl.Out[pl.Tensor[[MAX_LOGIT_ROWS, VOCAB], pl.FP32]],
     sampled_ids: pl.Out[pl.Tensor[[MAX_LOGIT_ROWS, SAMPLED_IDS_PAD], pl.INT32]],
     hidden_window: pld.DistributedTensor[[GROUP_LOGIT_ROWS, D], pl.BF16],
@@ -412,7 +345,7 @@ def lm_head_with_sampling(
     tp_rank: pl.Scalar[pl.INT32],
     done_epoch: pl.Scalar[pl.INT32],
 ):
-    """Project logits and sample top-1 tokens in one opaque L2 entry."""
+    """Project logits and sample tokens in one opaque L2 entry."""
     lm_head(
         hidden_states,
         lm_head_weight,
@@ -426,7 +359,14 @@ def lm_head_with_sampling(
         tp_rank,
         done_epoch,
     )
-    greedy_sample(logits, sampled_ids)
+    sampled_ids = sample(
+        logits,
+        sampling_temperatures,
+        sampling_top_ks,
+        sampling_seeds,
+        sampling_positions,
+        sampled_ids,
+    )
     return logits, sampled_ids
 
 
@@ -435,6 +375,10 @@ def lm_head_with_sampling_test(
     hidden_states: pl.Tensor[[T_DYN, D], pl.BF16],
     lm_head_weight: pl.Tensor[[VOCAB_PER_TP, D], pl.BF16],
     logit_row_indices: pl.Tensor[[MAX_LOGIT_ROWS], pl.INT32],
+    sampling_temperatures: pl.Tensor[[MAX_LOGIT_ROWS], pl.FP32],
+    sampling_top_ks: pl.Tensor[[MAX_LOGIT_ROWS], pl.INT32],
+    sampling_seeds: pl.Tensor[[MAX_LOGIT_ROWS], pl.INT32],
+    sampling_positions: pl.Tensor[[MAX_LOGIT_ROWS], pl.INT32],
     logits: pl.Out[pl.Tensor[[MAX_LOGIT_ROWS, VOCAB], pl.FP32]],
     sampled_ids: pl.Out[pl.Tensor[[MAX_LOGIT_ROWS, SAMPLED_IDS_PAD], pl.INT32]],
     hidden_window: pld.DistributedTensor[[GROUP_LOGIT_ROWS, D], pl.BF16],
@@ -445,11 +389,15 @@ def lm_head_with_sampling_test(
     tp_rank: pl.Scalar[pl.INT32],
     done_epoch: pl.Scalar[pl.INT32],
 ):
-    """Standalone opaque entry for projection plus greedy sampling tests."""
+    """Standalone opaque entry for projection plus sampling tests."""
     return lm_head_with_sampling(
         hidden_states,
         lm_head_weight,
         logit_row_indices,
+        sampling_temperatures,
+        sampling_top_ks,
+        sampling_seeds,
+        sampling_positions,
         logits,
         sampled_ids,
         hidden_window,
@@ -466,6 +414,10 @@ def lm_head_with_sampling_test(
 def l3_lm_head(
     hidden_states: pl.Tensor[[WORLD_SIZE, TEST_TOKENS, D], pl.BF16],
     lm_head_weight: pl.Tensor[[WORLD_SIZE, VOCAB_PER_TP, D], pl.BF16],
+    sampling_temperatures: pl.Tensor[[WORLD_SIZE, MAX_LOGIT_ROWS], pl.FP32],
+    sampling_top_ks: pl.Tensor[[WORLD_SIZE, MAX_LOGIT_ROWS], pl.INT32],
+    sampling_seeds: pl.Tensor[[WORLD_SIZE, MAX_LOGIT_ROWS], pl.INT32],
+    sampling_positions: pl.Tensor[[WORLD_SIZE, MAX_LOGIT_ROWS], pl.INT32],
     logits: pl.Out[pl.Tensor[[WORLD_SIZE, MAX_LOGIT_ROWS, VOCAB], pl.FP32]],
     sampled_ids: pl.Out[
         pl.Tensor[[WORLD_SIZE, MAX_LOGIT_ROWS, SAMPLED_IDS_PAD], pl.INT32]
@@ -485,8 +437,10 @@ def l3_lm_head(
         logits_window = pld.window(logits_window_buf, [MAX_LOGIT_ROWS, VOCAB], dtype=pl.FP32)
         logits_done = pld.window(logits_done_buf, [TP_SIZE, 1], dtype=pl.INT32)
         lm_head_with_sampling_test(
-            hidden_states[r], lm_head_weight[r], logit_row_indices[r], logits[r],
-            sampled_ids[r],
+            hidden_states[r], lm_head_weight[r], logit_row_indices[r],
+            sampling_temperatures[r], sampling_top_ks[r],
+            sampling_seeds[r], sampling_positions[r],
+            logits[r], sampled_ids[r],
             hidden_window, hidden_done, logits_window, logits_done,
             r // TP_SIZE * TP_SIZE, r % TP_SIZE, DONE_VALUE, device=r,
         )
@@ -501,7 +455,8 @@ def golden_lm_head(tensors):
     weight = tensors["lm_head_weight"].float()
     full_weight = torch.cat([weight[tp] for tp in range(TP_SIZE)], dim=0)
     full_logits = []
-    for owner_rank in range(WORLD_SIZE):
+    world_size = hidden.shape[0]
+    for owner_rank in range(world_size):
         selected = torch.zeros((MAX_LOGIT_ROWS, D), dtype=torch.float32)
         for row in range(MAX_LOGIT_ROWS):
             source_row = int(tensors["logit_row_indices"][owner_rank, row])
@@ -511,11 +466,17 @@ def golden_lm_head(tensors):
         full_logits.append(torch.matmul(selected, full_weight.t()))
     tensors["logits"][:] = torch.stack(full_logits, dim=0)
     if "sampled_ids" in tensors:
-        tensors["sampled_ids"].zero_()
-        tensors["sampled_ids"][:, :, 0] = torch.argmax(
-            tensors["logits"],
-            dim=-1,
-        ).to(torch.int32)
+        for rank in range(world_size):
+            golden_sample(
+                {
+                    "logits": tensors["logits"][rank],
+                    "temperatures": tensors["sampling_temperatures"][rank],
+                    "top_ks": tensors["sampling_top_ks"][rank],
+                    "seeds": tensors["sampling_seeds"][rank],
+                    "positions": tensors["sampling_positions"][rank],
+                    "sampled_ids": tensors["sampled_ids"][rank],
+                }
+            )
 
 
 def build_tensor_specs(num_tokens=TEST_TOKENS):
@@ -552,6 +513,32 @@ def build_tensor_specs(num_tokens=TEST_TOKENS):
             torch.bfloat16,
             init_value=init_lm_head_weight,
             resident="stacked",
+        ),
+        TensorSpec(
+            "sampling_temperatures",
+            [WORLD_SIZE, MAX_LOGIT_ROWS],
+            torch.float32,
+            init_value=lambda: torch.zeros(WORLD_SIZE, MAX_LOGIT_ROWS),
+        ),
+        TensorSpec(
+            "sampling_top_ks",
+            [WORLD_SIZE, MAX_LOGIT_ROWS],
+            torch.int32,
+            init_value=lambda: torch.full(
+                (WORLD_SIZE, MAX_LOGIT_ROWS), VOCAB, dtype=torch.int32
+            ),
+        ),
+        TensorSpec(
+            "sampling_seeds",
+            [WORLD_SIZE, MAX_LOGIT_ROWS],
+            torch.int32,
+            init_value=lambda: torch.zeros(WORLD_SIZE, MAX_LOGIT_ROWS, dtype=torch.int32),
+        ),
+        TensorSpec(
+            "sampling_positions",
+            [WORLD_SIZE, MAX_LOGIT_ROWS],
+            torch.int32,
+            init_value=lambda: torch.zeros(WORLD_SIZE, MAX_LOGIT_ROWS, dtype=torch.int32),
         ),
         TensorSpec(
             "logits",

--- a/models/deepseek_v4_flash_mtp/sample.py
+++ b/models/deepseek_v4_flash_mtp/sample.py
@@ -22,6 +22,8 @@ SAMPLED_IDS_PAD = 8
 SAMPLE_ROW_WIDTH_TILE = 256
 SAMPLE_BLOCK_ROWS_TILE = 8
 SAMPLE_CANDIDATES_TILE = 512
+GREEDY_ROW_WIDTH_TILE = 808
+GREEDY_BLOCK_ROWS_TILE = 8
 TOPK_ROW_WIDTH_TILE = 640
 TOPK_SEARCH_STEPS = 18
 
@@ -32,6 +34,7 @@ HASH_MULTIPLIER = 0x045D9F3B
 POSITION_MULTIPLIER = 65537
 UINT23_SCALE = 1.0 / 8388608.0
 FP32_POS_INF = 3.4028234663852886e38
+GREEDY_INDEX_SENTINEL = 1073741824
 
 
 @pl.jit.inline
@@ -153,6 +156,51 @@ def _sample_filtered_logits(
 
 
 @pl.jit.inline
+def _greedy_sample_logits(
+    logits_grid: pl.Tensor,
+    row: pl.Scalar[pl.INDEX],
+):
+    """Select the first maximum token id from one full-vocabulary logits row."""
+    row_base = row * (VOCAB // GREEDY_ROW_WIDTH_TILE)
+    running_max = pl.full(
+        [GREEDY_BLOCK_ROWS_TILE, GREEDY_ROW_WIDTH_TILE], dtype=pl.FP32, value=FP32_NEG_INF
+    )
+    running_base = pl.full([GREEDY_BLOCK_ROWS_TILE, GREEDY_ROW_WIDTH_TILE], dtype=pl.INT32, value=0)
+    for block in pl.range(VOCAB // GREEDY_ROW_WIDTH_TILE // GREEDY_BLOCK_ROWS_TILE):
+        block_row = row_base + block * GREEDY_BLOCK_ROWS_TILE
+        scores = logits_grid[block_row : block_row + GREEDY_BLOCK_ROWS_TILE, 0:GREEDY_ROW_WIDTH_TILE]
+        is_newer = pl.cmp(scores, running_max, cmp_type=4)
+        newer = pl.cast(is_newer, target_type=pl.INT32)
+        running_max = pl.maximum(running_max, scores)
+        block_base = pl.cast(block * GREEDY_BLOCK_ROWS_TILE * GREEDY_ROW_WIDTH_TILE, pl.INT32)
+        to_new = pl.add(pl.neg(running_base), block_base)
+        running_base = pl.add(running_base, pl.mul(newer, to_new))
+
+    lane_maxima = pl.row_max(running_max)
+    lane_zeros = pl.full([GREEDY_BLOCK_ROWS_TILE, GREEDY_ROW_WIDTH_TILE], dtype=pl.FP32, value=0.0)
+    lane_broadcast = pl.row_expand_add(lane_zeros, lane_maxima)
+    best_value = pl.read(pl.col_max(lane_broadcast), [0, 0])
+
+    ramp_zeros = pl.full([GREEDY_BLOCK_ROWS_TILE, GREEDY_ROW_WIDTH_TILE], dtype=pl.INT32, value=0)
+    column_ids = pl.arange(0, [1, GREEDY_ROW_WIDTH_TILE], dtype=pl.INT32)
+    column_ramp = pl.col_expand(ramp_zeros, column_ids)
+    flat_index = pl.add(running_base, column_ramp)
+    is_max = pl.cmp(running_max, best_value, cmp_type=0)
+    hit = pl.cast(is_max, target_type=pl.INT32)
+    index_sentinel = pl.cast(GREEDY_INDEX_SENTINEL, pl.INT32)
+    negative_index_sentinel = pl.cast(-GREEDY_INDEX_SENTINEL, pl.INT32)
+    offset_index = pl.add(flat_index, negative_index_sentinel)
+    candidates = pl.add(pl.mul(hit, offset_index), index_sentinel)
+    lane_indices = pl.row_min(candidates)
+    best_index = pl.read(lane_indices, [0, 0])
+    for lane in pl.range(1, GREEDY_BLOCK_ROWS_TILE):
+        lane_term = pl.cast(lane * GREEDY_ROW_WIDTH_TILE, pl.INT32)
+        lane_best = pl.read(lane_indices, [lane, 0]) + lane_term
+        best_index = pl.min(best_index, lane_best)
+    return best_index
+
+
+@pl.jit.inline
 def apply_temperature(
     logits: pl.Tensor,
     temperatures: pl.Tensor,
@@ -162,26 +210,27 @@ def apply_temperature(
     sample_rows = pl.tensor.dim(logits, 0)
     for row in pl.spmd(sample_rows, name_hint="sample_apply_temperature"):
         temperature = pl.read(temperatures, [row])
-        for vocab_tile in pl.range(VOCAB // SAMPLE_ROW_WIDTH_TILE):
-            vocab_start = vocab_tile * SAMPLE_ROW_WIDTH_TILE
-            scores = pl.slice(logits, [1, SAMPLE_ROW_WIDTH_TILE], [row, vocab_start])
-            scaled_scores = pl.mul(scores, 1.0)
-            if temperature >= SAMPLING_EPS:
+        if temperature >= SAMPLING_EPS:
+            for vocab_tile in pl.range(VOCAB // SAMPLE_ROW_WIDTH_TILE):
+                vocab_start = vocab_tile * SAMPLE_ROW_WIDTH_TILE
+                scores = pl.slice(logits, [1, SAMPLE_ROW_WIDTH_TILE], [row, vocab_start])
                 scaled_scores = pl.div(scores, temperature)
-            scaled_logits[row : row + 1, vocab_start : vocab_start + SAMPLE_ROW_WIDTH_TILE] = scaled_scores
+                scaled_logits[row : row + 1, vocab_start : vocab_start + SAMPLE_ROW_WIDTH_TILE] = scaled_scores
     return scaled_logits
 
 
 @pl.jit.inline
 def apply_top_k(
     scaled_logits: pl.Tensor,
+    temperatures: pl.Tensor,
     top_ks: pl.Tensor,
 ):
     """Mask logits below each row's top-k boundary in an independent stage."""
     sample_rows = pl.tensor.dim(scaled_logits, 0)
     for row in pl.spmd(sample_rows, name_hint="sample_apply_top_k"):
+        temperature = pl.read(temperatures, [row])
         top_k = pl.read(top_ks, [row])
-        if top_k > 0 and top_k < VOCAB:
+        if temperature >= SAMPLING_EPS and top_k > 0 and top_k < VOCAB:
             search_lower = pl.cast(FP32_POS_INF, pl.FP32)
             search_upper = pl.cast(FP32_NEG_INF, pl.FP32)
             for extrema_block in pl.range(VOCAB // TOPK_ROW_WIDTH_TILE // SAMPLE_BLOCK_ROWS_TILE):
@@ -421,26 +470,29 @@ def apply_top_k(
 
 @pl.jit.inline
 def gumbel_sample(
+    logits: pl.Tensor,
     filtered_logits: pl.Tensor,
     temperatures: pl.Tensor,
     seeds: pl.Tensor,
     positions: pl.Tensor,
     sampled_ids: pl.Tensor,
 ):
-    """Run greedy or Gumbel-max in an independent row-parallel stage."""
+    """Run direct-logits greedy or filtered-logits Gumbel-max sampling."""
     sample_rows = pl.tensor.dim(filtered_logits, 0)
+    logits_grid = pl.reshape(logits, [SAMPLE_ROWS * (VOCAB // GREEDY_ROW_WIDTH_TILE), GREEDY_ROW_WIDTH_TILE])
     for row in pl.spmd(sample_rows, name_hint="sample_gumbel_argmax"):
         temperature = pl.read(temperatures, [row])
-        random_flag = pl.cast(0, pl.INT32)
-        if temperature >= SAMPLING_EPS:
+        if temperature < SAMPLING_EPS:
+            best_index = _greedy_sample_logits(logits_grid, row)
+        else:
             random_flag = pl.cast(1, pl.INT32)
-        seed = pl.read(seeds, [row])
-        position = pl.read(positions, [row])
-        seed_index = pl.cast(seed, pl.INDEX)
-        position_index = pl.cast(position, pl.INDEX)
-        random_key_index = seed_index + position_index * POSITION_MULTIPLIER
-        random_key = pl.cast(random_key_index % RANDOM_KEY_MODULUS, pl.INT32)
-        best_index = _sample_filtered_logits(filtered_logits, row, random_flag, random_key)
+            seed = pl.read(seeds, [row])
+            position = pl.read(positions, [row])
+            seed_index = pl.cast(seed, pl.INDEX)
+            position_index = pl.cast(position, pl.INDEX)
+            random_key_index = seed_index + position_index * POSITION_MULTIPLIER
+            random_key = pl.cast(random_key_index % RANDOM_KEY_MODULUS, pl.INT32)
+            best_index = _sample_filtered_logits(filtered_logits, row, random_flag, random_key)
         sampled_row = pl.create_tensor([1, SAMPLED_IDS_PAD], dtype=pl.INT32)
         sampled_row[:, :] = pl.full([1, SAMPLED_IDS_PAD], dtype=pl.INT32, value=0)
         pl.write(sampled_row, [0, 0], best_index)
@@ -460,8 +512,9 @@ def sample(
     """Orchestrate independent temperature, top-k, and Gumbel stages."""
     processed_logits = pl.create_tensor([SAMPLE_ROWS, VOCAB], dtype=pl.FP32)
     apply_temperature(logits, sampling_temperatures, processed_logits)
-    apply_top_k(processed_logits, sampling_top_ks)
+    apply_top_k(processed_logits, sampling_temperatures, sampling_top_ks)
     return gumbel_sample(
+        logits,
         processed_logits,
         sampling_temperatures,
         sampling_seeds,


### PR DESCRIPTION
- Thread per-row sampling controls (temperature, top-k, seed, and
  position) through lm_head, decode_fwd, decode_mtp, and the fused MTP
  decode, at both the L2 and L3 entries.
- Replace lm_head's local greedy_sample with the shared sampler in
  sample.py, dropping the duplicated GREEDY_* layout constants and
  asserts.
- Route zero-temperature rows through a greedy scan of the raw logits
  and positive-temperature rows through temperature scaling, top-k
  masking, and Gumbel-max.
- Skip temperature scaling and top-k masking entirely on
  zero-temperature rows instead of computing and discarding them.
- Widen the fused decode state meta from 4 to 7 slots to persist
  temperature (as micros), top-k, and seed per request, and derive the
  main-token and next-draft sampling positions independently.
- Derive the golden's world size from the input shape and delegate its
  sampling to golden_sample.

The new sampling parameters are required at every entry, so
pypto-serving must pass them before it can drive these programs.
